### PR TITLE
Add second output button support for BleBox gateBox devices

### DIFF
--- a/homeassistant/components/blebox/button.py
+++ b/homeassistant/components/blebox/button.py
@@ -21,6 +21,9 @@ BUTTON_TYPES: dict[str, ButtonEntityDescription] = {
     "fav": ButtonEntityDescription(key="fav", translation_key="fav"),
     "open": ButtonEntityDescription(key="open", translation_key="open"),
     "close": ButtonEntityDescription(key="close", translation_key="close"),
+    "second_output": ButtonEntityDescription(
+        key="second_output", translation_key="second_output"
+    ),
 }
 
 _DEFAULT_BUTTON = ButtonEntityDescription(key="button")

--- a/homeassistant/components/blebox/strings.json
+++ b/homeassistant/components/blebox/strings.json
@@ -78,6 +78,7 @@
       "down": { "name": "Down" },
       "fav": { "name": "Favorite" },
       "open": { "name": "Open" },
+      "second_output": { "name": "Second output" },
       "up": { "name": "Up" }
     },
     "light": { "channel": { "name": "Channel {index}" } },

--- a/tests/components/blebox/test_button.py
+++ b/tests/components/blebox/test_button.py
@@ -56,6 +56,42 @@ async def test_tvliftbox_init(
     assert state.name == "My tvLiftBox"
 
 
+@pytest.fixture(name="gatebox_second_output")
+def gatebox_second_output_fixture(caplog: pytest.LogCaptureFixture):
+    """Return a gateBox second output button entity mock."""
+    caplog.set_level(logging.ERROR)
+
+    feature = mock_feature(
+        "buttons",
+        blebox_uniapi.button.Button,
+        unique_id="BleBox-gateBox-1afe34d27e4f-second_output",
+        full_name="gateBox-second_output",
+        query_string="second_output",
+    )
+
+    product = feature.product
+    type(product).name = PropertyMock(return_value="My gateBox")
+    type(product).type = PropertyMock(return_value="gateBox")
+    type(product).model = PropertyMock(return_value="gateBox")
+
+    return (feature, "button.my_gatebox_second_output")
+
+
+async def test_gatebox_second_output_init(
+    gatebox_second_output, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test gateBox second output button initialisation."""
+    caplog.set_level(logging.ERROR)
+
+    _, entity_id = gatebox_second_output
+    entry = await async_setup_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+
+    assert entry.unique_id == "BleBox-gateBox-1afe34d27e4f-second_output"
+    assert entry.translation_key == "second_output"
+    assert state.name == "My gateBox Second output"
+
+
 @pytest.mark.parametrize(
     ("query_string", "expected_translation_key", "expected_entity_id", "expected_name"),
     query_translation_key_matching,

--- a/tests/components/blebox/test_button.py
+++ b/tests/components/blebox/test_button.py
@@ -1,7 +1,7 @@
 """Blebox button entities tests."""
 
 import logging
-from unittest.mock import PropertyMock
+from unittest.mock import Mock, PropertyMock
 
 import blebox_uniapi
 import pytest
@@ -78,7 +78,9 @@ def gatebox_second_output_fixture(caplog: pytest.LogCaptureFixture):
 
 
 async def test_gatebox_second_output_init(
-    gatebox_second_output, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    gatebox_second_output: tuple[Mock, str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test gateBox second output button initialisation."""
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support the second output button exposed by blebox_uniapi for gateBox devices,
which can be configured as a walk-in gate trigger or any other user-defined
output on the device.

blebox_uniapi changes already merged: https://github.com/home-assistant/core/pull/178353
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
