### PR TITLE
Migrate calls to async_get_device in tests (part 3)

### DIFF
--- a/tests/components/homevolt/test_sensor.py
+++ b/tests/components/homevolt/test_sensor.py
@@ -25,8 +25,8 @@ async def test_entities(
     """Test the sensor entities."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "40580137858664_ems_40580137858664")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "40580137858664_ems_40580137858664"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/hortimax/test_init.py
+++ b/tests/components/hortimax/test_init.py
@@ -97,9 +97,12 @@ async def test_renamed_source_follows(
 ) -> None:
     """Test renaming a source in HortiMaX Pro renames its device."""
     await setup_integration(hass, mock_config_entry)
-    identifiers = {(DOMAIN, f"{DEVICE}::WeatherStation::Weather station 001")}
     assert (
-        device_registry.async_get_device(identifiers=identifiers).name == "Weerstation"
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{DEVICE}::WeatherStation::Weather station 001"),
+            mock_config_entry.entry_id,
+        ).name
+        == "Weerstation"
     )
 
     readouts = load_readouts()
@@ -113,7 +116,11 @@ async def test_renamed_source_follows(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(identifiers=identifiers).name == "Weerhuisje"
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{DEVICE}::WeatherStation::Weather station 001"),
+            mock_config_entry.entry_id,
+        ).name
+        == "Weerhuisje"
     )
 
 
@@ -126,14 +133,17 @@ async def test_devices(
     """Test the controller and its sources become linked devices."""
     await setup_integration(hass, mock_config_entry)
 
-    controller = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE)})
+    controller = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE), mock_config_entry.entry_id
+    )
     assert controller is not None
     assert controller.name == DEVICE_LABEL
     assert controller.manufacturer == "Ridder"
     assert controller.via_device_id is None
 
-    weather_station = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{DEVICE}::WeatherStation::Weather station 001")}
+    weather_station = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{DEVICE}::WeatherStation::Weather station 001"),
+        mock_config_entry.entry_id,
     )
     assert weather_station is not None
     # The user-defined name wins, with its trailing whitespace stripped.
@@ -143,11 +153,12 @@ async def test_devices(
 
     # Two sources share the user-defined name 'OV1 Tropen', so both get their
     # source type appended.
-    screen = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{DEVICE}::Screen::Screen 001")}
+    screen = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{DEVICE}::Screen::Screen 001"), mock_config_entry.entry_id
     )
-    ventilation = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{DEVICE}::VentilationGroup::Ventilation group 001")}
+    ventilation = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{DEVICE}::VentilationGroup::Ventilation group 001"),
+        mock_config_entry.entry_id,
     )
     assert screen is not None
     assert ventilation is not None

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -38,8 +38,8 @@ async def test_get_triggers(
     assert len(hass.states.async_all()) == 1
 
     # Get triggers for specific tap switch
-    hue_tap_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+    hue_tap_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "00:00:00:00:00:44:23:08"), mock_bridge_v1.config_entry.entry_id
     )
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, hue_tap_device.id
@@ -59,8 +59,8 @@ async def test_get_triggers(
     assert triggers == unordered(expected_triggers)
 
     # Get triggers for specific dimmer switch
-    hue_dimmer_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+    hue_dimmer_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "00:17:88:01:10:3e:3a:dc"), mock_bridge_v1.config_entry.entry_id
     )
     hue_bat_sensor = entity_registry.async_get(
         "sensor.hue_dimmer_switch_1_battery_level"
@@ -109,8 +109,8 @@ async def test_if_fires_on_state_change(
     assert len(hass.states.async_all()) == 1
 
     # Set an automation with a specific tap switch trigger
-    hue_tap_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+    hue_tap_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "00:00:00:00:00:44:23:08"), mock_bridge_v1.config_entry.entry_id
     )
     assert await async_setup_component(
         hass,

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -104,8 +104,9 @@ async def test_get_triggers(
     )
 
     # Get triggers for `Wall switch with 2 controls`
-    hue_wall_switch_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")}
+    hue_wall_switch_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da"),
+        mock_bridge_v2.config_entry.entry_id,
     )
     # The device is linked to the bridge device as its via_device.
     bridge_device = device_registry.async_get_device_by_identifier(

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -485,8 +485,9 @@ async def test_hue_events(
     assert len(hass.states.async_all()) == 7
     assert len(events) == 0
 
-    hue_tap_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+    hue_tap_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "00:00:00:00:00:44:23:08"),
+        mock_bridge_v1.config_entry.entry_id,
     )
     # The sensor device is linked to the bridge device as its via_device.
     bridge_device = device_registry.async_get_device_by_identifier(
@@ -522,8 +523,9 @@ async def test_hue_events(
         "last_updated": "2019-12-28T22:58:03",
     }
 
-    hue_dimmer_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+    hue_dimmer_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "00:17:88:01:10:3e:3a:dc"),
+        mock_bridge_v1.config_entry.entry_id,
     )
 
     new_sensor_response = dict(new_sensor_response)
@@ -621,8 +623,9 @@ async def test_hue_events(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    hue_aurora_device = device_registry.async_get_device(
-        identifiers={(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
+    hue_aurora_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7"),
+        mock_bridge_v1.config_entry.entry_id,
     )
 
     assert len(mock_bridge_v1.mock_requests) == 6

--- a/tests/components/husqvarna_automower/test_diagnostics.py
+++ b/tests/components/husqvarna_automower/test_diagnostics.py
@@ -59,8 +59,8 @@ async def test_device_diagnostics(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_MOWER_ID)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MOWER_ID), mock_config_entry.entry_id
     )
     assert reg_device is not None
     result = await get_diagnostics_for_device(

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -232,8 +232,8 @@ async def test_model_id_information(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_MOWER_ID)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MOWER_ID), mock_config_entry.entry_id
     )
     assert reg_device is not None
     assert reg_device.manufacturer == "Husqvarna"
@@ -253,8 +253,8 @@ async def test_device_info(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_MOWER_ID)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MOWER_ID), mock_config_entry.entry_id
     )
     assert reg_device == snapshot
 

--- a/tests/components/husqvarna_automower_ble/test_init.py
+++ b/tests/components/husqvarna_automower_ble/test_init.py
@@ -33,8 +33,9 @@ async def test_setup(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{AUTOMOWER_SERVICE_INFO_SERIAL.address}_1197489078")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{AUTOMOWER_SERVICE_INFO_SERIAL.address}_1197489078"),
+        mock_config_entry.entry_id,
     )
 
     assert device_entry == snapshot

--- a/tests/components/huum/test_init.py
+++ b/tests/components/huum/test_init.py
@@ -81,8 +81,8 @@ async def test_device_entry(
 ) -> None:
     """Test device registry entry."""
     assert (
-        device_entry := device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        device_entry := device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
         )
     )
     assert device_entry == snapshot

--- a/tests/components/hydrawise/test_device.py
+++ b/tests/components/hydrawise/test_device.py
@@ -18,12 +18,16 @@ def test_zones_in_device_registry(
 ) -> None:
     """Test that devices are added to the device registry."""
 
-    device1 = device_registry.async_get_device(identifiers={(DOMAIN, "5965394")})
+    device1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "5965394"), mock_added_config_entry.entry_id
+    )
     assert device1 is not None
     assert device1.name == "Zone One"
     assert device1.manufacturer == "Hydrawise"
 
-    device2 = device_registry.async_get_device(identifiers={(DOMAIN, "5965395")})
+    device2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "5965395"), mock_added_config_entry.entry_id
+    )
     assert device2 is not None
     assert device2.name == "Zone Two"
     assert device2.manufacturer == "Hydrawise"
@@ -36,7 +40,9 @@ def test_controller_in_device_registry(
     mock_pydrawise: Mock,
 ) -> None:
     """Test that devices are added to the device registry."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "52496")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "52496"), mock_added_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Home Controller"
     assert device.manufacturer == "Hydrawise"

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -51,13 +51,13 @@ async def test_auto_add_devices(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test new devices are auto-added to the device registry."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, str(controller.id))}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, str(controller.id)), mock_added_config_entry.entry_id
     )
     assert device is not None
     for zone in zones:
-        zone_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, str(zone.id))}
+        zone_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(zone.id)), mock_added_config_entry.entry_id
         )
         assert zone_device is not None
     all_devices = dr.async_entries_for_config_entry(
@@ -90,8 +90,8 @@ async def test_auto_add_devices(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    new_controller_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, str(controller2.id))}
+    new_controller_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, str(controller2.id)), mock_added_config_entry.entry_id
     )
     assert new_controller_device is not None
 
@@ -101,8 +101,8 @@ async def test_auto_add_devices(
     assert hass.states.get("binary_sensor.home_controller_2_connectivity") is not None
 
     for zone in zones2:
-        new_zone_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, str(zone.id))}
+        new_zone_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(zone.id)), mock_added_config_entry.entry_id
         )
         assert new_zone_device is not None
 
@@ -161,11 +161,15 @@ async def test_auto_remove_devices(
 ) -> None:
     """Test old devices are auto-removed from the device registry."""
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, str(controller.id))})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(controller.id)), mock_added_config_entry.entry_id
+        )
         is not None
     )
     for zone in zones:
-        device = device_registry.async_get_device(identifiers={(DOMAIN, str(zone.id))})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(zone.id)), mock_added_config_entry.entry_id
+        )
         assert device is not None
 
     user.controllers = []
@@ -175,11 +179,15 @@ async def test_auto_remove_devices(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, str(controller.id))})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(controller.id)), mock_added_config_entry.entry_id
+        )
         is None
     )
     for zone in zones:
-        device = device_registry.async_get_device(identifiers={(DOMAIN, str(zone.id))})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(zone.id)), mock_added_config_entry.entry_id
+        )
         assert device is None
     all_devices = dr.async_entries_for_config_entry(
         device_registry, mock_added_config_entry.entry_id

--- a/tests/components/hyperion/test_camera.py
+++ b/tests/components/hyperion/test_camera.py
@@ -194,7 +194,9 @@ async def test_device_info(
 
     device_id = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), TEST_CONFIG_ENTRY_ID
+    )
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_id)}

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -799,7 +799,9 @@ async def test_device_info(
 
     device_id = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), TEST_CONFIG_ENTRY_ID
+    )
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_id)}

--- a/tests/components/hyperion/test_sensor.py
+++ b/tests/components/hyperion/test_sensor.py
@@ -64,7 +64,9 @@ async def test_device_info(
 
     device_identifer = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_identifer)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_identifer), TEST_CONFIG_ENTRY_ID
+    )
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_identifer)}

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -168,7 +168,9 @@ async def test_device_info(
 
     device_identifer = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_identifer)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_identifer), TEST_CONFIG_ENTRY_ID
+    )
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_identifer)}

--- a/tests/components/hypontech/test_sensor.py
+++ b/tests/components/hypontech/test_sensor.py
@@ -47,15 +47,15 @@ async def test_device_manufacturer_uses_oem(
         await setup_integration(hass, mock_config_entry)
 
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    overview_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    overview_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert overview_device
     assert overview_device.manufacturer == "Nexen"
 
     plant = mock_hyponcloud.get_list.return_value[0]
-    plant_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, plant.plant_id)}
+    plant_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, plant.plant_id), mock_config_entry.entry_id
     )
     assert plant_device
     assert plant_device.manufacturer == "Nexen"

--- a/tests/components/ialarm/test_init.py
+++ b/tests/components/ialarm/test_init.py
@@ -70,8 +70,8 @@ async def test_device_registry(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:54:12:34:56")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:54:12:34:56"), mock_config_entry.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -36,13 +36,12 @@ async def test_device_remove_devices(
     inject_bluetooth_service_info(hass, BLUECHARM_BEACON_SERVICE_INFO)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                "426c7565-4368-6172-6d42-6561636f6e73_3838_4949_61DE521B-F0BF-9F44-64D4-75BBE1738105",
-            )
-        },
+    device_entry = device_registry.async_get_device_by_identifier(
+        (
+            DOMAIN,
+            "426c7565-4368-6172-6d42-6561636f6e73_3838_4949_61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        ),
+        entry.entry_id,
     )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, entry.entry_id)

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -156,7 +156,9 @@ async def test_dhcp_flow_simple(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # Check the gateway device is discovered
-    gateway_device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id)})
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry_id), entry_id
+    )
     assert gateway_device is not None
     assert gateway_device.name == "RFGateway"
     assert gateway_device.manufacturer == "Intergas"
@@ -164,13 +166,13 @@ async def test_dhcp_flow_simple(
 
     devices = device_registry.devices.get_devices_for_config_entry_id(entry_id)
     assert len(devices) == 3
-    boiler_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "c0ffeec0ffee")}
+    boiler_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee"), entry_id
     )
     assert boiler_device.via_device_id == gateway_device.id
     assert boiler_device is not None
-    climate_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "c0ffeec0ffee_1")}
+    climate_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee_1"), entry_id
     )
     assert climate_device is not None
     assert climate_device.via_device_id == gateway_device.id
@@ -202,8 +204,8 @@ async def test_dhcp_flow_migrates_existing_entry_without_unique_id(
 
     # Check the gateway device is discovered after a reload
     # And has updated connections
-    gateway_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert gateway_device is not None
     assert gateway_device.name == "RFGateway"
@@ -214,13 +216,13 @@ async def test_dhcp_flow_migrates_existing_entry_without_unique_id(
         mock_config_entry.entry_id
     )
     assert len(devices) == 3
-    boiler_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "c0ffeec0ffee")}
+    boiler_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee"), mock_config_entry.entry_id
     )
     assert boiler_device.via_device_id == gateway_device.id
     assert boiler_device is not None
-    climate_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "c0ffeec0ffee_1")}
+    climate_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee_1"), mock_config_entry.entry_id
     )
     assert climate_device is not None
     assert climate_device.via_device_id == gateway_device.id

--- a/tests/components/incomfort/test_init.py
+++ b/tests/components/incomfort/test_init.py
@@ -85,12 +85,18 @@ async def test_stale_devices_cleanup(
         mock_config_entry.entry_id
     )
     assert len(old_entries) == 3
-    old_heater = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee")})
+    old_heater = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c01d00c0ffee"), mock_config_entry.entry_id
+    )
     assert old_heater is not None
     assert old_heater.serial_number == "c01d00c0ffee"
-    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    old_climate = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c01d00c0ffee_1"), mock_config_entry.entry_id
+    )
     assert old_heater is not None
-    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    old_climate = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c01d00c0ffee_1"), mock_config_entry.entry_id
+    )
     assert old_climate is not None
 
     mock_heater_status["serial_no"] = "c0ffeec0ffee"
@@ -101,15 +107,23 @@ async def test_stale_devices_cleanup(
         mock_config_entry.entry_id
     )
     assert len(new_entries) == 3
-    new_heater = device_registry.async_get_device({(DOMAIN, "c0ffeec0ffee")})
+    new_heater = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee"), mock_config_entry.entry_id
+    )
     assert new_heater is not None
     assert new_heater.serial_number == "c0ffeec0ffee"
-    new_climate = device_registry.async_get_device({(DOMAIN, "c0ffeec0ffee_1")})
+    new_climate = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee_1"), mock_config_entry.entry_id
+    )
     assert new_climate is not None
 
-    old_heater = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee")})
+    old_heater = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c01d00c0ffee"), mock_config_entry.entry_id
+    )
     assert old_heater is None
-    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    old_climate = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c01d00c0ffee_1"), mock_config_entry.entry_id
+    )
     assert old_climate is None
 
 

--- a/tests/components/indevolt/test_init.py
+++ b/tests/components/indevolt/test_init.py
@@ -46,8 +46,8 @@ async def test_device_info(
     await setup_integration(hass, mock_config_entry)
 
     device_info = DEVICE_MAPPING[generation]
-    device_entry = device_registry.async_get_device(
-        connections={(CONNECTION_NETWORK_MAC, device_info["mac"])}
+    device_entry = device_registry.async_get_device_by_connection(
+        (CONNECTION_NETWORK_MAC, device_info["mac"]), mock_config_entry.entry_id
     )
 
     assert device_entry is not None

--- a/tests/components/indevolt/test_services.py
+++ b/tests/components/indevolt/test_services.py
@@ -23,8 +23,8 @@ from tests.common import MockConfigEntry
 def _get_device_id(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> str:
     """Return the device registry ID for the given config entry."""
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     return device_entry.id

--- a/tests/components/inels/common.py
+++ b/tests/components/inels/common.py
@@ -111,7 +111,10 @@ async def old_entity_and_device_removal(
     entity_registry.async_update_entity(old_entity.entity_id, device_id=device.id)
 
     assert (
-        device_registry.async_get_device({(DOMAIN, old_entity.unique_id)}) is not None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, old_entity.unique_id), config_entry.entry_id
+        )
+        is not None
     )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -134,4 +137,9 @@ async def old_entity_and_device_removal(
     assert entity_registry.async_get(old_entity.entity_id) is None
 
     # Verify that the device no longer exists in the registry
-    assert device_registry.async_get_device({(DOMAIN, old_entity.unique_id)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, old_entity.unique_id), config_entry.entry_id
+        )
+        is None
+    )

--- a/tests/components/iometer/test_init.py
+++ b/tests/components/iometer/test_init.py
@@ -41,8 +41,8 @@ async def test_new_firmware_version(
     assert mock_config_entry.unique_id is not None
 
     await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.sw_version == "build-58/build-65"
@@ -53,8 +53,8 @@ async def test_new_firmware_version(
     get_status_callback(mock_iometer_client)(Status.from_json(json.dumps(status_data)))
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.sw_version == "build-62/build-69"

--- a/tests/components/iron_os/test_init.py
+++ b/tests/components/iron_os/test_init.py
@@ -109,8 +109,8 @@ async def test_device_info_update(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(
-        connections={(CONNECTION_BLUETOOTH, config_entry.unique_id)}
+    device = device_registry.async_get_device_by_connection(
+        (CONNECTION_BLUETOOTH, config_entry.unique_id), config_entry.entry_id
     )
     assert device
     assert device.sw_version is None
@@ -128,8 +128,8 @@ async def test_device_info_update(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(CONNECTION_BLUETOOTH, config_entry.unique_id)}
+    device = device_registry.async_get_device_by_connection(
+        (CONNECTION_BLUETOOTH, config_entry.unique_id), config_entry.entry_id
     )
     assert device
     assert device.sw_version == "v2.22"

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -119,13 +119,12 @@ async def test_device_remove_devices(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                "DEVICE-UUID",
-            )
-        },
+    device_entry = device_registry.async_get_device_by_identifier(
+        (
+            DOMAIN,
+            "DEVICE-UUID",
+        ),
+        mock_config_entry.entry_id,
     )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, mock_config_entry.entry_id)

--- a/tests/components/jvc_projector/test_init.py
+++ b/tests/components/jvc_projector/test_init.py
@@ -26,7 +26,9 @@ async def test_init(
 ) -> None:
     """Test initialization."""
     mac = format_mac(MOCK_MAC)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, mac)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mac), mock_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {(DOMAIN, mac)}
 
@@ -39,8 +41,8 @@ async def test_device_registry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the device registry entry, including the network MAC connection."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, format_mac(MOCK_MAC))}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, format_mac(MOCK_MAC)), mock_integration.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/kaleidescape/test_init.py
+++ b/tests/components/kaleidescape/test_init.py
@@ -61,11 +61,13 @@ async def test_disconnect_on_hass_stop(
     assert mock_device.disconnect.call_count == 1
 
 
-@pytest.mark.usefixtures("mock_device", "mock_integration")
-async def test_device(device_registry: dr.DeviceRegistry) -> None:
+@pytest.mark.usefixtures("mock_device")
+async def test_device(
+    device_registry: dr.DeviceRegistry, mock_integration: MockConfigEntry
+) -> None:
     """Test device."""
-    device = device_registry.async_get_device(
-        identifiers={("kaleidescape", MOCK_SERIAL)}
+    device = device_registry.async_get_device_by_identifier(
+        ("kaleidescape", MOCK_SERIAL), mock_integration.entry_id
     )
     assert device is not None
     assert device.identifiers == {("kaleidescape", MOCK_SERIAL)}

--- a/tests/components/kaleidescape/test_media_player.py
+++ b/tests/components/kaleidescape/test_media_player.py
@@ -26,6 +26,8 @@ from homeassistant.helpers import device_registry as dr
 
 from . import MOCK_SERIAL
 
+from tests.common import MockConfigEntry
+
 ENTITY_ID = f"media_player.theater_kaleidescape_device_{MOCK_SERIAL}"
 FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
@@ -158,11 +160,13 @@ async def test_services(hass: HomeAssistant, mock_device: MagicMock) -> None:
     assert mock_device.previous.call_count == 1
 
 
-@pytest.mark.usefixtures("mock_device", "mock_integration")
-async def test_device(device_registry: dr.DeviceRegistry) -> None:
+@pytest.mark.usefixtures("mock_device")
+async def test_device(
+    device_registry: dr.DeviceRegistry, mock_integration: MockConfigEntry
+) -> None:
     """Test device attributes."""
-    device = device_registry.async_get_device(
-        identifiers={("kaleidescape", MOCK_SERIAL)}
+    device = device_registry.async_get_device_by_identifier(
+        ("kaleidescape", MOCK_SERIAL), mock_integration.entry_id
     )
     assert device.name == FRIENDLY_NAME
     assert device.model == "Strato"

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -87,8 +87,8 @@ async def test_setup_entry_version_unavailable(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.sw_version is None

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -39,8 +39,8 @@ async def test_device_info(
     """Test device registry entry."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("karakeep", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("karakeep", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.name == "Karakeep"

--- a/tests/components/kiosker/test_init.py
+++ b/tests/components/kiosker/test_init.py
@@ -50,8 +50,8 @@ async def test_device_info(
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "A98BE1CE-5FE7-4A8D-B2C3-123456789ABC")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "A98BE1CE-5FE7-4A8D-B2C3-123456789ABC"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/kiosker/test_services.py
+++ b/tests/components/kiosker/test_services.py
@@ -65,7 +65,9 @@ async def test_navigate_url(
     """Test navigate_url service calls the API with the correct URL."""
     await _setup(hass, mock_kiosker_api, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, KIOSKER_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, KIOSKER_DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device is not None
 
     await hass.services.async_call(
@@ -114,7 +116,9 @@ async def test_set_blackout(
     """Test set_blackout service builds the correct Blackout object."""
     await _setup(hass, mock_kiosker_api, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, KIOSKER_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, KIOSKER_DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device is not None
 
     await hass.services.async_call(
@@ -136,7 +140,9 @@ async def test_service_entry_not_loaded(
     """Test services raise HomeAssistantError when the config entry is not loaded."""
     await _setup(hass, mock_kiosker_api, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, KIOSKER_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, KIOSKER_DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device is not None
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
@@ -186,7 +192,9 @@ async def test_schema_rejects_invalid_input(
     """Test that invalid service data is rejected by schema validation."""
     await _setup(hass, mock_kiosker_api, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, KIOSKER_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, KIOSKER_DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device is not None
 
     with pytest.raises(vol.Invalid):
@@ -222,7 +230,9 @@ async def test_api_errors_are_wrapped(
     """Test that kiosker API exceptions are translated to HA exceptions."""
     await _setup(hass, mock_kiosker_api, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, KIOSKER_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, KIOSKER_DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device is not None
 
     mock_kiosker_api.navigate_url.side_effect = exception

--- a/tests/components/knocki/test_config_flow.py
+++ b/tests/components/knocki/test_config_flow.py
@@ -156,7 +156,9 @@ async def test_dhcp_mac(
     """Test updating the mac address in the DHCP discovery."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "KNC1-W-00000214")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "KNC1-W-00000214"), mock_config_entry.entry_id
+    )
     assert device
     assert device.connections == set()
 
@@ -166,7 +168,9 @@ async def test_dhcp_mac(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "KNC1-W-00000214")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "KNC1-W-00000214"), mock_config_entry.entry_id
+    )
     assert device
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")}
 

--- a/tests/components/knx/test_device.py
+++ b/tests/components/knx/test_device.py
@@ -39,7 +39,9 @@ async def test_create_device(
     assert res["result"]["config_entries"][0] == knx.mock_config_entry.entry_id
 
     device_identifier = res["result"]["identifiers"][0][1]
-    assert device_registry.async_get_device({(DOMAIN, device_identifier)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_identifier), knx.mock_config_entry.entry_id
+    )
     device_id = res["result"]["id"]
     assert device_registry.async_get(device_id)
 
@@ -61,8 +63,9 @@ async def test_remove_device(
     await knx.assert_read("1/0/45", response=True, ignore_order=True)  # test switch
 
     assert hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["entities"].get("switch")
-    test_device = device_registry.async_get_device(
-        {(DOMAIN, "knx_vdev_4c80a564f5fe5da701ed293966d6384d")}
+    test_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "knx_vdev_4c80a564f5fe5da701ed293966d6384d"),
+        knx.mock_config_entry.entry_id,
     )
     device_id = test_device.id
     device_entities = entity_registry.entities.get_entries_for_device_id(device_id)
@@ -70,8 +73,9 @@ async def test_remove_device(
 
     response = await client.remove_device(device_id, knx.mock_config_entry.entry_id)
     assert response["success"]
-    assert not device_registry.async_get_device(
-        {(DOMAIN, "knx_vdev_4c80a564f5fe5da701ed293966d6384d")}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "knx_vdev_4c80a564f5fe5da701ed293966d6384d"),
+        knx.mock_config_entry.entry_id,
     )
     assert not entity_registry.entities.get_entries_for_device_id(device_id)
     assert not hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["entities"].get("switch")

--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -29,8 +29,9 @@ async def test_if_fires_on_telegram(
 ) -> None:
     """Test telegram device triggers firing."""
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
 
     # "id" field added to action to test if `trigger_data` passed
@@ -128,8 +129,9 @@ async def test_default_if_fires_on_telegram(
     # "group_value_write", "group_value_response",
     # "group_value_read", "incoming", "outgoing"
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
 
     assert await async_setup_component(
@@ -210,8 +212,9 @@ async def test_remove_device_trigger(
     """Test for removed callback when device trigger not used."""
     automation_name = "telegram_trigger_automation"
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
     assert await async_setup_component(
         hass,
@@ -260,8 +263,9 @@ async def test_get_triggers(
 ) -> None:
     """Test we get the expected device triggers from knx."""
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
     expected_trigger = {
         "platform": "device",
@@ -283,8 +287,9 @@ async def test_get_trigger_capabilities(
 ) -> None:
     """Test we get the expected capabilities telegram device trigger."""
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
 
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -371,8 +376,9 @@ async def test_invalid_device_trigger(
 ) -> None:
     """Test invalid telegram device trigger configuration."""
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
     caplog.clear()
     with caplog.at_level(logging.ERROR):
@@ -414,8 +420,9 @@ async def test_invalid_trigger_configuration(
 ) -> None:
     """Test invalid telegram device trigger configuration at attach_trigger."""
     await knx.setup_integration()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface"),
+        knx.mock_config_entry.entry_id,
     )
     # After changing the config in async_attach_trigger, the config is validated again
     # against the integration trigger. This test checks if this validation works.

--- a/tests/components/lamarzocco/test_bluetooth.py
+++ b/tests/components/lamarzocco/test_bluetooth.py
@@ -290,8 +290,9 @@ async def test_setup_through_bluetooth_only(
         assert state == snapshot(name=entity)
 
     # snapshot device
-    device = device_registry.async_get_device(
-        {(DOMAIN, mock_lamarzocco_bluetooth.serial_number)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_lamarzocco_bluetooth.serial_number),
+        mock_config_entry_bluetooth.entry_id,
     )
     assert device
     assert device == snapshot(

--- a/tests/components/laundrify/test_sensor.py
+++ b/tests/components/laundrify/test_sensor.py
@@ -50,7 +50,9 @@ async def test_laundrify_sensor_init(
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
     assert state.state == STATE_UNKNOWN
 
-    device = device_registry.async_get_device({(DOMAIN, mock_device.id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), laundrify_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == mock_device.name
     assert device.identifiers == {(DOMAIN, mock_device.id)}

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -137,7 +137,7 @@ def get_device(
 ) -> dr.DeviceEntry:
     """Get LCN device for specified address."""
     device_registry = dr.async_get(hass)
-    identifiers = {(DOMAIN, generate_unique_id(entry.entry_id, address))}
-    device = device_registry.async_get_device(identifiers=identifiers)
+    identifier = (DOMAIN, generate_unique_id(entry.entry_id, address))
+    device = device_registry.async_get_device_by_identifier(identifier, entry.entry_id)
     assert device
     return device

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -64,8 +64,8 @@ async def test_get_triggers_non_module_device(
 
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
-    host_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, entry.entry_id)}
+    host_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
     )
     group_device = get_device(hass, entry, (0, 5, True))
 

--- a/tests/components/lektrico/test_init.py
+++ b/tests/components/lektrico/test_init.py
@@ -22,8 +22,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/lg_infrared/test_button.py
+++ b/tests/components/lg_infrared/test_button.py
@@ -33,8 +33,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Verify all entities belong to the same device
-    device_entry = device_registry.async_get_device(
-        identifiers={("lg_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("lg_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/lg_infrared/test_media_player.py
+++ b/tests/components/lg_infrared/test_media_player.py
@@ -47,8 +47,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Verify entity belongs to the correct device
-    device_entry = device_registry.async_get_device(
-        identifiers={("lg_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("lg_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/lg_netcast/test_device_trigger.py
+++ b/tests/components/lg_netcast/test_device_trigger.py
@@ -33,9 +33,11 @@ async def test_get_triggers(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test we get the expected triggers."""
-    await setup_lgnetcast(hass)
+    entry = await setup_lgnetcast(hass)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, UNIQUE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, UNIQUE_ID), entry.entry_id
+    )
     assert device is not None
 
     turn_on_trigger = {
@@ -58,9 +60,11 @@ async def test_if_fires_on_turn_on_request(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for turn_on triggers firing."""
-    await setup_lgnetcast(hass)
+    entry = await setup_lgnetcast(hass)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, UNIQUE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, UNIQUE_ID), entry.entry_id
+    )
     assert device is not None
 
     assert await async_setup_component(

--- a/tests/components/lg_netcast/test_trigger.py
+++ b/tests/components/lg_netcast/test_trigger.py
@@ -31,9 +31,11 @@ async def test_lg_netcast_turn_on_trigger_device_id(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for turn_on trigger by device_id firing."""
-    await setup_lgnetcast(hass)
+    config_entry = await setup_lgnetcast(hass)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, UNIQUE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, UNIQUE_ID), config_entry.entry_id
+    )
     assert device, repr(device_registry.devices)
 
     assert await async_setup_component(

--- a/tests/components/lichess/test_init.py
+++ b/tests/components/lichess/test_init.py
@@ -25,7 +25,9 @@ async def test_device(
     """Test the Lichess device."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device({(DOMAIN, "drnykterstein")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "drnykterstein"), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot
 

--- a/tests/components/lidarr/test_init.py
+++ b/tests/components/lidarr/test_init.py
@@ -55,7 +55,9 @@ async def test_device_info(
     await setup_integration()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.configuration_url == "http://127.0.0.1:8668"
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/liebherr/test_init.py
+++ b/tests/components/liebherr/test_init.py
@@ -241,7 +241,9 @@ async def test_dynamic_device_discovery_coordinator_setup_failure(
     await hass.async_block_till_done()
 
     # New device should NOT be added
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "new_device_id")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "new_device_id"), mock_config_entry.entry_id
+    )
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
@@ -294,8 +296,12 @@ async def test_dynamic_device_discovery(
     assert hass.states.get("sensor.test_fridge_top_zone") is not None
 
     # Both devices should be in the device registry
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "new_device_id")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "new_device_id"), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
 
 
 async def test_stale_device_removal(
@@ -328,15 +334,21 @@ async def test_stale_device_removal(
         await hass.async_block_till_done()
 
     # Both devices should exist
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "new_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "new_device_id"), mock_config_entry.entry_id
+    )
     assert hass.states.get("sensor.test_fridge_top_zone") is not None
     assert hass.states.get("sensor.new_fridge") is not None
 
     # Verify both devices are in the device registry
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
-    new_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "new_device_id")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
+    new_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "new_device_id"), mock_config_entry.entry_id
     )
     assert new_device_entry
 
@@ -359,8 +371,12 @@ async def test_stale_device_removal(
     await hass.async_block_till_done()
 
     # Stale device should be removed from device registry
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "new_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "new_device_id"), mock_config_entry.entry_id
+    )
 
     # Advance past the coordinator update interval to confirm the stale
     # coordinator is no longer polling (would raise AssertionError above)
@@ -390,7 +406,9 @@ async def test_stale_device_removal_without_coordinator(
         identifiers={(DOMAIN, "old_device_id")},
         name="Old Appliance",
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "old_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "old_device_id"), mock_config_entry.entry_id
+    )
 
     # Start integration — only MOCK_DEVICE is returned, so no coordinator
     # is created for "old_device_id".
@@ -398,8 +416,12 @@ async def test_stale_device_removal_without_coordinator(
     await hass.async_block_till_done()
 
     # The orphaned device still exists in the registry after setup
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "old_device_id")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "old_device_id"), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
 
     # Trigger the periodic device scan
     freezer.tick(timedelta(minutes=5, seconds=1))
@@ -407,7 +429,11 @@ async def test_stale_device_removal_without_coordinator(
     await hass.async_block_till_done()
 
     # The orphaned device should now be removed from the registry
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "old_device_id")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "old_device_id"), mock_config_entry.entry_id
+    )
     # The active device should still be present
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test_device_id"), mock_config_entry.entry_id
+    )
     assert mock_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -110,8 +110,8 @@ async def test_light_unique_id(
     entity_id = "light.my_group_my_bulb"
     assert entity_registry.async_get(entity_id).unique_id == SERIAL
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, SERIAL)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, SERIAL), already_migrated_config_entry.entry_id
     )
     assert device.identifiers == {(DOMAIN, SERIAL)}
 
@@ -137,8 +137,8 @@ async def test_light_unique_id_new_firmware(
 
     entity_id = "light.my_group_my_bulb"
     assert entity_registry.async_get(entity_id).unique_id == SERIAL
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS), already_migrated_config_entry.entry_id
     )
     assert device.identifiers == {(DOMAIN, SERIAL)}
 

--- a/tests/components/lojack/test_init.py
+++ b/tests/components/lojack/test_init.py
@@ -149,8 +149,8 @@ async def test_device_info(
     """Test device registry entry is created."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_ID), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/lunatone/test_init.py
+++ b/tests/components/lunatone/test_init.py
@@ -29,8 +29,8 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_config_entry.unique_id
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.manufacturer == MANUFACTURER

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -152,11 +152,15 @@ async def test_keypad_integer_migration(
     await hass.async_block_till_done()
 
     # Verify the device identifier has been updated
-    device = device_registry.async_get_device(identifiers={(DOMAIN, cast(Any, 1))})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, cast(Any, 1)), mock_config_entry.entry_id
+    )
     assert device is None
 
     new_unique_id = f"{controller_guid}_{keypad.legacy_uuid}"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, new_unique_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, new_unique_id), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Test Keypad"
 
@@ -192,13 +196,13 @@ async def test_keypad_uuid_migration(
     await hass.async_block_till_done()
 
     # Verify the device identifier has been updated to use the proper UUID
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{controller_guid}_{legacy_uuid}")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{controller_guid}_{legacy_uuid}"), mock_config_entry.entry_id
     )
     assert device is None
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{controller_guid}_{proper_uuid}")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{controller_guid}_{proper_uuid}"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.name == "Test Keypad"
@@ -232,11 +236,15 @@ async def test_keypad_integer_to_uuid_migration(
     await hass.async_block_till_done()
 
     # Verify the device identifier has been updated to the proper UUID
-    device = device_registry.async_get_device(identifiers={(DOMAIN, cast(Any, 1))})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, cast(Any, 1)), mock_config_entry.entry_id
+    )
     assert device is None
 
     new_unique_id = f"{controller_guid}_{keypad.uuid}"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, new_unique_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, new_unique_id), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Test Keypad"
 

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -277,11 +277,11 @@ async def test_if_fires_on_button_event(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for press trigger firing."""
-    await _async_setup_lutron_with_picos(hass)
+    config_entry_id = await _async_setup_lutron_with_picos(hass)
 
     device = MOCK_BUTTON_DEVICES[0]
-    dr_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, device["serial"])}
+    dr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device["serial"]), config_entry_id
     )
     device_id = dr_device.id
 
@@ -330,11 +330,11 @@ async def test_if_fires_on_long_press_button_event(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for long_press trigger firing on a QSX bridge."""
-    await _async_setup_lutron_with_picos(hass, MockQSXBridge)
+    config_entry_id = await _async_setup_lutron_with_picos(hass, MockQSXBridge)
 
     device = MOCK_BUTTON_DEVICES[0]
-    dr_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, device["serial"])}
+    dr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device["serial"]), config_entry_id
     )
     device_id = dr_device.id
 
@@ -413,10 +413,10 @@ async def test_if_fires_on_button_event_without_lip(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for press trigger firing on a device that does not support lip."""
-    await _async_setup_lutron_with_picos(hass)
+    config_entry_id = await _async_setup_lutron_with_picos(hass)
     device = MOCK_BUTTON_DEVICES[1]
-    dr_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, device["serial"])}
+    dr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device["serial"]), config_entry_id
     )
     device_id = dr_device.id
     assert await async_setup_component(
@@ -602,8 +602,8 @@ async def test_if_fires_on_button_event_late_setup(
     await hass.async_block_till_done()
 
     device = MOCK_BUTTON_DEVICES[0]
-    dr_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, device["serial"])}
+    dr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device["serial"]), config_entry_id
     )
     device_id = dr_device.id
 

--- a/tests/components/lutron_caseta/test_logbook.py
+++ b/tests/components/lutron_caseta/test_logbook.py
@@ -137,10 +137,10 @@ async def test_humanify_lutron_caseta_button_event_ra3(
     """Test humanifying lutron_caseta_button_events from an RA3 hub."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
-    await async_setup_integration(hass, MockBridge)
+    config_entry = await async_setup_integration(hass, MockBridge)
 
-    keypad = device_registry.async_get_device(
-        identifiers={(DOMAIN, 66286451)}, connections=set()
+    keypad = device_registry.async_get_device_by_identifier(
+        (DOMAIN, 66286451), config_entry.entry_id
     )
     assert keypad
 
@@ -174,10 +174,10 @@ async def test_humanify_lutron_caseta_button_unknown_type(
     """Test humanifying lutron_caseta_button_events with an unknown type."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
-    await async_setup_integration(hass, MockBridge)
+    config_entry = await async_setup_integration(hass, MockBridge)
 
-    keypad = device_registry.async_get_device(
-        identifiers={(DOMAIN, 66286451)}, connections=set()
+    keypad = device_registry.async_get_device_by_identifier(
+        (DOMAIN, 66286451), config_entry.entry_id
     )
     assert keypad
 

--- a/tests/components/lyngdorf/test_init.py
+++ b/tests/components/lyngdorf/test_init.py
@@ -121,7 +121,9 @@ async def test_mac_connection_registered_when_serial_is_mac(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, serial.lower())})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, serial.lower()), entry.entry_id
+    )
     assert device is not None
     mac_connections = {
         value for kind, value in device.connections if kind == dr.CONNECTION_NETWORK_MAC
@@ -146,7 +148,7 @@ async def test_no_zone_b_device_for_model_without_zone_b(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_zone_b")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.unique_id}_zone_b"), mock_config_entry.entry_id
     )
     assert device is None

--- a/tests/components/marantz_infrared/test_button.py
+++ b/tests/components/marantz_infrared/test_button.py
@@ -39,8 +39,8 @@ async def test_entities(
     """Test all button entities are created with correct attributes."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("marantz_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("marantz_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/marantz_infrared/test_media_player.py
+++ b/tests/components/marantz_infrared/test_media_player.py
@@ -60,8 +60,8 @@ async def test_entities(
     """Test the media player entity is created with correct attributes."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("marantz_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("marantz_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -39,8 +39,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -32,10 +32,9 @@ async def test_device_registry_single_node_device(
     name: str,
 ) -> None:
     """Test bridge devices are set up correctly with via_device."""
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, f"deviceid_00000000000004D2-{unique_id}-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"deviceid_00000000000004D2-{unique_id}-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -58,10 +57,9 @@ async def test_device_registry_single_node_device_alt(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test additional device with different attribute values."""
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001A-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001A-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -82,8 +80,8 @@ async def test_device_registry_bridge(
 ) -> None:
     """Test bridge devices are set up correctly with via_device."""
     # Validate bridge
-    bridge_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "mock-hub-id")}
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "mock-hub-id"), hass.config_entries.async_entries(DOMAIN)[0].entry_id
     )
     assert bridge_entry is not None
 
@@ -94,8 +92,9 @@ async def test_device_registry_bridge(
     assert bridge_entry.sw_version == "123.4.5"
 
     # Device 1
-    device1_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "mock-id-kitchen-ceiling")}
+    device1_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "mock-id-kitchen-ceiling"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert device1_entry is not None
 
@@ -107,8 +106,9 @@ async def test_device_registry_bridge(
     assert device1_entry.sw_version == "67.8.9"
 
     # Device 2
-    device2_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "mock-id-living-room-ceiling")}
+    device2_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "mock-id-living-room-ceiling"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert device2_entry is not None
 

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -198,10 +198,9 @@ async def test_node_diagnostics(
 ) -> None:
     """Test the node diagnostics command."""
     # get the device registry entry for the mocked node
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -267,10 +266,9 @@ async def test_ping_node(
 ) -> None:
     """Test the ping_node command."""
     # get the device registry entry for the mocked node
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -322,10 +320,9 @@ async def test_open_commissioning_window(
 ) -> None:
     """Test the open_commissioning_window command."""
     # get the device registry entry for the mocked node
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -383,10 +380,9 @@ async def test_remove_matter_fabric(
 ) -> None:
     """Test the remove_matter_fabric command."""
     # get the device registry entry for the mocked node
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -434,10 +430,9 @@ async def test_interview_node(
 ) -> None:
     """Test the interview_node command."""
     # get the device registry entry for the mocked node
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
     # issue command on the ws api

--- a/tests/components/mealie/test_init.py
+++ b/tests/components/mealie/test_init.py
@@ -25,8 +25,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/meater/test_init.py
+++ b/tests/components/meater/test_init.py
@@ -25,7 +25,9 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, PROBE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, PROBE_ID), mock_config_entry.entry_id
+    )
     assert device_entry is not None
     assert device_entry == snapshot
 

--- a/tests/components/melcloud_home/test_init.py
+++ b/tests/components/melcloud_home/test_init.py
@@ -118,8 +118,12 @@ async def test_stale_devices_removed(
     fixture = await async_load_json_object_fixture(hass, "context.json", DOMAIN)
     await setup_integration(hass, mock_config_entry)
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "ata-unit-uuid-1")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "atw-unit-uuid-1")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ata-unit-uuid-1"), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "atw-unit-uuid-1"), mock_config_entry.entry_id
+    )
 
     # Poof, now they're gone
     mock_melcloud_client.get_context.return_value = UserContext.model_validate(
@@ -136,11 +140,15 @@ async def test_stale_devices_removed(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "ata-unit-uuid-1")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "ata-unit-uuid-1"), mock_config_entry.entry_id
+        )
         is None
     )
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "atw-unit-uuid-1")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "atw-unit-uuid-1"), mock_config_entry.entry_id
+        )
         is None
     )
 

--- a/tests/components/melnor/test_init.py
+++ b/tests/components/melnor/test_init.py
@@ -31,8 +31,8 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, FAKE_ADDRESS_1)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, FAKE_ADDRESS_1), entry.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -13,11 +13,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import (
-    DEVICE_KEY_KINGSLYNN,
-    DEVICE_KEY_WAVERTREE,
     KINGSLYNN_SENSOR_RESULTS,
     METOFFICE_CONFIG_KINGSLYNN,
     METOFFICE_CONFIG_WAVERTREE,
+    TEST_COORDINATES_KINGSLYNN,
+    TEST_COORDINATES_WAVERTREE,
     TEST_DATETIME_STRING,
     TEST_LATITUDE_WAVERTREE,
     TEST_LONGITUDE_WAVERTREE,
@@ -59,8 +59,8 @@ async def test_one_sensor_site_running(
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == 1
-    device_wavertree = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_WAVERTREE
+    device_wavertree = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_WAVERTREE), entry.entry_id
     )
     assert device_wavertree.name == "Met Office Wavertree"
 
@@ -129,12 +129,12 @@ async def test_two_sensor_sites_running(
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == 2
-    device_kingslynn = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_KINGSLYNN
+    device_kingslynn = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_KINGSLYNN), entry2.entry_id
     )
     assert device_kingslynn.name == "Met Office King's Lynn"
-    device_wavertree = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_WAVERTREE
+    device_wavertree = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_WAVERTREE), entry.entry_id
     )
     assert device_wavertree.name == "Met Office Wavertree"
 

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -22,10 +22,10 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import utcnow
 
 from .const import (
-    DEVICE_KEY_KINGSLYNN,
-    DEVICE_KEY_WAVERTREE,
     METOFFICE_CONFIG_KINGSLYNN,
     METOFFICE_CONFIG_WAVERTREE,
+    TEST_COORDINATES_KINGSLYNN,
+    TEST_COORDINATES_WAVERTREE,
     WAVERTREE_SENSOR_RESULTS,
 )
 
@@ -170,8 +170,8 @@ async def test_one_weather_site_running(
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == 1
-    device_wavertree = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_WAVERTREE
+    device_wavertree = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_WAVERTREE), entry.entry_id
     )
     assert device_wavertree.name == "Met Office Wavertree"
 
@@ -226,12 +226,12 @@ async def test_two_weather_sites_running(
     await hass.async_block_till_done()
 
     assert len(device_registry.devices) == 2
-    device_kingslynn = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_KINGSLYNN
+    device_kingslynn = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_KINGSLYNN), entry2.entry_id
     )
     assert device_kingslynn.name == "Met Office King's Lynn"
-    device_wavertree = device_registry.async_get_device(
-        identifiers=DEVICE_KEY_WAVERTREE
+    device_wavertree = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_COORDINATES_WAVERTREE), entry.entry_id
     )
     assert device_wavertree.name == "Met Office Wavertree"
 

--- a/tests/components/midea/test_entity.py
+++ b/tests/components/midea/test_entity.py
@@ -117,8 +117,8 @@ async def test_device_info_optional_metadata(
     await setup_integration(hass, config_entry, device)
 
     assert (
-        device_entry := device_registry.async_get_device(
-            identifiers={(DOMAIN, str(TEST_DEVICE_ID))}
+        device_entry := device_registry.async_get_device_by_identifier(
+            (DOMAIN, str(TEST_DEVICE_ID)), config_entry.entry_id
         )
     ) is not None
 

--- a/tests/components/miele/test_diagnostics.py
+++ b/tests/components/miele/test_diagnostics.py
@@ -55,7 +55,9 @@ async def test_diagnostics_device(
     TEST_DEVICE = "Dummy_Appliance_1"
 
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     result = await get_diagnostics_for_device(

--- a/tests/components/miele/test_init.py
+++ b/tests/components/miele/test_init.py
@@ -121,8 +121,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "Dummy_Appliance_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "Dummy_Appliance_1"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot
@@ -143,13 +143,9 @@ async def test_device_remove_devices(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                "Dummy_Appliance_1",
-            )
-        },
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "Dummy_Appliance_1"),
+        mock_config_entry.entry_id,
     )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, mock_config_entry.entry_id)

--- a/tests/components/miele/test_services.py
+++ b/tests/components/miele/test_services.py
@@ -37,7 +37,9 @@ async def test_services(
     """Tests that the custom services are correct."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_PROGRAM,
@@ -84,7 +86,9 @@ async def test_services_oven(
     """Tests that the custom services are correct for ovens."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_PROGRAM_OVEN,
@@ -106,7 +110,9 @@ async def test_services_with_response(
     """Tests that the custom services that returns a response are correct."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
     assert snapshot == await hass.services.async_call(
         DOMAIN,
         SERVICE_GET_PROGRAMS,
@@ -135,7 +141,9 @@ async def test_service_api_errors(
 ) -> None:
     """Test service api errors."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
 
     # Test http error
     mock_miele_client.set_program.side_effect = ClientResponseError(Mock(), Mock())
@@ -159,7 +167,9 @@ async def test_get_service_api_errors(
 ) -> None:
     """Test service api errors."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
 
     # Test http error
     mock_miele_client.get_programs.side_effect = ClientResponseError(Mock(), Mock())
@@ -183,7 +193,9 @@ async def test_service_validation_errors(
     """Tests that the custom services handle bad data."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_APPLIANCE)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_APPLIANCE), mock_config_entry.entry_id
+    )
 
     # Test missing program_id
     with pytest.raises(MultipleInvalid, match="required key not provided"):

--- a/tests/components/mitsubishi_comfort/test_init.py
+++ b/tests/components/mitsubishi_comfort/test_init.py
@@ -98,8 +98,8 @@ async def test_setup_entry_no_address_loads_and_registers(
 
     assert entry.state is ConfigEntryState.LOADED
     assert not er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(MOCK_MAC))}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(MOCK_MAC)), entry.entry_id
     )
 
 

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -166,17 +166,21 @@ async def test_setup_camera_new_data_camera_removed(
 
     await hass.async_block_till_done()
     assert hass.states.get(TEST_CAMERA_ENTITY_ID)
-    assert device_registry.async_get_device(identifiers={TEST_CAMERA_DEVICE_IDENTIFIER})
+    assert device_registry.async_get_device_by_identifier(
+        TEST_CAMERA_DEVICE_IDENTIFIER, config_entry.entry_id
+    )
 
     client.async_get_cameras = AsyncMock(return_value={KEY_CAMERAS: []})
     async_fire_time_changed(hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     assert not hass.states.get(TEST_CAMERA_ENTITY_ID)
-    assert not device_registry.async_get_device(
-        identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
+    assert not device_registry.async_get_device_by_identifier(
+        TEST_CAMERA_DEVICE_IDENTIFIER, config_entry.entry_id
     )
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, old_device_id)})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, old_device_id), config_entry.entry_id
+    )
     assert not entity_registry.async_get_entity_id(
         DOMAIN, "camera", old_entity_unique_id
     )
@@ -330,7 +334,9 @@ async def test_device_info(
 
     device_identifier = get_motioneye_device_identifier(entry.entry_id, TEST_CAMERA_ID)
 
-    device = device_registry.async_get_device(identifiers={device_identifier})
+    device = device_registry.async_get_device_by_identifier(
+        device_identifier, entry.entry_id
+    )
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {device_identifier}

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -96,7 +96,9 @@ async def test_sensor_device_info(
         config_entry.entry_id, TEST_CAMERA_ID
     )
 
-    device = device_registry.async_get_device(identifiers={device_identifer})
+    device = device_registry.async_get_device_by_identifier(
+        device_identifer, config_entry.entry_id
+    )
     assert device
 
     entities_from_device = [

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -205,7 +205,9 @@ async def test_switch_device_info(
         config_entry.entry_id, TEST_CAMERA_ID
     )
 
-    device = device_registry.async_get_device(identifiers={device_identifer})
+    device = device_registry.async_get_device_by_identifier(
+        device_identifer, config_entry.entry_id
+    )
     assert device
 
     entities_from_device = [

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -71,8 +71,8 @@ async def test_setup_camera_without_webhook(
     client = create_mock_motioneye_client()
     config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    device = device_registry.async_get_device(
-        identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
+    device = device_registry.async_get_device_by_identifier(
+        TEST_CAMERA_DEVICE_IDENTIFIER, config_entry.entry_id
     )
     assert device
 
@@ -126,8 +126,8 @@ async def test_setup_camera_with_wrong_webhook(
         await hass.config_entries.async_reload(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
+    device = device_registry.async_get_device_by_identifier(
+        TEST_CAMERA_DEVICE_IDENTIFIER, config_entry.entry_id
     )
     assert device
 
@@ -179,8 +179,8 @@ async def test_setup_camera_with_old_webhook(
     )
     assert client.async_set_camera.called
 
-    device = device_registry.async_get_device(
-        identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
+    device = device_registry.async_get_device_by_identifier(
+        TEST_CAMERA_DEVICE_IDENTIFIER, config_entry.entry_id
     )
     assert device
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
