### PR TITLE
Bump zhong-hong-hvac to 1.0.16

### DIFF
--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["zhong_hong_hvac"],
   "quality_scale": "legacy",
-  "requirements": ["zhong-hong-hvac==1.0.15"]
+  "requirements": ["zhong-hong-hvac==1.0.16"]
 }

--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["zhong_hong_hvac"],
   "quality_scale": "legacy",
-  "requirements": ["zhong-hong-hvac==1.0.13"]
+  "requirements": ["zhong-hong-hvac==1.0.15"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3479,7 +3479,7 @@ zha-quirks==2.2.0
 zha==2.1.0
 
 # homeassistant.components.zhong_hong
-zhong-hong-hvac==1.0.13
+zhong-hong-hvac==1.0.15
 
 # homeassistant.components.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3479,7 +3479,7 @@ zha-quirks==2.2.0
 zha==2.1.0
 
 # homeassistant.components.zhong_hong
-zhong-hong-hvac==1.0.15
+zhong-hong-hvac==1.0.16
 
 # homeassistant.components.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.1.0


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Bump `zhong-hong-hvac` from 1.0.13 to 1.0.16. The library release fixes silent gateway connection death (tolerant parsing of undefined status values, listener self-healing, health probes and reconnect) and propagates the send result through all control methods.

**Diff between library versions: https://github.com/crhan/ZhongHongHVAC/compare/v1.0.13...v1.0.16**

This PR only contains the dependency bump; the Home Assistant component changes that use the new library features are in #177945.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #(none)
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] The manifest file includes all dependencies (these are listed in the [dependency docs][dependency-docs]).
- [x] New dependencies are fully documented in the [manifest file][manifest-docs] and the [dependency docs][dependency-docs].

If the code communicates with devices, web services, or third-party tools:

- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] New or updated dependencies have been added to `requirements_test_all.txt`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/development_catching_up/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[dependency-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/#dependencies
