### PR TITLE
Share a gateway for the FHT test fixtures

### DIFF
--- a/tests/components/vicare/snapshots/test_binary_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_binary_sensor.ambr
@@ -740,7 +740,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'identification_mode',
-    'unique_id': 'gateway3_zigbee_################-identification_mode',
+    'unique_id': 'fht_gateway_zigbee_################-identification_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -790,7 +790,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'valve',
-    'unique_id': 'gateway4_zigbee_################_2-valve',
+    'unique_id': 'fht_gateway_zigbee_################_2-valve',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -1257,7 +1257,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'active_mode',
-    'unique_id': 'gateway11_zigbee_################-active_mode',
+    'unique_id': 'fht_gateway_zigbee_################-active_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -1315,7 +1315,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'zigbee_signal_strength',
-    'unique_id': 'gateway11_zigbee_################-zigbee_signal_strength',
+    'unique_id': 'fht_gateway_zigbee_################-zigbee_signal_strength',
     'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
   })
 # ---
@@ -1372,7 +1372,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'supply_temperature',
-    'unique_id': 'gateway11_zigbee_################-supply_temperature',
+    'unique_id': 'fht_gateway_zigbee_################-supply_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---

--- a/tests/components/vicare/test_binary_sensor.py
+++ b/tests/components/vicare/test_binary_sensor.py
@@ -45,8 +45,12 @@ async def test_all_entities(
         Fixture({"type:boiler"}, "vicare/Vitodens300W.json"),
         Fixture({"type:radiator"}, "vicare/ZigbeeTRV.json"),
         Fixture({"type:repeater"}, "vicare/ZigbeeRepeater.json"),
-        Fixture({"type:fhtMain"}, "vicare/FHTMain.json"),
-        Fixture({"type:fhtChannel"}, "vicare/FHTChannel.json"),
+        # FHT main and channel are the same physical zigbee node, so they share
+        # a gateway; this lets the channel link to the main via via_device.
+        Fixture({"type:fhtMain"}, "vicare/FHTMain.json", gateway_id="fht_gateway"),
+        Fixture(
+            {"type:fhtChannel"}, "vicare/FHTChannel.json", gateway_id="fht_gateway"
+        ),
     ]
     with (
         patch(

--- a/tests/components/vicare/test_sensor.py
+++ b/tests/components/vicare/test_sensor.py
@@ -35,8 +35,12 @@ async def test_all_entities(
         Fixture({"type:climateSensor"}, "vicare/RoomSensor2.json"),
         Fixture({"type:radiator"}, "vicare/ZigbeeTRV.json"),
         Fixture({"type:repeater"}, "vicare/ZigbeeRepeater.json"),
-        Fixture({"type:fhtMain"}, "vicare/FHTMain.json"),
-        Fixture({"type:fhtChannel"}, "vicare/FHTChannel.json"),
+        # FHT main and channel are the same physical zigbee node, so they share
+        # a gateway; this lets the channel link to the main via via_device.
+        Fixture({"type:fhtMain"}, "vicare/FHTMain.json", gateway_id="fht_gateway"),
+        Fixture(
+            {"type:fhtChannel"}, "vicare/FHTChannel.json", gateway_id="fht_gateway"
+        ),
     ]
     with (
         patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
FHTMain and FHTChannel are the same physical zigbee node (same IEEE address, the channel serial just adds a `-2` suffix), but the test fixtures put them on separate mock gateways. The channel's `via_device` is derived from its own gateway serial, so it pointed at a gateway the main device was never registered under and the main/channel link never resolved in the fixtures.

Give both FHT fixtures a shared `gateway_id` so they model one node and the `via_device` link resolves, like a real installation.

Test-only follow-up to #178229, which added the `gateway_id` fixture field and where @emontnemery asked the `vicare` code owners to check the fixtures for realism.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178229
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
