### PR TITLE
Migrate calls to async_get_device in unifi_access tests

### DIFF
--- a/tests/components/unifi_access/test_services.py
+++ b/tests/components/unifi_access/test_services.py
@@ -28,9 +28,13 @@ from tests.common import MockConfigEntry
 FRONT_DOOR_LOCK_RULE_ENTITY = "sensor.front_door_lock_rule"
 
 
-def _device_id(device_registry: dr.DeviceRegistry, identifier: str) -> str:
+def _device_id(
+    device_registry: dr.DeviceRegistry, identifier: str, config_entry_id: str
+) -> str:
     """Return the device ID for a UniFi Access identifier."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, identifier)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, identifier), config_entry_id
+    )
     assert device is not None
     return device.id
 
@@ -48,7 +52,9 @@ async def test_set_lock_rule_service_calls_api(
         DOMAIN,
         SERVICE_SET_LOCK_RULE,
         {
-            ATTR_DEVICE_ID: _device_id(device_registry, "door-001"),
+            ATTR_DEVICE_ID: _device_id(
+                device_registry, "door-001", mock_config_entry.entry_id
+            ),
             ATTR_RULE: "keep_lock",
             ATTR_INTERVAL: {"minutes": 30},
         },
@@ -73,7 +79,9 @@ async def test_set_lock_rule_service_defaults_interval(
         DOMAIN,
         SERVICE_SET_LOCK_RULE,
         {
-            ATTR_DEVICE_ID: _device_id(device_registry, "door-001"),
+            ATTR_DEVICE_ID: _device_id(
+                device_registry, "door-001", mock_config_entry.entry_id
+            ),
             ATTR_RULE: "keep_unlock",
         },
         blocking=True,
@@ -98,7 +106,9 @@ async def test_set_lock_rule_service_updates_sensor_state(
         DOMAIN,
         SERVICE_SET_LOCK_RULE,
         {
-            ATTR_DEVICE_ID: _device_id(device_registry, "door-001"),
+            ATTR_DEVICE_ID: _device_id(
+                device_registry, "door-001", mock_config_entry.entry_id
+            ),
             ATTR_RULE: "keep_lock",
         },
         blocking=True,
@@ -126,7 +136,9 @@ async def test_set_lock_rule_service_raises_on_api_error(
             DOMAIN,
             SERVICE_SET_LOCK_RULE,
             {
-                ATTR_DEVICE_ID: _device_id(device_registry, "door-001"),
+                ATTR_DEVICE_ID: _device_id(
+                    device_registry, "door-001", mock_config_entry.entry_id
+                ),
                 ATTR_RULE: "keep_lock",
             },
             blocking=True,
@@ -150,7 +162,11 @@ async def test_set_lock_rule_service_rejects_hub_device(
             DOMAIN,
             SERVICE_SET_LOCK_RULE,
             {
-                ATTR_DEVICE_ID: _device_id(device_registry, mock_config_entry.entry_id),
+                ATTR_DEVICE_ID: _device_id(
+                    device_registry,
+                    mock_config_entry.entry_id,
+                    mock_config_entry.entry_id,
+                ),
                 ATTR_RULE: "keep_lock",
             },
             blocking=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in `unifi_access` tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
