### PR TITLE
Migrate calls to async_get_device in tests (part 4)

### DIFF
--- a/tests/components/motionmount/test_entity.py
+++ b/tests/components/motionmount/test_entity.py
@@ -27,8 +27,8 @@ async def test_entity_rename(
     await hass.async_block_till_done()
 
     mac = format_mac(mock_motionmount.mac.hex())
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mac), mock_config_entry.entry_id
     )
     assert device
     assert device.name == ZEROCONF_NAME
@@ -40,8 +40,8 @@ async def test_entity_rename(
         callback[0][0]()
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mac), mock_config_entry.entry_id
     )
     assert device
     assert device.name == "Blub"

--- a/tests/components/motionmount/test_init.py
+++ b/tests/components/motionmount/test_init.py
@@ -25,8 +25,8 @@ async def test_setup_entry_with_mac(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     mac = format_mac(mock_motionmount.mac.hex())
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mac), mock_config_entry.entry_id
     )
     assert device
     assert device.name == mock_config_entry.title
@@ -47,8 +47,8 @@ async def test_setup_entry_without_mac(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device
     assert device.name == mock_config_entry.title

--- a/tests/components/music_assistant/test_init.py
+++ b/tests/components/music_assistant/test_init.py
@@ -94,7 +94,9 @@ async def test_player_config_expose_to_ha_toggle(
     player_id = "00:00:00:00:00:01"
     assert hass.states.get(entity_id)
     assert entity_registry.async_get(entity_id)
-    device_entry = device_registry.async_get_device({(DOMAIN, player_id)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, player_id), config_entry.entry_id
+    )
     assert device_entry
     assert player_id in config_entry.runtime_data.discovered_players
 
@@ -125,7 +127,9 @@ async def test_player_config_expose_to_ha_toggle(
     assert player_id not in config_entry.runtime_data.discovered_players
     assert not hass.states.get(entity_id)
     assert not entity_registry.async_get(entity_id)
-    device_entry = device_registry.async_get_device({(DOMAIN, player_id)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, player_id), config_entry.entry_id
+    )
     assert not device_entry
 
     # Now test re-adding the player: expose_to_ha = True
@@ -153,7 +157,9 @@ async def test_player_config_expose_to_ha_toggle(
     assert player_id in config_entry.runtime_data.discovered_players
     assert hass.states.get(entity_id)
     assert entity_registry.async_get(entity_id)
-    device_entry = device_registry.async_get_device({(DOMAIN, player_id)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, player_id), config_entry.entry_id
+    )
     assert device_entry
 
 

--- a/tests/components/mysensors/test_init.py
+++ b/tests/components/mysensors/test_init.py
@@ -77,8 +77,8 @@ async def test_remove_config_entry_device(
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}-{node_id}")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}-{node_id}"), config_entry.entry_id
     )
     state = hass.states.get(entity_id)
 
@@ -94,8 +94,8 @@ async def test_remove_config_entry_device(
 
     assert node_id not in gateway.sensors
     assert gateway.tasks.persistence.need_save is True
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}-1")}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}-1"), config_entry.entry_id
     )
     assert not entity_registry.async_get(entity_id)
     assert not hass.states.get(entity_id)

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -79,7 +79,9 @@ async def test_device_registry_bulb(
     """Test the bulb device registry entry, including the network MAC connection."""
     await init_integration(hass, config_entry, 102)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_MAC)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_MAC), config_entry.entry_id
+    )
     assert device_entry == snapshot
 
 

--- a/tests/components/myuplink/test_init.py
+++ b/tests/components/myuplink/test_init.py
@@ -216,13 +216,12 @@ async def test_device_remove_devices(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                "batman-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff",
-            )
-        },
+    device_entry = device_registry.async_get_device_by_identifier(
+        (
+            DOMAIN,
+            "batman-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff",
+        ),
+        mock_config_entry.entry_id,
     )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, mock_config_entry.entry_id)
@@ -277,6 +276,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), mock_config_entry.entry_id
+    )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/nederlandse_spoorwegen/test_diagnostics.py
+++ b/tests/components/nederlandse_spoorwegen/test_diagnostics.py
@@ -56,7 +56,9 @@ async def test_device_diagnostics(
     # Ensure integration is set up so device exists
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, SUBENTRY_ID_1)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SUBENTRY_ID_1), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Trigger update for the coordinator before diagnostics

--- a/tests/components/neopool/test_init.py
+++ b/tests/components/neopool/test_init.py
@@ -55,7 +55,9 @@ async def test_device_registered_with_firmware(
     """The first successful read populates firmware on the device entry."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert "18.52" in (device.sw_version or "")
 

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -103,7 +103,9 @@ async def test_get_triggers(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     expected_triggers = [
         {
@@ -202,7 +204,9 @@ async def test_triggers_for_invalid_device_id(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device_entry is not None
 
     # Create an additional device that does not exist.  Fetching supported
@@ -258,7 +262,9 @@ async def test_fires_on_camera_motion(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 
@@ -292,7 +298,9 @@ async def test_fires_on_camera_person(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_person")
 
@@ -326,7 +334,9 @@ async def test_fires_on_camera_sound(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_sound")
 
@@ -360,7 +370,9 @@ async def test_fires_on_doorbell_chime(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "doorbell_chime")
 
@@ -394,7 +406,9 @@ async def test_trigger_for_wrong_device_id(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 
@@ -427,7 +441,9 @@ async def test_trigger_for_wrong_event_type(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 
@@ -460,7 +476,9 @@ async def test_subscriber_automation(
     )
     await setup_platform()
 
-    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("nest", DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -97,7 +97,9 @@ async def test_device_diagnostics(
     await setup_platform()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, NEST_DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, NEST_DEVICE_ID), config_entry.entry_id
+    )
     assert device is not None
 
     assert (

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -263,7 +263,9 @@ async def test_supported_device(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -327,7 +329,9 @@ async def test_camera_event(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -460,7 +464,9 @@ async def test_event_order(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -505,7 +511,9 @@ async def test_multiple_image_events_in_session(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -619,7 +627,9 @@ async def test_multiple_clip_preview_events_in_session(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -706,7 +716,9 @@ async def test_browse_invalid_device_id(
     """Test a media source request for an invalid device id."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -726,7 +738,9 @@ async def test_browse_invalid_event_id(
     """Test a media source browsing for an invalid event id."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -748,7 +762,9 @@ async def test_resolve_missing_event_id(
     """Test a media source request missing an event id."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -779,7 +795,9 @@ async def test_resolve_invalid_event_id(
     """Test resolving media for an invalid event id."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -828,7 +846,9 @@ async def test_camera_event_clip_preview(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -926,7 +946,9 @@ async def test_event_media_render_invalid_event_id(
 ) -> None:
     """Test event media API called with an invalid device id."""
     await setup_platform()
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -966,7 +988,9 @@ async def test_event_media_failure(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1004,7 +1028,9 @@ async def test_media_permission_unauthorized(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1040,9 +1066,13 @@ async def test_multiple_devices(
     )
     await setup_platform()
 
-    device1 = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device1
-    device2 = device_registry.async_get_device(identifiers={(DOMAIN, device_id2)})
+    device2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id2), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device2
 
     # Very no events have been received yet
@@ -1127,7 +1157,9 @@ async def test_media_store_persistence(
     """Test the disk backed media store persistence."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), config_entry.entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1179,7 +1211,9 @@ async def test_media_store_persistence(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), config_entry.entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1238,7 +1272,9 @@ async def test_media_store_save_filesystem_error(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1277,7 +1313,9 @@ async def test_media_store_load_filesystem_error(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1327,7 +1365,9 @@ async def test_camera_event_media_eviction(
     """Test media files getting evicted from the cache."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1404,7 +1444,9 @@ async def test_camera_image_resize(
     """Test scaling a thumbnail for an event image."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1487,7 +1529,9 @@ async def test_event_media_attachment(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1542,7 +1586,9 @@ async def test_event_clip_media_attachment(
     camera = hass.states.get("camera.front")
     assert camera is not None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1594,7 +1640,9 @@ async def test_remove_stale_media(
     """Test media files getting evicted from the cache."""
     await setup_platform()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     assert device.name == DEVICE_NAME
 

--- a/tests/components/netatmo/test_device_trigger.py
+++ b/tests/components/netatmo/test_device_trigger.py
@@ -157,7 +157,9 @@ async def test_if_fires_on_event(
         },
     )
 
-    device = device_registry.async_get_device(connections={connection})
+    device = device_registry.async_get_device_by_connection(
+        connection, config_entry.entry_id
+    )
     assert device is not None
 
     # Fake that the entity is turning on.
@@ -242,7 +244,9 @@ async def test_if_fires_on_event_legacy(
         },
     )
 
-    device = device_registry.async_get_device(connections={connection})
+    device = device_registry.async_get_device_by_connection(
+        connection, config_entry.entry_id
+    )
     assert device is not None
 
     # Fake that the entity is turning on.
@@ -326,7 +330,9 @@ async def test_if_fires_on_event_with_subtype(
         },
     )
 
-    device = device_registry.async_get_device(connections={connection})
+    device = device_registry.async_get_device_by_connection(
+        connection, config_entry.entry_id
+    )
     assert device is not None
 
     # Fake that the entity is turning on.

--- a/tests/components/netgear_lte/test_init.py
+++ b/tests/components/netgear_lte/test_init.py
@@ -50,7 +50,9 @@ async def test_device(
     """Test device info."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.unique_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.unique_id), entry.entry_id
+    )
     assert device == snapshot
 
 

--- a/tests/components/nextdns/test_init.py
+++ b/tests/components/nextdns/test_init.py
@@ -143,7 +143,9 @@ async def test_migrate_entry_v1_to_v2(
     assert subentry.unique_id == "xyz12"
 
     # Verify device was migrated and linked to subentry
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "xyz12")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "xyz12"), mock_config_entry_v1.entry_id
+    )
     assert device is not None
     assert device.config_entries_subentries == {
         mock_config_entry_v1.entry_id: {subentry.subentry_id}
@@ -234,11 +236,15 @@ async def test_migrate_entry_v1_to_v2_merge_same_api_key(
     assert titles == {"Profile One", "Profile Two"}
 
     # Verify devices were migrated to entry1 with existing identifiers
-    device_abc = device_registry.async_get_device(identifiers={(DOMAIN, "abc11")})
+    device_abc = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "abc11"), entry1.entry_id
+    )
     assert device_abc is not None
     assert entry1.entry_id in device_abc.config_entries
 
-    device_def = device_registry.async_get_device(identifiers={(DOMAIN, "def22")})
+    device_def = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "def22"), entry1.entry_id
+    )
     assert device_def is not None
     assert entry1.entry_id in device_def.config_entries
 
@@ -323,7 +329,9 @@ async def test_migrate_entry_v1_to_v2_disabled_entry(
     )
 
     # Verify device disabled_by was changed from CONFIG_ENTRY to USER
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "def22")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "def22"), entry1.entry_id
+    )
     assert device is not None
     assert device.disabled_by is dr.DeviceEntryDisabler.USER
 

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -31,7 +31,9 @@ async def test_add_bonus_time(
 ) -> None:
     """Test add bonus time service."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "testdevid")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "testdevid"), mock_config_entry.entry_id
+    )
     assert device_entry
     await hass.services.async_call(
         DOMAIN,
@@ -151,7 +153,9 @@ async def test_update_pin_code(
 ) -> None:
     """Test update pin code service."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "testdevid")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "testdevid"), mock_config_entry.entry_id
+    )
     assert device_entry
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -221,7 +221,9 @@ async def test_setup_registers_hub_device(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.config_entries == {mock_config_entry.entry_id}
     assert device.name == "My Eco Hub"
@@ -255,7 +257,9 @@ async def test_setup_registers_hub_device_with_mac(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), entry.entry_id
+    )
     assert device is not None
     assert device.connections == {
         (dr.CONNECTION_NETWORK_MAC, "7c:83:06:01:11:92"),

--- a/tests/components/nordpool/test_init.py
+++ b/tests/components/nordpool/test_init.py
@@ -101,8 +101,12 @@ async def test_reconfigure_cleans_up_device(
 
     assert entry.state is ConfigEntryState.LOADED
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "SE3")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "SE4")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SE3"), entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SE4"), entry.entry_id
+    )
     assert entity_registry.async_get("sensor.nord_pool_se3_current_price")
     assert entity_registry.async_get("sensor.nord_pool_se4_current_price")
     assert hass.states.get("sensor.nord_pool_se3_current_price")
@@ -162,13 +166,19 @@ async def test_reconfigure_cleans_up_device(
     }
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "NL")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "NL"), entry.entry_id
+    )
     assert entity_registry.async_get("sensor.nord_pool_nl_current_price")
     assert hass.states.get("sensor.nord_pool_nl_current_price")
 
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "SE3")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SE3"), entry.entry_id
+    )
     assert not entity_registry.async_get("sensor.nord_pool_se3_current_price")
     assert not hass.states.get("sensor.nord_pool_se3_current_price")
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "SE4")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SE4"), entry.entry_id
+    )
     assert not entity_registry.async_get("sensor.nord_pool_se4_current_price")
     assert not hass.states.get("sensor.nord_pool_se4_current_price")

--- a/tests/components/nrgkick/test_init.py
+++ b/tests/components/nrgkick/test_init.py
@@ -71,8 +71,8 @@ async def test_device(
     """Test successful load and unload of entry."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device is not None
     assert device == snapshot

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -107,8 +107,8 @@ async def test_remove_device_valid(
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert device_registry is not None
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_serial_number)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_serial_number), config_entry.entry_id
     )
 
     assert device_entry is not None
@@ -152,8 +152,8 @@ async def test_remove_device_stale(
     assert response["success"]
 
     # Verify that device entry is removed
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "remove-device-id")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "remove-device-id"), config_entry.entry_id
     )
     assert device_entry is None
 
@@ -228,7 +228,7 @@ async def test_serial_number(
 ) -> None:
     """Test for serial number set on device."""
     mock_serial_number = "A00000000000"
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         username="someuser",
         password="somepassword",
@@ -237,8 +237,8 @@ async def test_serial_number(
         list_commands_return_value=[],
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_serial_number)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_serial_number), config_entry.entry_id
     )
 
     assert device_entry is not None
@@ -253,7 +253,7 @@ async def test_device_location(
     """Test for suggested location on device."""
     mock_serial_number = "A00000000000"
     mock_device_location = "XYZ Location"
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         username="someuser",
         password="somepassword",
@@ -265,8 +265,8 @@ async def test_device_location(
         list_commands_return_value=[],
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_serial_number)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_serial_number), config_entry.entry_id
     )
 
     assert device_entry is not None
@@ -282,7 +282,7 @@ async def test_device_info_strips_whitespace(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that leading and trailing whitespace is stripped from device info fields."""
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         username="someuser",
         password="somepassword",
@@ -301,8 +301,8 @@ async def test_device_info_strips_whitespace(
 
     # The device identifier is intentionally built from the raw (unstripped)
     # status values, as changing it would orphan existing device entries
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "Tripp Lite _Tripp Lite UPS _A00000000000")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "Tripp Lite _Tripp Lite UPS _A00000000000"), config_entry.entry_id
     )
 
     assert device_entry is not None
@@ -325,7 +325,7 @@ async def test_device_info_whitespace_only_values(
 ) -> None:
     """Test that whitespace-only device info fields are treated as missing."""
     mock_serial_number = "A00000000000"
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         username="someuser",
         password="somepassword",
@@ -340,8 +340,8 @@ async def test_device_info_whitespace_only_values(
         list_commands_return_value=[],
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_serial_number)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_serial_number), config_entry.entry_id
     )
 
     assert device_entry is not None

--- a/tests/components/nyt_games/test_init.py
+++ b/tests/components/nyt_games/test_init.py
@@ -23,8 +23,9 @@ async def test_device_info(
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
     for entity in ("wordle", "spelling_bee", "connections"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_{entity}")}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{mock_config_entry.unique_id}_{entity}"),
+            mock_config_entry.entry_id,
         )
         assert device_entry is not None
         assert device_entry == snapshot(name=f"device_{entity}")

--- a/tests/components/ohme/test_init.py
+++ b/tests/components/ohme/test_init.py
@@ -42,6 +42,8 @@ async def test_device(
     """Snapshot the device from registry."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device({(DOMAIN, mock_client.serial)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_client.serial), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -239,12 +239,12 @@ async def test_migration_from_v1(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        migrated_device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        migrated_device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -355,8 +355,8 @@ async def test_migration_from_v1_with_multiple_urls(
         assert ai_task_subentry.subentry_type == "ai_task_data"
         assert ai_task_subentry.title == "Ollama AI Task"
 
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -458,8 +458,8 @@ async def test_migration_from_v1_with_same_urls(
         assert subentry.data == expected_subentry_data
 
         # Check devices were migrated correctly
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {mock_config_entry.entry_id}
@@ -652,11 +652,11 @@ async def test_migration_from_v1_disabled(
     assert ai_task_subentries[0].data == {"model": "llama3.2:latest"}
     assert ai_task_subentries[0].title == "Ollama AI Task"
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -668,8 +668,9 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device(
-                identifiers={(DOMAIN, subentry.subentry_id)}
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, subentry.subentry_id),
+                mock_config_entries[main_config_entry].entry_id,
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -799,12 +800,12 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -820,12 +821,12 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}

--- a/tests/components/onedrive/test_init.py
+++ b/tests/components/onedrive/test_init.py
@@ -186,7 +186,9 @@ async def test_device(
 
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device({(DOMAIN, mock_drive.id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_drive.id), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot
 

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -63,7 +63,9 @@ async def test_device_diagnostics(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "EF.111111111113")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "EF.111111111113"), config_entry.entry_id
+    )
     assert device is not None
 
     assert (

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -161,16 +161,22 @@ async def test_registry_cleanup(
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
 
     # Try to remove "10.111111111111" - fails as it is live
-    device = device_registry.async_get_device(identifiers={(DOMAIN, live_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
     client = await hass_ws_client(hass)
     response = await client.remove_device(device.id, entry_id)
     assert not response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
-    assert device_registry.async_get_device(identifiers={(DOMAIN, live_id)}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
+        is not None
+    )
 
     # Try to remove "28.111111111111" - succeeds as it is dead
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
     response = await client.remove_device(device.id, entry_id)
     assert response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
-    assert device_registry.async_get_device(identifiers={(DOMAIN, dead_id)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
+        is None
+    )

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -736,12 +736,12 @@ async def test_migration_from_v1(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        migrated_device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        migrated_device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -848,8 +848,8 @@ async def test_migration_from_v1_with_multiple_keys(
         # Use conversation subentry for device assertions
         subentry = conversation_subentry
 
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -969,8 +969,8 @@ async def test_migration_from_v1_with_same_keys(
         assert subentry.data == options
 
         # Check devices were migrated correctly
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {mock_config_entry.entry_id}
@@ -1192,11 +1192,11 @@ async def test_migration_from_v1_disabled(
         assert tts_subentries[0].data == RECOMMENDED_TTS_OPTIONS
         assert tts_subentries[0].title == DEFAULT_TTS_NAME
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -1208,8 +1208,9 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device(
-                identifiers={(DOMAIN, subentry.subentry_id)}
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, subentry.subentry_id),
+                mock_config_entries[main_config_entry].entry_id,
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -1361,12 +1362,12 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -1382,12 +1383,12 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -1421,8 +1422,8 @@ async def test_devices(
         for subentry in mock_config_entry.subentries.values()
         if subentry.subentry_type == "conversation"
     )
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, conversation_subentry.subentry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, conversation_subentry.subentry_id), mock_config_entry.entry_id
     )
     assert device is not None
     assert device == snapshot(exclude=props("identifiers"))

--- a/tests/components/opengarage/test_button.py
+++ b/tests/components/opengarage/test_button.py
@@ -50,8 +50,8 @@ async def test_device_info_sw_version_is_string(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff"), mock_config_entry.entry_id
     )
     assert device_entry
     assert device_entry.sw_version == "120"

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -49,8 +49,8 @@ async def test_remove_config_entry_device_server(
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    server_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    server_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
 
     assert server_device is not None

--- a/tests/components/openrgb/test_light.py
+++ b/tests/components/openrgb/test_light.py
@@ -69,22 +69,21 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure entities are correctly assigned to device
-    device_entry = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                UID_SEPARATOR.join(
-                    [
-                        mock_config_entry.entry_id,
-                        "DRAM",
-                        "ENE",
-                        "ENE SMBus Device",
-                        "none",
-                        "I2C: PIIX4, address 0x70",
-                    ]
-                ),
-            )
-        }
+    device_entry = device_registry.async_get_device_by_identifier(
+        (
+            DOMAIN,
+            UID_SEPARATOR.join(
+                [
+                    mock_config_entry.entry_id,
+                    "DRAM",
+                    "ENE",
+                    "ENE SMBus Device",
+                    "none",
+                    "I2C: PIIX4, address 0x70",
+                ]
+            ),
+        ),
+        mock_config_entry.entry_id,
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(
@@ -852,11 +851,11 @@ async def test_duplicate_device_names(
     )
 
     # Verify devices exist with correct names (suffix based on device.id position)
-    device1_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, device1_key)}
+    device1_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device1_key), mock_config_entry.entry_id
     )
-    device2_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, device2_key)}
+    device2_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device2_key), mock_config_entry.entry_id
     )
 
     assert device1_entry

--- a/tests/components/openrgb/test_select.py
+++ b/tests/components/openrgb/test_select.py
@@ -59,8 +59,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure entity is correctly assigned to the OpenRGB server device
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -32,8 +32,9 @@ async def test_device_registry_insert(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    gw_dev = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.GATEWAY}")}
+    gw_dev = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.GATEWAY}"),
+        mock_config_entry.entry_id,
     )
     assert gw_dev is not None
     assert gw_dev.sw_version == VERSION_TEST
@@ -64,8 +65,9 @@ async def test_device_registry_update(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    gw_dev = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.GATEWAY}")}
+    gw_dev = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.GATEWAY}"),
+        mock_config_entry.entry_id,
     )
     assert gw_dev is not None
     assert gw_dev.sw_version == VERSION_NEW
@@ -105,8 +107,9 @@ async def test_device_registry_report_numeric_fields(
     )
     await hass.async_block_till_done()
 
-    boiler_dev = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.BOILER}")}
+    boiler_dev = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.BOILER}"),
+        mock_config_entry.entry_id,
     )
     assert boiler_dev is not None
     assert boiler_dev.manufacturer == "42"
@@ -114,10 +117,9 @@ async def test_device_registry_report_numeric_fields(
     assert boiler_dev.hw_version == "7"
     assert boiler_dev.sw_version == "2.5"
 
-    thermostat_dev = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.THERMOSTAT}")
-        }
+    thermostat_dev = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.THERMOSTAT}"),
+        mock_config_entry.entry_id,
     )
     assert thermostat_dev is not None
     assert thermostat_dev.manufacturer == "10"

--- a/tests/components/overkiz/test_diagnostics.py
+++ b/tests/components/overkiz/test_diagnostics.py
@@ -50,8 +50,8 @@ async def test_device_diagnostics(
         hass, "diagnostics/cloud_somfy_tahoma_switch_europe.json", DOMAIN
     )
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "rts://1234-5678-6867/16756006")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "rts://1234-5678-6867/16756006"), init_integration.entry_id
     )
     assert device is not None
 
@@ -79,8 +79,8 @@ async def test_device_diagnostics_execution_history_subsystem(
         hass, "diagnostics/cloud_somfy_tahoma_switch_europe.json", DOMAIN
     )
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "rts://1234-5678-6867/16756006")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "rts://1234-5678-6867/16756006"), init_integration.entry_id
     )
     assert device is not None
 

--- a/tests/components/overseerr/test_init.py
+++ b/tests/components/overseerr/test_init.py
@@ -57,8 +57,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/ovhcloud_ai_endpoints/test_init.py
+++ b/tests/components/ovhcloud_ai_endpoints/test_init.py
@@ -107,8 +107,8 @@ async def test_new_subentry_creates_entity_and_device(
     assert entities[0].domain == "conversation"
     assert entities[0].unique_id == subentry.subentry_id
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, subentry.subentry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, subentry.subentry_id), entry.entry_id
     )
     assert device is not None
     assert device.name == "Meta-Llama-3_3-70B-Instruct"

--- a/tests/components/paj_gps/test_entity.py
+++ b/tests/components/paj_gps/test_entity.py
@@ -24,7 +24,9 @@ async def test_entity_device_info(
     """Test that device info is correctly set up."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "42_1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "42_1"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Device 1"
     assert device.manufacturer == "PAJ GPS"
@@ -48,7 +50,9 @@ async def test_entity_device_info_with_model(
 
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "42_1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "42_1"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.model == "ALLROUND Finder 4G"
 
@@ -66,7 +70,9 @@ async def test_entity_device_info_fallback_name(
 
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "42_1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "42_1"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "PAJ GPS 1"
 
@@ -84,6 +90,8 @@ async def test_entity_device_info_non_dict_device_models(
 
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "42_1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "42_1"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.model is None

--- a/tests/components/palazzetti/test_init.py
+++ b/tests/components/palazzetti/test_init.py
@@ -39,8 +39,8 @@ async def test_device(
     """Test the device information."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:66")}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:66"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device == snapshot

--- a/tests/components/peblar/test_binary_sensor.py
+++ b/tests/components/peblar/test_binary_sensor.py
@@ -24,8 +24,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_button.py
+++ b/tests/components/peblar/test_button.py
@@ -35,8 +35,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_init.py
+++ b/tests/components/peblar/test_init.py
@@ -85,12 +85,13 @@ async def test_config_entry_authentication_failed(
 @pytest.mark.usefixtures("init_integration")
 async def test_peblar_device_entry(
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test authentication error, aborts setup."""
     assert (
-        device_entry := device_registry.async_get_device(
-            identifiers={(DOMAIN, "23-45-A4O-MOF")}
+        device_entry := device_registry.async_get_device_by_identifier(
+            (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
         )
     )
     assert device_entry == snapshot

--- a/tests/components/peblar/test_number.py
+++ b/tests/components/peblar/test_number.py
@@ -38,8 +38,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_select.py
+++ b/tests/components/peblar/test_select.py
@@ -42,8 +42,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_sensor.py
+++ b/tests/components/peblar/test_sensor.py
@@ -25,8 +25,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_switch.py
+++ b/tests/components/peblar/test_switch.py
@@ -37,8 +37,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/peblar/test_update.py
+++ b/tests/components/peblar/test_update.py
@@ -24,8 +24,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure all entities are correctly assigned to the Peblar EV charger
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23-45-A4O-MOF"), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/pglab/test_discovery.py
+++ b/tests/components/pglab/test_discovery.py
@@ -27,8 +27,9 @@ async def test_device_discover(
     await send_discovery_message(hass, payload)
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, payload["mac"])}
+    device_entry = device_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, payload["mac"]),
+        hass.config_entries.async_entries("pglab")[0].entry_id,
     )
     assert device_entry is not None
     assert device_entry.configuration_url == f"http://{payload['ip']}/"
@@ -55,8 +56,9 @@ async def test_device_update(
     await send_discovery_message(hass, payload)
 
     # Verify device is created
-    device_entry = device_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, payload["mac"])}
+    device_entry = device_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, payload["mac"]),
+        hass.config_entries.async_entries("pglab")[0].entry_id,
     )
     assert device_entry is not None
 
@@ -67,8 +69,9 @@ async def test_device_update(
     await send_discovery_message(hass, payload)
 
     # Verify device is created
-    device_entry = device_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, payload["mac"])}
+    device_entry = device_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, payload["mac"]),
+        hass.config_entries.async_entries("pglab")[0].entry_id,
     )
     assert device_entry is not None
     assert device_entry.sw_version == "1.0.1"
@@ -91,15 +94,19 @@ async def test_device_remove(
     await send_discovery_message(hass, payload)
 
     # Verify device is created
-    device_entry = device_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, payload["mac"])}
+    device_entry = device_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, payload["mac"]),
+        hass.config_entries.async_entries("pglab")[0].entry_id,
     )
     assert device_entry is not None
 
     await send_discovery_message(hass, None)
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, payload["mac"])}
+    assert (
+        device_reg.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, payload["mac"]),
+            hass.config_entries.async_entries("pglab")[0].entry_id,
+        )
+        is None
     )
-    assert device_entry is None

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -586,8 +586,9 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         await self._setup_platform(use_default_responses=True)
 
         device_registry = dr.async_get(self.hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-        picnic_service = device_registry.async_get_device(
-            identifiers={(const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"])}
+        picnic_service = device_registry.async_get_device_by_identifier(
+            (const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"]),
+            self.config_entry.entry_id,
         )
         assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
         assert picnic_service.name == "Mock Title"

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -33,7 +33,9 @@ async def test_cleanup_orphaned_devices(
 
     # Ensure device is not removed with an entity
     await setup_plex_server()
-    device = device_registry.async_get_device(identifiers=test_device_id)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "temporary_device_123"), entry.entry_id
+    )
     assert device is not None
 
     await hass.config_entries.async_unload(entry.entry_id)
@@ -41,7 +43,9 @@ async def test_cleanup_orphaned_devices(
     # Ensure device is removed without an entity
     entity_registry.async_remove(test_entity.entity_id)
     await setup_plex_server()
-    device = device_registry.async_get_device(identifiers=test_device_id)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "temporary_device_123"), entry.entry_id
+    )
     assert device is None
 
 
@@ -57,7 +61,6 @@ async def test_migrate_transient_devices(
     """Test cleaning up transient devices on startup."""
     plexweb_device_id = {(DOMAIN, "plexweb_id")}
     non_plexweb_device_id = {(DOMAIN, "1234567890123456-com-plexapp-android")}
-    plex_client_service_device_id = {(DOMAIN, "plex.tv-clients")}
 
     entry.add_to_hass(hass)
 
@@ -92,12 +95,14 @@ async def test_migrate_transient_devices(
     # Ensure the Plex Web client is available
     requests_mock.get("/resources", text=player_plexweb_resources)
 
-    plexweb_device = device_registry.async_get_device(identifiers=plexweb_device_id)
-    non_plexweb_device = device_registry.async_get_device(
-        identifiers=non_plexweb_device_id
+    plexweb_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "plexweb_id"), entry.entry_id
     )
-    plex_service_device = device_registry.async_get_device(
-        identifiers=plex_client_service_device_id
+    non_plexweb_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890123456-com-plexapp-android"), entry.entry_id
+    )
+    plex_service_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "plex.tv-clients"), entry.entry_id
     )
 
     assert (
@@ -117,8 +122,8 @@ async def test_migrate_transient_devices(
     # Ensure Plex Web entity is migrated to a service
     await setup_plex_server()
 
-    plex_service_device = device_registry.async_get_device(
-        identifiers=plex_client_service_device_id
+    plex_service_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "plex.tv-clients"), entry.entry_id
     )
 
     assert (

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -134,8 +134,8 @@ async def test_device_in_dr(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "a455b61e52394b2db5081ce025a430f3")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "a455b61e52394b2db5081ce025a430f3"), mock_config_entry.entry_id
     )
     assert device_entry.hw_version == "AME Smile 2.0 board"
     assert device_entry.manufacturer == "Plugwise"
@@ -327,8 +327,8 @@ async def test_update_device(
             )
             == 12
         )
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, "01234567890abcdefghijklmnopqrstu")}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "01234567890abcdefghijklmnopqrstu"), mock_config_entry.entry_id
         )
         assert device_entry is not None
 
@@ -358,8 +358,8 @@ async def test_update_device(
             )
             == 11
         )
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, "1772a4ea304041adb83f357b751341ff")}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "1772a4ea304041adb83f357b751341ff"), mock_config_entry.entry_id
         )
         assert device_entry is None
 
@@ -377,8 +377,8 @@ async def test_delete_removed_device(
     """Test device removal after a coordinator refresh."""
     data = mock_smile_adam_heat_cool.async_update.return_value
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6"), mock_config_entry.entry_id
     )
     assert device_entry is not None
 
@@ -388,8 +388,8 @@ async def test_delete_removed_device(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6"), mock_config_entry.entry_id
     )
     assert device_entry is None
 
@@ -407,8 +407,8 @@ async def test_update_device_firmware(
     """Test device firmware update via coordinator."""
     data = mock_smile_adam_heat_cool.async_update.return_value
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "da224107914542988a88561b4452b0f6")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "da224107914542988a88561b4452b0f6"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert str(device_entry.sw_version) == "3.9.0"
@@ -419,8 +419,8 @@ async def test_update_device_firmware(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "da224107914542988a88561b4452b0f6")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "da224107914542988a88561b4452b0f6"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert str(device_entry.sw_version) == "3.10.13"

--- a/tests/components/pooldose/test_init.py
+++ b/tests/components/pooldose/test_init.py
@@ -27,7 +27,9 @@ async def test_devices(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "TEST123456789")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TEST123456789"), mock_config_entry.entry_id
+    )
 
     assert device is not None
     assert device == snapshot

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -304,42 +304,43 @@ async def test_container_stack_device_links(
     """Test that stack-linked containers are nested under the correct stack device."""
     await setup_integration(hass, mock_config_entry)
 
-    endpoint_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_1")}
+    endpoint_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1"), mock_config_entry.entry_id
     )
     assert endpoint_device is not None
 
-    dashy_stack_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_1_stack_2")}
+    dashy_stack_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_stack_2"), mock_config_entry.entry_id
     )
     assert dashy_stack_device is not None
     assert dashy_stack_device.via_device_id == endpoint_device.id
 
-    webstack_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_1_stack_1")}
+    webstack_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_stack_1"), mock_config_entry.entry_id
     )
     assert webstack_device is not None
     assert webstack_device.via_device_id == endpoint_device.id
 
-    swarm_container_device = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                f"{mock_config_entry.entry_id}_1_dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05",
-            )
-        }
+    swarm_container_device = device_registry.async_get_device_by_identifier(
+        (
+            DOMAIN,
+            f"{mock_config_entry.entry_id}_1_dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05",
+        ),
+        mock_config_entry.entry_id,
     )
     assert swarm_container_device is not None
     assert swarm_container_device.via_device_id == dashy_stack_device.id
 
-    compose_container_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_1_serene_banach")}
+    compose_container_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_serene_banach"),
+        mock_config_entry.entry_id,
     )
     assert compose_container_device is not None
     assert compose_container_device.via_device_id == webstack_device.id
 
-    standalone_container_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_1_focused_einstein")}
+    standalone_container_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_focused_einstein"),
+        mock_config_entry.entry_id,
     )
 
     assert standalone_container_device is not None

--- a/tests/components/portainer/test_services.py
+++ b/tests/components/portainer/test_services.py
@@ -49,8 +49,8 @@ async def test_services(
     """Tests that the services are correct."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_IDENTIFIER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert device is not None
     await hass.services.async_call(
@@ -94,8 +94,8 @@ async def test_service_prune_images(
     """Test prune images service with the variants."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_IDENTIFIER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert device is not None
     await hass.services.async_call(
@@ -137,8 +137,8 @@ async def test_service_recreate_container(
     """Test recreate container service with the variants."""
 
     await setup_integration(hass, mock_config_entry)
-    container = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER)}
+    container = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert container is not None
     await hass.services.async_call(
@@ -186,8 +186,8 @@ async def test_service_recreate_container_portainer_exceptions(
 ) -> None:
     """Test recreate container service handles Portainer exceptions."""
     await setup_integration(hass, mock_config_entry)
-    container = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER)}
+    container = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert container is not None
 
@@ -213,12 +213,12 @@ async def test_service_validation_errors(
     """Tests that the Portainer services handle bad data."""
 
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_IDENTIFIER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert device is not None
-    container = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER)}
+    container = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_CONTAINER_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
     assert container is not None
 
@@ -335,8 +335,8 @@ async def test_service_portainer_exceptions(
 ) -> None:
     """Test service handles Portainer exceptions."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_IDENTIFIER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_IDENTIFIER), mock_config_entry.entry_id
     )
 
     mock_portainer_client.images_prune.side_effect = exception

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -51,8 +51,8 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("powerwall", MOCK_GATEWAY_DIN)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("powerwall", MOCK_GATEWAY_DIN), config_entry.entry_id
     )
     assert reg_device.model == "PowerWall 2 (GW1)"
     assert reg_device.sw_version == "1.50.1 c58c2df3"
@@ -389,11 +389,11 @@ async def test_unique_id_migrate(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("powerwall", MOCK_GATEWAY_DIN)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("powerwall", MOCK_GATEWAY_DIN), config_entry.entry_id
     )
-    old_reg_device = device_registry.async_get_device(
-        identifiers={("powerwall", old_unique_id)},
+    old_reg_device = device_registry.async_get_device_by_identifier(
+        ("powerwall", old_unique_id), config_entry.entry_id
     )
     assert old_reg_device is None
     assert reg_device is not None
@@ -439,8 +439,8 @@ async def test_pw3_restricted_entities(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("powerwall", "aa:bb:cc:dd:ee:ff"), config_entry.entry_id
     )
     assert reg_device.model == "PowerWall 2"
     assert reg_device.sw_version is None

--- a/tests/components/prana/test_init.py
+++ b/tests/components/prana/test_init.py
@@ -35,8 +35,8 @@ async def test_device_info_registered(
     """Device info from the API should be registered on the device registry."""
     await async_init_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
 
     assert device is not None

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -519,11 +519,11 @@ async def test_stale_devices_removed(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     entry_id = mock_config_entry.entry_id
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry_id}_vm_100")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_vm_100"), entry_id
     )
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry_id}_vm_101")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_vm_101"), entry_id
     )
 
     # VM 100 is gone, VM 101 remains
@@ -538,9 +538,11 @@ async def test_stale_devices_removed(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, f"{entry_id}_vm_100")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{entry_id}_vm_100"), entry_id
+        )
         is None
     )
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry_id}_vm_101")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_vm_101"), entry_id
     )

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -33,8 +33,8 @@ async def test_device_info(
     """Test device info is populated with serial and firmware."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.serial_number == "serial-1337"

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -314,7 +314,9 @@ async def test_device_info_is_set_from_status_correctly(
     mock_state = hass.states.get(mock_entity_id).state
 
     mock_d_entries = device_registry.devices
-    mock_entry = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_HOST_ID)})
+    mock_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_HOST_ID), MOCK_ENTRY_ID
+    )
     assert mock_state == STATE_OFF
 
     assert len(mock_d_entries) == 1
@@ -336,8 +338,8 @@ async def test_device_registry(
 
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_HOST_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_HOST_ID), MOCK_ENTRY_ID
     )
     assert device_entry == snapshot
 

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -285,8 +285,8 @@ async def test_options_remove_sensor(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "remove_sensor"
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, str(TEST_SENSOR_INDEX1))}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, str(TEST_SENSOR_INDEX1)), config_entry.entry_id
     )
     assert device_entry is not None
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/rabbitair/test_init.py
+++ b/tests/components/rabbitair/test_init.py
@@ -69,5 +69,7 @@ async def test_device_registry(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, TEST_MAC)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC), entry.entry_id
+    )
     assert device_entry == snapshot

--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -56,7 +56,9 @@ async def test_device_info(
     """Test device info."""
     entry = await setup_integration(hass, aioclient_mock)
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.configuration_url == "http://192.168.1.189:7887/test"
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -56,8 +56,8 @@ async def test_device_registry(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MAC_ADDRESS_UNIQUE_ID), config_entry.entry_id
     )
     assert device_entry == snapshot
 
@@ -351,8 +351,8 @@ async def test_fix_entity_unique_ids(
     assert entity_entry
     assert entity_entry.unique_id == expected_unique_id
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, expected_device_identifier)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, expected_device_identifier), config_entry.entry_id
     )
     assert device_entry
     assert device_entry.identifiers == {(DOMAIN, expected_device_identifier)}
@@ -469,7 +469,9 @@ async def test_fix_duplicate_device_ids(
     )
     assert len(device_entries) == 1
 
-    device_entry = device_registry.async_get_device({(DOMAIN, MAC_ADDRESS_UNIQUE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MAC_ADDRESS_UNIQUE_ID), config_entry.entry_id
+    )
     assert device_entry
     assert device_entry.identifiers == {(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
     assert device_entry.name_by_user == expected_device_name
@@ -528,8 +530,8 @@ async def test_reload_migration_with_leading_zero_mac(
     await hass.async_block_till_done()
 
     # Verify the device and entity were migrated to the new format
-    migrated_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mac_address_unique_id}-1")}
+    migrated_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mac_address_unique_id}-1"), config_entry.entry_id
     )
     assert migrated_device_entry is not None
     migrated_entity_entry = entity_registry.async_get(entity_entry.entity_id)

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -74,14 +74,15 @@ async def test_set_value(
     device_registry: dr.DeviceRegistry,
     aioclient_mock: AiohttpClientMocker,
     responses: list[str],
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test setting the rain delay number."""
 
     raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
     assert raindelay is not None
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MAC_ADDRESS.lower())}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MAC_ADDRESS.lower()), config_entry.entry_id
     )
     assert device
     assert device.name == "Rain Bird Controller"

--- a/tests/components/rainmachine/test_sensor.py
+++ b/tests/components/rainmachine/test_sensor.py
@@ -52,8 +52,8 @@ async def test_device_info_hw_version_is_string(
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff"), config_entry.entry_id
     )
     assert device_entry
     assert device_entry.hw_version == "3"

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -48,7 +48,9 @@ async def test_device_diagnostics(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "VF1ZOE40VIN")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "VF1ZOE40VIN"), config_entry.entry_id
+    )
     assert device is not None
 
     assert (
@@ -70,7 +72,9 @@ async def test_device_diagnostics_invalid_upstream_exception(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "VF1ZOE40VIN")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "VF1ZOE40VIN"), config_entry.entry_id
+    )
     assert device is not None
 
     data = await get_diagnostics_for_device(hass, hass_client, config_entry, device)

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -260,16 +260,22 @@ async def test_registry_cleanup(
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
 
     # Try to remove "VF1ZOE40VIN" - fails as it is live
-    device = device_registry.async_get_device(identifiers={(DOMAIN, live_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
     client = await hass_ws_client(hass)
     response = await client.remove_device(device.id, entry_id)
     assert not response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
-    assert device_registry.async_get_device(identifiers={(DOMAIN, live_id)}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
+        is not None
+    )
 
     # Try to remove "VF1AAAAA555777888" - succeeds as it is dead
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
     response = await client.remove_device(device.id, entry_id)
     assert response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
-    assert device_registry.async_get_device(identifiers={(DOMAIN, dead_id)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
+        is None
+    )

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -49,8 +49,9 @@ def override_vehicle_type(request: pytest.FixtureRequest) -> str:
 def get_device_id(hass: HomeAssistant) -> str:
     """Get device_id."""
     device_registry = dr.async_get(hass)
-    identifiers = {(DOMAIN, "VF1ZOE40VIN")}
-    device = device_registry.async_get_device(identifiers=identifiers)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "VF1ZOE40VIN"), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     return device.id
 
 
@@ -429,8 +430,8 @@ async def test_service_invalid_device_id2(
         identifiers={(DOMAIN, "VF1AAAAA111222333")},
         name="REG-NUMBER",
     )
-    device_id = device_registry.async_get_device(
-        identifiers={(DOMAIN, "VF1AAAAA111222333")},
+    device_id = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "VF1AAAAA111222333"), config_entry.entry_id
     ).id
 
     data = {RenaultServiceArgument.VEHICLE: device_id}

--- a/tests/components/renson/test_init.py
+++ b/tests/components/renson/test_init.py
@@ -58,7 +58,7 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "80:7d:3a:bd:1e:32")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "80:7d:3a:bd:1e:32"), entry.entry_id
     )
     assert device_entry == snapshot

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -124,8 +124,8 @@ async def test_dual_lens_sub_devices(
     assert config_entry.state is ConfigEntryState.LOADED
 
     for channel in (0, 1):
-        lens_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{TEST_UID}_lens{channel}")}
+        lens_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{TEST_UID}_lens{channel}"), config_entry.entry_id
         )
         assert lens_device is not None
         assert lens_device.name == f"{TEST_CAM_NAME} lens {channel}"
@@ -144,8 +144,8 @@ async def test_dual_lens_sub_devices(
     assert entity.device_id == host_device.id
 
     # the pre-existing lens sub-device and entity should have been reused
-    lens_0_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_UID}_lens0")}
+    lens_0_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_lens0"), config_entry.entry_id
     )
     assert lens_0_device is not None
     assert lens_0_device.id == old_lens_device.id
@@ -185,12 +185,12 @@ async def test_dual_lens_sub_devices_nvr(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, parent_dev_id)}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, parent_dev_id), config_entry.entry_id
     )
     assert parent_device is not None
-    lens_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_UID}_lens0")}
+    lens_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_lens0"), config_entry.entry_id
     )
     assert lens_device is not None
     assert lens_device.via_device_id == parent_device.id

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -491,10 +491,15 @@ async def test_migrate_entity_ids(
     if original_id != new_id:
         assert entity_registry.async_get_entity_id(domain, DOMAIN, new_id) is None
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, original_dev_id), config_entry.entry_id
+    )
     if new_dev_id != original_dev_id:
         assert (
-            device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)}) is None
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, new_dev_id), config_entry.entry_id
+            )
+            is None
         )
 
     # setup CH 0 and host entities/device
@@ -508,10 +513,14 @@ async def test_migrate_entity_ids(
 
     if new_dev_id != original_dev_id:
         assert (
-            device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, original_dev_id), config_entry.entry_id
+            )
             is None
         )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, new_dev_id), config_entry.entry_id
+    )
 
 
 async def test_migrate_entity_id_zoom(
@@ -616,8 +625,12 @@ async def test_migrate_with_already_existing_device(
         disabled_by=None,
     )
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, original_dev_id), config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, new_dev_id), config_entry.entry_id
+    )
 
     # setup CH 0 and host entities/device
     with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
@@ -625,10 +638,14 @@ async def test_migrate_with_already_existing_device(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, original_dev_id), config_entry.entry_id
+        )
         is None
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, new_dev_id), config_entry.entry_id
+    )
 
 
 @pytest.mark.parametrize(
@@ -731,7 +748,9 @@ async def test_cleanup_mac_connection(
     )
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.connections == {(CONNECTION_NETWORK_MAC, TEST_MAC)}
 
@@ -741,7 +760,9 @@ async def test_cleanup_mac_connection(
     await hass.async_block_till_done()
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.connections == set()
 
@@ -783,7 +804,9 @@ async def test_cleanup_combined_with_NVR(
     )
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.identifiers == start_identifiers
 
@@ -793,10 +816,14 @@ async def test_cleanup_combined_with_NVR(
     await hass.async_block_till_done()
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.identifiers == {(DOMAIN, dev_id)}
-    host_device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_UID)})
+    host_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_UID), config_entry.entry_id
+    )
     assert host_device
     assert host_device.identifiers == {
         (DOMAIN, TEST_UID),
@@ -840,7 +867,9 @@ async def test_cleanup_hub_and_direct_connection(
     )
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.identifiers == start_identifiers
 
@@ -850,7 +879,9 @@ async def test_cleanup_hub_and_direct_connection(
     await hass.async_block_till_done()
 
     assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dev_id), config_entry.entry_id
+    )
     assert device
     assert device.identifiers == start_identifiers
 

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -52,8 +52,8 @@ async def test_device_registry(
 ) -> None:
     """Test the device registry entry, including the network MAC connection."""
     # device_id "aacdef987654" is the Front Door doorbell's MAC.
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "aacdef987654")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "aacdef987654"), mock_added_config_entry.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -163,14 +163,14 @@ async def test_cloud_setup(
     assert entity_registry.async_is_registered(FIRST_CLOUD_ENTITY_ID)
     assert entity_registry.async_is_registered(SECOND_CLOUD_ENTITY_ID)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_0"), setup_risco_cloud.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_1")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_1"), setup_risco_cloud.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
@@ -581,14 +581,14 @@ async def test_local_setup(
     assert entity_registry.async_is_registered(FIRST_LOCAL_ENTITY_ID)
     assert entity_registry.async_is_registered(SECOND_LOCAL_ENTITY_ID)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_0_local")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_0_local"), setup_risco_local.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_1_local")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_1_local"), setup_risco_local.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -48,14 +48,14 @@ async def test_cloud_setup(
     assert entity_registry.async_is_registered(FIRST_ENTITY_ID)
     assert entity_registry.async_is_registered(SECOND_ENTITY_ID)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_zone_0"), setup_risco_cloud.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_1")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_zone_1"), setup_risco_cloud.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
@@ -120,19 +120,21 @@ async def test_local_setup(
     assert entity_registry.async_is_registered(FIRST_ALARMED_ENTITY_ID)
     assert entity_registry.async_is_registered(SECOND_ALARMED_ENTITY_ID)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_0_local")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_zone_0_local"), setup_risco_local.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_1_local")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID + "_zone_1_local"), setup_risco_local.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_SITE_UUID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SITE_UUID), setup_risco_local.entry_id
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 

--- a/tests/components/rituals_perfume_genie/test_switch.py
+++ b/tests/components/rituals_perfume_genie/test_switch.py
@@ -90,8 +90,8 @@ async def test_device_info_sw_version_dict(
     with caplog.at_level(logging.WARNING, logger="homeassistant.helpers.frame"):
         await init_integration(hass, config_entry, [diffuser])
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("rituals_perfume_genie", "lot123dict")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("rituals_perfume_genie", "lot123dict"), config_entry.entry_id
     )
     assert device_entry
     assert device_entry.sw_version == "5.2-rc15"

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -72,7 +72,10 @@ async def test_dock_buttons_absent_for_non_wash_n_fill_dock(
         assert hass.states.get(entity_id) is not None
     # No phantom dock device should be registered for the non-wash-n-fill vacuum.
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "abc123_dock")}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "abc123_dock"), setup_entry.entry_id
+        )
+        is None
     )
 
 

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -558,8 +558,8 @@ async def test_zeo_device_fails_setup(
 
     # The Zeo device should be in the registry and have entities
     # because entities are registered immediately without blocking on coordinator refresh.
-    zeo_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, zeo_device.duid)}
+    zeo_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, zeo_device.duid), mock_roborock_entry.entry_id
     )
     assert zeo_device_entry is not None
     zeo_entities = er.async_entries_for_device(
@@ -618,8 +618,8 @@ async def test_dyad_device_fails_setup(
 
     # The Dyad device should be in the registry and have entities
     # because entities are registered immediately without blocking on coordinator refresh.
-    dyad_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, dyad_device.duid)}
+    dyad_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dyad_device.duid), mock_roborock_entry.entry_id
     )
     assert dyad_device_entry is not None
     dyad_entities = er.async_entries_for_device(
@@ -680,8 +680,8 @@ async def test_disabled_device_no_coordinator(
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
     # The disabled device should still be registered in the device registry
-    disabled_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, first_device.duid)}
+    disabled_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, first_device.duid), mock_roborock_entry.entry_id
     )
     assert disabled_device_entry is not None
     assert disabled_device_entry.disabled
@@ -769,8 +769,8 @@ async def test_all_devices_disabled(
 
     # All devices should still exist in the registry but be disabled
     for fake_device in fake_devices:
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, fake_device.duid)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, fake_device.duid), mock_roborock_entry.entry_id
         )
         assert device_entry is not None
         assert device_entry.disabled

--- a/tests/components/rova/test_init.py
+++ b/tests/components/rova/test_init.py
@@ -43,8 +43,8 @@ async def test_service(
     """Test the Rova service."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
