### PR TITLE
Update default Tuya SDK logging

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -24,7 +24,7 @@ from .services import async_setup_services
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # Suppress logs from the library, it logs unneeded on error
-logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
+logging.getLogger("tuya_sharing").setLevel(logging.WARNING)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -23,7 +23,7 @@ from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-# Suppress logs from the library, it logs unneeded on error
+# Suppress verbose library logs while retaining warnings and errors
 logging.getLogger("tuya_sharing").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
## Summary

One-line fix in `homeassistant/components/tuya/__init__.py`:

```python
# before
logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
# after
logging.getLogger("tuya_sharing").setLevel(logging.WARNING)
```

## Why

The integration calls `setLevel(logging.CRITICAL)` on every `async_setup_entry`, which silences **every** `logger.error()` and `logger.warning()` inside the `tuya-device-sharing-sdk` — including all token refresh failures.

The practical effect on users:
1. Token refresh fails (narrow refresh window, transient network error, Tuya server error)
2. Failure is swallowed silently — nothing in the HA log
3. Device cloud polling eventually hits the expired token → `sign invalid (-9999999)`
4. HA raises `ConfigEntryAuthFailed` — user sees "authentication expired, please re-configure"

The root cause (the refresh failure) is never visible. This is why issue #178281 persisted so long — the failures were structurally invisible.

`WARNING` still suppresses the SDK's verbose `DEBUG`-level noise (MQTT payloads, per-request traces). It only surfaces genuine errors, which is what users and developers need for diagnosis.

## Related

- Issue #178281 — persistent re-auth every ~2 hours
- `tuya/tuya-device-sharing-sdk` PR #74 — widens refresh window to 30 min + retry + fast-fail on permanent errors

## Test plan

- [ ] Set up Tuya integration normally, confirm no new log noise at default log level
- [ ] Force a token refresh failure (e.g. bad network, or by manually expiring the token in `.storage/core.config_entries`) — confirm the error now appears in the HA log at WARNING level
- [ ] Confirm the integration still loads and devices are available after normal setup