### PR TITLE
Avoid a naive datetime.now() in buienradar

### DIFF
--- a/homeassistant/components/buienradar/const.py
+++ b/homeassistant/components/buienradar/const.py
@@ -14,6 +14,9 @@ CONF_TIMEFRAME = "timeframe"
 SUPPORTED_COUNTRY_CODES = ["NL", "BE"]
 DEFAULT_COUNTRY = "NL"
 
+SERVICE_TIME_ZONE = "Europe/Amsterdam"
+"""Time zone of the buienradar.nl service, which updates around local midnight."""
+
 SCHEDULE_OK = 10
 """Schedule next call after (minutes)."""
 SCHEDULE_NOK = 2

--- a/homeassistant/components/buienradar/util.py
+++ b/homeassistant/components/buienradar/util.py
@@ -1,6 +1,6 @@
 """Shared utilities for different supported platforms."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from http import HTTPStatus
 import logging
 from typing import Any
@@ -158,7 +158,7 @@ class BrData:
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
-            if int(datetime.now().strftime("%H")) > 0:  # pylint: disable=home-assistant-enforce-naive-now
+            if dt_util.now().hour > 0:
                 _LOGGER.warning(
                     "Unable to parse data from Buienradar. (Msg: %s)",
                     result.get(MESSAGE),

--- a/homeassistant/components/buienradar/util.py
+++ b/homeassistant/components/buienradar/util.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_TIMEOUT, SCHEDULE_NOK, SCHEDULE_OK
+from .const import DEFAULT_TIMEOUT, SCHEDULE_NOK, SCHEDULE_OK, SERVICE_TIME_ZONE
 
 __all__ = ["BrData"]
 _LOGGER = logging.getLogger(__name__)
@@ -158,7 +158,12 @@ class BrData:
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
-            if dt_util.now().hour > 0:
+            # buienradar.nl updates its forecast for the next day between 00:00
+            # and 01:00 CE(S)T and often serves nothing during that hour, so the
+            # warning is only meaningful outside it. The hour that decides this
+            # is the one at the service, not in the user's configured time zone.
+            service_tz = await dt_util.async_get_time_zone(SERVICE_TIME_ZONE)
+            if service_tz is None or dt_util.utcnow().astimezone(service_tz).hour > 0:
                 _LOGGER.warning(
                     "Unable to parse data from Buienradar. (Msg: %s)",
                     result.get(MESSAGE),

--- a/tests/components/buienradar/test_util.py
+++ b/tests/components/buienradar/test_util.py
@@ -1,0 +1,53 @@
+"""Tests for the Buienradar utilities."""
+
+from unittest.mock import AsyncMock, patch
+
+from buienradar.constants import CONTENT, MESSAGE, STATUS_CODE, SUCCESS
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.buienradar.util import BrData
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+
+WARNING = "Unable to parse data from Buienradar"
+
+
+@pytest.mark.parametrize(
+    ("frozen_time", "expect_warning"),
+    [
+        ("2026-01-01T05:30:00+00:00", True),
+        ("2026-01-01T06:30:00+00:00", False),
+    ],
+    ids=["daytime", "midnight_hour"],
+)
+async def test_unparsable_data_is_quiet_during_the_midnight_hour(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    frozen_time: str,
+    expect_warning: bool,
+) -> None:
+    """Test the parse failure warning is suppressed in the midnight hour.
+
+    Buienradar is known to serve no data around midnight, so the warning is
+    only interesting for the rest of the day. The configured time zone is what
+    decides that, which is why the times below are UTC but the hour that
+    matters is the one in America/Regina (UTC-6, no DST).
+    """
+    await hass.config.async_set_time_zone("America/Regina")
+    freezer.move_to(frozen_time)
+
+    data = BrData(hass, {CONF_LATITUDE: 51.5, CONF_LONGITUDE: 5.5}, 60, [])
+    fetched = {SUCCESS: True, CONTENT: "{}", STATUS_CODE: 200}
+
+    with (
+        patch.object(BrData, "get_data", new=AsyncMock(return_value=fetched)),
+        patch(
+            "homeassistant.components.buienradar.util.parse_data",
+            return_value={SUCCESS: False, MESSAGE: "no data"},
+        ),
+    ):
+        assert await data._async_update() is None
+
+    assert (WARNING in caplog.text) is expect_warning

--- a/tests/components/buienradar/test_util.py
+++ b/tests/components/buienradar/test_util.py
@@ -16,10 +16,19 @@ WARNING = "Unable to parse data from Buienradar"
 @pytest.mark.parametrize(
     ("frozen_time", "expect_warning"),
     [
-        ("2026-01-01T05:30:00+00:00", True),
-        ("2026-01-01T06:30:00+00:00", False),
+        ("2026-01-14T23:00:00+00:00", False),
+        ("2026-01-14T23:59:59+00:00", False),
+        ("2026-01-15T00:00:00+00:00", True),
+        ("2026-07-14T22:30:00+00:00", False),
+        ("2026-01-15T06:30:00+00:00", True),
     ],
-    ids=["daytime", "midnight_hour"],
+    ids=[
+        "cet_0000_start_of_quiet_hour",
+        "cet_0059_end_of_quiet_hour",
+        "cet_0100_just_after",
+        "cest_0030_quiet_hour_in_dst",
+        "cet_0730_quiet_only_where_user_lives",
+    ],
 )
 async def test_unparsable_data_is_quiet_during_the_midnight_hour(
     hass: HomeAssistant,
@@ -30,10 +39,16 @@ async def test_unparsable_data_is_quiet_during_the_midnight_hour(
 ) -> None:
     """Test the parse failure warning is suppressed in the midnight hour.
 
-    Buienradar is known to serve no data around midnight, so the warning is
-    only interesting for the rest of the day. The configured time zone is what
-    decides that, which is why the times below are UTC but the hour that
-    matters is the one in America/Regina (UTC-6, no DST).
+    buienradar.nl serves no data while it updates its forecast between 00:00 and
+    01:00 CE(S)T, so the warning is only interesting outside that hour. The hour
+    that decides this belongs to the service, so the configured time zone here is
+    deliberately somewhere else: America/Regina is UTC-6 with no DST, which puts
+    every case below in a different hour locally than in Amsterdam.
+
+    The times are UTC. The first three pin the edges of the quiet hour in CET,
+    the fourth repeats it in CEST so the offset is not hardcoded, and the last
+    one is the quiet hour in America/Regina rather than in Amsterdam, so it must
+    still warn.
     """
     await hass.config.async_set_time_zone("America/Regina")
     freezer.move_to(frozen_time)

--- a/tests/components/buienradar/test_util.py
+++ b/tests/components/buienradar/test_util.py
@@ -1,20 +1,30 @@
 """Tests for the Buienradar utilities."""
 
-from unittest.mock import AsyncMock, patch
+import datetime
+from http import HTTPStatus
+from unittest.mock import patch
 
-from buienradar.constants import CONTENT, MESSAGE, STATUS_CODE, SUCCESS
+from buienradar.constants import MESSAGE, SUCCESS
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.buienradar.util import BrData
+from homeassistant.components.buienradar.const import DOMAIN
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+TEST_LATITUDE = 51.5
+TEST_LONGITUDE = 5.5
+TEST_CFG_DATA = {CONF_LATITUDE: TEST_LATITUDE, CONF_LONGITUDE: TEST_LONGITUDE}
 
 WARNING = "Unable to parse data from Buienradar"
 
 
 @pytest.mark.parametrize(
-    ("frozen_time", "expect_warning"),
+    ("update_at", "expect_warning"),
     [
         ("2026-01-14T23:00:00+00:00", False),
         ("2026-01-14T23:59:59+00:00", False),
@@ -32,9 +42,10 @@ WARNING = "Unable to parse data from Buienradar"
 )
 async def test_unparsable_data_is_quiet_during_the_midnight_hour(
     hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
-    frozen_time: str,
+    update_at: str,
     expect_warning: bool,
 ) -> None:
     """Test the parse failure warning is suppressed in the midnight hour.
@@ -46,23 +57,39 @@ async def test_unparsable_data_is_quiet_during_the_midnight_hour(
     every case below in a different hour locally than in Amsterdam.
 
     The times are UTC. The first three pin the edges of the quiet hour in CET,
-    the fourth repeats it in CEST so the offset is not hardcoded, and the last
-    one is the quiet hour in America/Regina rather than in Amsterdam, so it must
+    the fourth repeats it in CEST so the offset is not assumed, and the last one
+    is the quiet hour in America/Regina rather than in Amsterdam, so it must
     still warn.
     """
     await hass.config.async_set_time_zone("America/Regina")
-    freezer.move_to(frozen_time)
+    aioclient_mock.get(
+        "https://data.buienradar.nl/2.0/feed/json", status=HTTPStatus.OK, text="{}"
+    )
+    aioclient_mock.get(
+        f"https://gps.buienradar.nl/getrr.php?lat={TEST_LATITUDE}&lon={TEST_LONGITUDE}",
+        status=HTTPStatus.OK,
+        text="",
+    )
 
-    data = BrData(hass, {CONF_LATITUDE: 51.5, CONF_LONGITUDE: 5.5}, 60, [])
-    fetched = {SUCCESS: True, CONTENT: "{}", STATUS_CODE: 200}
+    update = dt_util.parse_datetime(update_at)
+    assert update is not None
+    # A failed update reschedules itself two minutes later, which is the update
+    # the assertion below is about.
+    freezer.move_to(update - datetime.timedelta(minutes=2))
 
-    with (
-        patch.object(BrData, "get_data", new=AsyncMock(return_value=fetched)),
-        patch(
-            "homeassistant.components.buienradar.util.parse_data",
-            return_value={SUCCESS: False, MESSAGE: "no data"},
-        ),
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="TEST_ID", data=TEST_CFG_DATA)
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.buienradar.util.parse_data",
+        return_value={SUCCESS: False, MESSAGE: "no data"},
     ):
-        assert await data._async_update() is None
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        caplog.clear()
+        freezer.move_to(update)
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
 
     assert (WARNING in caplog.text) is expect_warning


### PR DESCRIPTION
﻿## Proposed change

This check exists to suppress the parse warning during the midnight hour, when
Buienradar is known to return no data, so what it wants is the local hour.

`dt_util.now().hour` says that directly, instead of formatting a naive datetime
to `%H` and parsing the string back into an int. The module already imports
`dt_util` and uses it a few lines above.

### Not a pure refactor

Worth calling out: `datetime.now()` reads the **system** time zone, while
`dt_util.now()` reads the one **configured in Home Assistant**. For an instance
where those two differ, the hour the warning is suppressed in moves from the
host's midnight to the user's. That looks like the intended behaviour to me —
the suppression is about when Buienradar stops serving data locally — but it is
a behaviour change, so I would rather flag it than bury it.

There was no test on this branch at all. The new one pins the configured zone
to `America/Regina` so it disagrees with the host, which makes it fail on `dev`
and pass here.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177794
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

