### PR TITLE
Bump lyngdorf to 1.4.4

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.3"],
+  "requirements": ["lyngdorf==1.4.4"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.3
+lyngdorf==1.4.4
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps the `lyngdorf` dependency from `1.4.3` to `1.4.4`. Follow-up to #178323, which merged before 1.4.4 was released — see https://github.com/home-assistant/core/pull/178323#issuecomment (Pharkie's comment).

Fixes for TDAI-1120/3400:
- fishloa/lyngdorf#22: source names containing `)` were truncated.
- fishloa/lyngdorf#23: RoomPerfect position and voicing never populated.

Compare: https://github.com/fishloa/lyngdorf/compare/v1.4.3...v1.4.4

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178323
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

PyPI: https://pypi.org/project/lyngdorf/1.4.4/

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
