### PR TITLE
Use entity attribute enums for reads in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -10,7 +10,6 @@ from homeassistant.components import (
     fan,
     humidifier,
     input_number,
-    light,
     media_player,
     number,
     remote,
@@ -27,23 +26,56 @@ from homeassistant.components.alarm_control_panel import (
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityCapabilityAttribute,
     ClimateEntityStateAttribute,
     HVACMode,
 )
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
-from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    CoverEntityStateAttribute,
+)
+from homeassistant.components.fan import (
+    DOMAIN as FAN_DOMAIN,
+    FanEntityCapabilityAttribute,
+    FanEntityStateAttribute,
+)
+from homeassistant.components.humidifier import (
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    HumidifierEntityCapabilityAttribute,
+    HumidifierEntityStateAttribute,
+)
 from homeassistant.components.image_processing import DOMAIN as IMAGE_PROCESSING_DOMAIN
 from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
 from homeassistant.components.light import LightEntityStateAttribute
 from homeassistant.components.lock import LockState
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.media_player import (
+    MediaPlayerEntityCapabilityAttribute,
+    MediaPlayerEntityStateAttribute,
+)
+from homeassistant.components.number import (
+    DOMAIN as NUMBER_DOMAIN,
+    NumberEntityCapabilityAttribute,
+)
+from homeassistant.components.remote import (
+    DOMAIN as REMOTE_DOMAIN,
+    RemoteEntityStateAttribute,
+)
 from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
-from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
-from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.components.vacuum import (
+    DOMAIN as VACUUM_DOMAIN,
+    VacuumEntityCapabilityAttribute,
+    VacuumEntityStateAttribute,
+)
+from homeassistant.components.valve import (
+    DOMAIN as VALVE_DOMAIN,
+    ValveEntityStateAttribute,
+)
+from homeassistant.components.water_heater import (
+    DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterCapabilityAttribute,
+    WaterHeaterStateAttribute,
+)
 from homeassistant.const import (
     PERCENTAGE,
     STATE_IDLE,
@@ -683,9 +715,17 @@ class AlexaColorController(AlexaCapability):
             raise UnsupportedProperty(name)
 
         hue_saturation: tuple[float, float] | None
-        if (hue_saturation := self.entity.attributes.get(light.ATTR_HS_COLOR)) is None:
+        if (
+            hue_saturation := self.entity.attributes.get(
+                LightEntityStateAttribute.HS_COLOR
+            )
+        ) is None:
             hue_saturation = (0, 0)
-        if (brightness := self.entity.attributes.get(light.ATTR_BRIGHTNESS)) is None:
+        if (
+            brightness := self.entity.attributes.get(
+                LightEntityStateAttribute.BRIGHTNESS
+            )
+        ) is None:
             brightness = 0
 
         return {
@@ -804,14 +844,16 @@ class AlexaSpeaker(AlexaCapability):
         """Read and return a property."""
         if name == "volume":
             current_level = self.entity.attributes.get(
-                media_player.ATTR_MEDIA_VOLUME_LEVEL
+                MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL
             )
             if current_level is not None:
                 return round(float(current_level) * 100)
 
         if name == "muted":
             return bool(
-                self.entity.attributes.get(media_player.ATTR_MEDIA_VOLUME_MUTED)
+                self.entity.attributes.get(
+                    MediaPlayerEntityStateAttribute.MEDIA_VOLUME_MUTED
+                )
             )
 
         return None
@@ -940,7 +982,10 @@ class AlexaInputController(AlexaCapability):
     def inputs(self) -> list[dict[str, str]] | None:
         """Return the list of valid supported inputs."""
         source_list: list[Any] = (
-            self.entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
+            self.entity.attributes.get(
+                MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST
+            )
+            or []
         )
         return AlexaInputController.get_valid_inputs(source_list)
 
@@ -1025,10 +1070,14 @@ class AlexaTemperatureSensor(AlexaCapability):
         temp: str | None = self.entity.state
         if self.entity.domain == CLIMATE_DOMAIN:
             unit = self.hass.config.units.temperature_unit
-            temp = self.entity.attributes.get(climate.ATTR_CURRENT_TEMPERATURE)
+            temp = self.entity.attributes.get(
+                ClimateEntityStateAttribute.CURRENT_TEMPERATURE
+            )
         elif self.entity.domain == WATER_HEATER_DOMAIN:
             unit = self.hass.config.units.temperature_unit
-            temp = self.entity.attributes.get(water_heater.ATTR_CURRENT_TEMPERATURE)
+            temp = self.entity.attributes.get(
+                WaterHeaterStateAttribute.CURRENT_TEMPERATURE
+            )
 
         if temp is None or temp in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return None
@@ -1244,7 +1293,7 @@ class AlexaThermostatController(AlexaCapability):
         if name == "thermostatMode":
             if self.entity.domain == WATER_HEATER_DOMAIN:
                 return None
-            preset = self.entity.attributes.get(climate.ATTR_PRESET_MODE)
+            preset = self.entity.attributes.get(ClimateEntityStateAttribute.PRESET_MODE)
 
             mode: dict[str, str] | str | None
             if preset in API_THERMOSTAT_PRESETS:
@@ -1269,9 +1318,13 @@ class AlexaThermostatController(AlexaCapability):
                 ClimateEntityStateAttribute.TARGET_TEMPERATURE
             )
         elif name == "lowerSetpoint":
-            temp = self.entity.attributes.get(climate.ATTR_TARGET_TEMP_LOW)
+            temp = self.entity.attributes.get(
+                ClimateEntityStateAttribute.TARGET_TEMP_LOW
+            )
         elif name == "upperSetpoint":
-            temp = self.entity.attributes.get(climate.ATTR_TARGET_TEMP_HIGH)
+            temp = self.entity.attributes.get(
+                ClimateEntityStateAttribute.TARGET_TEMP_HIGH
+            )
         else:
             raise UnsupportedProperty(name)
 
@@ -1301,14 +1354,19 @@ class AlexaThermostatController(AlexaCapability):
         if self.entity.domain == WATER_HEATER_DOMAIN:
             return None
 
-        hvac_modes = self.entity.attributes.get(climate.ATTR_HVAC_MODES) or []
+        hvac_modes = (
+            self.entity.attributes.get(ClimateEntityCapabilityAttribute.HVAC_MODES)
+            or []
+        )
         supported_modes: list[str] = [
             API_THERMOSTAT_MODES[mode]
             for mode in hvac_modes
             if mode in API_THERMOSTAT_MODES
         ]
 
-        preset_modes = self.entity.attributes.get(climate.ATTR_PRESET_MODES)
+        preset_modes = self.entity.attributes.get(
+            ClimateEntityCapabilityAttribute.PRESET_MODES
+        )
         if preset_modes:
             for mode in preset_modes:
                 thermostat_mode = API_THERMOSTAT_PRESETS.get(mode)
@@ -1536,38 +1594,50 @@ class AlexaModeController(AlexaCapability):
 
         # Fan Direction
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_DIRECTION}":
-            mode = self.entity.attributes.get(fan.ATTR_DIRECTION, None)
+            mode = self.entity.attributes.get(FanEntityStateAttribute.DIRECTION, None)
             if mode in (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE, STATE_UNKNOWN):
                 return f"{fan.ATTR_DIRECTION}.{mode}"
 
         # Fan preset_mode
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}":
-            mode = self.entity.attributes.get(fan.ATTR_PRESET_MODE, None)
-            if mode in self.entity.attributes.get(fan.ATTR_PRESET_MODES, ()):
+            mode = self.entity.attributes.get(FanEntityStateAttribute.PRESET_MODE, None)
+            if mode in self.entity.attributes.get(
+                FanEntityCapabilityAttribute.PRESET_MODES, ()
+            ):
                 return f"{fan.ATTR_PRESET_MODE}.{mode}"
 
         # Humidifier mode
         if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
-            mode = self.entity.attributes.get(humidifier.ATTR_MODE)
+            mode = self.entity.attributes.get(HumidifierEntityStateAttribute.MODE)
             modes: list[str] = (
-                self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
+                self.entity.attributes.get(
+                    HumidifierEntityCapabilityAttribute.AVAILABLE_MODES
+                )
+                or []
             )
             if mode in modes:
                 return f"{humidifier.ATTR_MODE}.{mode}"
 
         # Remote Activity
         if self.instance == f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}":
-            activity = self.entity.attributes.get(remote.ATTR_CURRENT_ACTIVITY, None)
-            if activity in self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST, []):
+            activity = self.entity.attributes.get(
+                RemoteEntityStateAttribute.CURRENT_ACTIVITY, None
+            )
+            if activity in self.entity.attributes.get(
+                RemoteEntityStateAttribute.ACTIVITY_LIST, []
+            ):
                 return f"{remote.ATTR_ACTIVITY}.{activity}"
 
         # Water heater operation mode
         if self.instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
             operation_mode = self.entity.attributes.get(
-                water_heater.ATTR_OPERATION_MODE
+                WaterHeaterStateAttribute.OPERATION_MODE
             )
             operation_modes: list[str] = (
-                self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
+                self.entity.attributes.get(
+                    WaterHeaterCapabilityAttribute.OPERATION_LIST
+                )
+                or []
             )
             if operation_mode in operation_modes:
                 return f"{water_heater.ATTR_OPERATION_MODE}.{operation_mode}"
@@ -1630,7 +1700,10 @@ class AlexaModeController(AlexaCapability):
             self._resource = AlexaModeResource(
                 [AlexaGlobalCatalog.SETTING_PRESET], False
             )
-            preset_modes = self.entity.attributes.get(fan.ATTR_PRESET_MODES) or []
+            preset_modes = (
+                self.entity.attributes.get(FanEntityCapabilityAttribute.PRESET_MODES)
+                or []
+            )
             for preset_mode in preset_modes:
                 self._resource.add_mode(
                     f"{fan.ATTR_PRESET_MODE}.{preset_mode}", [preset_mode]
@@ -1646,7 +1719,12 @@ class AlexaModeController(AlexaCapability):
         # Humidifier modes
         if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
-            modes = self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
+            modes = (
+                self.entity.attributes.get(
+                    HumidifierEntityCapabilityAttribute.AVAILABLE_MODES
+                )
+                or []
+            )
             for mode in modes:
                 self._resource.add_mode(f"{humidifier.ATTR_MODE}.{mode}", [mode])
             # Humidifiers or Fans with a single mode completely break Alexa discovery,
@@ -1661,7 +1739,10 @@ class AlexaModeController(AlexaCapability):
         if self.instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
             operation_modes = (
-                self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
+                self.entity.attributes.get(
+                    WaterHeaterCapabilityAttribute.OPERATION_LIST
+                )
+                or []
             )
             for operation_mode in operation_modes:
                 self._resource.add_mode(
@@ -1682,7 +1763,10 @@ class AlexaModeController(AlexaCapability):
             # Use the mode controller for a remote because the input controller
             # only allows a preset of names as an input.
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
-            activities = self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST) or []
+            activities = (
+                self.entity.attributes.get(RemoteEntityStateAttribute.ACTIVITY_LIST)
+                or []
+            )
             for activity in activities:
                 self._resource.add_mode(
                     f"{remote.ATTR_ACTIVITY}.{activity}", [activity]
@@ -1893,11 +1977,15 @@ class AlexaRangeController(AlexaCapability):
 
         # Cover Position
         if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
-            return self.entity.attributes.get(cover.ATTR_CURRENT_POSITION)
+            return self.entity.attributes.get(
+                CoverEntityStateAttribute.CURRENT_POSITION
+            )
 
         # Cover Tilt
         if self.instance == f"{COVER_DOMAIN}.tilt":
-            return self.entity.attributes.get(cover.ATTR_CURRENT_TILT_POSITION)
+            return self.entity.attributes.get(
+                CoverEntityStateAttribute.CURRENT_TILT_POSITION
+            )
 
         # Fan speed percentage
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
@@ -1905,14 +1993,16 @@ class AlexaRangeController(AlexaCapability):
                 EntityStateAttribute.SUPPORTED_FEATURES, 0
             )
             if supported and fan.FanEntityFeature.SET_SPEED:
-                return self.entity.attributes.get(fan.ATTR_PERCENTAGE)
+                return self.entity.attributes.get(FanEntityStateAttribute.PERCENTAGE)
             return 100 if self.entity.state == fan.STATE_ON else 0
 
         # Humidifier target humidity
         if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
             # If the humidifier is turned off the target humidity attribute is not set.
             # We return 0 to make clear we do not know the current value.
-            return self.entity.attributes.get(humidifier.ATTR_HUMIDITY, 0)
+            return self.entity.attributes.get(
+                HumidifierEntityStateAttribute.HUMIDITY, 0
+            )
 
         # Input Number Value
         if self.instance == f"{INPUT_NUMBER_DOMAIN}.{input_number.ATTR_VALUE}":
@@ -1924,14 +2014,18 @@ class AlexaRangeController(AlexaCapability):
 
         # Vacuum Fan Speed
         if self.instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
-            speed_list = self.entity.attributes.get(vacuum.ATTR_FAN_SPEED_LIST)
-            speed = self.entity.attributes.get(vacuum.ATTR_FAN_SPEED)
+            speed_list = self.entity.attributes.get(
+                VacuumEntityCapabilityAttribute.FAN_SPEED_LIST
+            )
+            speed = self.entity.attributes.get(VacuumEntityStateAttribute.FAN_SPEED)
             if speed_list is not None and speed is not None:
                 return next((i for i, v in enumerate(speed_list) if v == speed), None)
 
         # Valve Position
         if self.instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
-            return self.entity.attributes.get(valve.ATTR_CURRENT_POSITION)
+            return self.entity.attributes.get(
+                ValveEntityStateAttribute.CURRENT_POSITION
+            )
 
         return None
 
@@ -1949,7 +2043,9 @@ class AlexaRangeController(AlexaCapability):
 
         # Fan Speed Percentage Resources
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
-            percentage_step = self.entity.attributes.get(fan.ATTR_PERCENTAGE_STEP)
+            percentage_step = self.entity.attributes.get(
+                FanEntityStateAttribute.PERCENTAGE_STEP
+            )
             self._resource = AlexaPresetResource(
                 labels=["Percentage", AlexaGlobalCatalog.SETTING_FAN_SPEED],
                 min_value=0,
@@ -1965,8 +2061,12 @@ class AlexaRangeController(AlexaCapability):
         if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
             self._resource = AlexaPresetResource(
                 labels=["Humidity", "Percentage", "Target humidity"],
-                min_value=self.entity.attributes.get(humidifier.ATTR_MIN_HUMIDITY, 10),
-                max_value=self.entity.attributes.get(humidifier.ATTR_MAX_HUMIDITY, 90),
+                min_value=self.entity.attributes.get(
+                    HumidifierEntityCapabilityAttribute.MIN_HUMIDITY, 10
+                ),
+                max_value=self.entity.attributes.get(
+                    HumidifierEntityCapabilityAttribute.MAX_HUMIDITY, 90
+                ),
                 precision=1,
                 unit=AlexaGlobalCatalog.UNIT_PERCENT,
             )
@@ -2018,9 +2118,15 @@ class AlexaRangeController(AlexaCapability):
 
         # Number Value
         if self.instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
-            min_value = float(self.entity.attributes[number.ATTR_MIN])
-            max_value = float(self.entity.attributes[number.ATTR_MAX])
-            precision = float(self.entity.attributes.get(number.ATTR_STEP, 1))
+            min_value = float(
+                self.entity.attributes[NumberEntityCapabilityAttribute.MIN]
+            )
+            max_value = float(
+                self.entity.attributes[NumberEntityCapabilityAttribute.MAX]
+            )
+            precision = float(
+                self.entity.attributes.get(NumberEntityCapabilityAttribute.STEP, 1)
+            )
             unit = self.entity.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
             self._resource = AlexaPresetResource(
@@ -2040,7 +2146,9 @@ class AlexaRangeController(AlexaCapability):
 
         # Vacuum Fan Speed Resources
         if self.instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
-            speed_list = self.entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
+            speed_list = self.entity.attributes[
+                VacuumEntityCapabilityAttribute.FAN_SPEED_LIST
+            ]
             max_value = len(speed_list) - 1
             self._resource = AlexaPresetResource(
                 labels=[AlexaGlobalCatalog.SETTING_FAN_SPEED],
@@ -2137,8 +2245,12 @@ class AlexaRangeController(AlexaCapability):
             lower_labels = [AlexaSemantics.ACTION_LOWER]
             raise_labels = [AlexaSemantics.ACTION_RAISE]
             self._semantics = AlexaSemantics()
-            min_value = self.entity.attributes.get(humidifier.ATTR_MIN_HUMIDITY, 10)
-            max_value = self.entity.attributes.get(humidifier.ATTR_MAX_HUMIDITY, 90)
+            min_value = self.entity.attributes.get(
+                HumidifierEntityCapabilityAttribute.MIN_HUMIDITY, 10
+            )
+            max_value = self.entity.attributes.get(
+                HumidifierEntityCapabilityAttribute.MAX_HUMIDITY, 90
+            )
 
             self._semantics.add_action_to_directive(
                 lower_labels, "SetRangeValue", {"rangeValue": min_value}
@@ -2243,7 +2355,9 @@ class AlexaToggleController(AlexaCapability):
 
         # Fan Oscillating
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}":
-            is_on = bool(self.entity.attributes.get(fan.ATTR_OSCILLATING))
+            is_on = bool(
+                self.entity.attributes.get(FanEntityStateAttribute.OSCILLATING)
+            )
             return "ON" if is_on else "OFF"
 
         # Stop Valve
@@ -2557,7 +2671,9 @@ class AlexaEqualizerController(AlexaCapability):
         if name != "mode":
             raise UnsupportedProperty(name)
 
-        sound_mode = self.entity.attributes.get(media_player.ATTR_SOUND_MODE)
+        sound_mode = self.entity.attributes.get(
+            MediaPlayerEntityStateAttribute.SOUND_MODE
+        )
         if sound_mode and sound_mode.upper() in self.VALID_SOUND_MODES:
             return sound_mode.upper()
 
@@ -2568,7 +2684,10 @@ class AlexaEqualizerController(AlexaCapability):
         """Return the sound modes supported in the configurations object."""
         configurations = None
         supported_sound_modes = self.get_valid_inputs(
-            self.entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST) or []
+            self.entity.attributes.get(
+                MediaPlayerEntityCapabilityAttribute.SOUND_MODE_LIST
+            )
+            or []
         )
         if supported_sound_modes:
             configurations = {"modes": {"supported": supported_sound_modes}}

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -20,17 +20,23 @@ from homeassistant.components import (
 )
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelEntityStateAttribute,
     AlarmControlPanelState,
     CodeFormat,
 )
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN, HVACMode
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityStateAttribute,
+    HVACMode,
+)
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
 from homeassistant.components.image_processing import DOMAIN as IMAGE_PROCESSING_DOMAIN
 from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
+from homeassistant.components.light import LightEntityStateAttribute
 from homeassistant.components.lock import LockState
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
@@ -39,10 +45,6 @@ from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
-    ATTR_CODE_FORMAT,
-    ATTR_SUPPORTED_FEATURES,
-    ATTR_TEMPERATURE,
-    ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     STATE_IDLE,
     STATE_OFF,
@@ -51,6 +53,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
     UnitOfLength,
     UnitOfMass,
     UnitOfTemperature,
@@ -103,7 +106,9 @@ UNIT_TO_CATALOG_TAG = {
 
 def get_resource_by_unit_of_measurement(entity: State) -> str:
     """Translate the unit of measurement to an Alexa Global Catalog keyword."""
-    unit: str = entity.attributes.get("unit_of_measurement", "preset")
+    unit: str = entity.attributes.get(
+        EntityStateAttribute.UNIT_OF_MEASUREMENT, "preset"
+    )
     return UNIT_TO_CATALOG_TAG.get(unit, AlexaGlobalCatalog.SETTING_PRESET)
 
 
@@ -619,7 +624,9 @@ class AlexaBrightnessController(AlexaCapability):
         """Read and return a property."""
         if name != "brightness":
             raise UnsupportedProperty(name)
-        if brightness := self.entity.attributes.get("brightness"):
+        if brightness := self.entity.attributes.get(
+            LightEntityStateAttribute.BRIGHTNESS
+        ):
             return round(brightness / 255.0 * 100)
         return 0
 
@@ -774,7 +781,9 @@ class AlexaSpeaker(AlexaCapability):
         """Return what properties this entity supports."""
         properties = [{"name": "volume"}]
 
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if supported & media_player.MediaPlayerEntityFeature.VOLUME_MUTE:
             properties.append({"name": "muted"})
 
@@ -871,7 +880,9 @@ class AlexaPlaybackController(AlexaCapability):
         Supported Operations: FastForward, Next, Pause, Play, Previous, Rewind,
         StartOver, Stop
         """
-        supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported_features = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
 
         operations: dict[
             cover.CoverEntityFeature | media_player.MediaPlayerEntityFeature, str
@@ -1008,7 +1019,8 @@ class AlexaTemperatureSensor(AlexaCapability):
             raise UnsupportedProperty(name)
 
         unit: str = self.entity.attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT, self.hass.config.units.temperature_unit
+            EntityStateAttribute.UNIT_OF_MEASUREMENT,
+            self.hass.config.units.temperature_unit,
         )
         temp: str | None = self.entity.state
         if self.entity.domain == CLIMATE_DOMAIN:
@@ -1197,7 +1209,9 @@ class AlexaThermostatController(AlexaCapability):
     def properties_supported(self) -> list[dict[str, str]]:
         """Return what properties this entity supports."""
         properties = [{"name": "thermostatMode"}]
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if self.entity.domain == CLIMATE_DOMAIN:
             if supported & climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
                 properties.append({"name": "lowerSetpoint"})
@@ -1251,7 +1265,9 @@ class AlexaThermostatController(AlexaCapability):
 
         unit = self.hass.config.units.temperature_unit
         if name == "targetSetpoint":
-            temp = self.entity.attributes.get(ATTR_TEMPERATURE)
+            temp = self.entity.attributes.get(
+                ClimateEntityStateAttribute.TARGET_TEMPERATURE
+            )
         elif name == "lowerSetpoint":
             temp = self.entity.attributes.get(climate.ATTR_TARGET_TEMP_LOW)
         elif name == "upperSetpoint":
@@ -1426,8 +1442,10 @@ class AlexaSecurityPanelController(AlexaCapability):
     @override
     def configuration(self) -> dict[str, Any] | None:
         """Return configuration object with supported authorization types."""
-        code_format = self.entity.attributes.get(ATTR_CODE_FORMAT)
-        supported = self.entity.attributes[ATTR_SUPPORTED_FEATURES]
+        code_format = self.entity.attributes.get(
+            AlarmControlPanelEntityStateAttribute.CODE_FORMAT
+        )
+        supported = self.entity.attributes[EntityStateAttribute.SUPPORTED_FEATURES]
         configuration = {}
 
         supported_arm_states = [{"value": "DISARMED"}]
@@ -1698,7 +1716,9 @@ class AlexaModeController(AlexaCapability):
 
         # Valve position resources
         if self.instance == f"{VALVE_DOMAIN}.state":
-            supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+            supported_features = self.entity.attributes.get(
+                EntityStateAttribute.SUPPORTED_FEATURES, 0
+            )
             self._resource = AlexaModeResource(
                 ["Preset", AlexaGlobalCatalog.SETTING_PRESET], False
             )
@@ -1727,7 +1747,9 @@ class AlexaModeController(AlexaCapability):
     @override
     def semantics(self) -> dict[str, Any] | None:
         """Build and return semantics object."""
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
 
         # Cover Position
         if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
@@ -1879,7 +1901,9 @@ class AlexaRangeController(AlexaCapability):
 
         # Fan speed percentage
         if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
-            supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+            supported = self.entity.attributes.get(
+                EntityStateAttribute.SUPPORTED_FEATURES, 0
+            )
             if supported and fan.FanEntityFeature.SET_SPEED:
                 return self.entity.attributes.get(fan.ATTR_PERCENTAGE)
             return 100 if self.entity.state == fan.STATE_ON else 0
@@ -1975,7 +1999,7 @@ class AlexaRangeController(AlexaCapability):
             min_value = float(self.entity.attributes[input_number.ATTR_MIN])
             max_value = float(self.entity.attributes[input_number.ATTR_MAX])
             precision = float(self.entity.attributes.get(input_number.ATTR_STEP, 1))
-            unit = self.entity.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            unit = self.entity.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
             self._resource = AlexaPresetResource(
                 ["Value", get_resource_by_unit_of_measurement(self.entity)],
@@ -1997,7 +2021,7 @@ class AlexaRangeController(AlexaCapability):
             min_value = float(self.entity.attributes[number.ATTR_MIN])
             max_value = float(self.entity.attributes[number.ATTR_MAX])
             precision = float(self.entity.attributes.get(number.ATTR_STEP, 1))
-            unit = self.entity.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            unit = self.entity.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
             self._resource = AlexaPresetResource(
                 ["Value", get_resource_by_unit_of_measurement(self.entity)],
@@ -2050,7 +2074,9 @@ class AlexaRangeController(AlexaCapability):
     @override
     def semantics(self) -> dict[str, Any] | None:
         """Build and return semantics object."""
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
 
         # Cover Position
         if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -22,6 +22,7 @@ from homeassistant.components import (
 )
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+    AlarmControlPanelEntityStateAttribute,
 )
 from homeassistant.components.alert import DOMAIN as ALERT_DOMAIN
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
@@ -53,10 +54,10 @@ from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
-    ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_DESCRIPTION,
     CONF_NAME,
+    EntityStateAttribute,
     UnitOfTemperature,
     __version__,
 )
@@ -444,7 +445,7 @@ class SwitchCapabilities(AlexaEntity):
         if self.entity.domain == INPUT_BOOLEAN_DOMAIN:
             return [DisplayCategory.OTHER]
 
-        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        device_class = self.entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if device_class == switch.SwitchDeviceClass.OUTLET:
             return [DisplayCategory.SMARTPLUG]
 
@@ -494,7 +495,9 @@ class ClimateCapabilities(AlexaEntity):
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
         # If we support two modes, one being off, we allow turning on too.
-        supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported_features = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if (
             (
                 self.entity.domain == CLIMATE_DOMAIN
@@ -550,7 +553,7 @@ class CoverCapabilities(AlexaEntity):
     @override
     def default_display_categories(self) -> list[str]:
         """Return the display categories for this entity."""
-        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        device_class = self.entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if device_class in (cover.CoverDeviceClass.GARAGE, cover.CoverDeviceClass.GATE):
             return [DisplayCategory.GARAGE_DOOR]
         if device_class == cover.CoverDeviceClass.DOOR:
@@ -573,14 +576,16 @@ class CoverCapabilities(AlexaEntity):
     @override
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
-        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        device_class = self.entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if device_class not in (
             cover.CoverDeviceClass.GARAGE,
             cover.CoverDeviceClass.GATE,
         ):
             yield AlexaPowerController(self.entity)
 
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if supported & cover.CoverEntityFeature.SET_POSITION:
             yield AlexaRangeController(
                 self.entity, instance=f"{COVER_DOMAIN}.{cover.ATTR_POSITION}"
@@ -663,7 +668,9 @@ class FanCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
         force_range_controller = True
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if supported & fan.FanEntityFeature.OSCILLATE:
             yield AlexaToggleController(
                 self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}"
@@ -709,7 +716,9 @@ class RemoteCapabilities(AlexaEntity):
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         activities = self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST) or []
         if (
             activities
@@ -736,7 +745,9 @@ class HumidifierCapabilities(AlexaEntity):
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if (
             supported & humidifier.HumidifierEntityFeature.MODES
         ) and self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES):
@@ -775,7 +786,7 @@ class MediaPlayerCapabilities(AlexaEntity):
     @override
     def default_display_categories(self) -> list[str]:
         """Return the display categories for this entity."""
-        device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
+        device_class = self.entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if device_class == media_player.MediaPlayerDeviceClass.SPEAKER:
             return [DisplayCategory.SPEAKER]
 
@@ -786,7 +797,9 @@ class MediaPlayerCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
 
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if supported & media_player.MediaPlayerEntityFeature.VOLUME_SET:
             yield AlexaSpeaker(self.entity)
         elif supported & media_player.MediaPlayerEntityFeature.VOLUME_STEP:
@@ -979,7 +992,9 @@ class AlarmControlPanelCapabilities(AlexaEntity):
     @override
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
-        if not self.entity.attributes.get("code_arm_required"):
+        if not self.entity.attributes.get(
+            AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED
+        ):
             yield AlexaSecurityPanelController(self.hass, self.entity)
             yield AlexaEndpointHealth(self.hass, self.entity)
             yield Alexa(self.entity)
@@ -1050,7 +1065,9 @@ class VacuumCapabilities(AlexaEntity):
     @override
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if (
             (supported & vacuum.VacuumEntityFeature.TURN_ON)
             or (supported & vacuum.VacuumEntityFeature.START)
@@ -1087,7 +1104,9 @@ class ValveCapabilities(AlexaEntity):
     @override
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
-        supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = self.entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if supported & valve.ValveEntityFeature.SET_POSITION:
             yield AlexaRangeController(
                 self.entity, instance=f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}"
@@ -1115,7 +1134,9 @@ class CameraCapabilities(AlexaEntity):
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
         if self._check_requirements():
-            supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+            supported = self.entity.attributes.get(
+                EntityStateAttribute.SUPPORTED_FEATURES, 0
+            )
             if supported & camera.CameraEntityFeature.STREAM:
                 yield AlexaCameraStreamController(self.entity)
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -29,21 +29,39 @@ from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityCapabilityAttribute,
+)
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.fan import (
+    DOMAIN as FAN_DOMAIN,
+    FanEntityCapabilityAttribute,
+)
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
-from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.humidifier import (
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    HumidifierEntityCapabilityAttribute,
+)
 from homeassistant.components.image_processing import DOMAIN as IMAGE_PROCESSING_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+    LightEntityCapabilityAttribute,
+)
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
-from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerEntityCapabilityAttribute,
+)
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.remote import (
+    DOMAIN as REMOTE_DOMAIN,
+    RemoteEntityStateAttribute,
+)
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -51,10 +69,11 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.components.water_heater import (
+    DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterCapabilityAttribute,
+)
 from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_DESCRIPTION,
     CONF_NAME,
     EntityStateAttribute,
@@ -502,7 +521,12 @@ class ClimateCapabilities(AlexaEntity):
             (
                 self.entity.domain == CLIMATE_DOMAIN
                 and climate.HVACMode.OFF
-                in (self.entity.attributes.get(climate.ATTR_HVAC_MODES) or [])
+                in (
+                    self.entity.attributes.get(
+                        ClimateEntityCapabilityAttribute.HVAC_MODES
+                    )
+                    or []
+                )
             )
             or (
                 self.entity.domain == CLIMATE_DOMAIN
@@ -536,7 +560,9 @@ class ClimateCapabilities(AlexaEntity):
                 supported_features
                 & water_heater.WaterHeaterEntityFeature.OPERATION_MODE
             )
-            and self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST)
+            and self.entity.attributes.get(
+                WaterHeaterCapabilityAttribute.OPERATION_LIST
+            )
         ):
             yield AlexaModeController(
                 self.entity,
@@ -614,7 +640,9 @@ class EventCapabilities(AlexaEntity):
     def default_display_categories(self) -> list[str] | None:
         """Return the display categories for this entity."""
         attrs = self.entity.attributes
-        device_class: event.EventDeviceClass | None = attrs.get(ATTR_DEVICE_CLASS)
+        device_class: event.EventDeviceClass | None = attrs.get(
+            EntityStateAttribute.DEVICE_CLASS
+        )
         if device_class == event.EventDeviceClass.DOORBELL:
             return [DisplayCategory.DOORBELL]
         return None
@@ -642,7 +670,9 @@ class LightCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
 
-        color_modes = self.entity.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES)
+        color_modes = self.entity.attributes.get(
+            LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES
+        )
         if light.brightness_supported(color_modes):
             yield AlexaBrightnessController(self.entity)
         if light.color_supported(color_modes):
@@ -677,7 +707,7 @@ class FanCapabilities(AlexaEntity):
             )
             force_range_controller = False
         if supported & fan.FanEntityFeature.PRESET_MODE and self.entity.attributes.get(
-            fan.ATTR_PRESET_MODES
+            FanEntityCapabilityAttribute.PRESET_MODES
         ):
             yield AlexaModeController(
                 self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}"
@@ -719,11 +749,13 @@ class RemoteCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(
             EntityStateAttribute.SUPPORTED_FEATURES, 0
         )
-        activities = self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST) or []
+        activities = (
+            self.entity.attributes.get(RemoteEntityStateAttribute.ACTIVITY_LIST) or []
+        )
         if (
             activities
             and (supported & remote.RemoteEntityFeature.ACTIVITY)
-            and self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST)
+            and self.entity.attributes.get(RemoteEntityStateAttribute.ACTIVITY_LIST)
         ):
             yield AlexaModeController(
                 self.entity, instance=f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}"
@@ -750,7 +782,9 @@ class HumidifierCapabilities(AlexaEntity):
         )
         if (
             supported & humidifier.HumidifierEntityFeature.MODES
-        ) and self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES):
+        ) and self.entity.attributes.get(
+            HumidifierEntityCapabilityAttribute.AVAILABLE_MODES
+        ):
             yield AlexaModeController(
                 self.entity, instance=f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}"
             )
@@ -821,7 +855,9 @@ class MediaPlayerCapabilities(AlexaEntity):
 
         if supported & media_player.MediaPlayerEntityFeature.SELECT_SOURCE:
             inputs = AlexaInputController.get_valid_inputs(
-                self.entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST, [])
+                self.entity.attributes.get(
+                    MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST, []
+                )
             )
             if len(inputs) > 0:
                 yield AlexaInputController(self.entity)
@@ -838,7 +874,10 @@ class MediaPlayerCapabilities(AlexaEntity):
             and domain != "denonavr"
         ):
             inputs = AlexaEqualizerController.get_valid_inputs(
-                self.entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST) or []
+                self.entity.attributes.get(
+                    MediaPlayerEntityCapabilityAttribute.SOUND_MODE_LIST
+                )
+                or []
             )
             if len(inputs) > 0:
                 yield AlexaEqualizerController(self.entity)
@@ -902,7 +941,7 @@ class SensorCapabilities(AlexaEntity):
     def interfaces(self) -> Generator[AlexaCapability]:
         """Yield the supported interfaces."""
         attrs = self.entity.attributes
-        if attrs.get(ATTR_UNIT_OF_MEASUREMENT) in {
+        if attrs.get(EntityStateAttribute.UNIT_OF_MEASUREMENT) in {
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.CELSIUS,
         }:
@@ -960,7 +999,7 @@ class BinarySensorCapabilities(AlexaEntity):
     def get_type(self) -> str | None:
         """Return the type of binary sensor."""
         attrs = self.entity.attributes
-        if attrs.get(ATTR_DEVICE_CLASS) in (
+        if attrs.get(EntityStateAttribute.DEVICE_CLASS) in (
             binary_sensor.BinarySensorDeviceClass.DOOR,
             binary_sensor.BinarySensorDeviceClass.GARAGE_DOOR,
             binary_sensor.BinarySensorDeviceClass.OPENING,
@@ -968,11 +1007,14 @@ class BinarySensorCapabilities(AlexaEntity):
         ):
             return self.TYPE_CONTACT
 
-        if attrs.get(ATTR_DEVICE_CLASS) == binary_sensor.BinarySensorDeviceClass.MOTION:
+        if (
+            attrs.get(EntityStateAttribute.DEVICE_CLASS)
+            == binary_sensor.BinarySensorDeviceClass.MOTION
+        ):
             return self.TYPE_MOTION
 
         if (
-            attrs.get(ATTR_DEVICE_CLASS)
+            attrs.get(EntityStateAttribute.DEVICE_CLASS)
             == binary_sensor.BinarySensorDeviceClass.PRESENCE
         ):
             return self.TYPE_PRESENCE

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -27,7 +27,11 @@ from homeassistant.components import (
     water_heater,
 )
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityCapabilityAttribute,
+    ClimateEntityStateAttribute,
+)
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
@@ -43,8 +47,6 @@ from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_ENTITY_PICTURE,
-    ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
@@ -65,6 +67,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
+    EntityStateAttribute,
     UnitOfTemperature,
 )
 from homeassistant.helpers import network
@@ -205,7 +208,7 @@ async def async_api_turn_on(
     elif domain == REMOTE_DOMAIN:
         service = remote.SERVICE_TURN_ON
     elif domain == VACUUM_DOMAIN:
-        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = entity.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
         if (
             not supported & vacuum.VacuumEntityFeature.TURN_ON
             and supported & vacuum.VacuumEntityFeature.START
@@ -214,7 +217,7 @@ async def async_api_turn_on(
     elif domain == TIMER_DOMAIN:
         service = timer.SERVICE_START
     elif domain == MEDIA_PLAYER_DOMAIN:
-        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = entity.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
         power_features = (
             media_player.MediaPlayerEntityFeature.TURN_ON
             | media_player.MediaPlayerEntityFeature.TURN_OFF
@@ -258,7 +261,7 @@ async def async_api_turn_off(
     elif domain == HUMIDIFIER_DOMAIN:
         service = humidifier.SERVICE_TURN_OFF
     elif domain == VACUUM_DOMAIN:
-        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = entity.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
         if (
             not supported & vacuum.VacuumEntityFeature.TURN_OFF
             and supported & vacuum.VacuumEntityFeature.RETURN_HOME
@@ -267,7 +270,7 @@ async def async_api_turn_off(
     elif domain == TIMER_DOMAIN:
         service = timer.SERVICE_CANCEL
     elif domain == MEDIA_PLAYER_DOMAIN:
-        supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported = entity.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
         power_features = (
             media_player.MediaPlayerEntityFeature.TURN_ON
             | media_player.MediaPlayerEntityFeature.TURN_OFF
@@ -782,7 +785,9 @@ async def async_api_stop(
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
     if entity.domain == COVER_DOMAIN:
-        supported: int = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported: int = entity.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         feature_services: dict[int, str] = {
             cover.CoverEntityFeature.STOP.value: cover.SERVICE_STOP_COVER,
             cover.CoverEntityFeature.STOP_TILT.value: cover.SERVICE_STOP_COVER_TILT,
@@ -875,7 +880,7 @@ async def async_api_set_target_temp(
     domain = entity.domain
 
     min_temp = entity.attributes[MIN_MAX_TEMP[domain]["min_temp"]]
-    max_temp = entity.attributes["max_temp"]
+    max_temp = entity.attributes[ClimateEntityCapabilityAttribute.MAX_TEMP]
     unit = hass.config.units.temperature_unit
 
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
@@ -985,7 +990,9 @@ async def async_api_adjust_target_temp(
             }
         )
     else:
-        current_target_temp: str | None = entity.attributes.get(ATTR_TEMPERATURE)
+        current_target_temp: str | None = entity.attributes.get(
+            ClimateEntityStateAttribute.TARGET_TEMPERATURE
+        )
         if current_target_temp is None:
             raise AlexaUnsupportedThermostatTargetStateError(
                 "The current target temperature is not set, "
@@ -1432,7 +1439,7 @@ async def async_api_set_range(
     service = None
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
     range_value = directive.payload["rangeValue"]
-    supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+    supported = entity.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
 
     # Cover Position
     if instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
@@ -1946,7 +1953,7 @@ async def async_api_initialize_camera_stream(
     stream_source = await camera.async_request_stream(hass, entity.entity_id, fmt="hls")
     state = hass.states.get(entity.entity_id)
     assert state
-    camera_image = state.attributes[ATTR_ENTITY_PICTURE]
+    camera_image = state.attributes[EntityStateAttribute.ENTITY_PICTURE]
 
     try:
         external_url = network.get_url(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -32,19 +32,51 @@ from homeassistant.components.climate import (
     ClimateEntityCapabilityAttribute,
     ClimateEntityStateAttribute,
 )
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    CoverEntityStateAttribute,
+)
+from homeassistant.components.fan import (
+    DOMAIN as FAN_DOMAIN,
+    FanEntityCapabilityAttribute,
+    FanEntityStateAttribute,
+)
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
-from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.humidifier import (
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    HumidifierEntityCapabilityAttribute,
+    HumidifierEntityStateAttribute,
+)
 from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
-from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.light import (
+    LightEntityCapabilityAttribute,
+    LightEntityStateAttribute,
+)
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerEntityCapabilityAttribute,
+    MediaPlayerEntityStateAttribute,
+)
+from homeassistant.components.number import (
+    DOMAIN as NUMBER_DOMAIN,
+    NumberEntityCapabilityAttribute,
+)
+from homeassistant.components.remote import (
+    DOMAIN as REMOTE_DOMAIN,
+    RemoteEntityStateAttribute,
+)
 from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
-from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.vacuum import (
+    DOMAIN as VACUUM_DOMAIN,
+    VacuumEntityCapabilityAttribute,
+    VacuumEntityStateAttribute,
+)
 from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.components.water_heater import (
+    DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterCapabilityAttribute,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
@@ -394,8 +426,10 @@ async def async_api_decrease_color_temp(
 ) -> AlexaResponse:
     """Process a decrease color temperature request."""
     entity = directive.entity
-    current = int(entity.attributes[light.ATTR_COLOR_TEMP_KELVIN])
-    min_kelvin = int(entity.attributes[light.ATTR_MIN_COLOR_TEMP_KELVIN])
+    current = int(entity.attributes[LightEntityStateAttribute.COLOR_TEMP_KELVIN])
+    min_kelvin = int(
+        entity.attributes[LightEntityCapabilityAttribute.MIN_COLOR_TEMP_KELVIN]
+    )
 
     value = max(min_kelvin, current - 500)
     await hass.services.async_call(
@@ -418,8 +452,10 @@ async def async_api_increase_color_temp(
 ) -> AlexaResponse:
     """Process an increase color temperature request."""
     entity = directive.entity
-    current = int(entity.attributes[light.ATTR_COLOR_TEMP_KELVIN])
-    max_kelvin = int(entity.attributes[light.ATTR_MAX_COLOR_TEMP_KELVIN])
+    current = int(entity.attributes[LightEntityStateAttribute.COLOR_TEMP_KELVIN])
+    max_kelvin = int(
+        entity.attributes[LightEntityCapabilityAttribute.MAX_COLOR_TEMP_KELVIN]
+    )
 
     value = min(max_kelvin, current + 500)
     await hass.services.async_call(
@@ -607,7 +643,10 @@ async def async_api_select_input(
 
     # Attempt to map the ALL UPPERCASE payload name to a source.
     # Strips trailing 1 to match single input devices.
-    source_list = entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
+    source_list = (
+        entity.attributes.get(MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST)
+        or []
+    )
     for source in source_list:
         formatted_source = (
             source.lower().replace("-", "").replace("_", "").replace(" ", "")
@@ -654,7 +693,9 @@ async def async_api_adjust_volume(
     volume_delta = int(directive.payload["volume"])
 
     entity = directive.entity
-    current_level = entity.attributes[media_player.ATTR_MEDIA_VOLUME_LEVEL]
+    current_level = entity.attributes[
+        MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL
+    ]
 
     # read current state
     try:
@@ -958,8 +999,12 @@ async def async_api_adjust_target_temp(
 
     response = directive.response()
 
-    current_target_temp_high = entity.attributes.get(climate.ATTR_TARGET_TEMP_HIGH)
-    current_target_temp_low = entity.attributes.get(climate.ATTR_TARGET_TEMP_LOW)
+    current_target_temp_high = entity.attributes.get(
+        ClimateEntityStateAttribute.TARGET_TEMP_HIGH
+    )
+    current_target_temp_low = entity.attributes.get(
+        ClimateEntityStateAttribute.TARGET_TEMP_LOW
+    )
     if current_target_temp_high is not None and current_target_temp_low is not None:
         target_temp_high = float(current_target_temp_high) + temp_delta
         if target_temp_high < min_temp or target_temp_high > max_temp:
@@ -1044,7 +1089,9 @@ async def async_api_set_thermostat_mode(
     ha_preset = next((k for k, v in API_THERMOSTAT_PRESETS.items() if v == mode), None)
 
     if ha_preset:
-        presets = entity.attributes.get(climate.ATTR_PRESET_MODES) or []
+        presets = (
+            entity.attributes.get(ClimateEntityCapabilityAttribute.PRESET_MODES) or []
+        )
 
         if ha_preset not in presets:
             msg = f"The requested thermostat mode {ha_preset} is not supported"
@@ -1054,7 +1101,9 @@ async def async_api_set_thermostat_mode(
         data[climate.ATTR_PRESET_MODE] = ha_preset
 
     elif mode == "CUSTOM":
-        operation_list = entity.attributes.get(climate.ATTR_HVAC_MODES) or []
+        operation_list = (
+            entity.attributes.get(ClimateEntityCapabilityAttribute.HVAC_MODES) or []
+        )
         custom_mode = directive.payload["thermostatMode"]["customName"]
         custom_mode = next(
             (k for k, v in API_THERMOSTAT_MODES_CUSTOM.items() if v == custom_mode),
@@ -1070,7 +1119,9 @@ async def async_api_set_thermostat_mode(
         data[climate.ATTR_HVAC_MODE] = custom_mode
 
     else:
-        operation_list = entity.attributes.get(climate.ATTR_HVAC_MODES) or []
+        operation_list = (
+            entity.attributes.get(ClimateEntityCapabilityAttribute.HVAC_MODES) or []
+        )
         ha_modes: dict[str, str] = {
             k: v for k, v in API_THERMOSTAT_MODES.items() if v == mode
         }
@@ -1228,7 +1279,9 @@ async def async_api_set_mode(
     # Fan preset_mode
     elif instance == f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}":
         preset_mode = mode.split(".")[1]
-        preset_modes: list[str] | None = entity.attributes.get(fan.ATTR_PRESET_MODES)
+        preset_modes: list[str] | None = entity.attributes.get(
+            FanEntityCapabilityAttribute.PRESET_MODES
+        )
         if (
             preset_mode != PRESET_MODE_NA
             and preset_modes
@@ -1243,7 +1296,9 @@ async def async_api_set_mode(
     # Humidifier mode
     elif instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
         mode = mode.split(".")[1]
-        modes: list[str] | None = entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES)
+        modes: list[str] | None = entity.attributes.get(
+            HumidifierEntityCapabilityAttribute.AVAILABLE_MODES
+        )
         if mode != PRESET_MODE_NA and modes and mode in modes:
             service = humidifier.SERVICE_SET_MODE
             data[humidifier.ATTR_MODE] = mode
@@ -1254,7 +1309,9 @@ async def async_api_set_mode(
     # Remote Activity
     elif instance == f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}":
         activity = mode.split(".")[1]
-        activities: list[str] | None = entity.attributes.get(remote.ATTR_ACTIVITY_LIST)
+        activities: list[str] | None = entity.attributes.get(
+            RemoteEntityStateAttribute.ACTIVITY_LIST
+        )
         if activity != PRESET_MODE_NA and activities and activity in activities:
             service = remote.SERVICE_TURN_ON
             data[remote.ATTR_ACTIVITY] = activity
@@ -1266,7 +1323,7 @@ async def async_api_set_mode(
     elif instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
         operation_mode = mode.split(".")[1]
         operation_modes: list[str] | None = entity.attributes.get(
-            water_heater.ATTR_OPERATION_LIST
+            WaterHeaterCapabilityAttribute.OPERATION_LIST
         )
         if (
             operation_mode != PRESET_MODE_NA
@@ -1492,14 +1549,14 @@ async def async_api_set_range(
     elif instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
         range_value = float(range_value)
         service = number.SERVICE_SET_VALUE
-        min_value = float(entity.attributes[number.ATTR_MIN])
-        max_value = float(entity.attributes[number.ATTR_MAX])
+        min_value = float(entity.attributes[NumberEntityCapabilityAttribute.MIN])
+        max_value = float(entity.attributes[NumberEntityCapabilityAttribute.MAX])
         data[number.ATTR_VALUE] = min(max_value, max(min_value, range_value))
 
     # Vacuum Fan Speed
     elif instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
         service = vacuum.SERVICE_SET_FAN_SPEED
-        speed_list = entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
+        speed_list = entity.attributes[VacuumEntityCapabilityAttribute.FAN_SPEED_LIST]
         speed = next(
             (v for i, v in enumerate(speed_list) if i == int(range_value)), None
         )
@@ -1562,7 +1619,9 @@ async def async_api_adjust_range(
     if instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
         range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_POSITION
-        if not (current := entity.attributes.get(cover.ATTR_CURRENT_POSITION)):
+        if not (
+            current := entity.attributes.get(CoverEntityStateAttribute.CURRENT_POSITION)
+        ):
             msg = f"Unable to determine {entity.entity_id} current position"
             raise AlexaInvalidValueError(msg)
         position = response_value = min(100, max(0, range_delta + current))
@@ -1591,14 +1650,16 @@ async def async_api_adjust_range(
 
     # Fan speed percentage
     elif instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
-        percentage_step = entity.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 20
+        percentage_step = (
+            entity.attributes.get(FanEntityStateAttribute.PERCENTAGE_STEP) or 20
+        )
         range_delta = (
             int(range_delta * percentage_step)
             if range_delta_default
             else int(range_delta)
         )
         service = fan.SERVICE_SET_PERCENTAGE
-        if not (current := entity.attributes.get(fan.ATTR_PERCENTAGE)):
+        if not (current := entity.attributes.get(FanEntityStateAttribute.PERCENTAGE)):
             msg = f"Unable to determine {entity.entity_id} current fan speed"
             raise AlexaInvalidValueError(msg)
         percentage = response_value = min(100, max(0, range_delta + current))
@@ -1616,11 +1677,17 @@ async def async_api_adjust_range(
             else int(range_delta)
         )
         service = humidifier.SERVICE_SET_HUMIDITY
-        if not (current := entity.attributes.get(humidifier.ATTR_HUMIDITY)):
+        if not (
+            current := entity.attributes.get(HumidifierEntityStateAttribute.HUMIDITY)
+        ):
             msg = f"Unable to determine {entity.entity_id} current target humidity"
             raise AlexaInvalidValueError(msg)
-        min_value = entity.attributes.get(humidifier.ATTR_MIN_HUMIDITY, 10)
-        max_value = entity.attributes.get(humidifier.ATTR_MAX_HUMIDITY, 90)
+        min_value = entity.attributes.get(
+            HumidifierEntityCapabilityAttribute.MIN_HUMIDITY, 10
+        )
+        max_value = entity.attributes.get(
+            HumidifierEntityCapabilityAttribute.MAX_HUMIDITY, 90
+        )
         percentage = response_value = min(
             max_value, max(min_value, range_delta + current)
         )
@@ -1642,8 +1709,8 @@ async def async_api_adjust_range(
     elif instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
         range_delta = float(range_delta)
         service = number.SERVICE_SET_VALUE
-        min_value = float(entity.attributes[number.ATTR_MIN])
-        max_value = float(entity.attributes[number.ATTR_MAX])
+        min_value = float(entity.attributes[NumberEntityCapabilityAttribute.MIN])
+        max_value = float(entity.attributes[NumberEntityCapabilityAttribute.MAX])
         current = float(entity.state)
         data[number.ATTR_VALUE] = response_value = min(
             max_value, max(min_value, range_delta + current)
@@ -1653,8 +1720,8 @@ async def async_api_adjust_range(
     elif instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
         range_delta = int(range_delta)
         service = vacuum.SERVICE_SET_FAN_SPEED
-        speed_list = entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
-        current_speed = entity.attributes[vacuum.ATTR_FAN_SPEED]
+        speed_list = entity.attributes[VacuumEntityCapabilityAttribute.FAN_SPEED_LIST]
+        current_speed = entity.attributes[VacuumEntityStateAttribute.FAN_SPEED]
         current_speed_index = next(
             (i for i, v in enumerate(speed_list) if v == current_speed), 0
         )
@@ -1805,14 +1872,18 @@ async def async_api_seek(
     entity = directive.entity
     position_delta = int(directive.payload["deltaPositionMilliseconds"])
 
-    current_position = entity.attributes.get(media_player.ATTR_MEDIA_POSITION)
+    current_position = entity.attributes.get(
+        MediaPlayerEntityStateAttribute.MEDIA_POSITION
+    )
     if not current_position:
         msg = f"{entity} did not return the current media position."
         raise AlexaVideoActionNotPermittedForContentError(msg)
 
     seek_position = max(int(current_position) + int(position_delta / 1000), 0)
 
-    media_duration = entity.attributes.get(media_player.ATTR_MEDIA_DURATION)
+    media_duration = entity.attributes.get(
+        MediaPlayerEntityStateAttribute.MEDIA_DURATION
+    )
     if media_duration and 0 < int(media_duration) < seek_position:
         seek_position = media_duration
 
@@ -1852,7 +1923,9 @@ async def async_api_set_eq_mode(
     entity = directive.entity
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
-    sound_mode_list = entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST)
+    sound_mode_list = entity.attributes.get(
+        MediaPlayerEntityCapabilityAttribute.SOUND_MODE_LIST
+    )
     if sound_mode_list and mode.lower() in sound_mode_list:
         data[media_player.ATTR_SOUND_MODE] = mode.lower()
     else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Alexa integration reads Home Assistant entity state/capability attributes when building Alexa discovery and directives. These **reads** now use the attribute enums instead of `ATTR_*` constants and bare string literals:

- Base `EntityStateAttribute`: `SUPPORTED_FEATURES`, `DEVICE_CLASS`, `UNIT_OF_MEASUREMENT` (incl. a bare `"unit_of_measurement"`), `ENTITY_PICTURE`.
- Platform enums: `LightEntityStateAttribute.BRIGHTNESS` (bare `"brightness"`), `ClimateEntityStateAttribute.TARGET_TEMPERATURE` (`ATTR_TEMPERATURE` reads), `ClimateEntityCapabilityAttribute.MAX_TEMP` (bare `"max_temp"`), `AlarmControlPanelEntityStateAttribute.CODE_FORMAT` and `.CODE_ARM_REQUIRED` (bare `"code_arm_required"`).

Scope is limited to attribute **reads** (`state.attributes.get(...)` / `[...]`). Constants used as service-call data keys are unchanged. The bare `"color_temp"` read is left as-is since there is no matching enum member (light exposes `color_temp_kelvin`).

Part of #175836.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
