### PR TITLE
Luci fix known_devices.yaml clash

### DIFF
--- a/homeassistant/components/luci/__init__.py
+++ b/homeassistant/components/luci/__init__.py
@@ -120,7 +120,7 @@ async def _async_check_legacy_known_devices(
         DOMAIN,
         _legacy_issue_id(entry),
         is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
+        severity=ir.IssueSeverity.ERROR,
         translation_key=ISSUE_LEGACY_KNOWN_DEVICES,
         translation_placeholders={
             "host": entry.data[CONF_HOST],

--- a/homeassistant/components/luci/__init__.py
+++ b/homeassistant/components/luci/__init__.py
@@ -1,8 +1,16 @@
 """The luci component."""
 
+from collections.abc import Mapping
+from datetime import timedelta
+from typing import Any
+
 from openwrt_luci_rpc import OpenWrtRpc
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from homeassistant.components.device_tracker.legacy import (
+    YAML_DEVICES,
+    async_load_config,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -12,8 +20,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 
-from .const import DEFAULT_SSL, DEFAULT_VERIFY_SSL, PLATFORMS
+from .const import (
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    ISSUE_LEGACY_KNOWN_DEVICES,
+    PLATFORMS,
+)
 from .coordinator import LuciConfigEntry, LuciCoordinator
 
 
@@ -49,9 +64,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool
 
     entry.runtime_data = coordinator
 
+    await _async_check_legacy_known_devices(hass, coordinator.data)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_check_legacy_known_devices(
+    hass: HomeAssistant, tracked: Mapping[str, Any]
+) -> None:
+    """Report leftover known_devices.yaml entries for devices we now track.
+
+    Legacy trackers are not in the entity registry, so they silently claim the
+    entity IDs our entities are registered under and those entities get dropped.
+    """
+    legacy_devices = await async_load_config(
+        hass.config.path(YAML_DEVICES), hass, timedelta(0)
+    )
+    # async_load_config upper cases the MAC addresses it reads.
+    macs = {mac.upper() for mac in tracked}
+    conflicting = sorted(
+        device.dev_id
+        for device in legacy_devices
+        if device.track and device.mac in macs
+    )
+
+    if not conflicting:
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+        return
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        ISSUE_LEGACY_KNOWN_DEVICES,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_LEGACY_KNOWN_DEVICES,
+        translation_placeholders={
+            "path": YAML_DEVICES,
+            "devices": "\n".join(f"- `{dev_id}`" for dev_id in conflicting),
+        },
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool:

--- a/homeassistant/components/luci/__init__.py
+++ b/homeassistant/components/luci/__init__.py
@@ -1,8 +1,7 @@
 """The luci component."""
 
-from collections.abc import Mapping
+from collections.abc import Collection
 from datetime import timedelta
-from typing import Any
 
 from openwrt_luci_rpc import OpenWrtRpc
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -18,7 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
 
@@ -64,7 +63,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool
 
     entry.runtime_data = coordinator
 
-    await _async_check_legacy_known_devices(hass, coordinator.data)
+    seen_macs = set(coordinator.data)
+
+    @callback
+    def _async_check_new_devices() -> None:
+        """Re-check conflicts when the router reports a MAC we haven't seen."""
+        if not coordinator.data.keys() - seen_macs:
+            return
+        seen_macs.update(coordinator.data)
+        entry.async_create_task(
+            hass, _async_check_legacy_known_devices(hass, set(seen_macs))
+        )
+
+    await _async_check_legacy_known_devices(hass, seen_macs)
+    entry.async_on_unload(coordinator.async_add_listener(_async_check_new_devices))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -72,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool
 
 
 async def _async_check_legacy_known_devices(
-    hass: HomeAssistant, tracked: Mapping[str, Any]
+    hass: HomeAssistant, tracked: Collection[str]
 ) -> None:
     """Report leftover known_devices.yaml entries for devices we now track.
 

--- a/homeassistant/components/luci/__init__.py
+++ b/homeassistant/components/luci/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Collection
 from datetime import timedelta
+from functools import partial
 
 from openwrt_luci_rpc import OpenWrtRpc
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -72,19 +73,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool
             return
         seen_macs.update(coordinator.data)
         entry.async_create_task(
-            hass, _async_check_legacy_known_devices(hass, set(seen_macs))
+            hass, _async_check_legacy_known_devices(hass, entry, set(seen_macs))
         )
 
-    await _async_check_legacy_known_devices(hass, seen_macs)
+    await _async_check_legacy_known_devices(hass, entry, seen_macs)
     entry.async_on_unload(coordinator.async_add_listener(_async_check_new_devices))
+    entry.async_on_unload(
+        partial(ir.async_delete_issue, hass, DOMAIN, _legacy_issue_id(entry))
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
+def _legacy_issue_id(entry: LuciConfigEntry) -> str:
+    """Return the issue ID, scoped per entry so routers don't clobber each other."""
+    return f"{ISSUE_LEGACY_KNOWN_DEVICES}_{entry.entry_id}"
+
+
 async def _async_check_legacy_known_devices(
-    hass: HomeAssistant, tracked: Collection[str]
+    hass: HomeAssistant, entry: LuciConfigEntry, tracked: Collection[str]
 ) -> None:
     """Report leftover known_devices.yaml entries for devices we now track.
 
@@ -103,17 +112,18 @@ async def _async_check_legacy_known_devices(
     )
 
     if not conflicting:
-        ir.async_delete_issue(hass, DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+        ir.async_delete_issue(hass, DOMAIN, _legacy_issue_id(entry))
         return
 
     ir.async_create_issue(
         hass,
         DOMAIN,
-        ISSUE_LEGACY_KNOWN_DEVICES,
+        _legacy_issue_id(entry),
         is_fixable=False,
         severity=ir.IssueSeverity.WARNING,
         translation_key=ISSUE_LEGACY_KNOWN_DEVICES,
         translation_placeholders={
+            "host": entry.data[CONF_HOST],
             "path": YAML_DEVICES,
             "devices": "\n".join(f"- `{dev_id}`" for dev_id in conflicting),
         },

--- a/homeassistant/components/luci/__init__.py
+++ b/homeassistant/components/luci/__init__.py
@@ -72,8 +72,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuciConfigEntry) -> bool
         if not coordinator.data.keys() - seen_macs:
             return
         seen_macs.update(coordinator.data)
-        entry.async_create_task(
-            hass, _async_check_legacy_known_devices(hass, entry, set(seen_macs))
+        # Background, so unload cancels an in-flight check instead of awaiting it
+        # and letting it recreate the issue we just deleted.
+        entry.async_create_background_task(
+            hass,
+            _async_check_legacy_known_devices(hass, entry, set(seen_macs)),
+            name=f"{DOMAIN} legacy known_devices check",
         )
 
     await _async_check_legacy_known_devices(hass, entry, seen_macs)

--- a/homeassistant/components/luci/const.py
+++ b/homeassistant/components/luci/const.py
@@ -6,5 +6,7 @@ DOMAIN = "luci"
 
 PLATFORMS = [Platform.DEVICE_TRACKER]
 
+ISSUE_LEGACY_KNOWN_DEVICES = "legacy_known_devices"
+
 DEFAULT_SSL = True
 DEFAULT_VERIFY_SSL = False

--- a/homeassistant/components/luci/strings.json
+++ b/homeassistant/components/luci/strings.json
@@ -40,6 +40,10 @@
     }
   },
   "issues": {
+    "legacy_known_devices": {
+      "description": "OpenWrt (luci) now creates its own device tracker entities, but the following entries left over from the old YAML setup still exist in `{path}`:\n\n{devices}\n\nBecause these legacy trackers claim the same entity IDs, the new entities are dropped at startup and stop updating.\n\nPlease remove these entries from `{path}` and restart Home Assistant.",
+      "title": "Remove leftover known devices for OpenWrt (luci)"
+    },
     "yaml_import_cannot_connect": {
       "description": "The YAML configuration for OpenWrt (luci) at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, update your `configuration.yaml` if needed, and restart Home Assistant.",
       "title": "YAML configuration import failed: cannot connect"

--- a/homeassistant/components/luci/strings.json
+++ b/homeassistant/components/luci/strings.json
@@ -41,7 +41,7 @@
   },
   "issues": {
     "legacy_known_devices": {
-      "description": "OpenWrt (luci) now creates its own device tracker entities, but the following entries left over from the old YAML setup still exist in `{path}`:\n\n{devices}\n\nBecause these legacy trackers claim the same entity IDs, the new entities are dropped at startup and stop updating.\n\nPlease remove these entries from `{path}` and restart Home Assistant.",
+      "description": "OpenWrt (luci) now creates its own device tracker entities, but the following entries left over from the old YAML setup still exist in `{path}` for devices tracked by the router at `{host}`:\n\n{devices}\n\nBecause these legacy trackers claim the same entity IDs, the new entities are dropped at startup and stop updating.\n\nPlease remove these entries from `{path}` and restart Home Assistant.",
       "title": "Remove leftover known devices for OpenWrt (luci)"
     },
     "yaml_import_cannot_connect": {

--- a/tests/components/luci/conftest.py
+++ b/tests/components/luci/conftest.py
@@ -42,6 +42,13 @@ MOCK_DEVICE_2 = MockDevice(
     reachable=True,
     host="192.168.1.1",
 )
+MOCK_DEVICE_3 = MockDevice(
+    mac="AA:AA:AA:BB:BB:BB",
+    hostname="device3",
+    ip="192.168.1.102",
+    reachable=True,
+    host="192.168.1.1",
+)
 
 
 @pytest.fixture

--- a/tests/components/luci/test_init.py
+++ b/tests/components/luci/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the luci integration."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -225,6 +226,56 @@ async def test_legacy_known_devices_issue_on_new_device(
         "path": "known_devices.yaml",
         "devices": "- `late_arrival`",
     }
+
+
+async def test_legacy_known_devices_issue_not_recreated_on_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luci_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a check still running when the entry unloads cannot recreate the issue."""
+    legacy_devices = [
+        Device(hass, timedelta(0), True, "late_arrival", MOCK_DEVICE_3.mac),
+    ]
+    release_load = asyncio.Event()
+    calls = 0
+
+    async def _load_config(
+        path: str, hass: HomeAssistant, consider_home: timedelta
+    ) -> list[Device]:
+        nonlocal calls
+        calls += 1
+        # Let the check during setup finish, but leave the later one suspended.
+        if calls > 1:
+            await release_load.wait()
+        return legacy_devices
+
+    mock_luci_client.get_all_connected_devices.return_value = [MOCK_DEVICE_1]
+
+    with patch(
+        "homeassistant.components.luci.async_load_config", side_effect=_load_config
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Released while unloading, after the integration deleted its issue.
+        mock_config_entry.async_on_unload(release_load.set)
+
+        # A conflicting MAC starts a check that blocks before it can raise.
+        coordinator = mock_config_entry.runtime_data
+        coordinator.async_set_updated_data(
+            {MOCK_DEVICE_1.mac: MOCK_DEVICE_1, MOCK_DEVICE_3.mac: MOCK_DEVICE_3}
+        )
+
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, _issue_id(mock_config_entry.entry_id))
+        is None
+    )
 
 
 async def test_legacy_known_devices_issue_per_entry(

--- a/tests/components/luci/test_init.py
+++ b/tests/components/luci/test_init.py
@@ -31,6 +31,11 @@ YAML_CONFIG = {
 }
 
 
+def _issue_id(entry_id: str) -> str:
+    """Return the per-entry issue ID for the legacy known_devices repair."""
+    return f"{ISSUE_LEGACY_KNOWN_DEVICES}_{entry_id}"
+
+
 @pytest.mark.usefixtures("mock_luci_client")
 async def test_unload_entry(
     hass: HomeAssistant,
@@ -136,10 +141,13 @@ async def test_legacy_known_devices_issue(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    issue = issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+    issue = issue_registry.async_get_issue(
+        DOMAIN, _issue_id(mock_config_entry.entry_id)
+    )
     assert issue is not None
     assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {
+        "host": "192.168.1.1",
         "path": "known_devices.yaml",
         "devices": "- `homeserver`\n- `router_phone`",
     }
@@ -165,7 +173,10 @@ async def test_legacy_known_devices_no_issue(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES) is None
+    assert (
+        issue_registry.async_get_issue(DOMAIN, _issue_id(mock_config_entry.entry_id))
+        is None
+    )
 
 
 async def test_legacy_known_devices_issue_on_new_device(
@@ -190,7 +201,10 @@ async def test_legacy_known_devices_issue_on_new_device(
         await hass.async_block_till_done()
 
         assert (
-            issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES) is None
+            issue_registry.async_get_issue(
+                DOMAIN, _issue_id(mock_config_entry.entry_id)
+            )
+            is None
         )
 
         mock_luci_client.get_all_connected_devices.return_value = [
@@ -199,11 +213,64 @@ async def test_legacy_known_devices_issue_on_new_device(
         ]
         freezer.tick(SCAN_INTERVAL)
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        # The scheduled coordinator refresh is a background task.
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    issue = issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+    issue = issue_registry.async_get_issue(
+        DOMAIN, _issue_id(mock_config_entry.entry_id)
+    )
     assert issue is not None
     assert issue.translation_placeholders == {
+        "host": "192.168.1.1",
         "path": "known_devices.yaml",
         "devices": "- `late_arrival`",
     }
+
+
+async def test_legacy_known_devices_issue_per_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luci_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a second router without conflicts keeps the first router's issue."""
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="01JBVVVJ87F6G5V0QJX6HBC94U",
+        data={
+            CONF_HOST: "192.168.2.1",
+            CONF_USERNAME: "root",
+            CONF_PASSWORD: "password",
+        },
+    )
+    legacy_devices = [
+        Device(hass, timedelta(0), True, "homeserver", MOCK_DEVICE_1.mac),
+    ]
+
+    with patch(
+        "homeassistant.components.luci.async_load_config",
+        return_value=legacy_devices,
+    ):
+        mock_luci_client.get_all_connected_devices.return_value = [MOCK_DEVICE_1]
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # The second router tracks a device with no known_devices.yaml entry.
+        mock_luci_client.get_all_connected_devices.return_value = [MOCK_DEVICE_3]
+        other_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(other_entry.entry_id)
+        await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, _issue_id(mock_config_entry.entry_id)
+    )
+    assert issue is not None
+    assert issue.translation_placeholders == {
+        "host": "192.168.1.1",
+        "path": "known_devices.yaml",
+        "devices": "- `homeserver`",
+    }
+    assert (
+        issue_registry.async_get_issue(DOMAIN, _issue_id(other_entry.entry_id)) is None
+    )

--- a/tests/components/luci/test_init.py
+++ b/tests/components/luci/test_init.py
@@ -145,7 +145,7 @@ async def test_legacy_known_devices_issue(
         DOMAIN, _issue_id(mock_config_entry.entry_id)
     )
     assert issue is not None
-    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {
         "host": "192.168.1.1",
         "path": "known_devices.yaml",

--- a/tests/components/luci/test_init.py
+++ b/tests/components/luci/test_init.py
@@ -1,17 +1,21 @@
 """Tests for the luci integration."""
 
-from unittest.mock import MagicMock
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
-from homeassistant.components.luci.const import DOMAIN
+from homeassistant.components.device_tracker.legacy import Device
+from homeassistant.components.luci.const import DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_DEVICE_1, MOCK_DEVICE_2
 
 from tests.common import MockConfigEntry
 
@@ -108,3 +112,55 @@ async def test_yaml_import_cannot_connect(
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {"host": "192.168.1.1"}
+
+
+@pytest.mark.usefixtures("mock_luci_client")
+async def test_legacy_known_devices_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an issue is raised for known_devices.yaml entries we now track."""
+    legacy_devices = [
+        Device(hass, timedelta(0), True, "router_phone", MOCK_DEVICE_2.mac),
+        Device(hass, timedelta(0), True, "homeserver", MOCK_DEVICE_1.mac),
+    ]
+
+    with patch(
+        "homeassistant.components.luci.async_load_config",
+        return_value=legacy_devices,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+    assert issue is not None
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders == {
+        "path": "known_devices.yaml",
+        "devices": "- `homeserver`\n- `router_phone`",
+    }
+
+
+@pytest.mark.usefixtures("mock_luci_client")
+async def test_legacy_known_devices_no_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test untracked and unrelated known_devices.yaml entries are ignored."""
+    legacy_devices = [
+        Device(hass, timedelta(0), False, "homeserver", MOCK_DEVICE_1.mac),
+        Device(hass, timedelta(0), True, "other_router_device", "99:99:99:99:99:99"),
+    ]
+
+    with patch(
+        "homeassistant.components.luci.async_load_config",
+        return_value=legacy_devices,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES) is None

--- a/tests/components/luci/test_init.py
+++ b/tests/components/luci/test_init.py
@@ -3,21 +3,23 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.device_tracker.legacy import Device
 from homeassistant.components.luci.const import DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES
+from homeassistant.components.luci.coordinator import SCAN_INTERVAL
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_DEVICE_1, MOCK_DEVICE_2
+from .conftest import MOCK_DEVICE_1, MOCK_DEVICE_2, MOCK_DEVICE_3
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 YAML_CONFIG = {
     DEVICE_TRACKER_DOMAIN: {
@@ -164,3 +166,44 @@ async def test_legacy_known_devices_no_issue(
         await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES) is None
+
+
+async def test_legacy_known_devices_issue_on_new_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luci_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the issue is raised for a device that only shows up after setup."""
+    mock_luci_client.get_all_connected_devices.return_value = [MOCK_DEVICE_1]
+    legacy_devices = [
+        Device(hass, timedelta(0), True, "late_arrival", MOCK_DEVICE_3.mac),
+    ]
+
+    with patch(
+        "homeassistant.components.luci.async_load_config",
+        return_value=legacy_devices,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES) is None
+        )
+
+        mock_luci_client.get_all_connected_devices.return_value = [
+            MOCK_DEVICE_1,
+            MOCK_DEVICE_3,
+        ]
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, ISSUE_LEGACY_KNOWN_DEVICES)
+    assert issue is not None
+    assert issue.translation_placeholders == {
+        "path": "known_devices.yaml",
+        "devices": "- `late_arrival`",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This should solve/clarify some issues with the config flow transition, mainly:

- Hint users to remove duplicate devices from known_devices.yaml to actually use the new entities with a repair issue (other stuff moved to other PRs)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178352
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally. (Including the known_devices yaml this time...)
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
