### PR TITLE
Use entity state attribute enums in emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -26,15 +26,24 @@ from homeassistant.components import (
 from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     ClimateEntityFeature,
+    ClimateEntityStateAttribute,
 )
 from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     CoverEntityFeature,
+    CoverEntityStateAttribute,
 )
-from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntityFeature
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    FanEntityFeature,
+    FanEntityStateAttribute,
+)
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.components.humidifier import ATTR_HUMIDITY, SERVICE_SET_HUMIDITY
+from homeassistant.components.humidifier import (
+    ATTR_HUMIDITY,
+    SERVICE_SET_HUMIDITY,
+    HumidifierEntityStateAttribute,
+)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
@@ -42,11 +51,14 @@ from homeassistant.components.light import (
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
     ColorMode,
+    LightEntityCapabilityAttribute,
     LightEntityFeature,
+    LightEntityStateAttribute,
 )
 from homeassistant.components.media_player import (
     ATTR_MEDIA_VOLUME_LEVEL,
     MediaPlayerEntityFeature,
+    MediaPlayerEntityStateAttribute,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -388,7 +400,7 @@ class HueOneLightChangeView(HomeAssistantView):
         if entity.domain == light.DOMAIN:
             color_modes = (
                 entity.attributes.get(
-                    light.LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES
+                    LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES
                 )
                 or []
             )
@@ -704,9 +716,9 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
     attributes = entity.attributes
     if is_on:
         data[STATE_BRIGHTNESS] = hass_to_hue_brightness(
-            attributes.get(ATTR_BRIGHTNESS) or 0
+            attributes.get(LightEntityStateAttribute.BRIGHTNESS) or 0
         )
-        if (hue_sat := attributes.get(ATTR_HS_COLOR)) is not None:
+        if (hue_sat := attributes.get(LightEntityStateAttribute.HS_COLOR)) is not None:
             hue = hue_sat[0]
             sat = hue_sat[1]
             # Convert hass hs values back to hue hs values
@@ -715,7 +727,7 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
         else:
             data[STATE_HUE] = HUE_API_STATE_HUE_MIN
             data[STATE_SATURATION] = HUE_API_STATE_SAT_MIN
-        kelvin = attributes.get(ATTR_COLOR_TEMP_KELVIN)
+        kelvin = attributes.get(LightEntityStateAttribute.COLOR_TEMP_KELVIN)
         data[STATE_COLOR_TEMP] = (
             color_util.color_temperature_kelvin_to_mired(kelvin)
             if kelvin is not None
@@ -729,23 +741,26 @@ def _build_entity_state_dict(entity: State) -> dict[str, Any]:
         data[STATE_COLOR_TEMP] = 0
 
     if entity.domain == climate.DOMAIN:
-        temperature = attributes.get(ATTR_TEMPERATURE, 0)
+        temperature = attributes.get(ClimateEntityStateAttribute.TARGET_TEMPERATURE, 0)
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(temperature * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == humidifier.DOMAIN:
-        humidity = attributes.get(ATTR_HUMIDITY, 0)
+        humidity = attributes.get(HumidifierEntityStateAttribute.HUMIDITY, 0)
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(humidity * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == media_player.DOMAIN:
-        level = attributes.get(ATTR_MEDIA_VOLUME_LEVEL, 1.0 if is_on else 0.0)
+        level = attributes.get(
+            MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL,
+            1.0 if is_on else 0.0,
+        )
         # Convert 0.0-1.0 to 0-254
         data[STATE_BRIGHTNESS] = round(min(1.0, level) * HUE_API_STATE_BRI_MAX)
     elif entity.domain == fan.DOMAIN:
-        percentage = attributes.get(ATTR_PERCENTAGE) or 0
+        percentage = attributes.get(FanEntityStateAttribute.PERCENTAGE) or 0
         # Convert 0-100 to 0-254
         data[STATE_BRIGHTNESS] = round(percentage * HUE_API_STATE_BRI_MAX / 100)
     elif entity.domain == cover.DOMAIN:
-        level = attributes.get(ATTR_CURRENT_POSITION, 0)
+        level = attributes.get(CoverEntityStateAttribute.CURRENT_POSITION, 0)
         data[STATE_BRIGHTNESS] = round(level / 100 * HUE_API_STATE_BRI_MAX)
     _clamp_values(data)
     return data
@@ -777,8 +792,7 @@ def _entity_unique_id(entity_id: str) -> str:
 def state_to_json(config: Config, state: State) -> dict[str, Any]:
     """Convert an entity to its Hue bridge JSON representation."""
     color_modes = (
-        state.attributes.get(light.LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES)
-        or []
+        state.attributes.get(LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES) or []
     )
     unique_id = _entity_unique_id(state.entity_id)
     state_dict = get_entity_state_dict(config, state)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

emulated_hue exposes Home Assistant entities as Hue devices and reads the source entity's state attributes to build the Hue state. These reads now use the platform attribute enums instead of `ATTR_*` constants:

- light: `LightEntityStateAttribute.BRIGHTNESS` / `HS_COLOR` / `COLOR_TEMP_KELVIN`
- climate: `ClimateEntityStateAttribute.TARGET_TEMPERATURE`
- humidifier: `HumidifierEntityStateAttribute.HUMIDITY`
- media_player: `MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL`
- fan: `FanEntityStateAttribute.PERCENTAGE`
- cover: `CoverEntityStateAttribute.CURRENT_POSITION`

The pre-existing module-prefixed `light.LightEntityCapabilityAttribute` accesses are switched to a direct import for consistency. The `ATTR_*` constants that build the outgoing service-call data (e.g. `light.turn_on`) are left unchanged, as those are service data keys, not state attributes.

Part of #175836.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
