### PR TITLE
Add Tuya two-channel energy meter sensors and numbers

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -596,6 +596,7 @@ class DPCode(StrEnum):
     ALARM_SWITCH = "alarm_switch"  # Alarm switch
     ALARM_TIME = "alarm_time"  # Alarm time
     ALARM_VOLUME = "alarm_volume"  # Alarm volume
+    ALL_ENERGY = "all_energy"  # Combined energy of all channels
     ANGLE_HORIZONTAL = "angle_horizontal"
     ANGLE_VERTICAL = "angle_vertical"
     ANION = "anion"  # Ionizer unit
@@ -683,9 +684,15 @@ class DPCode(StrEnum):
     CUMULATIVE_ENERGY_OUTPUT_INV = "cumulative_energy_output_inv"
     CUP_NUMBER = "cup_number"  # NUmber of cups
     CUR_CURRENT = "cur_current"  # Actual current
+    CUR_CURRENT1 = "cur_current1"  # Actual current, channel 1
+    CUR_CURRENT2 = "cur_current2"  # Actual current, channel 2
     CUR_NEUTRAL = "cur_neutral"  # Total reverse energy
     CUR_POWER = "cur_power"  # Actual power
+    CUR_POWER1 = "cur_power1"  # Actual power, channel 1
+    CUR_POWER2 = "cur_power2"  # Actual power, channel 2
     CUR_VOLTAGE = "cur_voltage"  # Actual voltage
+    CUR_VOLTAGE1 = "cur_voltage1"  # Actual voltage, channel 1
+    CUR_VOLTAGE2 = "cur_voltage2"  # Actual voltage, channel 2
     CURRENT_SOC = "current_soc"
     DECIBEL_SENSITIVITY = "decibel_sensitivity"
     DECIBEL_SWITCH = "decibel_switch"
@@ -694,6 +701,8 @@ class DPCode(StrEnum):
     DELAY_CLEAN_TIME = "delay_clean_time"
     DELAY_SET = "delay_set"
     DEVICE_RESTART = "device_restart"
+    DEVICE_STATE1 = "device_state1"  # Channel 1 monitoring state
+    DEVICE_STATE2 = "device_state2"  # Channel 2 monitoring state
     DEW_POINT_TEMP = "dew_point_temp"
     DISINFECTION = "disinfection"
     DO_NOT_DISTURB = "do_not_disturb"
@@ -945,9 +954,13 @@ class DPCode(StrEnum):
     TEMPER_ALARM = "temper_alarm"  # Tamper alarm
     TIME_TOTAL = "time_total"
     TIME_USE = "time_use"  # Total seconds of irrigation
+    TODAY_ACC_ENERGY1 = "today_acc_energy1"  # Energy today, channel 1
+    TODAY_ACC_ENERGY2 = "today_acc_energy2"  # Energy today, channel 2
     TOTAL_CLEAN_AREA = "total_clean_area"
     TOTAL_CLEAN_COUNT = "total_clean_count"
     TOTAL_CLEAN_TIME = "total_clean_time"
+    TOTAL_ENERGY1 = "total_energy1"  # Total energy, channel 1
+    TOTAL_ENERGY2 = "total_energy2"  # Total energy, channel 2
     TOTAL_FORWARD_ENERGY = "total_forward_energy"
     TOTAL_PM = "total_pm"
     TOTAL_POWER = "total_power"
@@ -971,6 +984,8 @@ class DPCode(StrEnum):
     VOLUME_SET = "volume_set"
     WARM = "warm"  # Heat preservation
     WARM_TIME = "warm_time"  # Heat preservation time
+    WARN_POWER1 = "warn_power1"  # Power warning threshold, channel 1
+    WARN_POWER2 = "warn_power2"  # Power warning threshold, channel 2
     WATER = "water"
     WATER_LEVEL = "water_level"
     WATER_RESET = "water_reset"  # Resetting of water usage days

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -88,6 +88,23 @@ NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
             translation_key="voice_times",
         ),
     ),
+    DeviceCategory.CZ: (
+        # Two-channel current transformer meters warn above these thresholds
+        NumberEntityDescription(
+            key=DPCode.WARN_POWER1,
+            translation_key="indexed_power_warning_threshold",
+            translation_placeholders={"index": "1"},
+            device_class=NumberDeviceClass.POWER,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.WARN_POWER2,
+            translation_key="indexed_power_warning_threshold",
+            translation_placeholders={"index": "2"},
+            device_class=NumberDeviceClass.POWER,
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
     DeviceCategory.DGNBJ: (
         NumberEntityDescription(
             key=DPCode.ALARM_TIME,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1673,8 +1673,111 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
     ),
 }
 
-# Socket (duplicate of `kg`)
-SENSORS[DeviceCategory.CZ] = SENSORS[DeviceCategory.KG]
+# Two-channel current transformer meters report a full set of electricity DPs
+# per channel, plus a combined energy total for both channels.
+DUAL_CHANNEL_METER_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
+    TuyaSensorEntityDescription(
+        key=DPCode.DEVICE_STATE1,
+        translation_key="indexed_meter_status",
+        translation_placeholders={"index": "1"},
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.DEVICE_STATE2,
+        translation_key="indexed_meter_status",
+        translation_placeholders={"index": "2"},
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_CURRENT1,
+        translation_key="indexed_current",
+        translation_placeholders={"index": "1"},
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_CURRENT2,
+        translation_key="indexed_current",
+        translation_placeholders={"index": "2"},
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_POWER1,
+        translation_key="indexed_power",
+        translation_placeholders={"index": "1"},
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_POWER2,
+        translation_key="indexed_power",
+        translation_placeholders={"index": "2"},
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_VOLTAGE1,
+        translation_key="indexed_voltage",
+        translation_placeholders={"index": "1"},
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.CUR_VOLTAGE2,
+        translation_key="indexed_voltage",
+        translation_placeholders={"index": "2"},
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.TOTAL_ENERGY1,
+        translation_key="indexed_total_energy",
+        translation_placeholders={"index": "1"},
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.TOTAL_ENERGY2,
+        translation_key="indexed_total_energy",
+        translation_placeholders={"index": "2"},
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.TODAY_ACC_ENERGY1,
+        translation_key="indexed_energy_today",
+        translation_placeholders={"index": "1"},
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.TODAY_ACC_ENERGY2,
+        translation_key="indexed_energy_today",
+        translation_placeholders={"index": "2"},
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    TuyaSensorEntityDescription(
+        key=DPCode.ALL_ENERGY,
+        translation_key="total_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+)
+
+# Socket (duplicate of `kg`, plus the two-channel meter DPs)
+SENSORS[DeviceCategory.CZ] = (
+    *SENSORS[DeviceCategory.KG],
+    *DUAL_CHANNEL_METER_SENSORS,
+)
 
 # Smart Camera - Low power consumption camera (duplicate of `sp`)
 SENSORS[DeviceCategory.DGHSXJ] = SENSORS[DeviceCategory.SP]

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -229,6 +229,9 @@
       "indexed_minimum_brightness": {
         "name": "Minimum brightness {index}"
       },
+      "indexed_power_warning_threshold": {
+        "name": "Power warning threshold {index}"
+      },
       "indexed_temperature": {
         "name": "Temperature {index}"
       },
@@ -764,11 +767,36 @@
       "illuminance": {
         "name": "[%key:component::sensor::entity_component::illuminance::name%]"
       },
+      "indexed_current": {
+        "name": "Current channel {index}"
+      },
+      "indexed_energy_today": {
+        "name": "Energy today channel {index}"
+      },
       "indexed_humidity_outdoor": {
         "name": "Outdoor humidity channel {index}"
       },
+      "indexed_meter_status": {
+        "name": "Status channel {index}",
+        "state": {
+          "close": "[%key:common::state::closed%]",
+          "idle": "[%key:common::state::idle%]",
+          "monitor": "Monitoring",
+          "warning": "Warning",
+          "working": "Working"
+        }
+      },
+      "indexed_power": {
+        "name": "Power channel {index}"
+      },
       "indexed_temperature_external": {
         "name": "Probe temperature channel {index}"
+      },
+      "indexed_total_energy": {
+        "name": "Total energy channel {index}"
+      },
+      "indexed_voltage": {
+        "name": "Voltage channel {index}"
       },
       "inverter_output_power": {
         "name": "Inverter output power"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
I recently bought a Tuya capable smart sensor (2 Channel DIN Rail CT Energy Meter) for monitoring power consumption, however it was 'unsupported' in Home Assistant. I created a quirk (home-assistant-libs/tuya-device-handlers#470) and then wanted more native Tuya integration with the entities listed etc.

This PR adds support for two-channel Tuya CT energy meters in category cz, which report a full set of electricity datapoints per channel plus a combined energy total. Specifically it adds 15 DPCode members, 13 cz sensors (per-channel current, power, voltage, total energy, energy today and status, plus the combined all_energy), 2 cz numbers for the per-channel power warning thresholds, and 7 translation keys using the existing indexed_* {index} convention.

cz previously aliased kg. It now takes kg's descriptions plus the meter ones, so nothing is removed from cz, and pc and dghsxj are untouched. I checked this by importing the maps on dev and on this branch and diffing every description across all 61 sensor categories: the only delta is +13 on cz and a new cz entry in NUMBERS, with nothing lost.

These datapoints reach Home Assistant via the quirk mentioned above, because Tuya advertises no schema for these products at all. Core already carries fixtures for two of them (cz_dhto3y4uachr1wll and cz_79a7z01v3n35kytb), both recorded with empty function / status_range.

add_ele1 / add_ele2 and today_energy_add1 / today_energy_add2 are deliberately not exposed: the cloud declares them report_type: sum, so they're per-report increments rather than running totals and would be wrong under TOTAL_INCREASING. total_energy1 / total_energy2 are the cumulative counters and are used instead.

Verified on hardware: running live in my personal Home Assistant instance with the patched integration from custom_components/, 15 entities built and both channels separated correctly, oven on channel 1 at 1533.6 W / 6.229 A and aircon on channel 2, with the device's own combined counter matching the sum of the two channels to the last Wh. It's wired into my HA Energy Dashboard and data is flowing correctly.

On test coverage
I haven't added tests. Rather than just leaving the box unticked, here's the reasoning: The Tuya platform tests apply the no_quirk fixture, which decouples core from the quirks library version, so datapoints that only exist via a quirk can't be exercised by the existing snapshot tests. The SENSORS / NUMBERS maps are static description tables, an entry only produces an entity for a device that actually has that datapoint, so these additions are inert for every other device. The existing suite passes unchanged. 

If you'd prefer this to wait until #470 is merged and released, so the dependency pin can be bumped and a quirk-aware test added, I'm happy to do that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #176755
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
