### PR TITLE
Adapt LLM integration migration tests to single config entry devices

### DIFF
--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -667,12 +667,7 @@ async def test_migration_from_v2_1_to_v2_2(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test migration from version 2.1 to version 2.2.
-
-    This tests we clean up the broken migration in Home Assistant Core
-    2025.7.0b0-2025.7.0b1:
-    - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
-    """
+    """Test migration from version 2.1 to version 2.2."""
     # Create a v2.1 config entry with 2 subentries, devices and entities
     options = {
         "recommended": True,

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -237,8 +237,8 @@ async def test_migration_from_v1_to_v2(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         migrated_device := device_registry.async_get_device_by_identifier(
@@ -436,11 +436,11 @@ async def test_migration_from_v1_disabled(
         assert subentry.data == options
         assert "Claude" in subentry.title
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -715,10 +715,6 @@ async def test_migration_from_v2_1_to_v2_2(
         model="Claude",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
-    device_1 = device_registry.async_update_device(
-        device_1.id, add_config_entry_id="mock_entry_id", add_config_subentry_id=None
-    )
-    assert device_1.config_entries_subentries == {"mock_entry_id": {"mock_id_1"}}
     entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,
@@ -778,8 +774,8 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(
@@ -799,8 +795,8 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -779,9 +779,7 @@ async def test_migration_from_v2_1(
 ) -> None:
     """Test migration from version 2.1.
 
-    This tests we clean up the broken migration in Home Assistant Core
-    2025.7.0b0-2025.7.0b1 and add AI Task and STT subentries:
-    - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
+    This tests we add TTS, AI Task and STT subentries:
     - Add TTS subentry (Added in Home Assistant Core 2025.7.0b1)
     - Add AI Task subentry (Added in version 2.3)
     - Add STT subentry (Added in version 2.3)

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -191,12 +191,12 @@ async def test_migration_from_v1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -214,12 +214,12 @@ async def test_migration_from_v1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -448,10 +448,10 @@ async def test_migration_from_v1_disabled(
     assert stt_subentries[0].data == RECOMMENDED_STT_OPTIONS
     assert stt_subentries[0].title == DEFAULT_STT_NAME
 
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
 
@@ -464,8 +464,9 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device(
-                identifiers={(DOMAIN, subentry.subentry_id)}
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, subentry.subentry_id),
+                mock_config_entries[main_config_entry].entry_id,
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -577,8 +578,8 @@ async def test_migration_from_v1_with_multiple_keys(
         assert subentry.data == RECOMMENDED_STT_OPTIONS
         assert subentry.title == DEFAULT_STT_NAME
 
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -709,12 +710,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -732,12 +733,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -749,19 +750,14 @@ async def test_migration_from_v1_with_same_keys(
 
 
 @pytest.mark.parametrize(
-    ("device_changes", "extra_subentries", "expected_device_subentries"),
+    "extra_subentries",
     [
         # Scenario where we have a v2.1 config entry migrated by HA Core 2025.7.0b0:
-        # Wrong device registry, no TTS subentry
-        (
-            {"add_config_entry_id": "mock_entry_id", "add_config_subentry_id": None},
-            [],
-            {"mock_entry_id": {"mock_id_1"}},
-        ),
-        # Scenario where we have a v2.1 config entry migrated by HA Core 2025.7.0b1:
-        # Wrong device registry, TTS subentry created
-        (
-            {"add_config_entry_id": "mock_entry_id", "add_config_subentry_id": None},
+        # no TTS subentry
+        pytest.param([], id="without_tts_subentry"),
+        # Scenario where we have a v2.1 config entry migrated by HA Core 2025.7.0b1
+        # or later: TTS subentry created
+        pytest.param(
             [
                 ConfigSubentryData(
                     data=RECOMMENDED_TTS_OPTIONS,
@@ -771,22 +767,7 @@ async def test_migration_from_v1_with_same_keys(
                     unique_id=None,
                 )
             ],
-            {"mock_entry_id": {"mock_id_1"}},
-        ),
-        # Scenario where we have a v2.1 config entry migrated by HA Core 2025.7.0b2
-        # or later: Correct device registry, TTS subentry created
-        (
-            {},
-            [
-                ConfigSubentryData(
-                    data=RECOMMENDED_TTS_OPTIONS,
-                    subentry_id="mock_id_3",
-                    subentry_type="tts",
-                    title=DEFAULT_TTS_NAME,
-                    unique_id=None,
-                )
-            ],
-            {"mock_entry_id": {"mock_id_1"}},
+            id="with_tts_subentry",
         ),
     ],
 )
@@ -794,9 +775,7 @@ async def test_migration_from_v2_1(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    device_changes: dict[str, str],
     extra_subentries: list[ConfigSubentryData],
-    expected_device_subentries: dict[str, set[str | None]],
 ) -> None:
     """Test migration from version 2.1.
 
@@ -850,8 +829,6 @@ async def test_migration_from_v2_1(
         model="Generative AI",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
-    device_1 = device_registry.async_update_device(device_1.id, **device_changes)
-    assert device_1.config_entries_subentries == expected_device_subentries
     entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,
@@ -939,12 +916,12 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -962,12 +939,12 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
+    assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -239,8 +239,8 @@ async def test_migration_from_v1(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         migrated_device := device_registry.async_get_device_by_identifier(
@@ -652,11 +652,11 @@ async def test_migration_from_v1_disabled(
     assert ai_task_subentries[0].data == {"model": "llama3.2:latest"}
     assert ai_task_subentries[0].title == "Ollama AI Task"
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -731,10 +731,6 @@ async def test_migration_from_v2_1(
         model="Ollama",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
-    device_1 = device_registry.async_update_device(
-        device_1.id, add_config_entry_id="mock_entry_id", add_config_subentry_id=None
-    )
-    assert device_1.config_entries_subentries == {"mock_entry_id": {"mock_id_1"}}
     entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,
@@ -800,8 +796,8 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(
@@ -821,8 +817,8 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -689,12 +689,7 @@ async def test_migration_from_v2_1(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test migration from version 2.1.
-
-    This tests we clean up the broken migration in Home Assistant Core
-    2025.7.0b0-2025.7.0b1:
-    - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
-    """
+    """Test migration from version 2.1."""
     # Create a v2.1 config entry with 2 subentries, devices and entities
     mock_config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -1229,12 +1229,7 @@ async def test_migration_from_v2_1(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test migration from version 2.1.
-
-    This tests we clean up the broken migration in Home Assistant Core
-    2025.7.0b0-2025.7.0b1:
-    - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
-    """
+    """Test migration from version 2.1."""
     # Create a v2.1 config entry with 2 subentries, devices and entities
     options = {
         "recommended": True,

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -736,8 +736,8 @@ async def test_migration_from_v1(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         migrated_device := device_registry.async_get_device_by_identifier(
@@ -1192,11 +1192,11 @@ async def test_migration_from_v1_disabled(
         assert tts_subentries[0].data == RECOMMENDED_TTS_OPTIONS
         assert tts_subentries[0].title == DEFAULT_TTS_NAME
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -1277,10 +1277,6 @@ async def test_migration_from_v2_1(
         model="ChatGPT",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
-    device_1 = device_registry.async_update_device(
-        device_1.id, add_config_entry_id="mock_entry_id", add_config_subentry_id=None
-    )
-    assert device_1.config_entries_subentries == {"mock_entry_id": {"mock_id_1"}}
     entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,
@@ -1362,8 +1358,8 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(
@@ -1383,8 +1379,8 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
         device := device_registry.async_get_device_by_identifier(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt config entry migration tests in LLM integrations `anthropic`, `google_generative_ai`, `ollama`, `openai_conversation` to single config entry devices

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
