### PR TITLE
Migrate calls to async_get_device in zwave_js tests

### DIFF
--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -116,7 +116,9 @@ def get_device(hass: HomeAssistant, node):
     """Get device ID for a node."""
     dev_reg = dr.async_get(hass)
     device_id = get_device_id(node.client.driver, node)
-    return dev_reg.async_get_device(identifiers={device_id})
+    return dev_reg.async_get_device_by_identifier(
+        device_id, hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
 
 async def test_no_driver(
@@ -180,8 +182,8 @@ async def test_network_status(
     assert result["controller"]["supports_long_range"]
 
     # Try API call with device ID
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "3245146787-52")},
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "3245146787-52"), entry.entry_id
     )
     assert device
     with patch(
@@ -491,7 +493,9 @@ async def test_node_alerts(
     entry = integration
     ws_client = await hass_ws_client(hass)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "3245146787-35")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "3245146787-35"), entry.entry_id
+    )
     assert device
 
     await ws_client.send_json_auto_id(
@@ -1284,8 +1288,8 @@ async def test_provision_smart_start_node(
     assert msg["success"]
 
     # verify a device was created
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "provision_test")},
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "provision_test"), entry.entry_id
     )
     assert device is not None
     assert device.name == "test_name"
@@ -1945,8 +1949,8 @@ async def test_remove_node(
     assert msg["event"]["event"] == "node removed"
 
     # Verify device was removed from device registry
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "3245146787-67")},
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "3245146787-67"), entry.entry_id
     )
     assert device is None
 
@@ -2133,8 +2137,8 @@ async def test_replace_failed_node(
 
     # Verify device was removed from device registry
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, "3245146787-67")},
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "3245146787-67"), entry.entry_id
         )
         is None
     )
@@ -2449,8 +2453,8 @@ async def test_remove_failed_node(
 
     # Verify device was removed from device registry
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, "3245146787-67")},
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "3245146787-67"), entry.entry_id
         )
         is None
     )
@@ -5290,8 +5294,8 @@ async def test_hard_reset_controller(
     msg = await ws_client.receive_json()
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, client.driver.controller.nodes[1]), entry.entry_id
     )
     assert device is not None
     assert msg["result"] == device.id
@@ -5315,8 +5319,8 @@ async def test_hard_reset_controller(
     msg = await ws_client.receive_json()
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, client.driver.controller.nodes[1]), entry.entry_id
     )
     assert device is not None
     assert msg["result"] == device.id
@@ -5350,8 +5354,8 @@ async def test_hard_reset_controller(
         msg = await ws_client.receive_json()
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, client.driver.controller.nodes[1]), entry.entry_id
     )
     assert device is not None
     assert msg["result"] == device.id

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4271,19 +4271,21 @@ async def test_reconfigure_migrate_with_addon(
 
     assert len(device_registry.devices) == 2
     # Verify there's a device entry for the controller.
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, controller_device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, controller_device_id), entry.entry_id
     )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, controller_device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, controller_device_id_ext), entry.entry_id
     )
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW090"
     assert device.name == "Z‐Stick Gen5 USB Controller"
     # Verify there's a device entry for the multisensor.
     sensor_device_id = f"{client.driver.controller.home_id}-{multisensor_6.node_id}"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, sensor_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, sensor_device_id), entry.entry_id
+    )
     assert device
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW100"
@@ -4419,14 +4421,16 @@ async def test_reconfigure_migrate_with_addon(
         f"{controller_device_id}-{controller_node.manufacturer_id}:"
         f"{controller_node.product_type}:{controller_node.product_id}"
     )
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, controller_device_id_ext)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, controller_device_id_ext), entry.entry_id
     )
     assert device
     assert device.manufacturer == "New Device Manufacturer"
     assert device.model == "New Device Model"
     assert device.name == "New Device Name"
-    device = device_registry.async_get_device(identifiers={(DOMAIN, sensor_device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, sensor_device_id), entry.entry_id
+    )
     assert device
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW100"

--- a/tests/components/zwave_js/test_credential_services.py
+++ b/tests/components/zwave_js/test_credential_services.py
@@ -88,11 +88,14 @@ def _mock_access_control(
 
 
 def _device_id(
-    device_registry: dr.DeviceRegistry, client: MagicMock, node: Node
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    node: Node,
+    config_entry_id: str,
 ) -> str:
     """Resolve the HA device_id for a mocked Z-Wave node."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), config_entry_id
     )
     assert device is not None
     return device.id
@@ -103,9 +106,10 @@ def _lock_entity_id(
     device_registry: dr.DeviceRegistry,
     client: MagicMock,
     node: Node,
+    config_entry_id: str,
 ) -> str:
     """Resolve the HA lock entity_id for a mocked Z-Wave node."""
-    device_id = _device_id(device_registry, client, node)
+    device_id = _device_id(device_registry, client, node, config_entry_id)
     for entry in entity_registry.entities.values():
         if entry.device_id == device_id and entry.entity_id.startswith("lock."):
             return entry.entity_id
@@ -124,7 +128,11 @@ async def test_set_user_new_user_auto_find(
     api = _mock_access_control(lock_schlage_be469)
     api.add_user.return_value = AddUserResult(user=SetUserResult.OK)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -166,7 +174,11 @@ async def test_set_user_existing_user(
     """With a user_id, set_user updates the existing user via setUser."""
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -220,7 +232,11 @@ async def test_set_user_no_slots(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_name": "Charlie",
             },
@@ -245,7 +261,11 @@ async def test_set_user_new_user_with_credential(
     """A new user and its credential are written in one addUser call."""
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -305,7 +325,11 @@ async def test_set_user_rolls_back_on_credential_failure(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_name": "Alice",
                 "credential_type": "pin_code",
@@ -343,7 +367,11 @@ async def test_set_user_rollback_failure_still_raises_credential_error(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_name": "Alice",
                 "credential_type": "pin_code",
@@ -392,7 +420,11 @@ async def test_set_user_new_user_credential_slot_allocation(
     user2.user_id = 2
     api.get_users_cached.return_value = [user1, user2]
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -454,7 +486,11 @@ async def test_set_user_existing_user_with_credential(
         supports_users_without_credentials=supports_users_without_credentials,
     )
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -504,7 +540,11 @@ async def test_set_user_existing_user_explicit_credential_slot(
     """An explicit credential_slot is honored on the existing-user path."""
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -554,7 +594,11 @@ async def test_set_user_invalid_pin(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "credential_type": "pin_code",
                 "credential_data": "abcd",
@@ -586,7 +630,11 @@ async def test_set_user_requires_credential_on_user_code_cc(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_name": "Alice",
             },
@@ -616,7 +664,11 @@ async def test_delete_user(
         "delete_user",
         {
             ATTR_ENTITY_ID: _lock_entity_id(
-                entity_registry, device_registry, client, lock_schlage_be469
+                entity_registry,
+                device_registry,
+                client,
+                lock_schlage_be469,
+                integration.entry_id,
             ),
             "user_id": 3,
         },
@@ -642,7 +694,11 @@ async def test_delete_all_users(
         "delete_all_users",
         {
             ATTR_ENTITY_ID: _lock_entity_id(
-                entity_registry, device_registry, client, lock_schlage_be469
+                entity_registry,
+                device_registry,
+                client,
+                lock_schlage_be469,
+                integration.entry_id,
             ),
         },
         blocking=True,
@@ -662,7 +718,11 @@ async def test_get_credential_capabilities(
     """Test get_credential_capabilities returns capability data."""
     _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -716,7 +776,11 @@ async def test_get_credential_capabilities_not_supported(
             "get_credential_capabilities",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 )
             },
             blocking=True,
@@ -758,7 +822,11 @@ async def test_get_users(
     api.get_all_credentials_cached.return_value = [credential]
 
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -800,7 +868,11 @@ async def test_set_credential_auto_slot(
     api = _mock_access_control(lock_schlage_be469)
 
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
     result = await hass.services.async_call(
         DOMAIN,
@@ -833,7 +905,11 @@ async def test_set_credential_explicit_slot(
     """Test set_credential with explicit user_id and slot."""
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -871,10 +947,14 @@ async def test_set_credential_multi_target(
     api2 = _mock_access_control(lock_august_pro)
 
     entity_1 = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
     entity_2 = _lock_entity_id(
-        entity_registry, device_registry, client, lock_august_pro
+        entity_registry, device_registry, client, lock_august_pro, integration.entry_id
     )
     result = await hass.services.async_call(
         DOMAIN,
@@ -935,7 +1015,11 @@ async def test_set_user_rejection_raises(
             "set_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "user_name": "Guest",
@@ -1008,7 +1092,11 @@ async def test_set_credential_rejection_raises(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "credential_type": "pin_code",
@@ -1042,7 +1130,11 @@ async def test_set_credential_requires_user_id(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "credential_type": "pin_code",
                 "credential_data": "1234",
@@ -1076,7 +1168,11 @@ async def test_set_credential_type_not_supported(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "credential_type": "pin_code",
@@ -1124,7 +1220,11 @@ async def test_set_credential_no_available_slots(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "credential_type": "pin_code",
@@ -1167,7 +1267,11 @@ async def test_set_credential_pin_not_digits(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "credential_type": "pin_code",
@@ -1195,7 +1299,11 @@ async def test_set_credential_password_allows_non_digits(
     """Password credentials must not be subject to the PIN-only digit check."""
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     result = await hass.services.async_call(
@@ -1237,7 +1345,11 @@ async def test_set_credential_length_validation(
             "set_credential",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 1,
                 "credential_type": "pin_code",
@@ -1276,7 +1388,11 @@ async def test_delete_credential(
         "delete_credential",
         {
             ATTR_ENTITY_ID: _lock_entity_id(
-                entity_registry, device_registry, client, lock_schlage_be469
+                entity_registry,
+                device_registry,
+                client,
+                lock_schlage_be469,
+                integration.entry_id,
             ),
             "user_id": 1,
             "credential_type": "pin_code",
@@ -1312,7 +1428,11 @@ async def test_delete_all_credentials(
         "delete_all_credentials",
         {
             ATTR_ENTITY_ID: _lock_entity_id(
-                entity_registry, device_registry, client, lock_schlage_be469
+                entity_registry,
+                device_registry,
+                client,
+                lock_schlage_be469,
+                integration.entry_id,
             ),
             "user_id": 1,
         },
@@ -1341,7 +1461,11 @@ async def test_set_credential_id_range_validation(
 
     payload: dict = {
         ATTR_ENTITY_ID: _lock_entity_id(
-            entity_registry, device_registry, client, lock_schlage_be469
+            entity_registry,
+            device_registry,
+            client,
+            lock_schlage_be469,
+            integration.entry_id,
         ),
         "user_id": 1,
         "credential_type": "pin_code",
@@ -1380,7 +1504,11 @@ async def test_delete_user_rejects_oversize_user_id(
             "delete_user",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 70000,
             },
@@ -1411,10 +1539,18 @@ async def test_mutation_supports_multi_target(
         {
             ATTR_ENTITY_ID: [
                 _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 _lock_entity_id(
-                    entity_registry, device_registry, client, lock_august_pro
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_august_pro,
+                    integration.entry_id,
                 ),
             ],
             "user_id": 3,
@@ -1456,10 +1592,14 @@ async def test_get_users_supports_multi_target(
     api2.get_users_cached.return_value = [user_2]
 
     entity_1 = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
     entity_2 = _lock_entity_id(
-        entity_registry, device_registry, client, lock_august_pro
+        entity_registry, device_registry, client, lock_august_pro, integration.entry_id
     )
 
     result = await hass.services.async_call(
@@ -1592,7 +1732,11 @@ async def test_server_error_wrapped_with_translation_key(
     getattr(api, failing_attr).side_effect = FailedZWaveCommand("boom", 1, "boom")
 
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     with pytest.raises(HomeAssistantError) as exc:
@@ -1636,7 +1780,11 @@ async def test_delete_all_credentials_failure_wrapped(
             "delete_all_credentials",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 7,
             },
@@ -1684,7 +1832,11 @@ async def test_delete_all_credentials_partial_failure(
             "delete_all_credentials",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 7,
             },
@@ -1729,7 +1881,11 @@ async def test_delete_all_credentials_single_failure_unwrapped(
             "delete_all_credentials",
             {
                 ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
+                    entity_registry,
+                    device_registry,
+                    client,
+                    lock_schlage_be469,
+                    integration.entry_id,
                 ),
                 "user_id": 7,
             },
@@ -1778,7 +1934,11 @@ async def test_service_access_control_not_supported(
     api = _mock_access_control(lock_schlage_be469)
     api.is_supported.return_value = False
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     with pytest.raises(HomeAssistantError) as exc:
@@ -1836,7 +1996,11 @@ async def test_service_requires_admin(
     hass_read_only_user.mock_policy({"entities": {"all": {"control": True}}})
     api = _mock_access_control(lock_schlage_be469)
     entity_id = _lock_entity_id(
-        entity_registry, device_registry, client, lock_schlage_be469
+        entity_registry,
+        device_registry,
+        client,
+        lock_schlage_be469,
+        integration.entry_id,
     )
 
     with pytest.raises(Unauthorized):

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -38,7 +38,9 @@ async def test_get_actions(
     node = lock_schlage_be469
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(driver, node), integration.entry_id
+    )
     assert device
     binary_sensor = entity_registry.async_get(
         "binary_sensor.touchscreen_deadbolt_low_battery_level"
@@ -105,8 +107,8 @@ async def test_get_actions(
         assert action in actions
 
     # Test that we don't return actions for a controller node
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(driver, client.driver.controller.nodes[1]), integration.entry_id
     )
     assert device
     assert (
@@ -126,7 +128,9 @@ async def test_get_actions_meter(
     node = aeon_smart_switch_6
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(driver, node), integration.entry_id
+    )
     assert device
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id
@@ -148,7 +152,9 @@ async def test_actions(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device(identifiers={device_id})
+    device = device_registry.async_get_device_by_identifier(
+        device_id, integration.entry_id
+    )
     assert device
 
     climate = entity_registry.async_get("climate.z_wave_thermostat")
@@ -302,7 +308,9 @@ async def test_actions_legacy(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device(identifiers={device_id})
+    device = device_registry.async_get_device_by_identifier(
+        device_id, integration.entry_id
+    )
     assert device
 
     climate = entity_registry.async_get("climate.z_wave_thermostat")
@@ -360,7 +368,9 @@ async def test_actions_multiple_calls(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device({device_id})
+    device = device_registry.async_get_device_by_identifier(
+        device_id, integration.entry_id
+    )
     assert device
     climate = entity_registry.async_get("climate.z_wave_thermostat")
     assert climate
@@ -410,7 +420,9 @@ async def test_lock_actions(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device(identifiers={device_id})
+    device = device_registry.async_get_device_by_identifier(
+        device_id, integration.entry_id
+    )
     assert device
     lock = entity_registry.async_get("lock.touchscreen_deadbolt")
     assert lock
@@ -484,7 +496,9 @@ async def test_reset_meter_action(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device(identifiers={device_id})
+    device = device_registry.async_get_device_by_identifier(
+        device_id, integration.entry_id
+    )
     assert device
     sensor = entity_registry.async_get("sensor.smart_switch_6_electric_consumed_kwh")
     assert sensor
@@ -530,8 +544,9 @@ async def test_get_action_capabilities(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected action capabilities."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_radio_thermostat_ct100_plus),
+        integration.entry_id,
     )
     assert device
 
@@ -767,7 +782,9 @@ async def test_get_action_capabilities_meter_triggers(
     node = aeon_smart_switch_6
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(driver, node), integration.entry_id
+    )
     assert device
     capabilities = await device_action.async_get_action_capabilities(
         hass,
@@ -824,7 +841,9 @@ async def test_unavailable_entity_actions(
     node = lock_schlage_be469
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(driver, node), integration.entry_id
+    )
     assert device
     binary_sensor = entity_registry.async_get(entity_id_unavailable)
     assert binary_sensor

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -34,8 +34,8 @@ async def test_get_conditions(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected onditions from a zwave_js."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     config_value = list(lock_schlage_be469.get_configuration_values().values())[0]
@@ -74,8 +74,9 @@ async def test_get_conditions(
         assert condition in conditions
 
     # Test that we don't return actions for a controller node
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, client.driver.controller.nodes[1]),
+        integration.entry_id,
     )
     assert device
     assert (
@@ -95,8 +96,8 @@ async def test_node_status_state(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for node_status conditions."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -260,8 +261,8 @@ async def test_config_parameter_state(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for config_parameter conditions."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -380,8 +381,8 @@ async def test_value_state(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for value conditions."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -431,8 +432,8 @@ async def test_get_condition_capabilities_node_status(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we don't get capabilities from a node_status condition."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -471,8 +472,8 @@ async def test_get_condition_capabilities_value(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected capabilities from a value condition."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -524,8 +525,9 @@ async def test_get_condition_capabilities_config_parameter(
 ) -> None:
     """Test we get the expected capabilities from a config_parameter condition."""
     node = climate_radio_thermostat_ct100_plus
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_radio_thermostat_ct100_plus),
+        integration.entry_id,
     )
     assert device
 
@@ -609,8 +611,8 @@ async def test_failure_scenarios(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test failure scenarios."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, hank_binary_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, hank_binary_switch), integration.entry_id
     )
     assert device
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -35,8 +35,9 @@ async def test_no_controller_triggers(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, client, integration
 ) -> None:
     """Test that we do not get triggers for the controller."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, client.driver.controller.nodes[1]),
+        integration.entry_id,
     )
     assert device
     assert (
@@ -55,8 +56,8 @@ async def test_get_notification_notification_triggers(
     integration,
 ) -> None:
     """Test expected triggers from a device with Notification CC."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -83,8 +84,8 @@ async def test_if_notification_notification_fires(
 ) -> None:
     """Test for event.notification.notification trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -181,8 +182,8 @@ async def test_get_trigger_capabilities_notification_notification(
     integration,
 ) -> None:
     """Test capabilities from a notification.notification trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -224,8 +225,8 @@ async def test_if_entry_control_notification_fires(
 ) -> None:
     """Test for notification.entry_control trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -321,8 +322,8 @@ async def test_get_trigger_capabilities_entry_control_notification(
     integration,
 ) -> None:
     """Test capabilities from a notification.entry_control trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -366,8 +367,8 @@ async def test_get_node_status_triggers(
     integration,
 ) -> None:
     """Test expected triggers from device with node status enabled."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     entity_id = async_get_node_status_sensor_entity_id(
@@ -402,8 +403,8 @@ async def test_if_node_status_change_fires(
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     entity_id = async_get_node_status_sensor_entity_id(
@@ -485,8 +486,8 @@ async def test_if_node_status_change_fires_legacy(
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     entity_id = async_get_node_status_sensor_entity_id(
@@ -566,8 +567,8 @@ async def test_get_trigger_capabilities_node_status(
     integration,
 ) -> None:
     """Test we get the expected capabilities from a node_status trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     entity_id = async_get_node_status_sensor_entity_id(
@@ -633,8 +634,8 @@ async def test_get_basic_value_notification_triggers(
     integration,
 ) -> None:
     """Test we get the expected triggers from a zwave_js device with the Basic CC."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, ge_in_wall_dimmer_switch), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -665,8 +666,8 @@ async def test_if_basic_value_notification_fires(
 ) -> None:
     """Test for event.value_notification.basic trigger firing."""
     node: Node = ge_in_wall_dimmer_switch
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, ge_in_wall_dimmer_switch), integration.entry_id
     )
     assert device
 
@@ -777,8 +778,8 @@ async def test_get_trigger_capabilities_basic_value_notification(
     integration,
 ) -> None:
     """Test we get the expected capabilities from a value_notification.basic trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, ge_in_wall_dimmer_switch), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -819,8 +820,8 @@ async def test_get_central_scene_value_notification_triggers(
     integration,
 ) -> None:
     """Test expected triggers from a device with Central Scene CC."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, wallmote_central_scene)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, wallmote_central_scene), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -851,8 +852,8 @@ async def test_if_central_scene_value_notification_fires(
 ) -> None:
     """Test for event.value_notification.central_scene trigger firing."""
     node: Node = wallmote_central_scene
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, wallmote_central_scene)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, wallmote_central_scene), integration.entry_id
     )
     assert device
 
@@ -973,8 +974,8 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
     integration,
 ) -> None:
     """Test capabilities from value_notification.central_scene."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, wallmote_central_scene)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, wallmote_central_scene), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1018,8 +1019,8 @@ async def test_get_scene_activation_value_notification_triggers(
     integration,
 ) -> None:
     """Test expected triggers from device with SceneActivation CC."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, hank_binary_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, hank_binary_switch), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -1050,8 +1051,8 @@ async def test_if_scene_activation_value_notification_fires(
 ) -> None:
     """Test for event.value_notification.scene_activation trigger firing."""
     node: Node = hank_binary_switch
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, hank_binary_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, hank_binary_switch), integration.entry_id
     )
     assert device
 
@@ -1166,8 +1167,8 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
     integration,
 ) -> None:
     """Test capabilities from value_notification.scene_activation."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, hank_binary_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, hank_binary_switch), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1208,8 +1209,8 @@ async def test_get_value_updated_value_triggers(
     integration,
 ) -> None:
     """Test we get the zwave_js.value_updated.value trigger from a zwave_js device."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -1235,8 +1236,8 @@ async def test_if_value_updated_value_fires(
 ) -> None:
     """Test for zwave_js.value_updated.value trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -1331,8 +1332,8 @@ async def test_value_updated_value_no_driver(
 ) -> None:
     """Test zwave_js.value_updated.value trigger with missing driver."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     driver = client.driver
@@ -1404,8 +1405,8 @@ async def test_get_trigger_capabilities_value_updated_value(
     integration,
 ) -> None:
     """Test capabilities from zwave_js.value_updated.value trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1458,8 +1459,8 @@ async def test_get_value_updated_config_parameter_triggers(
     integration,
 ) -> None:
     """Test value_updated.config_parameter trigger from a device."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     expected_trigger = {
@@ -1490,8 +1491,8 @@ async def test_if_value_updated_config_parameter_fires(
 ) -> None:
     """Test for zwave_js.value_updated.config_parameter trigger firing."""
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -1563,8 +1564,8 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
     integration,
 ) -> None:
     """Test capabilities from a range config_parameter trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1613,8 +1614,8 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
     integration,
 ) -> None:
     """Test capabilities from an enumerated config_parameter trigger."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1674,8 +1675,8 @@ async def test_failure_scenarios(
             {},
         )
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, hank_binary_switch)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, hank_binary_switch), integration.entry_id
     )
     assert device
 

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -62,8 +62,8 @@ async def test_device_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the device level diagnostics data dump."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, multisensor_6)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, multisensor_6), integration.entry_id
     )
     assert device
 
@@ -166,8 +166,8 @@ async def test_device_diagnostics_missing_primary_value(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test that device diagnostics handles an entity with a missing primary value."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, multisensor_6)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, multisensor_6), integration.entry_id
     )
     assert device
 
@@ -259,8 +259,8 @@ async def test_device_diagnostics_secret_value(
     client.driver.controller.nodes[node.node_id] = node
     client.driver.controller.emit("node added", {"node": node})
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
     )
     assert device
 

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -683,8 +683,9 @@ async def test_fibaro_fgms001_unknown_firmware_setup(
     """
     assert integration.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, fibaro_fgms001_unknown_firmware)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, fibaro_fgms001_unknown_firmware),
+        integration.entry_id,
     )
     assert device is not None
 
@@ -717,8 +718,8 @@ async def test_fibaro_fgms001_v2_8_motion_discovery(
     or be misclassified, so we assert that exactly one binary_sensor entity
     with device_class=motion is created and no light entity exists.
     """
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, fibaro_fgms001_v2_8)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, fibaro_fgms001_v2_8), integration.entry_id
     )
     assert device is not None
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -482,8 +482,8 @@ async def test_on_node_added_ready(
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # entity and device not yet added
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id), integration.entry_id
     )
 
     client.driver.controller.emit("node added", event)
@@ -625,7 +625,9 @@ async def test_on_node_added_not_ready(
     client.driver.receive_event(event)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
     assert device
     # no extended device identifier yet
     assert len(device.identifiers) == 1
@@ -655,12 +657,12 @@ async def test_existing_node_ready(
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id), integration.entry_id
     )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id_ext), integration.entry_id
     )
 
 
@@ -686,12 +688,12 @@ async def test_existing_node_reinterview(
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id), integration.entry_id
     )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id_ext), integration.entry_id
     )
     assert device.sw_version == "1.12"
 
@@ -713,12 +715,12 @@ async def test_existing_node_reinterview(
 
     assert state
     assert state.state != STATE_UNAVAILABLE
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id), integration.entry_id
     )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, air_temperature_device_id_ext), integration.entry_id
     )
     assert device.sw_version == "1.13"
 
@@ -735,14 +737,18 @@ async def test_existing_node_not_ready(
     node = zp3111_not_ready
     device_id = f"{client.driver.controller.home_id}-{node.node_id}"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
     assert device.name == f"Node {node.node_id}"
     assert not device.manufacturer
     assert not device.model
     assert not device.sw_version
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
     # no extended device identifier yet
     assert len(device.identifiers) == 1
@@ -775,7 +781,9 @@ async def test_existing_node_not_replaced_when_not_ready(
         f"{zp3111.product_type}:{zp3111.product_id}"
     )
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
     assert device.name == "4-in-1 Sensor"
     assert not device.name_by_user
@@ -783,8 +791,8 @@ async def test_existing_node_not_replaced_when_not_ready(
     assert device.model == "ZP3111-5"
     assert device.sw_version == "5.1"
     assert not device.area_id
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
 
     motion_entity = "binary_sensor.4_in_1_sensor_motion_detection"
@@ -796,7 +804,9 @@ async def test_existing_node_not_replaced_when_not_ready(
         device.id, name_by_user="Custom Device Name", area_id=kitchen_area.id
     )
 
-    custom_device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    custom_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert custom_device
     assert custom_device.name == "4-in-1 Sensor"
     assert custom_device.name_by_user == "Custom Device Name"
@@ -804,8 +814,8 @@ async def test_existing_node_not_replaced_when_not_ready(
     assert custom_device.model == "ZP3111-5"
     assert device.sw_version == "5.1"
     assert custom_device.area_id == kitchen_area.id
-    assert custom_device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert custom_device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
 
     custom_entity = "binary_sensor.custom_motion_sensor"
@@ -833,10 +843,12 @@ async def test_existing_node_not_replaced_when_not_ready(
     client.driver.receive_event(event)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
     assert device.id == custom_device.id
     assert device.identifiers == custom_device.identifiers
@@ -863,10 +875,12 @@ async def test_existing_node_not_replaced_when_not_ready(
     client.driver.receive_event(event)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
     assert device.id == custom_device.id
     assert device.identifiers == custom_device.identifiers
@@ -1452,7 +1466,9 @@ async def test_removed_device(
     )
     assert len(device_entries) == 2
     assert (
-        device_registry.async_get_device(identifiers={get_device_id(driver, old_node)})
+        device_registry.async_get_device_by_identifier(
+            get_device_id(driver, old_node), integration.entry_id
+        )
         is None
     )
 
@@ -1496,7 +1512,9 @@ async def test_node_removed(
 
     client.driver.controller.receive_event(Event("node added", event))
     await hass.async_block_till_done()
-    old_device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    old_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert old_device
     assert old_device.id
 
@@ -1531,10 +1549,12 @@ async def test_replace_same_node(
         f"{multisensor_6.product_type}:{multisensor_6.product_id}"
     )
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id), integration.entry_id
     )
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW100"
@@ -1613,9 +1633,11 @@ async def test_replace_same_node(
     # Device is the same
     device = device_registry.async_get(dev_id)
     assert device
-    assert device == device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id), integration.entry_id
     )
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW100"
@@ -1649,10 +1671,12 @@ async def test_replace_different_node(
         f"{state['productId']}"
     )
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id_ext), integration.entry_id
     )
     assert device.manufacturer == "AEON Labs"
     assert device.model == "ZW100"
@@ -1674,8 +1698,8 @@ async def test_replace_different_node(
     await hass.async_block_till_done()
 
     # Device should still be there after the node was removed
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id_ext)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id_ext), integration.entry_id
     )
     assert device
     assert len(device.identifiers) == 2
@@ -1734,10 +1758,12 @@ async def test_replace_different_node(
 
     # node ID based device identifier should be moved from the old multisensor device
     # to the new hank device and both the old and new devices should exist.
-    new_device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    new_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert new_device
-    hank_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, hank_device_id_ext)}
+    hank_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, hank_device_id_ext), integration.entry_id
     )
     assert hank_device
     assert hank_device == new_device
@@ -1745,8 +1771,8 @@ async def test_replace_different_node(
         (DOMAIN, device_id),
         (DOMAIN, hank_device_id_ext),
     }
-    multisensor_6_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id_ext)}
+    multisensor_6_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id_ext), integration.entry_id
     )
     assert multisensor_6_device
     assert multisensor_6_device != new_device
@@ -1776,8 +1802,8 @@ async def test_replace_different_node(
     await hass.async_block_till_done()
 
     # Device should still be there after the node was removed
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, hank_device_id_ext)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, hank_device_id_ext), integration.entry_id
     )
     assert device
     assert len(device.identifiers) == 2
@@ -1835,16 +1861,18 @@ async def test_replace_different_node(
 
     # node ID based device identifier should be moved from the new hank device
     # to the old multisensor device and both the old and new devices should exist.
-    old_device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    old_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert old_device
-    hank_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, hank_device_id_ext)}
+    hank_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, hank_device_id_ext), integration.entry_id
     )
     assert hank_device
     assert hank_device != old_device
     assert hank_device.identifiers == {(DOMAIN, hank_device_id_ext)}
-    multisensor_6_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, multisensor_6_device_id_ext)}
+    multisensor_6_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, multisensor_6_device_id_ext), integration.entry_id
     )
     assert multisensor_6_device
     assert multisensor_6_device == old_device
@@ -1873,10 +1901,12 @@ async def test_node_model_change(
     )
 
     # Verify device and entities have default names/ids
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
     assert device.manufacturer == "Vision Security"
     assert device.model == "ZP3111-5"
@@ -1892,11 +1922,13 @@ async def test_node_model_change(
 
     # Customize device and entity names/ids
     device_registry.async_update_device(device.id, name_by_user="Custom Device Name")
-    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), integration.entry_id
+    )
     assert device
     assert device.id == dev_id
-    assert device == device_registry.async_get_device(
-        identifiers={(DOMAIN, device_id_ext)}
+    assert device == device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id_ext), integration.entry_id
     )
     assert device.manufacturer == "Vision Security"
     assert device.model == "ZP3111-5"
@@ -2425,7 +2457,9 @@ async def test_factory_reset_node(
     assert "with the home ID" not in notifications[msg_id]["message"]
     async_dismiss(hass, msg_id)
     await hass.async_block_till_done()
-    assert not device_registry.async_get_device(identifiers={dev_id})
+    assert not device_registry.async_get_device_by_identifier(
+        dev_id, integration.entry_id
+    )
 
     # Add mock config entry to simulate having multiple entries
     new_entry = MockConfigEntry(domain=DOMAIN)

--- a/tests/components/zwave_js/test_logbook.py
+++ b/tests/components/zwave_js/test_logbook.py
@@ -22,8 +22,8 @@ async def test_humanifying_zwave_js_notification_event(
     integration,
 ) -> None:
     """Test humanifying Z-Wave JS notification events."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -123,8 +123,8 @@ async def test_humanifying_zwave_js_value_notification_event(
     integration,
 ) -> None:
     """Test humanifying Z-Wave JS value notification events."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 

--- a/tests/components/zwave_js/test_repairs.py
+++ b/tests/components/zwave_js/test_repairs.py
@@ -64,8 +64,8 @@ async def test_device_config_file_changed_confirm_step(
 
     client.async_send_command_no_wait.reset_mock()
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
     )
     assert device
     issue_id = f"device_config_file_changed.{device.id}"
@@ -126,8 +126,8 @@ async def test_device_config_file_changed_cleared(
     """Test the device_config_file_changed issue is cleared when no longer true."""
     node = await _trigger_repair_issue(hass, client, multisensor_6_state)
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
     )
     assert device
     issue_id = f"device_config_file_changed.{device.id}"
@@ -168,8 +168,8 @@ async def test_device_config_file_changed_ignore_step(
 
     client.async_send_command_no_wait.reset_mock()
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
     )
     assert device
     issue_id = f"device_config_file_changed.{device.id}"
@@ -280,8 +280,8 @@ async def test_abort_confirm(
     """Test aborting device_config_file_changed issue in confirm step."""
     node = await _trigger_repair_issue(hass, client, multisensor_6_state)
 
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, node)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
     )
     assert device
     issue_id = f"device_config_file_changed.{device.id}"

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -608,8 +608,8 @@ async def test_bulk_set_config_parameters(
     integration,
 ) -> None:
     """Test the bulk_set_partial_config_parameters service."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, multisensor_6)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, multisensor_6), integration.entry_id
     )
     assert device
 
@@ -978,8 +978,8 @@ async def test_set_value(
     integration,
 ) -> None:
     """Test set_value service."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_danfoss_lc_13), integration.entry_id
     )
     assert device
 
@@ -1334,12 +1334,12 @@ async def test_multicast_set_value(
     client.async_send_command.reset_mock()
 
     # Test using area ID
-    device_eurotronic = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_eurotronic_spirit_z)}
+    device_eurotronic = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_eurotronic_spirit_z), integration.entry_id
     )
     assert device_eurotronic
-    device_danfoss = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
+    device_danfoss = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_danfoss_lc_13), integration.entry_id
     )
     assert device_danfoss
     area = area_registry.async_get_or_create("test")
@@ -1659,16 +1659,15 @@ async def test_ping(
     integration,
 ) -> None:
     """Test ping service."""
-    device_radio_thermostat = device_registry.async_get_device(
-        identifiers={
-            get_device_id(
-                client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
-            )
-        }
+    device_radio_thermostat = device_registry.async_get_device_by_identifier(
+        get_device_id(
+            client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
+        ),
+        integration.entry_id,
     )
     assert device_radio_thermostat
-    device_danfoss = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
+    device_danfoss = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_danfoss_lc_13), integration.entry_id
     )
     assert device_danfoss
 
@@ -1816,16 +1815,15 @@ async def test_invoke_cc_api(
     integration,
 ) -> None:
     """Test invoke_cc_api service."""
-    device_radio_thermostat = device_registry.async_get_device(
-        identifiers={
-            get_device_id(
-                client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
-            )
-        }
+    device_radio_thermostat = device_registry.async_get_device_by_identifier(
+        get_device_id(
+            client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
+        ),
+        integration.entry_id,
     )
     assert device_radio_thermostat
-    device_danfoss = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
+    device_danfoss = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, climate_danfoss_lc_13), integration.entry_id
     )
     assert device_danfoss
 
@@ -1983,12 +1981,12 @@ async def test_refresh_notifications(
     integration,
 ) -> None:
     """Test refresh_notifications service."""
-    zen_31_device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, zen_31)}
+    zen_31_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, zen_31), integration.entry_id
     )
     assert zen_31_device
-    multisensor_6_device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, multisensor_6)}
+    multisensor_6_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, multisensor_6), integration.entry_id
     )
     assert multisensor_6_device
 

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -35,8 +35,8 @@ async def test_zwave_js_value_updated(
     """Test for zwave_js.value_updated automation trigger."""
     trigger_type = f"{DOMAIN}.value_updated"
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -478,8 +478,8 @@ async def test_zwave_js_event(
     """Test for zwave_js.event automation trigger."""
     trigger_type = f"{DOMAIN}.event"
     node: Node = lock_schlage_be469
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 
@@ -1049,8 +1049,8 @@ async def test_zwave_js_trigger_config_entry_unloaded(
     integration,
 ) -> None:
     """Test zwave_js triggers bypass dynamic validation when needed."""
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, lock_schlage_be469)}
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in `zwave_js` tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
