### PR TITLE
Call async_remove_device to remove device in tests

### DIFF
--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -105,15 +105,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.derivative.async_unload_entry",
         wraps=derivative.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/generic_hygrostat/test_init.py
+++ b/tests/components/generic_hygrostat/test_init.py
@@ -183,15 +183,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
         hass, generic_hygrostat_entity_entry.entity_id
     )
 
-    # Remove the source entity's config entry from the device, this removes the
-    # source entity
+    # Remove the source device, this removes the source entity
     with patch(
         "homeassistant.components.generic_hygrostat.async_unload_entry",
         wraps=generic_hygrostat.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            source_device.id, remove_config_entry_id=source_entity_entry.config_entry_id
-        )
+        device_registry.async_remove_device(source_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/generic_thermostat/test_init.py
+++ b/tests/components/generic_thermostat/test_init.py
@@ -187,15 +187,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
         hass, generic_thermostat_entity_entry.entity_id
     )
 
-    # Remove the source entity's config entry from the device, this removes the
-    # source entity
+    # Remove the source device, this removes the source entity
     with patch(
         "homeassistant.components.generic_thermostat.async_unload_entry",
         wraps=generic_thermostat.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            source_device.id, remove_config_entry_id=source_entity_entry.config_entry_id
-        )
+        device_registry.async_remove_device(source_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/history_stats/test_init.py
+++ b/tests/components/history_stats/test_init.py
@@ -135,15 +135,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.history_stats.async_unload_entry",
         wraps=history_stats.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_called_once()
@@ -161,7 +158,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     # Check we got the expected events: the helper entity's device link is
     # cleared when the source device is removed (the helper entity belongs to
-    # the history_stats config entry, not the removed source config entry),
+    # the history_stats config entry, not the removed source device's config entry),
     # then the helper entity is removed when the history_stats config entry is
     # removed. Both registry actions are observed in fire order.
     assert events == ["update", "remove"]

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -234,15 +234,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.integration.async_unload_entry",
         wraps=integration.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/mold_indicator/test_init.py
+++ b/tests/components/mold_indicator/test_init.py
@@ -228,15 +228,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
-    # Remove the source entity's config entry from the device, this removes the
-    # source entity
+    # Remove the source device, this removes the source entity
     with patch(
         "homeassistant.components.mold_indicator.async_unload_entry",
         wraps=mold_indicator.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            source_device.id, remove_config_entry_id=source_entity_entry.config_entry_id
-        )
+        device_registry.async_remove_device(source_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -603,11 +603,9 @@ async def test_cleanup_tag(
     device_entry2 = device_registry.async_get_device(identifiers={("mqtt", "hejhopp")})
     assert device_entry2 is not None
 
-    # Removing the test config entry deletes its device; the MQTT device is untouched
+    # Removing the test config entry's device leaves the MQTT device untouched
     # and MQTT does not clear its discovery topic
-    device_registry.async_update_device(
-        device_entry1.id, remove_config_entry_id=config_entry.entry_id
-    )
+    device_registry.async_remove_device(device_entry1.id)
     assert (
         _get_device_for_config_entry(
             device_registry,

--- a/tests/components/statistics/test_init.py
+++ b/tests/components/statistics/test_init.py
@@ -123,15 +123,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.statistics.async_unload_entry",
         wraps=statistics.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_called_once()
@@ -147,7 +144,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     # Check we got the expected events: the helper entity's device link is
     # cleared when the source device is removed (the helper entity belongs to
-    # the statistics config entry, not the removed source config entry), then
+    # the statistics config entry, not the removed source device's config entry), then
     # the helper entity is removed when the statistics config entry is removed.
     # Both registry actions are observed in fire order.
     assert events == ["update", "remove"]

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -422,15 +422,13 @@ async def test_device_remove_multiple_config_entries_2(
     assert device_entry.config_entries == {tasmota_entry.entry_id}
     assert other_device_entry.id != device_entry.id
 
-    # Remove the config entry from the other (non-Tasmota) device sharing the connection
+    # Remove the other (non-Tasmota) device sharing the connection
     mock_device_entry = _get_device_for_config_entry(
         device_registry,
         mock_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
-    device_registry.async_update_device(
-        mock_device_entry.id, remove_config_entry_id=mock_entry.entry_id
-    )
+    device_registry.async_remove_device(mock_device_entry.id)
     await hass.async_block_till_done()
 
     # Verify the Tasmota device entry is not removed
@@ -441,11 +439,9 @@ async def test_device_remove_multiple_config_entries_2(
     assert device_entry.config_entries == {tasmota_entry.entry_id}
     mqtt_mock.async_publish.assert_not_called()
 
-    # Remove other config entry from the other device
+    # Remove the other (non-Tasmota) device
     # Tasmota should not do any cleanup
-    device_registry.async_update_device(
-        other_device_entry.id, remove_config_entry_id=mock_entry.entry_id
-    )
+    device_registry.async_remove_device(other_device_entry.id)
     await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
 

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -233,15 +233,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.threshold.async_unload_entry",
         wraps=threshold.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/trend/test_init.py
+++ b/tests/components/trend/test_init.py
@@ -155,15 +155,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.trend.async_unload_entry",
         wraps=trend.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_called_once()
@@ -179,7 +176,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     # Check we got the expected events: the helper entity's device link is
     # cleared when the source device is removed (the helper entity belongs to
-    # the trend config entry, not the removed source config entry), then the
+    # the trend config entry, not the removed source device's config entry), then the
     # helper entity is removed when the trend config entry is removed. Both
     # registry actions are observed in fire order.
     assert events == ["update", "remove"]

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -600,15 +600,12 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     sensor_device = device_registry.async_get(sensor_device.id)
     assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
-    # Remove the source sensor's config entry from the device, this removes the
-    # source sensor
+    # Remove the source device, this removes the source sensor
     with patch(
         "homeassistant.components.utility_meter.async_unload_entry",
         wraps=utility_meter.async_unload_entry,
     ) as mock_unload_entry:
-        device_registry.async_update_device(
-            sensor_device.id, remove_config_entry_id=sensor_config_entry.entry_id
-        )
+        device_registry.async_remove_device(sensor_device.id)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -250,9 +250,7 @@ async def test_remove_config_entry_device(
     )
     result = await async_remove_config_entry_device(hass, config_entry, stale_device)
     assert result is True
-    device_registry.async_update_device(
-        stale_device.id, remove_config_entry_id=config_entry.entry_id
-    )
+    device_registry.async_remove_device(stale_device.id)
 
     stale_device_after = device_registry.async_get(stale_device.id)
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Call `async_remove_device` to remove device in tests instead of passing `async_remove_config_entry_id` to `async_update_device`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
