### PR TITLE
Luci restablish consider_home functionality

### DIFF
--- a/homeassistant/components/luci/config_flow.py
+++ b/homeassistant/components/luci/config_flow.py
@@ -7,13 +7,29 @@ from openwrt_luci_rpc import OpenWrtRpc
 from requests.exceptions import ConnectionError as RequestsConnectionError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.components.device_tracker import (
+    CONF_CONSIDER_HOME,
+    DEFAULT_CONSIDER_HOME,
+)
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    UnitOfTime,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
 )
 
 from .const import DEFAULT_SSL, DEFAULT_VERIFY_SSL, DOMAIN
@@ -37,6 +53,15 @@ class LuciConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenWrt (luci)."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> LuciOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return LuciOptionsFlowHandler()
 
     @override
     async def async_step_user(
@@ -123,6 +148,40 @@ class LuciConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=import_data[CONF_HOST],
             data=import_data,
+        )
+
+
+class LuciOptionsFlowHandler(OptionsFlowWithReload):
+    """Handle an options flow for OpenWrt (luci)."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_CONSIDER_HOME,
+                        default=self.config_entry.options.get(
+                            CONF_CONSIDER_HOME,
+                            DEFAULT_CONSIDER_HOME.total_seconds(),
+                        ),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0,
+                            max=900,
+                            step=1,
+                            mode=NumberSelectorMode.BOX,
+                            unit_of_measurement=UnitOfTime.SECONDS,
+                        )
+                    ),
+                }
+            ),
         )
 
 

--- a/homeassistant/components/luci/coordinator.py
+++ b/homeassistant/components/luci/coordinator.py
@@ -1,6 +1,6 @@
 """DataUpdateCoordinator for the OpenWrt (luci) integration."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import Any, override
 
@@ -8,9 +8,14 @@ from openwrt_luci_rpc import OpenWrtRpc
 from openwrt_luci_rpc.exceptions import LuciRpcUnknownError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from homeassistant.components.device_tracker import (
+    CONF_CONSIDER_HOME,
+    DEFAULT_CONSIDER_HOME,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +44,17 @@ class LuciCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=SCAN_INTERVAL,
         )
         self.router = router
+        self._devices: dict[str, Any] = {}
+        self._last_seen: dict[str, datetime] = {}
+
+    @property
+    def consider_home(self) -> timedelta:
+        """Return how long a device stays home after the router stops seeing it."""
+        return timedelta(
+            seconds=self.config_entry.options.get(
+                CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
+            )
+        )
 
     @override
     async def _async_update_data(self) -> dict[str, Any]:
@@ -52,4 +68,17 @@ class LuciCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         _LOGGER.debug("Luci get_all_connected_devices returned: %s", result)
 
-        return {device.mac: device for device in result}
+        now = dt_util.utcnow()
+        for device in result:
+            self._devices[device.mac] = device
+            self._last_seen[device.mac] = now
+
+        # A device missing from the scan keeps its last known details and stays
+        # home until consider_home has elapsed, so brief dropouts don't flap.
+        consider_home = self.consider_home
+        for mac, last_seen in list(self._last_seen.items()):
+            if now - last_seen > consider_home:
+                del self._last_seen[mac]
+                del self._devices[mac]
+
+        return dict(self._devices)

--- a/homeassistant/components/luci/quality_scale.yaml
+++ b/homeassistant/components/luci/quality_scale.yaml
@@ -36,9 +36,7 @@ rules:
     status: exempt
     comment: This integration does not provide any actions.
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: This integration does not have an options flow.
+  docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
@@ -63,9 +61,7 @@ rules:
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
-  dynamic-devices:
-    status: todo
-    comment: Clients connecting after setup are not added until Home Assistant restarts.
+  dynamic-devices: done
   entity-category:
     status: exempt
     comment: This integration only creates device tracker entities.
@@ -83,9 +79,7 @@ rules:
     status: exempt
     comment: Device tracker entities use the icon of their source type.
   reconfiguration-flow: todo
-  repair-issues:
-    status: exempt
-    comment: This integration has no repairs beyond the deprecated YAML import issue.
+  repair-issues: done
   stale-devices:
     status: todo
     comment: Clients that stop connecting are not removed automatically.

--- a/homeassistant/components/luci/strings.json
+++ b/homeassistant/components/luci/strings.json
@@ -48,5 +48,17 @@
       "description": "The YAML configuration for OpenWrt (luci) at `{host}` could not be imported because the credentials are invalid.\n\nPlease update your `configuration.yaml` with valid credentials and restart Home Assistant.",
       "title": "YAML configuration import failed: invalid authentication"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "consider_home": "Seconds to consider a device at 'home'"
+        },
+        "data_description": {
+          "consider_home": "Time a device stays at home after the router stops reporting it. Raise this if devices that sleep, such as phones, flap between home and away. Default is 180 seconds."
+        }
+      }
+    }
   }
 }

--- a/tests/components/luci/test_config_flow.py
+++ b/tests/components/luci/test_config_flow.py
@@ -1,11 +1,13 @@
 """Tests for the luci config flow."""
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from homeassistant.components.device_tracker import CONF_CONSIDER_HOME
 from homeassistant.components.luci.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import (
@@ -201,3 +203,27 @@ async def test_reauth_flow_errors(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
+
+
+@pytest.mark.usefixtures("mock_luci_client")
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow updates consider_home."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_CONSIDER_HOME: 300}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options == {CONF_CONSIDER_HOME: 300}
+    assert mock_config_entry.runtime_data.consider_home == timedelta(seconds=300)

--- a/tests/components/luci/test_device_tracker.py
+++ b/tests/components/luci/test_device_tracker.py
@@ -7,12 +7,16 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.components.device_tracker import (
+    CONF_CONSIDER_HOME,
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
+    ScannerEntityStateAttribute,
+)
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MOCK_DEVICE_2
+from .conftest import MOCK_DEVICE_1, MOCK_DEVICE_2
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -39,7 +43,7 @@ async def test_device_tracker_disconnect(
     mock_luci_client: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test device goes not_home when disconnected."""
+    """Test a disconnected device stays home until consider_home has elapsed."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -55,6 +59,52 @@ async def test_device_tracker_disconnect(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
+    # Still home, the default consider_home of 180 seconds has not elapsed yet
+    state = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.device1")
+    assert state is not None
+    assert state.state == STATE_HOME
+    # The last known details are kept while the device is considered home
+    assert state.attributes[ScannerEntityStateAttribute.IP] == MOCK_DEVICE_1.ip
+
+    freezer.tick(timedelta(seconds=180))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
     state = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.device1")
     assert state is not None
     assert state.state == STATE_NOT_HOME
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("consider_home", "expected_state"),
+    [
+        pytest.param(0, STATE_NOT_HOME, id="disabled"),
+        pytest.param(900, STATE_HOME, id="maximum"),
+    ],
+)
+async def test_consider_home_option(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luci_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    consider_home: int,
+    expected_state: str,
+) -> None:
+    """Test the consider_home option controls how long a device stays home."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={CONF_CONSIDER_HOME: consider_home}
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_luci_client.get_all_connected_devices.return_value = [MOCK_DEVICE_2]
+
+    freezer.tick(timedelta(seconds=300))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.device1")
+    assert state is not None
+    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This reimplements the consider_home functionality (from before the config-flow migration), as requested in the issue.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178352 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47286
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
