### PR TITLE
Migrate calls to async_get_device in tests (part 5)

### DIFF
--- a/tests/components/samsung_infrared/test_media_player.py
+++ b/tests/components/samsung_infrared/test_media_player.py
@@ -48,8 +48,8 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Verify entity belongs to the correct device
-    device_entry = device_registry.async_get_device(
-        identifiers={("samsung_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("samsung_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/samsungtv/test_device_trigger.py
+++ b/tests/components/samsungtv/test_device_trigger.py
@@ -26,10 +26,10 @@ async def test_get_triggers(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test we get the expected triggers."""
-    await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
+    entry = await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4"), entry.entry_id
     )
 
     turn_on_trigger = {
@@ -53,11 +53,11 @@ async def test_if_fires_on_turn_on_request(
     service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
+    entry = await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
     entity_id = "media_player.mock_title"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4"), entry.entry_id
     )
 
     assert await async_setup_component(

--- a/tests/components/samsungtv/test_trigger.py
+++ b/tests/components/samsungtv/test_trigger.py
@@ -26,12 +26,12 @@ async def test_turn_on_trigger_device_id(
     entity_domain: str,
 ) -> None:
     """Test for turn_on triggers by device_id firing."""
-    await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
+    entry = await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
 
     entity_id = f"{entity_domain}.mock_title"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4"), entry.entry_id
     )
     assert device, repr(device_registry.devices)
 

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -64,8 +64,9 @@ async def test_alarm_control_panel(
 
     await snapshot_platform(hass, entity_registry, snapshot, MOCK_ENTRY_ID)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "1234567890_alarm_panel_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890_alarm_panel_1"),
+        mock_config_entry_with_subentries.entry_id,
     )
 
     assert device_entry == snapshot(name="device")

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -57,14 +57,14 @@ async def test_binary_sensors(
         hass, entity_registry, snapshot, mock_config_entry_with_subentries.entry_id
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "1234567890_zones_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890_zones_1"), mock_config_entry_with_subentries.entry_id
     )
 
     assert device_entry == snapshot(name="device-zone")
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "1234567890_outputs_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890_outputs_1"), mock_config_entry_with_subentries.entry_id
     )
     assert device_entry == snapshot(name="device-output")
 

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -218,8 +218,8 @@ async def test_parent_device_exists(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_ENTRY_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_ENTRY_ID), mock_config_entry.entry_id
     )
     assert device_entry == snapshot(name="parent-device")
 

--- a/tests/components/satel_integra/test_sensor.py
+++ b/tests/components/satel_integra/test_sensor.py
@@ -71,8 +71,9 @@ async def test_sensors(
         mock_config_entry_with_temperature_zone.entry_id,
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_ENTRY_ID}_zones_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_ENTRY_ID}_zones_1"),
+        mock_config_entry_with_temperature_zone.entry_id,
     )
     assert device_entry == snapshot(name="device-zone")
 

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -66,8 +66,8 @@ async def test_switches(
 
     await snapshot_platform(hass, entity_registry, snapshot, MOCK_ENTRY_ID)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "1234567890_switch_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890_switch_1"), mock_config_entry_with_subentries.entry_id
     )
 
     assert device_entry == snapshot(name="device")

--- a/tests/components/saunum/test_init.py
+++ b/tests/components/saunum/test_init.py
@@ -58,8 +58,8 @@ async def test_device_entry(
 ) -> None:
     """Test device registry entry."""
     assert (
-        device_entry := device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        device_entry := device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
         )
     )
     assert device_entry == snapshot

--- a/tests/components/schlage/test_init.py
+++ b/tests/components/schlage/test_init.py
@@ -112,7 +112,9 @@ async def test_lock_device_registry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test lock is added to device registry."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "test")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test"), mock_added_config_entry.entry_id
+    )
     assert device == snapshot
 
 
@@ -126,7 +128,9 @@ async def test_auto_add_device(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test new devices are auto-added to the device registry."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "test")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test"), mock_added_config_entry.entry_id
+    )
     assert device is not None
     all_devices = dr.async_entries_for_config_entry(
         device_registry, mock_added_config_entry.entry_id
@@ -143,7 +147,9 @@ async def test_auto_add_device(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    new_device = device_registry.async_get_device(identifiers={(DOMAIN, "test2")})
+    new_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "test2"), mock_added_config_entry.entry_id
+    )
     assert new_device is not None
 
     all_devices = dr.async_entries_for_config_entry(
@@ -160,7 +166,12 @@ async def test_auto_remove_device(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test new devices are auto-added to the device registry."""
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test")}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "test"), mock_added_config_entry.entry_id
+        )
+        is not None
+    )
 
     mock_schlage.locks.return_value = []
 
@@ -169,7 +180,12 @@ async def test_auto_remove_device(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "test")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "test"), mock_added_config_entry.entry_id
+        )
+        is None
+    )
     all_devices = dr.async_entries_for_config_entry(
         device_registry, mock_added_config_entry.entry_id
     )

--- a/tests/components/scorpiontrack/test_init.py
+++ b/tests/components/scorpiontrack/test_init.py
@@ -39,7 +39,9 @@ async def test_device_is_registered(
     """Test the ScorpionTrack vehicle device is registered."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={("scorpiontrack", "101_1")})
+    device = device_registry.async_get_device_by_identifier(
+        ("scorpiontrack", "101_1"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.name == "AB12 CDE"
     assert device.manufacturer == "Volkswagen"

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -229,7 +229,9 @@ async def test_device_properties(
     target_value: str,
 ) -> None:
     """Test device properties."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "AC000Wxxxxxxxxx")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "AC000Wxxxxxxxxx"), ENTRY_ID
+    )
     assert getattr(device, device_property) == target_value
 
 

--- a/tests/components/simplisafe/test_init.py
+++ b/tests/components/simplisafe/test_init.py
@@ -33,7 +33,6 @@ async def test_base_station_migration(
 ) -> None:
     """Test that old integer-based device identifiers are migrated to strings."""
     old_identifiers = {(DOMAIN, 12345)}
-    new_identifiers = {(DOMAIN, "12345")}
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -45,8 +44,18 @@ async def test_base_station_migration(
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers=old_identifiers) is None
-    assert device_registry.async_get_device(identifiers=new_identifiers) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, 12345), config_entry.entry_id
+        )
+        is None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "12345"), config_entry.entry_id
+        )
+        is not None
+    )
 
 
 async def test_base_station_model_is_string(
@@ -59,7 +68,9 @@ async def test_base_station_model_is_string(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345"), config_entry.entry_id
+    )
     assert device is not None
     assert isinstance(device.model, str)
 

--- a/tests/components/sky_remote/test_init.py
+++ b/tests/components/sky_remote/test_init.py
@@ -25,8 +25,8 @@ async def test_setup_entry(
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     mock_remote_control.assert_called_once_with("example.com", DEFAULT_PORT)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.name == "example.com"

--- a/tests/components/slide_local/test_init.py
+++ b/tests/components/slide_local/test_init.py
@@ -24,8 +24,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_platform(hass, mock_config_entry, [Platform.COVER])
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "1234567890ab")}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "1234567890ab"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/smartthings/test_diagnostics.py
+++ b/tests/components/smartthings/test_diagnostics.py
@@ -64,8 +64,8 @@ async def test_device_diagnostics(
     mock_smartthings.get_raw_device.return_value = device_items["items"][0]
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "96a5ef74-5832-a84b-f1f7-ca799957065d")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "96a5ef74-5832-a84b-f1f7-ca799957065d"), mock_config_entry.entry_id
     )
 
     mock_smartthings.get_raw_device_status.reset_mock()

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -86,7 +86,9 @@ async def test_devices(
     for specs in devices.get_devices.return_value:
         device_id = specs.device_id
 
-        device = device_registry.async_get_device({(DOMAIN, device_id)})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
+        )
 
         assert device is not None
         assert device == snapshot(name=get_fixture_name(device_id))
@@ -105,21 +107,27 @@ async def test_device_not_resetting_area(
 
     device_id = devices.get_devices.return_value[0].device_id
 
-    device = device_registry.async_get_device({(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), mock_config_entry.entry_id
+    )
 
     assert device.area_id == "theater"
 
     device_registry.async_update_device(device_id=device.id, area_id=None)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), mock_config_entry.entry_id
+    )
 
     assert device.area_id is None
 
     await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), mock_config_entry.entry_id
+    )
     assert device.area_id is None
 
 
@@ -343,7 +351,9 @@ async def test_removing_stale_devices(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not device_registry.async_get_device({(DOMAIN, "aaa-bbb-ccc")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "aaa-bbb-ccc"), mock_config_entry.entry_id
+    )
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
@@ -404,8 +414,8 @@ async def test_hub_via_device(
     ]
     await setup_integration(hass, mock_config_entry)
 
-    hub_device = device_registry.async_get_device(
-        {(DOMAIN, "074fa784-8be8-4c70-8e22-6f5ed6f81b7e")}
+    hub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "074fa784-8be8-4c70-8e22-6f5ed6f81b7e"), mock_config_entry.entry_id
     )
     assert hub_device == snapshot
     child_device = device_registry.async_get_device_by_identifier(

--- a/tests/components/smarty/test_init.py
+++ b/tests/components/smarty/test_init.py
@@ -22,8 +22,8 @@ async def test_device(
 ) -> None:
     """Test device."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device
     assert device == snapshot

--- a/tests/components/smlight/test_init.py
+++ b/tests/components/smlight/test_init.py
@@ -153,8 +153,8 @@ async def test_device_info(
     """Test device registry information."""
     entry = await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot
@@ -178,8 +178,8 @@ async def test_device_legacy_firmware(
 
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff"
 
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert LEGACY_VERSION in device_entry.sw_version
 

--- a/tests/components/snooz/test_init.py
+++ b/tests/components/snooz/test_init.py
@@ -55,8 +55,8 @@ async def test_device_registry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the device registry entry, including the Bluetooth connection."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_ADDRESS)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_ADDRESS), mock_connected_snooz.entry.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -147,7 +147,9 @@ async def test_state(
     assert attributes["sound_mode"] == "Sound Mode 2"
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (songpal.DOMAIN, MAC), entry.entry_id
+    )
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
     assert device.manufacturer == "Sony Corporation"
     assert device.name == FRIENDLY_NAME
@@ -184,7 +186,9 @@ async def test_state_nosoundmode(
     assert "sound_mode" not in attributes
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (songpal.DOMAIN, MAC), entry.entry_id
+    )
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
     assert device.manufacturer == "Sony Corporation"
     assert device.name == FRIENDLY_NAME
@@ -221,8 +225,8 @@ async def test_state_wireless(
     assert attributes["sound_mode"] == "Sound Mode 2"
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device = device_registry.async_get_device(
-        identifiers={(songpal.DOMAIN, WIRELESS_MAC)}
+    device = device_registry.async_get_device_by_identifier(
+        (songpal.DOMAIN, WIRELESS_MAC), entry.entry_id
     )
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, WIRELESS_MAC)}
     assert device.manufacturer == "Sony Corporation"
@@ -260,7 +264,9 @@ async def test_state_both(
     assert attributes["sound_mode"] == "Sound Mode 2"
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (songpal.DOMAIN, MAC), entry.entry_id
+    )
     assert device.connections == {
         (dr.CONNECTION_NETWORK_MAC, MAC),
         (dr.CONNECTION_NETWORK_MAC, WIRELESS_MAC),

--- a/tests/components/sonos/test_diagnostics.py
+++ b/tests/components/sonos/test_diagnostics.py
@@ -48,7 +48,9 @@ async def test_diagnostics_device(
 
     TEST_DEVICE = "RINCON_test"
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE), config_entry.entry_id
+    )
     assert device_entry is not None
 
     result = await get_diagnostics_for_device(

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -105,8 +105,8 @@ async def test_device_registry(
     hass: HomeAssistant, device_registry: DeviceRegistry, async_autosetup_sonos, soco
 ) -> None:
     """Test sonos device registered in the device registry."""
-    reg_device = device_registry.async_get_device(
-        identifiers={("sonos", "RINCON_test")}
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("sonos", "RINCON_test"), hass.config_entries.async_entries("sonos")[0].entry_id
     )
     assert reg_device is not None
     assert reg_device.model == "Model Name"
@@ -133,8 +133,8 @@ async def test_device_registry_not_portable(
     soco.get_battery_info.return_value = {}
     await async_setup_sonos()
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("sonos", "RINCON_test")}
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("sonos", "RINCON_test"), hass.config_entries.async_entries("sonos")[0].entry_id
     )
     assert reg_device is not None
     assert reg_device.area_id == area_registry.async_get_area_by_name("Zone A").id

--- a/tests/components/squeezebox/test_init.py
+++ b/tests/components/squeezebox/test_init.py
@@ -114,11 +114,14 @@ async def test_init_missing_uuid(
 async def test_device_registry(
     hass: HomeAssistant,
     device_registry: DeviceRegistry,
+    config_entry: MockConfigEntry,
     configured_player: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test squeezebox device registered in the device registry."""
-    reg_device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_MAC[0])})
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC[0]), config_entry.entry_id
+    )
     assert reg_device is not None
     assert reg_device == snapshot
 
@@ -137,7 +140,9 @@ async def test_device_registry_numeric_firmware(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    reg_device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_MAC[0])})
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC[0]), config_entry.entry_id
+    )
     assert reg_device is not None
     assert reg_device.hw_version == "137"
 
@@ -145,11 +150,14 @@ async def test_device_registry_numeric_firmware(
 async def test_device_registry_server_merged(
     hass: HomeAssistant,
     device_registry: DeviceRegistry,
+    config_entry: MockConfigEntry,
     configured_players: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test squeezebox device registered in the device registry."""
-    reg_device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_MAC[2])})
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC[2]), config_entry.entry_id
+    )
     assert reg_device is not None
     # The player shares the server's device, so it must not be linked to itself.
     assert reg_device.via_device_id is None
@@ -184,7 +192,9 @@ async def test_remove_device_blocked(
     else:
         player_id = TEST_MAC[0]
         entry.runtime_data.player_coordinators[player_id].available = is_online
-        device = device_registry.async_get_device(identifiers={(DOMAIN, player_id)})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, player_id), entry.entry_id
+        )
 
     assert device is not None
     with pytest.raises(HomeAssistantError, match=expected_error):
@@ -202,7 +212,9 @@ async def test_remove_device_allowed_offline_player(
     # Ensure the player coordinator exists and is marked offline/unavailable.
     coordinator = entry.runtime_data.player_coordinators[player_id]
     coordinator.available = False
-    device = device_registry.async_get_device(identifiers={(DOMAIN, player_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, player_id), entry.entry_id
+    )
     assert device is not None
     result = await async_remove_config_entry_device(hass, entry, device)
     assert result is True

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -110,7 +110,10 @@ async def test_device_info(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, ACCOUNT_1)}) == snapshot
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, ACCOUNT_1), config_entry.entry_id
+        )
+        == snapshot
     )
 
 
@@ -172,4 +175,6 @@ async def test_migrate_entry(
 
     assert config_entry.options == {}
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, ACCOUNT_2)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, ACCOUNT_2), config_entry.entry_id
+    )

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -108,8 +108,8 @@ async def test_config_entry_fills_unique_id_with_directed_discovery(
     assert config_entry.data[CONF_NAME] == DEVICE_NAME
     assert config_entry.title == DEVICE_NAME
 
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC_ADDRESS)}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC_ADDRESS), config_entry.entry_id
     )
     assert isinstance(device_entry, dr.DeviceEntry)
     assert device_entry.name == DEVICE_NAME

--- a/tests/components/stiebel_eltron/test_climate.py
+++ b/tests/components/stiebel_eltron/test_climate.py
@@ -60,8 +60,8 @@ async def test_climate_entity(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Verify entity is correctly assigned to device
-    device_entry = device_registry.async_get_device(
-        identifiers={("stiebel_eltron", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("stiebel_eltron", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/subaru/test_diagnostics.py
+++ b/tests/components/subaru/test_diagnostics.py
@@ -53,8 +53,8 @@ async def test_device_diagnostics(
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_VIN_2_EV)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_VIN_2_EV), config_entry.entry_id
     )
     assert reg_device is not None
 
@@ -79,8 +79,8 @@ async def test_device_diagnostics_vehicle_not_found(
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_VIN_2_EV)},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_VIN_2_EV), config_entry.entry_id
     )
     assert reg_device is not None
 

--- a/tests/components/sunricher_dali/test_init.py
+++ b/tests/components/sunricher_dali/test_init.py
@@ -160,8 +160,8 @@ async def test_remove_stale_devices(
     )
     assert len(devices_after) < initial_count
 
-    gateway_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_gateway.gw_sn)}
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_gateway.gw_sn), mock_config_entry.entry_id
     )
     assert gateway_device is not None
     assert mock_config_entry.entry_id in gateway_device.config_entries

--- a/tests/components/sunricher_dali/test_scene.py
+++ b/tests/components/sunricher_dali/test_scene.py
@@ -37,8 +37,8 @@ async def test_entities(
     """Test the scene entities and their attributes."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("sunricher_dali", "6A242121110E")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("sunricher_dali", "6A242121110E"), mock_config_entry.entry_id
     )
     assert device_entry
 

--- a/tests/components/switchbot_cloud/test_entity.py
+++ b/tests/components/switchbot_cloud/test_entity.py
@@ -22,10 +22,10 @@ async def test_sw_version_cast_to_string(
     mock_get_status.return_value = {"version": 123}
 
     with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.SENSOR]):
-        await configure_integration(hass)
+        entry = await configure_integration(hass)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, METER_INFO.device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, METER_INFO.device_id), entry.entry_id
     )
     assert device is not None
     assert device.sw_version == "123"
@@ -43,10 +43,10 @@ async def test_sw_version_none_when_missing(
     mock_get_status.return_value = {}
 
     with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.SENSOR]):
-        await configure_integration(hass)
+        entry = await configure_integration(hass)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, METER_INFO.device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, METER_INFO.device_id), entry.entry_id
     )
     assert device is not None
     assert device.sw_version is None

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -211,23 +211,32 @@ async def test_remove_device(
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 3
 
     # Try to remove a live device - fails
-    device = device_registry.async_get_device(identifiers={(DOMAIN, live_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, live_device_id), entry_id
+    )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device.id, entry_id)
     assert not response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 3
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, live_device_id)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, live_device_id), entry_id
+        )
         is not None
     )
 
     # Try to remove a dead device - succeeds
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dead_device_id), entry_id
+    )
     response = await client.remove_device(device.id, entry_id)
     assert response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, dead_device_id)}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, dead_device_id), entry_id
+        )
+        is None
     )
 
 
@@ -266,21 +275,30 @@ async def test_remove_device_token_needed(
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
 
     # Try to remove a live device - fails
-    device = device_registry.async_get_device(identifiers={(DOMAIN, live_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, live_device_id), entry_id
+    )
     client = await hass_ws_client(hass)
     response = await client.remove_device(device.id, entry_id)
     assert not response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, live_device_id)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, live_device_id), entry_id
+        )
         is not None
     )
 
     # Try to remove a dead device - succeeds
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, dead_device_id), entry_id
+    )
     response = await client.remove_device(device.id, entry_id)
     assert response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, dead_device_id)}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, dead_device_id), entry_id
+        )
+        is None
     )

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -400,7 +400,9 @@ async def test_hub_device_info_mac_connections(
 ) -> None:
     """Test that the hub DeviceInfo includes MAC address connections."""
     dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), setup_dsm_with_usb.mock_entry.entry_id
+    )
     assert device is not None
     assert device.connections == {
         ("mac", "00:11:32:xx:xx:59"),

--- a/tests/components/system_bridge/test_services.py
+++ b/tests/components/system_bridge/test_services.py
@@ -86,8 +86,8 @@ async def test_services(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, FIXTURE_UUID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, FIXTURE_UUID), mock_config_entry.entry_id
     )
     assert device_entry
 
@@ -136,8 +136,8 @@ async def test_get_process_services(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, FIXTURE_UUID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, FIXTURE_UUID), mock_config_entry.entry_id
     )
     assert device_entry
 

--- a/tests/components/tedee/test_init.py
+++ b/tests/components/tedee/test_init.py
@@ -137,7 +137,9 @@ async def test_lock_device(
     """Ensure the lock device is registered."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device({(mock_config_entry.domain, "12345")})
+    device = device_registry.async_get_device_by_identifier(
+        (mock_config_entry.domain, "12345"), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot
 
@@ -152,8 +154,9 @@ async def test_bridge_device(
     """Ensure the bridge device is registered."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        {(mock_config_entry.domain, mock_tedee.get_local_bridge.return_value.serial)}
+    device = device_registry.async_get_device_by_identifier(
+        (mock_config_entry.domain, mock_tedee.get_local_bridge.return_value.serial),
+        mock_config_entry.entry_id,
     )
     assert device
     assert device == snapshot

--- a/tests/components/telegram_bot/test_init.py
+++ b/tests/components/telegram_bot/test_init.py
@@ -158,8 +158,8 @@ async def test_migrate_entry_to_per_chat_devices(
     # even a chat whose notify entity was deleted before the migration ran. A surviving
     # notify entity is moved onto its chat's device.
     for subentry_id, chat_id in zip(subentry_ids, chat_ids, strict=True):
-        chat_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{bot_id}_{chat_id}")}
+        chat_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{bot_id}_{chat_id}"), config_entry.entry_id
         )
         assert chat_device is not None
         assert chat_device.config_subentry_id == subentry_id
@@ -190,13 +190,15 @@ async def test_per_chat_devices(
     await hass.async_block_till_done()
 
     # The bot device belongs to the config entry (no subentry) and holds the event entity
-    bot_device = device_registry.async_get_device(identifiers={(DOMAIN, "123456")})
+    bot_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456"), mock_broadcast_config_entry.entry_id
+    )
     assert bot_device is not None
     assert bot_device.config_subentry_id is None
 
     for chat_id in (123456, 654321):
-        chat_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, f"123456_{chat_id}")}
+        chat_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"123456_{chat_id}"), mock_broadcast_config_entry.entry_id
         )
         assert chat_device is not None
         assert chat_device.config_subentry_id is not None
@@ -225,7 +227,9 @@ async def test_remove_chat_subentry_removes_per_chat_device(
         for sid, subentry in mock_broadcast_config_entry.subentries.items()
         if subentry.data[CONF_CHAT_ID] == 123456
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456_123456")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456_123456"), mock_broadcast_config_entry.entry_id
+    )
     assert entity_registry.async_get_entity_id("notify", DOMAIN, "123456_123456")
 
     hass.config_entries.async_remove_subentry(mock_broadcast_config_entry, subentry_id)
@@ -233,7 +237,13 @@ async def test_remove_chat_subentry_removes_per_chat_device(
 
     # The removed chat's device and notify entity are gone; the other chat and the bot
     # device remain
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "123456_123456")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456_123456"), mock_broadcast_config_entry.entry_id
+    )
     assert not entity_registry.async_get_entity_id("notify", DOMAIN, "123456_123456")
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456_654321")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456_654321"), mock_broadcast_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456"), mock_broadcast_config_entry.entry_id
+    )

--- a/tests/components/teltonika/test_init.py
+++ b/tests/components/teltonika/test_init.py
@@ -65,9 +65,12 @@ async def test_setup_errors(
 @pytest.mark.usefixtures("init_integration")
 async def test_device_registry_creation(
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device registry creation."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "1234567890")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890"), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device == snapshot

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -246,8 +246,8 @@ async def test_vehicle_device_model_from_library(
     ):
         await setup_platform(hass, normal_config_entry)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "LRWXF7EK4KC700000")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "LRWXF7EK4KC700000"), normal_config_entry.entry_id
     )
     assert device is not None
     assert device.model == "Cybercab"

--- a/tests/components/tesla_wall_connector/test_init.py
+++ b/tests/components/tesla_wall_connector/test_init.py
@@ -32,7 +32,9 @@ async def test_init_success(
     )
 
     assert entry.state is ConfigEntryState.LOADED
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "abc123")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "abc123"), entry.entry_id
+    )
     assert device
     assert device.manufacturer == WALLCONNECTOR_DEVICE_MANUFACTURER
     assert device.model == WALLCONNECTOR_DEVICE_MODEL

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -305,8 +305,8 @@ async def test_stale_device_removal(
 
         # Verify the device itself has been completely removed from the registry
         # since it had no other config entries
-        updated_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, "stale-vin")}
+        updated_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "stale-vin"), entry.entry_id
         )
         assert updated_device is None
 
@@ -338,7 +338,9 @@ async def test_skipped_energy_site_is_removed_as_stale_device(
         await hass.config_entries.async_reload(entry.entry_id)
         await hass.async_block_till_done()
 
-    updated_device = device_registry.async_get_device(identifiers={(DOMAIN, "98765")})
+    updated_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "98765"), entry.entry_id
+    )
     assert updated_device is None
 
 
@@ -762,7 +764,9 @@ async def test_vehicle_streaming_version_update(
 
     # Check initial device sw_version
     vin = "LRW3F7EK4NC700000"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "2026.0.0"
 
@@ -772,7 +776,9 @@ async def test_vehicle_streaming_version_update(
     await hass.async_block_till_done()
 
     # Check device sw_version was updated (build hash removed)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "2026.1.0"
 
@@ -796,7 +802,9 @@ async def test_vehicle_streaming_version_update_ignores_none(
         assert entry.state is ConfigEntryState.LOADED
 
     vin = "LRW3F7EK4NC700000"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     original_version = device.sw_version
 
@@ -806,7 +814,9 @@ async def test_vehicle_streaming_version_update_ignores_none(
     await hass.async_block_till_done()
 
     # Check device sw_version was not changed
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == original_version
 
@@ -823,7 +833,9 @@ async def test_vehicle_polling_version_update(
     assert entry.state is ConfigEntryState.LOADED
 
     vin = "LRW3F7EK4NC700000"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "2026.0.0"
 
@@ -838,7 +850,9 @@ async def test_vehicle_polling_version_update(
     await hass.async_block_till_done()
 
     # Check device sw_version was updated (build hash removed)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, vin)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, vin), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "2026.2.0"
 
@@ -854,7 +868,9 @@ async def test_energy_site_version_update(
     assert entry.state is ConfigEntryState.LOADED
 
     site_id = "123456"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, site_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, site_id), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "23.44.0 eb113390"
 
@@ -869,7 +885,9 @@ async def test_energy_site_version_update(
     await hass.async_block_till_done()
 
     # Check device sw_version was updated
-    device = device_registry.async_get_device(identifiers={(DOMAIN, site_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, site_id), entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "24.1.0 abc123"
 

--- a/tests/components/thethingsnetwork/test_sensor.py
+++ b/tests/components/thethingsnetwork/test_sensor.py
@@ -28,8 +28,8 @@ async def test_sensor(
 
     # Check devices
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{APP_ID}_{DEVICE_ID}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{APP_ID}_{DEVICE_ID}"), mock_config_entry.entry_id
         ).name
         == DEVICE_ID
     )

--- a/tests/components/tile/test_init.py
+++ b/tests/components/tile/test_init.py
@@ -22,8 +22,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "19264d2dffdbca32")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "19264d2dffdbca32"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/togrill/test_init.py
+++ b/tests/components/togrill/test_init.py
@@ -30,8 +30,8 @@ async def test_setup_device_present(
     await setup_entry(hass, mock_entry, [])
     assert mock_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, TOGRILL_SERVICE_INFO.address)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, TOGRILL_SERVICE_INFO.address), mock_entry.entry_id
     )
     assert device == snapshot
 

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -78,8 +78,12 @@ async def test_zones_with_same_id_across_modules_get_distinct_devices(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_a = device_registry.async_get_device(identifiers={(DOMAIN, "module-aaa-1")})
-    device_b = device_registry.async_get_device(identifiers={(DOMAIN, "module-bbb-1")})
+    device_a = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "module-aaa-1"), mock_config_entry.entry_id
+    )
+    device_b = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "module-bbb-1"), mock_config_entry.entry_id
+    )
 
     assert device_a is not None
     assert device_b is not None
@@ -117,9 +121,16 @@ async def test_migrate_device_identifiers(
     await hass.async_block_till_done()
 
     # Old identifier should no longer exist.
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "1")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "1"), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     # New identifier should exist and point to the same device entry.
-    migrated = device_registry.async_get_device(identifiers={(DOMAIN, "deadbeef-1")})
+    migrated = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deadbeef-1"), mock_config_entry.entry_id
+    )
     assert migrated is not None
     assert migrated.id == old_device.id

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -927,14 +927,14 @@ async def test_automatic_feature_device_addition_and_removal(
         assert state
         assert entity_registry.async_get(entity_id)
 
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "hub_parent")}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "hub_parent"), mock_config_entry.entry_id
     )
     assert parent_device
 
     for device_id in ("child1", "child2"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id
@@ -949,7 +949,12 @@ async def test_automatic_feature_device_addition_and_removal(
     assert state is None
     assert entity_registry.async_get(entity_id) is None
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "child2")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "child2"), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     # Re-dd the previously removed child device
     mock_device.children = [
@@ -966,8 +971,8 @@ async def test_automatic_feature_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child2"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id
@@ -984,7 +989,9 @@ async def test_automatic_feature_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child3", "child4"):
-        assert device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
+        )
 
     # Add the previously removed child device
     mock_device.children = [
@@ -1003,8 +1010,8 @@ async def test_automatic_feature_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child2", "child3", "child4"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id
@@ -1091,14 +1098,14 @@ async def test_automatic_module_device_addition_and_removal(
         assert state
         assert entity_registry.async_get(entity_id)
 
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "hub_parent")}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "hub_parent"), mock_camera_config_entry.entry_id
     )
     assert parent_device
 
     for device_id in ("child1", "child2"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_camera_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id
@@ -1114,7 +1121,12 @@ async def test_automatic_module_device_addition_and_removal(
     assert state is None
     assert entity_registry.async_get(entity_id) is None
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "child2")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "child2"), mock_camera_config_entry.entry_id
+        )
+        is None
+    )
 
     # Re-dd the previously removed child device
     mock_device.children = [
@@ -1132,8 +1144,8 @@ async def test_automatic_module_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child2"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_camera_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id
@@ -1151,7 +1163,9 @@ async def test_automatic_module_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child3", "child4"):
-        assert device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_camera_config_entry.entry_id
+        )
 
     # Add the previously removed child device
     mock_device.children = [
@@ -1171,8 +1185,8 @@ async def test_automatic_module_device_addition_and_removal(
         assert entity_registry.async_get(entity_id)
 
     for device_id in ("child1", "child2", "child3", "child4"):
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_camera_config_entry.entry_id
         )
         assert device_entry
         assert device_entry.via_device_id == parent_device.id

--- a/tests/components/tractive/test_binary_sensor.py
+++ b/tests/components/tractive/test_binary_sensor.py
@@ -41,8 +41,8 @@ async def test_binary_sensor_device_assignment(
     with patch("homeassistant.components.tractive.PLATFORMS", [Platform.BINARY_SENSOR]):
         await init_integration(hass, mock_config_entry)
 
-    tracker_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "device_id_123")}
+    tracker_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "device_id_123"), mock_config_entry.entry_id
     )
     assert tracker_device is not None
 

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -107,8 +107,8 @@ async def test_device_tracker_device_assignment(
     ):
         await init_integration(hass, mock_config_entry)
 
-    tracker_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "device_id_123")}
+    tracker_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "device_id_123"), mock_config_entry.entry_id
     )
     assert tracker_device is not None
 

--- a/tests/components/tractive/test_sensor.py
+++ b/tests/components/tractive/test_sensor.py
@@ -42,12 +42,14 @@ async def test_sensor_device_assignment(
     with patch("homeassistant.components.tractive.PLATFORMS", [Platform.SENSOR]):
         await init_integration(hass, mock_config_entry)
 
-    tracker_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "device_id_123")}
+    tracker_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "device_id_123"), mock_config_entry.entry_id
     )
     assert tracker_device is not None
 
-    pet_device = device_registry.async_get_device(identifiers={(DOMAIN, "pet_id_123")})
+    pet_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "pet_id_123"), mock_config_entry.entry_id
+    )
     assert pet_device is not None
     assert pet_device.via_device_id == tracker_device.id
 

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -289,8 +289,8 @@ async def test_switch_device_assignment(
     with patch("homeassistant.components.tractive.PLATFORMS", [Platform.SWITCH]):
         await init_integration(hass, mock_config_entry)
 
-    tracker_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "device_id_123")}
+    tracker_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "device_id_123"), mock_config_entry.entry_id
     )
     assert tracker_device is not None
 

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -176,15 +176,15 @@ async def test_migrate_config_entry_and_identifiers(
 
     # Bulb 1 kept the same device entry, its identifier migrated to the unique
     # format, and it is still owned only by gateway 1's config entry.
-    migrated_bulb1 = device_registry.async_get_device(
-        identifiers={(tradfri.DOMAIN, f"{GATEWAY_ID1}-65537")}
+    migrated_bulb1 = device_registry.async_get_device_by_identifier(
+        (tradfri.DOMAIN, f"{GATEWAY_ID1}-65537"), config_entry1.entry_id
     )
     assert migrated_bulb1.id == gateway1_bulb1.id
     assert migrated_bulb1.config_entry_id == config_entry1.entry_id
 
     # The gateway device is unchanged.
-    migrated_gateway1 = device_registry.async_get_device(
-        identifiers={(tradfri.DOMAIN, GATEWAY_ID1)}
+    migrated_gateway1 = device_registry.async_get_device_by_identifier(
+        (tradfri.DOMAIN, GATEWAY_ID1), config_entry1.entry_id
     )
     assert migrated_gateway1.id == gateway1_device.id
     assert migrated_gateway1.identifiers == gateway1_device.identifiers
@@ -192,8 +192,8 @@ async def test_migrate_config_entry_and_identifiers(
 
     # Bulb 2 is stale and has been removed, not moved to another config entry.
     assert (
-        device_registry.async_get_device(
-            identifiers={(tradfri.DOMAIN, f"{GATEWAY_ID1}-65538")}
+        device_registry.async_get_device_by_identifier(
+            (tradfri.DOMAIN, f"{GATEWAY_ID1}-65538"), config_entry1.entry_id
         )
         is None
     )
@@ -205,8 +205,8 @@ async def test_migrate_config_entry_and_identifiers(
         device_registry, config_entry2.entry_id
     )
     assert len(device_entries) == 2
-    gateway2_bulb = device_registry.async_get_device(
-        identifiers={(tradfri.DOMAIN, f"{GATEWAY_ID2}-65537")}
+    gateway2_bulb = device_registry.async_get_device_by_identifier(
+        (tradfri.DOMAIN, f"{GATEWAY_ID2}-65537"), config_entry2.entry_id
     )
     assert gateway2_bulb.config_entry_id == config_entry2.entry_id
 

--- a/tests/components/trmnl/test_init.py
+++ b/tests/components/trmnl/test_init.py
@@ -44,8 +44,8 @@ async def test_device(
     """Test the TRMNL device."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        connections={(CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC")}
+    device = device_registry.async_get_device_by_connection(
+        (CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC"), mock_config_entry.entry_id
     )
     assert device
     assert device == snapshot
@@ -61,8 +61,8 @@ async def test_stale_device_removed(
     """Test that a device is removed from the device registry when it disappears."""
     await setup_integration(hass, mock_config_entry)
 
-    assert device_registry.async_get_device(
-        connections={(CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC")}
+    assert device_registry.async_get_device_by_connection(
+        (CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC"), mock_config_entry.entry_id
     )
 
     mock_trmnl_client.get_devices.return_value = []
@@ -70,8 +70,8 @@ async def test_stale_device_removed(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert not device_registry.async_get_device(
-        connections={(CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC")}
+    assert not device_registry.async_get_device_by_connection(
+        (CONNECTION_NETWORK_MAC, "B0:A6:04:AA:BB:CC"), mock_config_entry.entry_id
     )
 
 

--- a/tests/components/tuya/test_diagnostics.py
+++ b/tests/components/tuya/test_diagnostics.py
@@ -66,7 +66,9 @@ async def test_device_diagnostics(
     """Test device diagnostics."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, mock_device.id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), mock_config_entry.entry_id
+    )
     assert device, repr(device_registry.devices)
 
     result = await get_diagnostics_for_device(

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -338,7 +338,9 @@ async def test_dynamic_remove_device(
     )
     assert len(all_entries) == 1
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, main_device.id)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, main_device.id), mock_config_entry.entry_id
+        )
         in all_entries
     )
 

--- a/tests/components/tuya/test_services.py
+++ b/tests/components/tuya/test_services.py
@@ -58,8 +58,8 @@ async def test_get_feeder_meal_plan(
 ) -> None:
     """Test GET_FEEDER_MEAL_PLAN with valid meal plan data."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_device.id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     device_id = device_entry.id
@@ -84,8 +84,8 @@ async def test_get_feeder_meal_plan_invalid_meal_plan(
 ) -> None:
     """Test GET_FEEDER_MEAL_PLAN error when meal plan data is missing."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_device.id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     device_id = device_entry.id
@@ -114,8 +114,8 @@ async def test_set_feeder_meal_plan(
 ) -> None:
     """Test SET_FEEDER_MEAL_PLAN with valid device and meal plan data."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_device.id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     device_id = device_entry.id
@@ -145,8 +145,8 @@ async def test_set_feeder_meal_plan_unsupported_device(
 ) -> None:
     """Test SET_FEEDER_MEAL_PLAN error when device is unsupported."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_device.id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     device_id = device_entry.id

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -80,7 +80,7 @@ async def test_mac_migration(
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert entity_registry.async_get(entity_entry.entity_id).unique_id == TEST_MAC
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry.unique_id)}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry.unique_id), config_entry.entry_id
     ).identifiers == {(DOMAIN, TEST_MAC)}
     assert config_entry.unique_id == TEST_MAC

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -316,7 +316,9 @@ async def test_update_name(
 
     await setup_integration(hass, mock_config_entry)
 
-    dev_entry = device_registry.async_get_device({(DOMAIN, TEST_MAC)})
+    dev_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC), mock_config_entry.entry_id
+    )
 
     assert dev_entry.name == "Tree 1"
 
@@ -326,6 +328,8 @@ async def test_update_name(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    dev_entry = device_registry.async_get_device({(DOMAIN, TEST_MAC)})
+    dev_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC), mock_config_entry.entry_id
+    )
 
     assert dev_entry.name == "new_device_name"

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -739,24 +739,24 @@ async def test_pruning_stale_restored_clients(
     # Recently seen client is restored with its tracker and device intact
     assert hass.states.get("device_tracker.recent")
     assert entity_registry.async_get(entries[recent["mac"]].entity_id)
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, recent["mac"])}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, recent["mac"]), config_entry.entry_id
     )
 
     # Stale client is pruned together with its device
     assert not hass.states.get("device_tracker.stale")
     assert entity_registry.async_get(entries[stale["mac"]].entity_id) is None
     assert (
-        device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, stale["mac"])}
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, stale["mac"]), config_entry.entry_id
         )
         is None
     )
 
     # Client absent from clients_all is left untouched, never pruned on missing data
     assert entity_registry.async_get(entries[absent_mac].entity_id)
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, absent_mac)}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, absent_mac), config_entry.entry_id
     )
 
 

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -179,23 +179,23 @@ async def test_remove_config_entry_device(
     ws_client = await hass_ws_client(hass)
 
     # Try to remove an active client from UI: allowed
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"])}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"]), config_entry.entry_id
     )
     response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert response["success"]
-    assert not device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"])}
+    assert not device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"]), config_entry.entry_id
     )
 
     # Try to remove an active device from UI: not allowed
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device_payload[0]["mac"])}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device_payload[0]["mac"]), config_entry.entry_id
     )
     response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert not response["success"]
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device_payload[0]["mac"])}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device_payload[0]["mac"]), config_entry.entry_id
     )
 
     # Remove a client from Unifi API
@@ -203,11 +203,11 @@ async def test_remove_config_entry_device(
     await hass.async_block_till_done()
 
     # Try to remove an inactive client from UI: allowed
-    device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, client_payload[1]["mac"])}
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, client_payload[1]["mac"]), config_entry.entry_id
     )
     response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert response["success"]
-    assert not device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, client_payload[1]["mac"])}
+    assert not device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, client_payload[1]["mac"]), config_entry.entry_id
     )

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -671,18 +671,19 @@ async def test_ignore_local_mac_client_sensors(
     ],
 )
 @pytest.mark.parametrize("client_payload", [[WIRED_CLIENT]])
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_wired_client_speed_sensor_not_created_when_untracked(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
     client_payload: list[dict[str, Any]],
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Verify untracked wired clients create neither a link speed sensor nor a device."""
     assert entity_registry.async_get("sensor.wired_client_link_speed") is None
     assert (
-        device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"])}
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"]),
+            config_entry_setup.entry_id,
         )
         is None
     )

--- a/tests/components/unifi_access/test_init.py
+++ b/tests/components/unifi_access/test_init.py
@@ -447,8 +447,12 @@ async def test_stale_device_removed_on_refresh(
 ) -> None:
     """Test that stale devices are automatically removed on data refresh."""
     # Verify both doors exist after initial setup
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-001")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-002")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-001"), init_integration.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-002"), init_integration.entry_id
+    )
 
     # Simulate door-002 being removed from the hub
     mock_client.get_doors.return_value = [
@@ -464,8 +468,12 @@ async def test_stale_device_removed_on_refresh(
     await hass.async_block_till_done()
 
     # door-001 still exists, door-002 was removed
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-001")})
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "door-002")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-001"), init_integration.entry_id
+    )
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-002"), init_integration.entry_id
+    )
 
 
 async def test_stale_device_removed_on_startup(
@@ -482,12 +490,20 @@ async def test_stale_device_removed_on_startup(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={(DOMAIN, "door-003")},
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-003")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-003"), mock_config_entry.entry_id
+    )
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     # Valid doors from the hub should exist, stale device should be removed
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-001")})
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "door-002")})
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "door-003")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-001"), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-002"), mock_config_entry.entry_id
+    )
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "door-003"), mock_config_entry.entry_id
+    )

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -439,8 +439,8 @@ async def test_public_only_camera(
     # device identity degrades to name-only; the NVR link is omitted (resolving
     # the NVR identity publicly is wired with the config-mode setup)
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, public.mac)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, public.mac), ufp.entry.entry_id
     )
     assert device is not None
     assert device.via_device_id is None

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -61,8 +61,8 @@ async def test_setup_creates_nvr_device(
 
     # Verify NVR device was created
     nvr = ufp.api.bootstrap.nvr
-    nvr_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, nvr.mac)},
+    nvr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, nvr.mac), ufp.entry.entry_id
     )
     assert nvr_device == snapshot
 

--- a/tests/components/unifiprotect/test_migrate.py
+++ b/tests/components/unifiprotect/test_migrate.py
@@ -250,7 +250,9 @@ async def test_migrate_remove_aiport_device(
 
     assert entity_registry.async_get(entity.entity_id) is None
     assert (
-        device_registry.async_get_device(connections={(dr.CONNECTION_NETWORK_MAC, mac)})
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, mac), ufp.entry.entry_id
+        )
         is None
     )
 

--- a/tests/components/uptime_kuma/test_init.py
+++ b/tests/components/uptime_kuma/test_init.py
@@ -104,8 +104,8 @@ async def test_remove_stale_device(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "123456789_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456789_1"), config_entry.entry_id
     )
 
     config_entry.runtime_data.data.pop(1)
@@ -113,7 +113,10 @@ async def test_remove_stale_device(
 
     assert response["success"]
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "123456789_1")}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "123456789_1"), config_entry.entry_id
+        )
+        is None
     )
 
 
@@ -134,14 +137,16 @@ async def test_remove_current_device(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "123456789_1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456789_1"), config_entry.entry_id
     )
 
     response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
 
     assert response["success"] is False
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456789_1")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456789_1"), config_entry.entry_id
+    )
 
 
 @pytest.mark.usefixtures("mock_pythonkuma")
@@ -161,9 +166,13 @@ async def test_remove_entry_device(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "123456789")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456789"), config_entry.entry_id
+    )
 
     response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
 
     assert response["success"] is False
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456789")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456789"), config_entry.entry_id
+    )

--- a/tests/components/uptime_kuma/test_sensor.py
+++ b/tests/components/uptime_kuma/test_sensor.py
@@ -101,8 +101,8 @@ async def test_migrate_unique_id(
     assert entity.unique_id == "123456789_1_status"
 
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{entity.config_entry_id}_1")}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{entity.config_entry_id}_1"), config_entry.entry_id
         )
     )
     assert device.sw_version == "2.0.2"

--- a/tests/components/vesync/test_diagnostics.py
+++ b/tests/components/vesync/test_diagnostics.py
@@ -72,8 +72,8 @@ async def test_async_get_device_diagnostics__single_fan(
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "fan")},
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "fan"), config_entry.entry_id
     )
     assert device is not None
 

--- a/tests/components/victron_gx/test_binary_sensor.py
+++ b/tests/components/victron_gx/test_binary_sensor.py
@@ -50,8 +50,8 @@ async def test_victron_binary_sensor(
     assert state.state == "on"
 
     # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_device_tracker.py
+++ b/tests/components/victron_gx/test_device_tracker.py
@@ -65,8 +65,8 @@ async def test_victron_device_tracker(
         "tracking_type": TrackingType.POSITION,
     }
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_gps_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_gps_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_number.py
+++ b/tests/components/victron_gx/test_number.py
@@ -53,8 +53,8 @@ async def test_victron_number_with_step(
     assert state.attributes["min"] == 0.0
     assert state.attributes["max"] == 100.0
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_select.py
+++ b/tests/components/victron_gx/test_select.py
@@ -44,8 +44,8 @@ async def test_victron_select(
     assert state.attributes["options"] == ["manual", "auto", "scheduled_charge"]
 
     # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -33,8 +33,8 @@ async def test_victron_battery_sensor(
     await hass.async_block_till_done()
 
     # Verify system device has no via_device (it IS the gateway)
-    system_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0"), mock_config_entry.entry_id
     )
     assert system_device is not None
     assert system_device.via_device_id is None
@@ -69,8 +69,8 @@ async def test_victron_battery_sensor(
     assert state.attributes["unit_of_measurement"] == "A"
 
     # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_battery_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_battery_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"
@@ -114,8 +114,8 @@ async def test_victron_enum_sensor(
     assert state.state == "low_power"
 
     # Verify system device has no via_device (it IS the gateway)
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0"), _mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_switch.py
+++ b/tests/components/victron_gx/test_switch.py
@@ -48,8 +48,8 @@ async def test_victron_switch(
     assert state.state == BINARY_SENSOR_ON_ID
 
     # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_evcharger_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/victron_gx/test_time.py
+++ b/tests/components/victron_gx/test_time.py
@@ -53,8 +53,8 @@ async def test_victron_time(
     assert state.state == "00:08:00"
 
     # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.manufacturer == "Victron Energy"

--- a/tests/components/vistapool/test_init.py
+++ b/tests/components/vistapool/test_init.py
@@ -151,7 +151,9 @@ async def test_user_pools_snapshot_adds_new_pool(
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.spa_temperature") is not None
-    assert device_registry.async_get_device(identifiers={(DOMAIN, _SECOND_POOL_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, _SECOND_POOL_ID), mock_config_entry.entry_id
+    )
 
 
 async def test_user_pools_snapshot_retries_new_pool_after_refresh_failure(
@@ -224,7 +226,9 @@ async def test_user_pools_snapshot_removes_stale_pool(
 
     assert hass.states.get("sensor.spa_temperature") is None
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, _SECOND_POOL_ID)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, _SECOND_POOL_ID), mock_config_entry.entry_id
+        )
         is None
     )
 
@@ -253,7 +257,10 @@ async def test_user_pools_snapshot_drops_stale_even_if_get_pools_fails(
     # New pool skipped (no name available), stale pool removed regardless.
     assert hass.states.get("sensor.spa_temperature") is None
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, _THIRD_POOL_ID)}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, _THIRD_POOL_ID), mock_config_entry.entry_id
+        )
+        is None
     )
 
 
@@ -274,9 +281,13 @@ async def test_setup_prunes_devices_removed_while_offline(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, MOCK_POOL_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_POOL_ID), mock_config_entry.entry_id
+    )
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, _SECOND_POOL_ID)})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, _SECOND_POOL_ID), mock_config_entry.entry_id
+        )
         is None
     )
 

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -147,7 +147,9 @@ async def test_device_registry_model_and_version(
     """Test that coordinator populates device registry with model and version."""
     await setup_integration(hass, mock_tv_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, UNIQUE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, UNIQUE_ID), mock_tv_config_entry.entry_id
+    )
     assert device is not None
     assert device.model == MODEL
     assert device.sw_version == VERSION
@@ -163,7 +165,9 @@ async def test_device_registry_without_model_or_version(
     """Test device registry when model and version are unavailable."""
     await setup_integration(hass, mock_tv_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, UNIQUE_ID)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, UNIQUE_ID), mock_tv_config_entry.entry_id
+    )
     assert device is not None
     assert device.model is None
     assert device.sw_version is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
