### PR TITLE
Migrate calls to async_get_device in rfxtrx tests

### DIFF
--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -22,17 +22,17 @@ class DeviceTestData(NamedTuple):
     """Test data linked to a device."""
 
     code: str
-    device_identifiers: set[tuple[str, str, str, str]]
+    device_identifier: tuple[str, str, str, str]
 
 
-DEVICE_LIGHTING_1 = DeviceTestData("0710002a45050170", {("rfxtrx", "10", "0", "E5")})
+DEVICE_LIGHTING_1 = DeviceTestData("0710002a45050170", ("rfxtrx", "10", "0", "E5"))
 
 DEVICE_BLINDS_1 = DeviceTestData(
-    "09190000009ba8010100", {("rfxtrx", "19", "0", "009ba8:1")}
+    "09190000009ba8010100", ("rfxtrx", "19", "0", "009ba8:1")
 )
 
 DEVICE_TEMPHUM_1 = DeviceTestData(
-    "0a52080705020095220269", {("rfxtrx", "52", "8", "05:02")}
+    "0a52080705020095220269", ("rfxtrx", "52", "8", "05:02")
 )
 
 
@@ -40,12 +40,15 @@ DEVICE_TEMPHUM_1 = DeviceTestData(
 async def test_device_test_data(rfxtrx, device: DeviceTestData) -> None:
     """Verify that our testing data remains correct."""
     pkt: RFXtrx.lowlevel.Packet = RFXtrx.lowlevel.parse(bytearray.fromhex(device.code))
-    assert device.device_identifiers == {
-        ("rfxtrx", f"{pkt.packettype:x}", f"{pkt.subtype:x}", pkt.id_string)
-    }
+    assert device.device_identifier == (
+        "rfxtrx",
+        f"{pkt.packettype:x}",
+        f"{pkt.subtype:x}",
+        pkt.id_string,
+    )
 
 
-async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
+async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> MockConfigEntry:
     """Construct a config setup."""
     entry_data = create_rfx_test_cfg(devices=devices)
     mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
@@ -55,6 +58,8 @@ async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
+
+    return mock_entry
 
 
 def _get_expected_actions(data):
@@ -83,10 +88,10 @@ async def test_get_actions(
     expected,
 ) -> None:
     """Test we get the expected actions from a rfxtrx."""
-    await setup_entry(hass, {device.code: {}})
+    mock_entry = await setup_entry(hass, {device.code: {}})
 
-    device_entry = device_registry.async_get_device(
-        identifiers=device.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        device.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
@@ -95,8 +100,8 @@ async def test_get_actions(
     device_registry.async_update_device(
         device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
     )
-    device_entry = device_registry.async_get_device(
-        identifiers=device.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        device.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
@@ -143,10 +148,10 @@ async def test_action(
 ) -> None:
     """Test for actions."""
 
-    await setup_entry(hass, {device.code: {}})
+    mock_entry = await setup_entry(hass, {device.code: {}})
 
-    device_entry = device_registry.async_get_device(
-        identifiers=device.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        device.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
@@ -184,10 +189,11 @@ async def test_invalid_action(
     """Test for invalid actions."""
     device = DEVICE_LIGHTING_1
 
-    await setup_entry(hass, {device.code: {}})
+    mock_entry = await setup_entry(hass, {device.code: {}})
 
-    device_identifiers: Any = device.device_identifiers
-    device_entry = device_registry.async_get_device(identifiers=device_identifiers)
+    device_entry = device_registry.async_get_device_by_identifier(
+        device.device_identifier, mock_entry.entry_id
+    )
     assert device_entry
 
     assert await async_setup_component(

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -25,26 +25,26 @@ class EventTestData(NamedTuple):
     """Test data linked to a device."""
 
     code: str
-    device_identifiers: set[tuple[str, str, str, str]]
+    device_identifier: tuple[str, str, str, str]
     type: str
     subtype: str
 
 
-DEVICE_LIGHTING_1 = {("rfxtrx", "10", "0", "E5")}
+DEVICE_LIGHTING_1 = ("rfxtrx", "10", "0", "E5")
 EVENT_LIGHTING_1 = EventTestData("0710002a45050170", DEVICE_LIGHTING_1, "command", "On")
 
-DEVICE_ROLLERTROL_1 = {("rfxtrx", "19", "0", "009ba8:1")}
+DEVICE_ROLLERTROL_1 = ("rfxtrx", "19", "0", "009ba8:1")
 EVENT_ROLLERTROL_1 = EventTestData(
     "09190000009ba8010100", DEVICE_ROLLERTROL_1, "command", "Down"
 )
 
-DEVICE_FIREALARM_1 = {("rfxtrx", "20", "3", "a10900:32")}
+DEVICE_FIREALARM_1 = ("rfxtrx", "20", "3", "a10900:32")
 EVENT_FIREALARM_1 = EventTestData(
     "08200300a109000670", DEVICE_FIREALARM_1, "status", "Panic"
 )
 
 
-async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
+async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> MockConfigEntry:
     """Construct a config setup."""
     entry_data = create_rfx_test_cfg(devices=devices)
     mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
@@ -54,6 +54,8 @@ async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
+
+    return mock_entry
 
 
 @pytest.mark.parametrize(
@@ -84,20 +86,20 @@ async def test_get_triggers(
     expected,
 ) -> None:
     """Test we get the expected triggers from a rfxtrx."""
-    await setup_entry(hass, {event.code: {}})
+    mock_entry = await setup_entry(hass, {event.code: {}})
 
-    device_entry = device_registry.async_get_device(
-        identifiers=event.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        event.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
     # Add alternate identifiers, to make sure we can handle future formats
-    identifiers: list[str] = list(*event.device_identifiers)
+    identifiers: list[str] = list(event.device_identifier)
     device_registry.async_update_device(
         device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
     )
-    device_entry = device_registry.async_get_device(
-        identifiers=event.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        event.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
@@ -132,10 +134,10 @@ async def test_firing_event(
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
 
-    await setup_entry(hass, {event.code: {"fire_event": True}})
+    mock_entry = await setup_entry(hass, {event.code: {"fire_event": True}})
 
-    device_entry = device_registry.async_get_device(
-        identifiers=event.device_identifiers
+    device_entry = device_registry.async_get_device_by_identifier(
+        event.device_identifier, mock_entry.entry_id
     )
     assert device_entry
 
@@ -178,10 +180,11 @@ async def test_invalid_trigger(
     """Test for invalid actions."""
     event = EVENT_LIGHTING_1
 
-    await setup_entry(hass, {event.code: {"fire_event": True}})
+    mock_entry = await setup_entry(hass, {event.code: {"fire_event": True}})
 
-    device_identifiers: Any = event.device_identifiers
-    device_entry = device_registry.async_get_device(identifiers=device_identifiers)
+    device_entry = device_registry.async_get_device_by_identifier(
+        event.device_identifier, mock_entry.entry_id
+    )
     assert device_entry
 
     assert await async_setup_component(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -21,7 +21,7 @@ async def test_fire_event(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, rfxtrx
 ) -> None:
     """Test fire event."""
-    await setup_rfx_test_cfg(
+    mock_entry = await setup_rfx_test_cfg(
         hass,
         device="/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
         automatic_add=True,
@@ -44,13 +44,13 @@ async def test_fire_event(
     await rfxtrx.signal("0b1100cd0213c7f210010f51")
     await rfxtrx.signal("0716000100900970")
 
-    device_id_1 = device_registry.async_get_device(
-        identifiers={("rfxtrx", "11", "0", "213c7f2:16")}
+    device_id_1 = device_registry.async_get_device_by_identifier(
+        ("rfxtrx", "11", "0", "213c7f2:16"), mock_entry.entry_id
     )
     assert device_id_1
 
-    device_id_2 = device_registry.async_get_device(
-        identifiers={("rfxtrx", "16", "0", "00:90")}
+    device_id_2 = device_registry.async_get_device_by_identifier(
+        ("rfxtrx", "16", "0", "00:90"), mock_entry.entry_id
     )
     assert device_id_2
 
@@ -105,8 +105,8 @@ async def test_ws_device_remove(
         },
     )
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("rfxtrx", *device_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("rfxtrx", *device_id), mock_entry.entry_id
     )
     assert device_entry
 
@@ -117,7 +117,10 @@ async def test_ws_device_remove(
 
     # Verify device entry is removed
     assert (
-        device_registry.async_get_device(identifiers={("rfxtrx", *device_id)}) is None
+        device_registry.async_get_device_by_identifier(
+            ("rfxtrx", *device_id), mock_entry.entry_id
+        )
+        is None
     )
 
     # Verify that the config entry has removed the device


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in `rfxtrx` tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
