### PR TITLE
Pass config entry explicitly in Supla coordinator

### DIFF
--- a/homeassistant/components/supla/coordinator.py
+++ b/homeassistant/components/supla/coordinator.py
@@ -28,6 +28,7 @@ class SuplaCoordinator(DataUpdateCoordinator[dict[int, dict]]):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=None,
             name=f"supla-{server_name}",
             update_interval=SCAN_INTERVAL,
         )


### PR DESCRIPTION
## Proposed change

`SuplaCoordinator.__init__` calls `super().__init__()` without `config_entry`, so `DataUpdateCoordinator` takes the `UNDEFINED` branch and calls `frame.report_usage(...)` with `core_integration_behavior=ReportBehavior.ERROR`. For a core integration that raises, and setup of `supla` aborts completely:

```
Error during setup of component supla: Detected that integration 'supla' relies on
ContextVar, but should pass the config entry explicitly.
at homeassistant/components/supla/coordinator.py, line 28: super().__init__(
```

Supla is a YAML-only integration — it sets up through `async_setup` and has no config flow, so there is no config entry to be found in the ContextVar. Passing `config_entry=None` explicitly is the semantically correct value here rather than a workaround, and it takes the coordinator off the deprecated code path.

This is a regression: the integration works on 2026.7 and fails on 2026.8.0.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178321
- This PR fixes or closes issue: fixes #178335
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

### Notes on the unchecked boxes

- **Local tests pass** — the full `pytest` suite was not run locally. `supla` has no test module, and CI covers the rest.
- **Tests have been added** — `supla` is `quality_scale: legacy` with no existing test suite, and this change adds no new behaviour to cover.
- **Reviewed two other PRs** — not done yet.

Verified instead on a live Home Assistant OS 2026.8.0 instance: with this exact change applied, `supla` sets up and `cover.supla_*` goes from `unavailable` to a real state fetched from the Supla Cloud API. `ruff format --check` and `ruff check` both pass using this repository's own `pyproject.toml` configuration.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
