### PR TITLE
Add Entity.async_get_recent_context helper

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -972,6 +972,20 @@ class Entity(
         self._context = context
         self._context_set = time.time()
 
+    @callback
+    def async_get_recent_context(self) -> Context | None:
+        """Return the context the entity operates under if it is still recent.
+
+        A context which is no longer recent is discarded and None is returned.
+        """
+        if (
+            self._context_set is not None
+            and timer() - self._context_set > CONTEXT_RECENT_TIME_SECONDS
+        ):
+            self._context = None
+            self._context_set = None
+        return self._context
+
     async def async_update_ha_state(self, force_refresh: bool = False) -> None:
         """Update Home Assistant with current state of entity.
 
@@ -1283,20 +1297,13 @@ class Entity(
             if custom:
                 attr |= custom
 
-        if (
-            self._context_set is not None
-            and time_now - self._context_set > CONTEXT_RECENT_TIME_SECONDS
-        ):
-            self._context = None
-            self._context_set = None
-
         # Intentionally called with positional args for performance reasons
         self.hass.states.async_set_internal(
             self.entity_id,
             state,
             attr,
             self.force_update,
-            self._context,
+            self.async_get_recent_context(),
             self._state_info,
             time_now,
         )

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -693,6 +693,25 @@ async def test_set_context_expired(hass: HomeAssistant) -> None:
     assert ent._context_set is None
 
 
+async def test_get_recent_context(hass: HomeAssistant) -> None:
+    """Test getting the context only while it is recent."""
+    context = Context()
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = "hello.world"
+
+    assert ent.async_get_recent_context() is None
+
+    ent.async_set_context(context)
+    assert ent.async_get_recent_context() is context
+
+    with patch("homeassistant.helpers.entity.CONTEXT_RECENT_TIME_SECONDS", -5):
+        assert ent.async_get_recent_context() is None
+
+    assert ent._context is None
+    assert ent._context_set is None
+
+
 async def test_warn_disabled(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extracted from #178230.

An entity already tracks the context it operates under, but until now that context was only reachable while writing state, where `_async_write_ha_state` inlined the check that expires a context older than `CONTEXT_RECENT_TIME_SECONDS`.

This moves that logic into `Entity.async_get_recent_context()`, so entities can ask for the context they are currently operating under from anywhere — for example to resolve the user behind an action and check their permissions. The behavior is unchanged: a context which is no longer recent is discarded and `None` is returned, and the state write path now calls the new method instead of inlining the expiry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178230
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_019XCffnc8g47rZBwz4bFa3Z)_