### PR TITLE
Migrate calls to async_get_device in duco tests

### DIFF
--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -37,9 +37,13 @@ from .conftest import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-def _get_duco_node_device(device_registry: dr.DeviceRegistry) -> dr.DeviceEntry:
+def _get_duco_node_device(
+    device_registry: dr.DeviceRegistry, config_entry_id: str
+) -> dr.DeviceEntry:
     """Return the primary Duco node device used in setup tests."""
-    device = device_registry.async_get_device(identifiers={("duco", f"{TEST_MAC}_1")})
+    device = device_registry.async_get_device_by_identifier(
+        ("duco", f"{TEST_MAC}_1"), config_entry_id
+    )
     assert device is not None
     return device
 
@@ -243,7 +247,7 @@ async def test_setup_entry_ignores_node_name_config_failures(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    device = _get_duco_node_device(device_registry)
+    device = _get_duco_node_device(device_registry, mock_config_entry.entry_id)
     assert device.name == mock_nodes[0].general.name
     assert mock_duco_client.async_get_node_configs.call_count == 1
 
@@ -384,7 +388,7 @@ async def test_setup_entry_uses_configured_node_name(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = _get_duco_node_device(device_registry)
+    device = _get_duco_node_device(device_registry, mock_config_entry.entry_id)
     assert device.name == "Kitchen"
     assert mock_duco_client.async_get_node_configs.call_count == 1
 
@@ -407,7 +411,7 @@ async def test_node_name_refresh_updates_device_registry_name(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = _get_duco_node_device(device_registry)
+    device = _get_duco_node_device(device_registry, mock_config_entry.entry_id)
     assert device.name == "Kitchen"
     assert mock_duco_client.async_get_node_configs.call_count == 1
 
@@ -415,13 +419,13 @@ async def test_node_name_refresh_updates_device_registry_name(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    device = _get_duco_node_device(device_registry)
+    device = _get_duco_node_device(device_registry, mock_config_entry.entry_id)
     assert device.name == "Kitchen"
     assert mock_duco_client.async_get_node_configs.call_count == 1
 
     assert await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = _get_duco_node_device(device_registry)
+    device = _get_duco_node_device(device_registry, mock_config_entry.entry_id)
     assert device.name == "Living Room"
     assert mock_duco_client.async_get_node_configs.call_count == 2

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -377,8 +377,8 @@ async def test_deregistered_node_removes_device(
 ) -> None:
     """Test a node disappearing from the API removes its device from the registry."""
     # Verify node 2 (UCCO2 RF sensor) device exists before deregistration.
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_2")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.unique_id}_2"), mock_config_entry.entry_id
     )
     assert device is not None
 
@@ -392,8 +392,8 @@ async def test_deregistered_node_removes_device(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # The device should be removed from the device registry.
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_2")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.unique_id}_2"), mock_config_entry.entry_id
     )
     assert device is None
 
@@ -413,8 +413,9 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
         hass, mock_config_entry, [Platform.FAN, Platform.SENSOR]
     )
 
-    box_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}")}
+    box_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}"),
+        mock_config_entry.entry_id,
     )
     assert box_device is not None
     assert hass.states.get("fan.living") is not None
@@ -428,8 +429,9 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}"),
+            mock_config_entry.entry_id,
         )
         is not None
     )
@@ -483,8 +485,8 @@ async def test_unknown_node_type_logs_warning_and_creates_no_entities(
     assert "unsupported" in caplog.text.lower()
     assert hass.states.get("sensor.unsupported_device_humidity") is None
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_99")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.unique_id}_99"), mock_config_entry.entry_id
     )
     assert device is None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in `duco` tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
