### PR TITLE
Update honeywell device cleanup test

### DIFF
--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -162,23 +162,7 @@ async def test_remove_stale_device(
     """Test that the stale device is removed."""
     location.devices_by_id[another_device.deviceid] = another_device
 
-    config_entry_other = MockConfigEntry(
-        domain="OtherDomain",
-        data={},
-        unique_id="unique_id",
-    )
-    config_entry_other.add_to_hass(hass)
-    device_entry_other = device_registry.async_get_or_create(
-        config_entry_id=config_entry_other.entry_id,
-        identifiers={("OtherDomain", 7654321)},
-    )
-
     config_entry.add_to_hass(hass)
-    device_registry.async_update_device(
-        device_entry_other.id,
-        add_config_entry_id=config_entry.entry_id,
-        merge_identifiers={(DOMAIN, 7654321)},
-    )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -188,28 +172,9 @@ async def test_remove_stale_device(
     device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-
-    device_entries_other = dr.async_entries_for_config_entry(
-        device_registry, config_entry_other.entry_id
-    )
-
     assert len(device_entries) == 2
     assert any((DOMAIN, 1234567) in device.identifiers for device in device_entries)
     assert any((DOMAIN, 7654321) in device.identifiers for device in device_entries)
-    # Identifiers are unique per config entry, so Honeywell and OtherDomain have
-    # separate devices for 7654321; Honeywell's devices do not carry the OtherDomain
-    # identifier
-    assert not any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entries
-    )
-    assert len(device_entries_other) == 1
-    assert any(
-        ("OtherDomain", 7654321) in device.identifiers
-        for device in device_entries_other
-    )
-    assert any(
-        (DOMAIN, 7654321) in device.identifiers for device in device_entries_other
-    )
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -233,15 +198,3 @@ async def test_remove_stale_device(
     assert len(device_entries) == 1
     assert any((DOMAIN, 1234567) in device.identifiers for device in device_entries)
     assert not any((DOMAIN, 7654321) in device.identifiers for device in device_entries)
-    assert not any(
-        ("OtherDomain", 7654321) in device.identifiers for device in device_entries
-    )
-
-    device_entries_other = dr.async_entries_for_config_entry(
-        device_registry, config_entry_other.entry_id
-    )
-    assert len(device_entries_other) == 1
-    assert any(
-        ("OtherDomain", 7654321) in device.identifiers
-        for device in device_entries_other
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `honeywell` device cleanup test to align with single config entry devices

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
