### PR TITLE
Add iZone supply and return temperature sensors

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -20,7 +20,7 @@ from .discovery import (
     yaml_excluded_uids,
 )
 
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/izone/sensor.py
+++ b/homeassistant/components/izone/sensor.py
@@ -1,0 +1,89 @@
+"""Support for iZone sensors."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from pizone import Controller, Power, PowerChannel, PowerDevice, PowerGroup, Zone
+
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .const import DOMAIN
+from .coordinator import IZoneConfigEntry, IZoneCoordinator
+from .entity import IZoneCoordinatorEntity
+
+PARALLEL_UPDATES = 0
+
+type IZoneSensorSource = (
+    Controller | Zone | Power | PowerDevice | PowerChannel | PowerGroup
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class IZoneSensorEntityDescription[SourceT: IZoneSensorSource](SensorEntityDescription):
+    """Describes an iZone sensor; value_fn reads from a pizone source object."""
+
+    value_fn: Callable[[SourceT], StateType]
+
+
+CONTROLLER_SENSOR_DESCRIPTIONS: tuple[
+    IZoneSensorEntityDescription[Controller], ...
+] = ()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IZoneConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up iZone sensor entities from the entry coordinator."""
+    coordinator = entry.runtime_data
+    controller = coordinator.controller
+    async_add_entities(
+        IZoneSensor(
+            coordinator,
+            description,
+            controller,
+            unique_id=f"{controller.device_uid}_{description.key}",
+            device_info=DeviceInfo(
+                identifiers={(DOMAIN, controller.device_uid)},
+                manufacturer="IZone",
+                model=controller.sys_type,
+                name=f"iZone Controller {controller.device_uid}",
+            ),
+        )
+        for description in CONTROLLER_SENSOR_DESCRIPTIONS
+    )
+
+
+class IZoneSensor[SourceT: IZoneSensorSource](IZoneCoordinatorEntity, SensorEntity):
+    """Sensor backed by a pizone Controller, Zone, or Power* object."""
+
+    _attr_has_entity_name = True
+    entity_description: IZoneSensorEntityDescription[SourceT]
+
+    def __init__(
+        self,
+        coordinator: IZoneCoordinator,
+        description: IZoneSensorEntityDescription[SourceT],
+        source: SourceT,
+        *,
+        unique_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the sensor for *source*."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._source = source
+        self._attr_unique_id = unique_id
+        self._attr_device_info = device_info
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the sensor value from the pizone source object."""
+        return self.entity_description.value_fn(self._source)

--- a/homeassistant/components/izone/sensor.py
+++ b/homeassistant/components/izone/sensor.py
@@ -2,11 +2,18 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from operator import attrgetter
 from typing import override
 
 from pizone import Controller, Power, PowerChannel, PowerDevice, PowerGroup, Zone
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -30,9 +37,28 @@ class IZoneSensorEntityDescription[SourceT: IZoneSensorSource](SensorEntityDescr
     value_fn: Callable[[SourceT], StateType]
 
 
-CONTROLLER_SENSOR_DESCRIPTIONS: tuple[
-    IZoneSensorEntityDescription[Controller], ...
-] = ()
+CONTROLLER_SENSOR_DESCRIPTIONS: tuple[IZoneSensorEntityDescription[Controller], ...] = (
+    IZoneSensorEntityDescription[Controller](
+        key="supply_temperature",
+        translation_key="supply_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=attrgetter("temp_supply"),
+    ),
+    IZoneSensorEntityDescription[Controller](
+        key="return_temperature",
+        translation_key="return_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=attrgetter("temp_return"),
+    ),
+)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -20,6 +20,16 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "return_temperature": {
+        "name": "Return temperature"
+      },
+      "supply_temperature": {
+        "name": "Supply temperature"
+      }
+    }
+  },
   "exceptions": {
     "bridge_unpaired": {
       "message": "iZone bridge is not paired with an air conditioner"

--- a/tests/components/izone/snapshots/test_sensor.ambr
+++ b/tests/components/izone/snapshots/test_sensor.ambr
@@ -1,0 +1,117 @@
+# serializer version: 1
+# name: test_sensor_entities[sensor.izone_controller_000000001_return_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.izone_controller_000000001_return_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Return temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Return temperature',
+    'platform': 'izone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'return_temperature',
+    'unique_id': '000000001_return_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities[sensor.izone_controller_000000001_return_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'iZone Controller 000000001 Return temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.izone_controller_000000001_return_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_sensor_entities[sensor.izone_controller_000000001_supply_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.izone_controller_000000001_supply_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Supply temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Supply temperature',
+    'platform': 'izone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'supply_temperature',
+    'unique_id': '000000001_supply_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities[sensor.izone_controller_000000001_supply_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'iZone Controller 000000001 Supply temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.izone_controller_000000001_supply_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16.0',
+  })
+# ---

--- a/tests/components/izone/test_sensor.py
+++ b/tests/components/izone/test_sensor.py
@@ -6,12 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.izone.const import DOMAIN
-from homeassistant.const import (
-    STATE_UNKNOWN,
-    EntityCategory,
-    Platform,
-    UnitOfTemperature,
-)
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
@@ -40,9 +35,6 @@ async def test_sensor_entities(
     """Controller supply and return temperature sensors are created."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    assert hass.states.get(SUPPLY_ENTITY) is not None
-    assert hass.states.get(RETURN_ENTITY) is not None
-
 
 @pytest.mark.usefixtures("init_integration")
 async def test_sensor_device_linked_to_controller(
@@ -60,35 +52,6 @@ async def test_sensor_device_linked_to_controller(
         entry = entity_registry.async_get(entity_id)
         assert entry is not None
         assert entry.device_id == controller_device.id
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_sensor_states_and_registry(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Sensors report controller temps and are diagnostic, enabled by default."""
-    supply = hass.states.get(SUPPLY_ENTITY)
-    return_state = hass.states.get(RETURN_ENTITY)
-    assert supply is not None
-    assert return_state is not None
-    assert supply.state == "16.0"
-    assert return_state.state == "22.0"
-    assert supply.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
-    assert return_state.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
-
-    supply_entry = entity_registry.async_get(SUPPLY_ENTITY)
-    return_entry = entity_registry.async_get(RETURN_ENTITY)
-    assert supply_entry is not None
-    assert return_entry is not None
-    assert supply_entry.entity_category == EntityCategory.DIAGNOSTIC
-    assert return_entry.entity_category == EntityCategory.DIAGNOSTIC
-    assert supply_entry.disabled is False
-    assert return_entry.disabled is False
-    assert supply_entry.hidden_by is None
-    assert return_entry.hidden_by is None
-    assert supply_entry.unique_id == "000000001_supply_temperature"
-    assert return_entry.unique_id == "000000001_return_temperature"
 
 
 @pytest.mark.usefixtures("mock_create_discovery")

--- a/tests/components/izone/test_sensor.py
+++ b/tests/components/izone/test_sensor.py
@@ -1,0 +1,107 @@
+"""Tests for iZone sensor platform."""
+
+from unittest.mock import Mock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.izone.const import DOMAIN
+from homeassistant.const import (
+    STATE_UNKNOWN,
+    EntityCategory,
+    Platform,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
+import homeassistant.helpers.entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+SUPPLY_ENTITY = "sensor.izone_controller_000000001_supply_temperature"
+RETURN_ENTITY = "sensor.izone_controller_000000001_return_temperature"
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Only load the sensor platform for these tests."""
+    return [Platform.SENSOR]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Controller supply and return temperature sensors are created."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    assert hass.states.get(SUPPLY_ENTITY) is not None
+    assert hass.states.get(RETURN_ENTITY) is not None
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensor_device_linked_to_controller(
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Temperature sensors are attached to the controller device."""
+    controller_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "000000001"), mock_config_entry.entry_id
+    )
+    assert controller_device is not None
+
+    for entity_id in (SUPPLY_ENTITY, RETURN_ENTITY):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == controller_device.id
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensor_states_and_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Sensors report controller temps and are diagnostic, enabled by default."""
+    supply = hass.states.get(SUPPLY_ENTITY)
+    return_state = hass.states.get(RETURN_ENTITY)
+    assert supply is not None
+    assert return_state is not None
+    assert supply.state == "16.0"
+    assert return_state.state == "22.0"
+    assert supply.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
+    assert return_state.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
+
+    supply_entry = entity_registry.async_get(SUPPLY_ENTITY)
+    return_entry = entity_registry.async_get(RETURN_ENTITY)
+    assert supply_entry is not None
+    assert return_entry is not None
+    assert supply_entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert return_entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert supply_entry.disabled is False
+    assert return_entry.disabled is False
+    assert supply_entry.hidden_by is None
+    assert return_entry.hidden_by is None
+    assert supply_entry.unique_id == "000000001_supply_temperature"
+    assert return_entry.unique_id == "000000001_return_temperature"
+
+
+@pytest.mark.usefixtures("mock_create_discovery")
+async def test_sensor_unknown_when_temp_missing(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_controller: Mock,
+) -> None:
+    """Missing supply/return temps report as unknown."""
+    mock_controller.temp_supply = None
+    mock_controller.temp_return = None
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(SUPPLY_ENTITY).state == STATE_UNKNOWN
+    assert hass.states.get(RETURN_ENTITY).state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a sensor platform for iZone and expose controller duct **supply** and **return** air temperatures as diagnostic sensor entities (enabled by default).

The climate entity keeps its existing `supply_temperature` attribute for now. Prefer the new sensor entities for dashboards and automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47271
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr