### PR TITLE
Store Schlage coordinator data as a plain dict

### DIFF
--- a/homeassistant/components/schlage/binary_sensor.py
+++ b/homeassistant/components/schlage/binary_sensor.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
             for description in _DESCRIPTIONS
         )
 
-    _add_new_locks(coordinator.data.locks)
+    _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
 
 

--- a/homeassistant/components/schlage/coordinator.py
+++ b/homeassistant/components/schlage/coordinator.py
@@ -26,17 +26,10 @@ class LockData:
     logs: list[LockLog]
 
 
-@dataclass
-class SchlageData:
-    """Container for cached data from the Schlage API."""
-
-    locks: dict[str, LockData]
-
-
 type SchlageConfigEntry = ConfigEntry[SchlageDataUpdateCoordinator]
 
 
-class SchlageDataUpdateCoordinator(DataUpdateCoordinator[SchlageData]):
+class SchlageDataUpdateCoordinator(DataUpdateCoordinator[dict[str, LockData]]):
     """The Schlage data update coordinator."""
 
     config_entry: SchlageConfigEntry
@@ -56,13 +49,13 @@ class SchlageDataUpdateCoordinator(DataUpdateCoordinator[SchlageData]):
             name=f"{DOMAIN} ({username})",
             update_interval=UPDATE_INTERVAL,
         )
-        self.data = SchlageData(locks={})
+        self.data = {}
         self.api = api
         self.new_locks_callbacks: list[Callable[[dict[str, LockData]], None]] = []
         self.async_add_listener(self._add_remove_locks)
 
     @override
-    async def _async_update_data(self) -> SchlageData:
+    async def _async_update_data(self) -> dict[str, LockData]:
         """Fetch the latest data from the Schlage API."""
         try:
             locks = await self.hass.async_add_executor_job(self.api.locks)
@@ -78,12 +71,12 @@ class SchlageDataUpdateCoordinator(DataUpdateCoordinator[SchlageData]):
                 for lock in locks
             )
         )
-        return SchlageData(locks={ld.lock.device_id: ld for ld in lock_data})
+        return {ld.lock.device_id: ld for ld in lock_data}
 
     def _get_lock_data(self, lock: Lock) -> LockData:
         logs: list[LockLog] = []
         previous_lock_data = None
-        if self.data and (previous_lock_data := self.data.locks.get(lock.device_id)):
+        if self.data and (previous_lock_data := self.data.get(lock.device_id)):
             # Default to the previous data, in case a refresh fails.
             # It's not critical if we don't have the freshest data.
             logs = previous_lock_data.logs
@@ -111,7 +104,7 @@ class SchlageDataUpdateCoordinator(DataUpdateCoordinator[SchlageData]):
                     previous_locks.add(identifier)
                     previous_locks_by_lock_id[identifier] = device
                     continue
-        current_locks = set(self.data.locks.keys())
+        current_locks = set(self.data.keys())
 
         if removed_locks := previous_locks - current_locks:
             LOGGER.debug("Removed locks: %s", ", ".join(removed_locks))
@@ -122,6 +115,6 @@ class SchlageDataUpdateCoordinator(DataUpdateCoordinator[SchlageData]):
 
         if new_lock_ids := current_locks - previous_locks:
             LOGGER.debug("New locks found: %s", ", ".join(new_lock_ids))
-            new_locks = {lock_id: self.data.locks[lock_id] for lock_id in new_lock_ids}
+            new_locks = {lock_id: self.data[lock_id] for lock_id in new_lock_ids}
             for new_lock_callback in self.new_locks_callbacks:
                 new_lock_callback(new_locks)

--- a/homeassistant/components/schlage/diagnostics.py
+++ b/homeassistant/components/schlage/diagnostics.py
@@ -14,6 +14,4 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator = config_entry.runtime_data
     # NOTE: Schlage diagnostics are already redacted.
-    return {
-        "locks": [ld.lock.get_diagnostics() for ld in coordinator.data.locks.values()]
-    }
+    return {"locks": [ld.lock.get_diagnostics() for ld in coordinator.data.values()]}

--- a/homeassistant/components/schlage/entity.py
+++ b/homeassistant/components/schlage/entity.py
@@ -34,7 +34,7 @@ class SchlageEntity(CoordinatorEntity[SchlageDataUpdateCoordinator]):
     @property
     def _lock_data(self) -> LockData:
         """Fetch the LockData from our coordinator."""
-        return self.coordinator.data.locks[self.device_id]
+        return self.coordinator.data[self.device_id]
 
     @property
     def _lock(self) -> Lock:
@@ -47,6 +47,6 @@ class SchlageEntity(CoordinatorEntity[SchlageDataUpdateCoordinator]):
         """Return if entity is available."""
         return (
             super().available
-            and self.device_id in self.coordinator.data.locks
+            and self.device_id in self.coordinator.data
             and self._lock.connected
         )

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
             for device_id in locks
         )
 
-    _add_new_locks(coordinator.data.locks)
+    _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
 
 
@@ -49,7 +49,7 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
     @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.device_id in self.coordinator.data.locks:
+        if self.device_id in self.coordinator.data:
             self._update_attrs()
         super()._handle_coordinator_update()
 

--- a/homeassistant/components/schlage/select.py
+++ b/homeassistant/components/schlage/select.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
             for description in _DESCRIPTIONS
         )
 
-    _add_new_locks(coordinator.data.locks)
+    _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
 
 

--- a/homeassistant/components/schlage/sensor.py
+++ b/homeassistant/components/schlage/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
             for device_id in locks
         )
 
-    _add_new_locks(coordinator.data.locks)
+    _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
 
 
@@ -68,6 +68,6 @@ class SchlageBatterySensor(SchlageEntity, SensorEntity):
     @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.device_id in self.coordinator.data.locks:
+        if self.device_id in self.coordinator.data:
             self._attr_native_value = getattr(self._lock, self.entity_description.key)
         super()._handle_coordinator_update()

--- a/homeassistant/components/schlage/switch.py
+++ b/homeassistant/components/schlage/switch.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
             for description in SWITCHES
         )
 
-    _add_new_locks(coordinator.data.locks)
+    _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Drops the `SchlageData` wrapper in favour of `dict[str, LockData]`.

`SchlageData` only ever held a single `locks` field, so every read of coordinator data went through an extra attribute for no benefit. The coordinator now stores the dict directly.

Follow-up to a review comment on https://github.com/home-assistant/core/pull/131735. No behaviour change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
