### PR TITLE
Migrate calls to async_get_device in tests (part 7)

### DIFF
--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -116,7 +116,9 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(
     assert config_entry.unique_id == "ZXXX12345"
 
     # verify hub device is registered correctly
-    hub = device_registry.async_get_device(identifiers={(DOMAIN, "ZXXX12345")})
+    hub = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ZXXX12345"), config_entry.entry_id
+    )
     assert hub.name == "bond-name"
     assert hub.manufacturer == "Olibra"
     assert hub.model == "test-model"
@@ -201,8 +203,15 @@ async def test_old_identifiers_are_removed(
     assert config_entry.unique_id == "ZXXX12345"
 
     # verify the device info is cleaned up
-    assert device_registry.async_get_device(identifiers={old_identifers}) is None
-    assert device_registry.async_get_device(identifiers={new_identifiers}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            old_identifers, config_entry.entry_id
+        )
+        is None
+    )
+    assert device_registry.async_get_device_by_identifier(
+        new_identifiers, config_entry.entry_id
+    )
 
 
 async def test_device_via_device_links(
@@ -270,7 +279,9 @@ async def test_smart_by_bond_device_suggested_area(
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == "KXXX12345"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "KXXX12345")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "KXXX12345"), config_entry.entry_id
+    )
     assert device is not None
     assert device.area_id == area_registry.async_get_area_by_name("Den").id
 
@@ -320,7 +331,9 @@ async def test_bridge_device_suggested_area(
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == "ZXXX12345"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "ZXXX12345")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ZXXX12345"), config_entry.entry_id
+    )
     assert device is not None
     assert device.area_id == area_registry.async_get_area_by_name("Office").id
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -762,8 +762,8 @@ async def test_homekit_start(
 
     assert device_registry.async_get(bridge_with_wrong_mac.id) is None
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     formatted_mac = dr.format_mac(homekit.driver.state.mac)
@@ -784,8 +784,8 @@ async def test_homekit_start(
 
     assert load_mock.called
     assert not persist_mock.called
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     formatted_mac = dr.format_mac(homekit.driver.state.mac)
@@ -1101,8 +1101,8 @@ async def test_homekit_unpair(
         state.add_paired_client(str(uuid1()).encode("utf-8"), "any", b"0")
 
         formatted_mac = dr.format_mac(state.mac)
-        hk_bridge_dev = device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, formatted_mac)}
+        hk_bridge_dev = device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, formatted_mac), entry.entry_id
         )
 
         await hass.services.async_call(
@@ -2402,8 +2402,8 @@ async def test_homekit_start_in_accessory_mode(
     assert hk_driver_start.called
     assert homekit.status == STATUS_RUNNING
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     formatted_mac = dr.format_mac(homekit.driver.state.mac)

--- a/tests/components/russound_rio/test_init.py
+++ b/tests/components/russound_rio/test_init.py
@@ -43,8 +43,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/sensibo/test_init.py
+++ b/tests/components/sensibo/test_init.py
@@ -140,7 +140,9 @@ async def test_automatic_device_addition_and_removal(
     assert state
     assert entity_registry.async_get(entity_id)
     for device_id in device_ids:
-        assert device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), load_int.entry_id
+        )
 
     # Remove one of the devices
     new_device_list = [
@@ -162,7 +164,9 @@ async def test_automatic_device_addition_and_removal(
     assert not state
     assert not entity_registry.async_get(entity_id)
     for device_id in device_ids:
-        assert not device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+        assert not device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), load_int.entry_id
+        )
 
     # Add the device back
     mock_client.async_get_devices.return_value = get_data[2]
@@ -176,4 +180,6 @@ async def test_automatic_device_addition_and_removal(
     assert state
     assert entity_registry.async_get(entity_id)
     for device_id in device_ids:
-        assert device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), load_int.entry_id
+        )

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -74,29 +74,38 @@ async def test_device_identifier_migration(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test being able to unload an entry."""
-    original_identifiers = {(DOMAIN, "module_address", "module_serial")}
-    target_identifiers = {(DOMAIN, "module_address")}
+    original_identifier = (DOMAIN, "module_address", "module_serial")
+    target_identifier = (DOMAIN, "module_address")
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers=original_identifiers,  # type: ignore[arg-type]
+        identifiers={original_identifier},  # type: ignore[arg-type]
         name="channel_name",
         manufacturer="Velleman",
         model="module_type_name",
         sw_version="module_sw_version",
     )
-    assert device_registry.async_get_device(
-        identifiers=original_identifiers  # type: ignore[arg-type]
+    assert device_registry.async_get_device_by_identifier(
+        original_identifier,  # type: ignore[arg-type]
+        config_entry.entry_id,
     )
-    assert not device_registry.async_get_device(identifiers=target_identifiers)
+    assert (
+        device_registry.async_get_device_by_identifier(
+            target_identifier, config_entry.entry_id
+        )
+        is None
+    )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not device_registry.async_get_device(
-        identifiers=original_identifiers  # type: ignore[arg-type]
+    assert not device_registry.async_get_device_by_identifier(
+        original_identifier,  # type: ignore[arg-type]
+        config_entry.entry_id,
     )
-    device_entry = device_registry.async_get_device(identifiers=target_identifiers)
+    device_entry = device_registry.async_get_device_by_identifier(
+        target_identifier, config_entry.entry_id
+    )
     assert device_entry
     assert device_entry.name == "channel_name"
     assert device_entry.manufacturer == "Velleman"
@@ -216,13 +225,19 @@ async def test_device_registry(
     # Sort by identifier to ensure consistent order in snapshot
     assert sorted(device_entries, key=lambda x: list(x.identifiers)[0][1]) == snapshot
 
-    device_parent = device_registry.async_get_device(identifiers={(DOMAIN, "88")})
+    device_parent = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "88"), config_entry.entry_id
+    )
     assert device_parent.via_device_id is None
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "88-9")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "88-9"), config_entry.entry_id
+    )
     assert device.via_device_id == device_parent.id
 
-    device_no_sub = device_registry.async_get_device(identifiers={(DOMAIN, "2")})
+    device_no_sub = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "2"), config_entry.entry_id
+    )
     assert device_no_sub.via_device_id is None
 
 
@@ -235,7 +250,9 @@ async def test_remove_config_entry_device(
     await init_integration(hass, config_entry)
 
     # Active device (found on bus) can be removed; scan will recreate it
-    active_device = device_registry.async_get_device(identifiers={(DOMAIN, "1")})
+    active_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1"), config_entry.entry_id
+    )
     assert active_device is not None
     result = await async_remove_config_entry_device(hass, config_entry, active_device)
     assert result is True

--- a/tests/components/vilfo/test_init.py
+++ b/tests/components/vilfo/test_init.py
@@ -13,16 +13,16 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("mac", "identifiers"),
+    ("mac", "identifier"),
     [
         pytest.param(
             "FF-00-00-00-00-00",
-            {(DOMAIN, "testadmin.vilfo.com", "FF-00-00-00-00-00")},
+            (DOMAIN, "testadmin.vilfo.com", "FF-00-00-00-00-00"),
             id="with_mac",
         ),
         pytest.param(
             None,
-            {(DOMAIN, "testadmin.vilfo.com", None)},
+            (DOMAIN, "testadmin.vilfo.com", None),
             id="without_mac",
         ),
     ],
@@ -33,7 +33,7 @@ async def test_device_registry(
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
     mac: str | None,
-    identifiers: set[tuple[str, str | None]],
+    identifier: tuple[str, str, str | None],
 ) -> None:
     """Test the device registry entry.
 
@@ -55,5 +55,7 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(identifiers=identifiers)
+    device_entry = device_registry.async_get_device_by_identifier(
+        identifier, mock_config_entry.entry_id
+    )
     assert device_entry == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
