### PR TITLE
Migrate calls to async_get_device in homekit_controller tests

### DIFF
--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -315,7 +315,7 @@ async def setup_test_component(
 
 
 async def assert_devices_and_entities_created(
-    hass: HomeAssistant, expected: DeviceTestInfo
+    hass: HomeAssistant, config_entry_id: str, expected: DeviceTestInfo
 ):
     """Check all expected devices and entities are loaded correctly."""
     entity_registry = er.async_get(hass)
@@ -337,8 +337,8 @@ async def assert_devices_and_entities_created(
         #   This is only set when we have detected broken serial numbers
         #   (and serial number is not used as an identifier).
 
-        device = device_registry.async_get_device(
-            identifiers={(IDENTIFIER_ACCESSORY_ID, expected.unique_id)}
+        device = device_registry.async_get_device_by_identifier(
+            (IDENTIFIER_ACCESSORY_ID, expected.unique_id), config_entry_id
         )
 
         logger.debug("Comparing device %r to %r", device, expected)

--- a/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
+++ b/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
@@ -15,10 +15,11 @@ from ..common import (
 async def test_eufycam_setup(hass: HomeAssistant) -> None:
     """Test that a eufycam can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "anker_eufycam.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="eufy HomeBase2-0AAA",

--- a/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
@@ -24,10 +24,11 @@ from ..common import (
 async def test_aqara_switch_setup(hass: HomeAssistant) -> None:
     """Test that a Aqara Switch can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "aqara_switch.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="Programmable Switch",

--- a/tests/components/homekit_controller/specific_devices/test_connectsense.py
+++ b/tests/components/homekit_controller/specific_devices/test_connectsense.py
@@ -21,6 +21,7 @@ async def test_connectsense_setup(hass: HomeAssistant) -> None:
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="InWall Outlet-0394DE",
@@ -100,6 +101,7 @@ async def test_connectsense_setup(hass: HomeAssistant) -> None:
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="InWall Outlet-0394DE",

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -31,10 +31,11 @@ from ..common import (
 async def test_ecobee3_setup(hass: HomeAssistant) -> None:
     """Test that a Ecbobee 3 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="HomeW",

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -18,10 +18,11 @@ from ..common import (
 async def test_hue_bridge_setup(hass: HomeAssistant) -> None:
     """Test that a Hue hub can be correctly setup in HA via HomeKit."""
     accessories = await setup_accessories_from_file(hass, "hue_bridge.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="Philips hue - 482544",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -22,10 +22,11 @@ from ..common import (
 async def test_koogeek_sw2_setup(hass: HomeAssistant) -> None:
     """Test that a Koogeek LS1 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "koogeek_sw2.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="Koogeek-SW2-187A91",

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -19,10 +19,11 @@ from ..common import (
 async def test_lg_tv_setup(hass: HomeAssistant) -> None:
     """Test that a LG TV can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "lg_tv.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="LG webOS TV AF80",

--- a/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
+++ b/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
@@ -19,10 +19,11 @@ from ..common import (
 async def test_netamo_doorbell_setup(hass: HomeAssistant) -> None:
     """Test that a Netamo Doorbell can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "netamo_doorbell.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="Netatmo-Doorbell-g738658",

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
@@ -35,10 +35,11 @@ async def test_vocolinc_vp3_setup(
     )
 
     accessories = await setup_accessories_from_file(hass, "vocolinc_vp3.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, _ = await setup_test_accessories(hass, accessories)
 
     await assert_devices_and_entities_created(
         hass,
+        config_entry.entry_id,
         DeviceTestInfo(
             unique_id=HUB_TEST_ACCESSORY_ID,
             name="VOCOlinc-VP3-123456",

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -263,8 +263,8 @@ async def test_ble_device_populates_connections(
     assert config_entry.state is ConfigEntryState.LOADED
     dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
-        dev_reg.async_get_device(
-            identifiers={}, connections={("bluetooth", "AA:BB:CC:DD:EE:FF")}
+        dev_reg.async_get_device_by_connection(
+            ("bluetooth", "AA:BB:CC:DD:EE:FF"), config_entry.entry_id
         )
         is not None
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in `homekit_controller` tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
