### PR TITLE
Webostv turn on trigger UI

### DIFF
--- a/homeassistant/components/webostv/device_trigger.py
+++ b/homeassistant/components/webostv/device_trigger.py
@@ -7,16 +7,21 @@ from homeassistant.components.device_automation import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_DEVICE_ID, CONF_PLATFORM, CONF_TYPE
+from homeassistant.const import ATTR_DEVICE_ID, CONF_DEVICE_ID, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.trigger import (
+    PluggableAction,
+    TriggerActionType,
+    TriggerInfo,
+)
 from homeassistant.helpers.typing import ConfigType
 
-from . import DOMAIN, trigger
+from . import DOMAIN
 from .helpers import async_get_device_entry_by_device_id
 from .triggers.turn_on import (
     PLATFORM_TYPE as TURN_ON_PLATFORM_TYPE,
+    async_get_turn_on_description,
     async_get_turn_on_trigger,
 )
 
@@ -82,15 +87,15 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
     if (trigger_type := config[CONF_TYPE]) == TURN_ON_PLATFORM_TYPE:
-        trigger_config = {
+        device_id = config[CONF_DEVICE_ID]
+        variables = {
+            **trigger_info["trigger_data"],
             CONF_PLATFORM: trigger_type,
-            CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+            ATTR_DEVICE_ID: device_id,
+            "description": async_get_turn_on_description(hass, device_id),
         }
-        trigger_config = await trigger.async_validate_trigger_config(
-            hass, trigger_config
-        )
-        return await trigger.async_attach_trigger(
-            hass, trigger_config, action, trigger_info
+        return PluggableAction.async_attach_trigger(
+            hass, async_get_turn_on_trigger(device_id), action, {"trigger": variables}
         )
 
     raise HomeAssistantError(

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -3,8 +3,7 @@
 from aiowebostv import WebOsTvState
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, LIVE_TV_APP_ID
@@ -23,29 +22,6 @@ def async_get_device_entry_by_device_id(
         raise ValueError(f"Device {device_id} is not a valid {DOMAIN} device.")
 
     return device
-
-
-@callback
-def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
-    """Get device ID from an entity ID.
-
-    Raises HomeAssistantError if entity or device ID is invalid.
-    """
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(entity_id)
-
-    if (
-        entity_entry is None
-        or entity_entry.device_id is None
-        or entity_entry.platform != DOMAIN
-    ):
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_entity_id",
-            translation_placeholders={"entity_id": entity_id},
-        )
-
-    return entity_entry.device_id
 
 
 def get_sources(tv_state: WebOsTvState) -> list[str]:

--- a/homeassistant/components/webostv/icons.json
+++ b/homeassistant/components/webostv/icons.json
@@ -16,5 +16,10 @@
     "select_sound_output": {
       "service": "mdi:volume-source"
     }
+  },
+  "triggers": {
+    "turn_on": {
+      "trigger": "mdi:television-play"
+    }
   }
 }

--- a/homeassistant/components/webostv/quality_scale.yaml
+++ b/homeassistant/components/webostv/quality_scale.yaml
@@ -57,9 +57,7 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
-  repair-issues:
-    status: exempt
-    comment: The integration does not have anything to repair.
+  repair-issues: done
   stale-devices:
     status: exempt
     comment: The integration connects to a single device.

--- a/homeassistant/components/webostv/repairs.py
+++ b/homeassistant/components/webostv/repairs.py
@@ -1,0 +1,13 @@
+"""Repairs platform for the LG webOS TV integration."""
+
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    return ConfirmRepairFlow()

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -95,7 +95,7 @@
       "fix_flow": {
         "step": {
           "confirm": {
-            "description": "An automation or template entity uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nOpen each affected automation in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly and move the `entity_id` or `device_id` option into a `target` block.\n\nWhen this is done, select **Submit**.",
+            "description": "An automation or template entity uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nOpen each affected automation in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly and move the `entity_id` or `device_id` option into a `target` block.\n\nIf this issue reappears after a restart, the old option is still present. Edit your configuration files directly and remove the `entity_id` or `device_id` option from the trigger.\n\nWhen this is done, select **Submit**.",
             "title": "Deprecated LG webOS TV turn on trigger configuration"
           }
         }

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -95,7 +95,7 @@
       "fix_flow": {
         "step": {
           "confirm": {
-            "description": "An automation or script uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nOpen each affected automation or script in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly and move the `entity_id` or `device_id` option into a `target` block.\n\nWhen this is done, select **Submit**.",
+            "description": "An automation or template entity uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nOpen each affected automation in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly and move the `entity_id` or `device_id` option into a `target` block.\n\nWhen this is done, select **Submit**.",
             "title": "Deprecated LG webOS TV turn on trigger configuration"
           }
         }

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -90,6 +90,12 @@
       "message": "Unhandled trigger type: {trigger_type}"
     }
   },
+  "issues": {
+    "deprecated_turn_on_trigger_target": {
+      "description": "An automation or script uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nTo fix this issue, open each affected automation or script in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly, move the `entity_id` or `device_id` option into a `target` block, and restart Home Assistant.",
+      "title": "Deprecated LG webOS TV turn on trigger configuration"
+    }
+  },
   "options": {
     "error": {
       "cannot_connect": "[%key:component::webostv::config::error::cannot_connect%]",

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -92,7 +92,14 @@
   },
   "issues": {
     "deprecated_turn_on_trigger_target": {
-      "description": "An automation or script uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nTo fix this issue, open each affected automation or script in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly, move the `entity_id` or `device_id` option into a `target` block, and restart Home Assistant.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "description": "An automation or script uses the LG webOS TV turn on trigger with the `entity_id` or `device_id` option. Those options have been replaced by a target. They still work for now, but support for them will be removed in a future release.\n\nOpen each affected automation or script in the editor, select your TV as the target of the trigger, and save it again. Alternatively, edit your configuration files (for example `automations.yaml`) directly and move the `entity_id` or `device_id` option into a `target` block.\n\nWhen this is done, select **Submit**.",
+            "title": "Deprecated LG webOS TV turn on trigger configuration"
+          }
+        }
+      },
       "title": "Deprecated LG webOS TV turn on trigger configuration"
     }
   },

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -71,9 +71,6 @@
     "device_unavailable": {
       "message": "Device {device} is unavailable"
     },
-    "invalid_entity_id": {
-      "message": "Entity {entity_id} is not a valid webOS TV entity."
-    },
     "notify_communication_error": {
       "message": "Communication error while sending notification to device {name}: {error}"
     },
@@ -86,11 +83,11 @@
     "source_not_found": {
       "message": "Source {source} not found in the sources list for {name}."
     },
+    "trigger_without_target": {
+      "message": "The LG webOS TV turn on trigger requires a target."
+    },
     "unhandled_trigger_type": {
       "message": "Unhandled trigger type: {trigger_type}"
-    },
-    "unknown_trigger_platform": {
-      "message": "Unknown trigger platform: {platform}"
     }
   },
   "options": {
@@ -157,6 +154,12 @@
         }
       },
       "name": "Select sound output"
+    }
+  },
+  "triggers": {
+    "turn_on": {
+      "description": "Triggers when one or more LG webOS TVs are requested to turn on.",
+      "name": "TV is requested to turn on"
     }
   }
 }

--- a/homeassistant/components/webostv/trigger.py
+++ b/homeassistant/components/webostv/trigger.py
@@ -1,51 +1,15 @@
-"""LG webOS TV trigger dispatcher."""
+"""LG webOS TV triggers."""
 
-from typing import cast
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.trigger import Trigger
 
-from homeassistant.const import CONF_PLATFORM
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.trigger import (
-    TriggerActionType,
-    TriggerInfo,
-    TriggerProtocol,
-)
-from homeassistant.helpers.typing import ConfigType
+from .triggers.turn_on import TurnOnTrigger
 
-from .const import DOMAIN
-from .triggers import turn_on
-
-TRIGGERS = {
-    "turn_on": turn_on,
+TRIGGERS: dict[str, type[Trigger]] = {
+    "turn_on": TurnOnTrigger,
 }
 
 
-def _get_trigger_platform(config: ConfigType) -> TriggerProtocol:
-    """Return trigger platform."""
-    platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
-    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="unknown_trigger_platform",
-            translation_placeholders={"platform": config[CONF_PLATFORM]},
-        )
-    return cast(TriggerProtocol, TRIGGERS[platform_split[1]])
-
-
-async def async_validate_trigger_config(
-    hass: HomeAssistant, config: ConfigType
-) -> ConfigType:
-    """Validate config."""
-    platform = _get_trigger_platform(config)
-    return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
-
-
-async def async_attach_trigger(
-    hass: HomeAssistant,
-    config: ConfigType,
-    action: TriggerActionType,
-    trigger_info: TriggerInfo,
-) -> CALLBACK_TYPE:
-    """Attach trigger of specified platform."""
-    platform = _get_trigger_platform(config)
-    return await platform.async_attach_trigger(hass, config, action, trigger_info)
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers for LG webOS TV."""
+    return TRIGGERS

--- a/homeassistant/components/webostv/triggers.yaml
+++ b/homeassistant/components/webostv/triggers.yaml
@@ -1,0 +1,7 @@
+turn_on:
+  target:
+    entity:
+      - domain: media_player
+        integration: webostv
+    device:
+      - integration: webostv

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -91,12 +91,15 @@ class _TurnOnTargetTracker(TargetEntityChangeTracker):
     def _handle_entities_update(self, tracked_entities: set[str]) -> None:
         """Re-attach the turn on actions when the tracked devices change."""
         ent_reg = er.async_get(self._hass)
-        device_ids = {
+        # Directly targeted devices are used as-is, because resolving them through their
+        # entities would drop a device whose webOS TV entity is hidden.
+        device_ids = set(self._target_selection.device_ids)
+        device_ids.update(
             device_id
             for entity_id in tracked_entities
             if (entry := ent_reg.async_get(entity_id))
             and (device_id := entry.device_id)
-        }
+        )
         if device_ids == self._device_ids:
             return
 

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -18,6 +18,7 @@ from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
+    device_registry as dr,
     entity_registry as er,
     issue_registry as ir,
 )
@@ -91,14 +92,21 @@ class _TurnOnTargetTracker(TargetEntityChangeTracker):
     def _handle_entities_update(self, tracked_entities: set[str]) -> None:
         """Re-attach the turn on actions when the tracked devices change."""
         ent_reg = er.async_get(self._hass)
+        dev_reg = dr.async_get(self._hass)
         # Directly targeted devices are used as-is, because resolving them through their
         # entities would drop a device whose webOS TV entity is hidden.
-        device_ids = set(self._target_selection.device_ids)
+        device_ids: set[str] = set()
+        for device_id in self._target_selection.device_ids:
+            # A pre-migration composite id is not a device; it resolves to its splits
+            if splits := dev_reg.async_get_devices_for_composite_device_id(device_id):
+                device_ids.update(device.id for device in splits)
+            else:
+                device_ids.add(device_id)
         device_ids.update(
-            device_id
+            entity_device_id
             for entity_id in tracked_entities
             if (entry := ent_reg.async_get(entity_id))
-            and (device_id := entry.device_id)
+            and (entity_device_id := entry.device_id)
         )
         if device_ids == self._device_ids:
             return

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -83,6 +83,7 @@ class _TurnOnTargetTracker(TargetEntityChangeTracker):
             }
 
         super().__init__(hass, target_selection, entity_filter)
+        self._selection = target_selection
         self._run_action = run_action
         self._device_ids: set[str] = set()
         self._unsubs: list[CALLBACK_TYPE] = []
@@ -94,14 +95,15 @@ class _TurnOnTargetTracker(TargetEntityChangeTracker):
         ent_reg = er.async_get(self._hass)
         dev_reg = dr.async_get(self._hass)
         # Directly targeted devices are used as-is, because resolving them through their
-        # entities would drop a device whose webOS TV entity is hidden.
+        # entities would drop a device whose webOS TV entity is hidden. A device that no
+        # longer exists is skipped, like an entity that is not a webOS TV entity.
         device_ids: set[str] = set()
-        for device_id in self._target_selection.device_ids:
-            # A pre-migration composite id is not a device; it resolves to its splits
-            if splits := dev_reg.async_get_devices_for_composite_device_id(device_id):
-                device_ids.update(device.id for device in splits)
-            else:
+        for device_id in self._selection.device_ids:
+            if device_id in dev_reg.devices:
                 device_ids.add(device_id)
+            # A pre-migration composite id is not a device; it resolves to its splits
+            elif splits := dev_reg.async_get_devices_for_composite_device_id(device_id):
+                device_ids.update(device.id for device in splits)
         device_ids.update(
             entity_device_id
             for entity_id in tracked_entities

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -152,7 +152,8 @@ class TurnOnTrigger(Trigger):
         """Validate complete config, folding the legacy top-level fields into the target.
 
         A config edited in the UI can carry both the legacy top-level fields and a
-        target, so the two are merged instead of one shape taking precedence.
+        target. The target wins, since it is what the user last selected, but a legacy
+        field is still used when the target selects nothing for that key.
         """
         if legacy_keys := {ATTR_ENTITY_ID, ATTR_DEVICE_ID} & complete_config.keys():
             ir.async_create_issue(
@@ -167,7 +168,9 @@ class TurnOnTrigger(Trigger):
             complete_config = complete_config.copy()
             target = dict(complete_config.get(CONF_TARGET) or {})
             for key in legacy_keys:
-                target.setdefault(key, complete_config.pop(key))
+                legacy_value = complete_config.pop(key)
+                if not target.get(key):
+                    target[key] = legacy_value
             complete_config[CONF_TARGET] = target
         return await super().async_validate_complete_config(hass, complete_config)
 

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -1,5 +1,8 @@
 """LG webOS TV device turn on trigger."""
 
+from functools import partial
+from typing import TYPE_CHECKING, Any, cast, override
+
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -8,38 +11,29 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_PLATFORM,
+    CONF_TARGET,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import (
     PluggableAction,
-    TriggerActionType,
-    TriggerInfo,
+    Trigger,
+    TriggerActionRunner,
+    TriggerConfig,
+    TriggerNotTriggeredReporter,
 )
 from homeassistant.helpers.typing import ConfigType
 
 from ..const import DOMAIN
-from ..helpers import (
-    async_get_device_entry_by_device_id,
-    async_get_device_id_from_entity_id,
-)
+from ..helpers import async_get_device_entry_by_device_id
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
 PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
 
-TRIGGER_TYPE_TURN_ON = "turn_on"
-
-TRIGGER_SCHEMA = vol.All(
-    cv.TRIGGER_BASE_SCHEMA.extend(
-        {
-            vol.Required(CONF_PLATFORM): PLATFORM_TYPE,
-            vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-        },
-    ),
-    cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
-)
+_TRIGGER_SCHEMA = vol.Schema({vol.Required(CONF_TARGET): cv.TARGET_FIELDS})
 
 
 def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
@@ -53,55 +47,143 @@ def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
     }
 
 
-async def async_attach_trigger(
-    hass: HomeAssistant,
-    config: ConfigType,
-    action: TriggerActionType,
-    trigger_info: TriggerInfo,
-    *,
-    platform_type: str = PLATFORM_TYPE,
-) -> CALLBACK_TYPE | None:
-    """Attach a trigger."""
-    device_ids = set()
-    if ATTR_DEVICE_ID in config:
-        device_ids.update(config.get(ATTR_DEVICE_ID, []))
+@callback
+def async_get_turn_on_description(hass: HomeAssistant, device_id: str) -> str:
+    """Return the trigger description for a device."""
+    device = async_get_device_entry_by_device_id(hass, device_id)
+    return f"webostv turn on trigger for {device.name_by_user or device.name}"
 
-    if ATTR_ENTITY_ID in config:
-        device_ids.update(
-            {
-                async_get_device_id_from_entity_id(hass, entity_id)
-                for entity_id in config.get(ATTR_ENTITY_ID, [])
+
+class _TurnOnTargetTracker(TargetEntityChangeTracker):
+    """Attach turn on actions to the webOS TV devices selected by a target."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        target_selection: TargetSelection,
+        run_action: TriggerActionRunner,
+    ) -> None:
+        """Initialize the tracker."""
+
+        def entity_filter(entities: set[str]) -> set[str]:
+            ent_reg = er.async_get(hass)
+            return {
+                entity_id
+                for entity_id in entities
+                if (entry := ent_reg.async_get(entity_id)) is not None
+                and entry.platform == DOMAIN
+                and entry.device_id is not None
             }
-        )
 
-    trigger_data = trigger_info["trigger_data"]
-
-    unsubs = []
-
-    for device_id in device_ids:
-        device = async_get_device_entry_by_device_id(hass, device_id)
-        device_name = device.name_by_user or device.name
-
-        variables = {
-            **trigger_data,
-            CONF_PLATFORM: platform_type,
-            ATTR_DEVICE_ID: device_id,
-            "description": f"webostv turn on trigger for {device_name}",
-        }
-
-        turn_on_trigger = async_get_turn_on_trigger(device_id)
-
-        unsubs.append(
-            PluggableAction.async_attach_trigger(
-                hass, turn_on_trigger, action, {"trigger": variables}
-            )
-        )
+        super().__init__(hass, target_selection, entity_filter)
+        self._run_action = run_action
+        self._device_ids: set[str] = set()
+        self._unsubs: list[CALLBACK_TYPE] = []
 
     @callback
-    def async_remove() -> None:
-        """Remove state listeners async."""
-        for unsub in unsubs:
-            unsub()
-        unsubs.clear()
+    @override
+    def _handle_entities_update(self, tracked_entities: set[str]) -> None:
+        """Re-attach the turn on actions when the tracked devices change."""
+        ent_reg = er.async_get(self._hass)
+        device_ids = {
+            device_id
+            for entity_id in tracked_entities
+            if (entry := ent_reg.async_get(entity_id))
+            and (device_id := entry.device_id)
+        }
+        if device_ids == self._device_ids:
+            return
 
-    return async_remove
+        self._detach_actions()
+        self._device_ids = device_ids
+
+        for device_id in device_ids:
+            self._unsubs.append(
+                PluggableAction.async_attach_trigger(
+                    self._hass,
+                    async_get_turn_on_trigger(device_id),
+                    partial(
+                        self._run_turn_on_action,
+                        async_get_turn_on_description(self._hass, device_id),
+                    ),
+                    {ATTR_DEVICE_ID: device_id},
+                )
+            )
+
+    @callback
+    def _run_turn_on_action(
+        self,
+        description: str,
+        variables: dict[str, Any],
+        context: Context | None = None,
+    ) -> None:
+        """Run the trigger action."""
+        self._run_action(variables, description, context)
+
+    @callback
+    def _detach_actions(self) -> None:
+        """Detach the currently attached turn on actions."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+
+    @override
+    def _unsubscribe(self) -> None:
+        """Unsubscribe from all events."""
+        super()._unsubscribe()
+        self._detach_actions()
+        self._device_ids = set()
+
+
+class TurnOnTrigger(Trigger):
+    """LG webOS TV turn on trigger."""
+
+    @classmethod
+    @override
+    async def async_validate_complete_config(
+        cls, hass: HomeAssistant, complete_config: ConfigType
+    ) -> ConfigType:
+        """Validate complete config, folding the legacy top-level fields into the target.
+
+        A config edited in the UI can carry both the legacy top-level fields and a
+        target, so the two are merged instead of one shape taking precedence.
+        """
+        if legacy_keys := {ATTR_ENTITY_ID, ATTR_DEVICE_ID} & complete_config.keys():
+            complete_config = complete_config.copy()
+            target = dict(complete_config.get(CONF_TARGET) or {})
+            for key in legacy_keys:
+                target.setdefault(key, complete_config.pop(key))
+            complete_config[CONF_TARGET] = target
+        return await super().async_validate_complete_config(hass, complete_config)
+
+    @classmethod
+    @override
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return cast(ConfigType, _TRIGGER_SCHEMA(config))
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize trigger."""
+        super().__init__(hass, config)
+
+        if TYPE_CHECKING:
+            assert config.target is not None
+        self._target = config.target
+
+    @override
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,
+    ) -> CALLBACK_TYPE:
+        """Attach a trigger."""
+        target_selection = TargetSelection(self._target)
+        if not target_selection.has_any_target:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="trigger_without_target"
+            )
+
+        tracker = _TurnOnTargetTracker(self._hass, target_selection, run_action)
+        return await tracker.async_setup()

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -16,7 +16,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import (
     PluggableAction,
@@ -32,6 +36,8 @@ from ..helpers import async_get_device_entry_by_device_id
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
 PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+
+DEPRECATED_TARGET_ISSUE_ID = "deprecated_turn_on_trigger_target"
 
 _TRIGGER_SCHEMA = vol.Schema({vol.Required(CONF_TARGET): cv.TARGET_FIELDS})
 
@@ -149,6 +155,15 @@ class TurnOnTrigger(Trigger):
         target, so the two are merged instead of one shape taking precedence.
         """
         if legacy_keys := {ATTR_ENTITY_ID, ATTR_DEVICE_ID} & complete_config.keys():
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                DEPRECATED_TARGET_ISSUE_ID,
+                breaks_in_ha_version="2027.3",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key=DEPRECATED_TARGET_ISSUE_ID,
+            )
             complete_config = complete_config.copy()
             target = dict(complete_config.get(CONF_TARGET) or {})
             for key in legacy_keys:

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -42,6 +42,15 @@ DEPRECATED_TARGET_ISSUE_ID = "deprecated_turn_on_trigger_target"
 
 _TRIGGER_SCHEMA = vol.Schema({vol.Required(CONF_TARGET): cv.TARGET_FIELDS})
 
+# The legacy options were more lenient than the target fields they are folded into:
+# entity IDs could be given as a comma separated string and in any casing.
+_LEGACY_OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    }
+)
+
 
 def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
     """Return data for a turn on trigger."""
@@ -180,7 +189,9 @@ class TurnOnTrigger(Trigger):
             )
             complete_config = complete_config.copy()
             target = dict(complete_config.get(CONF_TARGET) or {})
-            legacy_target = {key: complete_config.pop(key) for key in legacy_keys}
+            legacy_target = _LEGACY_OPTIONS_SCHEMA(
+                {key: complete_config.pop(key) for key in legacy_keys}
+            )
             if not TargetSelection(target).has_any_target:
                 target.update(legacy_target)
             complete_config[CONF_TARGET] = target

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -152,8 +152,8 @@ class TurnOnTrigger(Trigger):
         """Validate complete config, folding the legacy top-level fields into the target.
 
         A config edited in the UI can carry both the legacy top-level fields and a
-        target. The target wins, since it is what the user last selected, but a legacy
-        field is still used when the target selects nothing for that key.
+        target. The target is what the user last selected, so the legacy fields are
+        only used when the target selects nothing at all.
         """
         if legacy_keys := {ATTR_ENTITY_ID, ATTR_DEVICE_ID} & complete_config.keys():
             ir.async_create_issue(
@@ -167,10 +167,9 @@ class TurnOnTrigger(Trigger):
             )
             complete_config = complete_config.copy()
             target = dict(complete_config.get(CONF_TARGET) or {})
-            for key in legacy_keys:
-                legacy_value = complete_config.pop(key)
-                if not target.get(key):
-                    target[key] = legacy_value
+            legacy_target = {key: complete_config.pop(key) for key in legacy_keys}
+            if not TargetSelection(target).has_any_target:
+                target.update(legacy_target)
             complete_config[CONF_TARGET] = target
         return await super().async_validate_complete_config(hass, complete_config)
 

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -160,7 +160,7 @@ class TurnOnTrigger(Trigger):
                 DOMAIN,
                 DEPRECATED_TARGET_ISSUE_ID,
                 breaks_in_ha_version="2027.3",
-                is_fixable=False,
+                is_fixable=True,
                 severity=ir.IssueSeverity.WARNING,
                 translation_key=DEPRECATED_TARGET_ISSUE_ID,
             )

--- a/script/hassfest/triggers.py
+++ b/script/hassfest/triggers.py
@@ -157,7 +157,6 @@ NON_MIGRATED_INTEGRATIONS = {
     "tag",
     "template",
     "webhook",
-    "webostv",
     "zone",
     "zwave_js",
 }

--- a/tests/components/webostv/test_repairs.py
+++ b/tests/components/webostv/test_repairs.py
@@ -1,0 +1,13 @@
+"""The tests for LG webOS TV repairs."""
+
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.components.webostv.repairs import async_create_fix_flow
+from homeassistant.components.webostv.triggers.turn_on import DEPRECATED_TARGET_ISSUE_ID
+from homeassistant.core import HomeAssistant
+
+
+async def test_async_create_fix_flow(hass: HomeAssistant) -> None:
+    """Test the deprecated trigger target issue is fixable by confirmation."""
+    flow = await async_create_fix_flow(hass, DEPRECATED_TARGET_ISSUE_ID, None)
+
+    assert isinstance(flow, ConfirmRepairFlow)

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
+import attr
 import pytest
 
 from homeassistant.components import automation
@@ -207,6 +208,60 @@ async def test_webostv_turn_on_trigger_hidden_entity(
             automation.DOMAIN: [
                 {
                     "trigger": build_trigger(device.id),
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.device_id }}"},
+                    },
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == device.id
+
+
+@pytest.mark.usefixtures("client")
+async def test_webostv_turn_on_trigger_composite_device_id(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a target using a pre-migration composite device id."""
+    await setup_webostv(hass)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, FAKE_UUID)})
+    composite_device_id = "composite00000000000000000000ab"
+    device_registry.devices[device.id] = attr.evolve(
+        device, composite_device_id=composite_device_id
+    )
+    # Hide the entities so the composite id can only resolve through the device registry
+    for entry in er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    ):
+        entity_registry.async_update_entity(
+            entry.entity_id, hidden_by=er.RegistryEntryHider.USER
+        )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "trigger": "webostv.turn_on",
+                        "target": {"device_id": composite_device_id},
+                    },
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "{{ trigger.device_id }}"},

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -311,12 +311,24 @@ async def test_unknown_trigger_platform_type(
     assert "Invalid trigger 'webostv.unknown' specified" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "build_legacy_option",
+    [
+        pytest.param(lambda device_id: {"entity_id": ENTITY_ID}, id="entity_id"),
+        pytest.param(lambda device_id: {"device_id": device_id}, id="device_id"),
+    ],
+)
 @pytest.mark.usefixtures("client")
 async def test_trigger_target_takes_precedence_over_legacy(
-    hass: HomeAssistant, service_calls: list[ServiceCall]
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    device_registry: dr.DeviceRegistry,
+    build_legacy_option: Callable[[str], dict[str, Any]],
 ) -> None:
-    """Test the target wins over a legacy option selecting a different entity."""
+    """Test the target wins over a legacy option selecting another device."""
     await setup_webostv(hass)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, FAKE_UUID)})
 
     platform = MockEntityPlatform(hass)
     other_entity = f"{DOMAIN}.other"
@@ -330,7 +342,7 @@ async def test_trigger_target_takes_precedence_over_legacy(
                 {
                     "trigger": {
                         "trigger": "webostv.turn_on",
-                        "entity_id": ENTITY_ID,
+                        **build_legacy_option(device.id),
                         "target": {"entity_id": other_entity},
                     },
                     "action": {

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
+    entity_registry as er,
     issue_registry as ir,
 )
 from homeassistant.setup import async_setup_component
@@ -161,6 +162,70 @@ async def test_webostv_turn_on_trigger_entity_id(
     assert len(service_calls) == 2
     assert service_calls[1].data["some"] == ENTITY_ID
     assert service_calls[1].data["id"] == 0
+
+
+@pytest.mark.parametrize(
+    "build_trigger",
+    [
+        pytest.param(
+            lambda device_id: {"trigger": "webostv.turn_on", "device_id": device_id},
+            id="legacy",
+        ),
+        pytest.param(
+            lambda device_id: {
+                "trigger": "webostv.turn_on",
+                "target": {"device_id": device_id},
+            },
+            id="target",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("client")
+async def test_webostv_turn_on_trigger_hidden_entity(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    build_trigger: Callable[[str], dict[str, Any]],
+) -> None:
+    """Test a device target still fires when the device entities are hidden."""
+    await setup_webostv(hass)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, FAKE_UUID)})
+    # Hidden entities are excluded when a device target is expanded to its entities
+    for entry in er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    ):
+        entity_registry.async_update_entity(
+            entry.entity_id, hidden_by=er.RegistryEntryHider.USER
+        )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": build_trigger(device.id),
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.device_id }}"},
+                    },
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == device.id
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -8,10 +8,15 @@ import pytest
 
 from homeassistant.components import automation
 from homeassistant.components.webostv import DOMAIN
+from homeassistant.components.webostv.triggers.turn_on import DEPRECATED_TARGET_ISSUE_ID
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import area_registry as ar, device_registry as dr
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    issue_registry as ir,
+)
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
@@ -294,3 +299,51 @@ async def test_trigger_without_target(
     )
 
     assert "The LG webOS TV turn on trigger requires a target" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("trigger_config", "issue_expected"),
+    [
+        pytest.param(
+            {"trigger": "webostv.turn_on", "entity_id": ENTITY_ID}, True, id="entity_id"
+        ),
+        pytest.param(
+            {"trigger": "webostv.turn_on", "device_id": "some-device-id"},
+            True,
+            id="device_id",
+        ),
+        pytest.param(
+            {"trigger": "webostv.turn_on", "target": {"entity_id": ENTITY_ID}},
+            False,
+            id="target",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("client")
+async def test_deprecated_target_repair_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    trigger_config: dict[str, Any],
+    issue_expected: bool,
+) -> None:
+    """Test the repair issue raised for the legacy top-level trigger options."""
+    await setup_webostv(hass)
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": trigger_config,
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ENTITY_ID},
+                    },
+                },
+            ],
+        },
+    )
+
+    issue = issue_registry.async_get_issue(DOMAIN, DEPRECATED_TARGET_ISSUE_ID)
+    assert (issue is not None) is issue_expected

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -201,6 +201,77 @@ async def test_webostv_turn_on_trigger_area_id(
 
 
 @pytest.mark.usefixtures("client")
+async def test_webostv_turn_on_trigger_follows_area_changes(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the targeted devices are updated when the device area changes."""
+    await setup_webostv(hass)
+
+    area = area_registry.async_create("Living room")
+    device = device_registry.async_get_device(identifiers={(DOMAIN, FAKE_UUID)})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "trigger": "webostv.turn_on",
+                        "target": {"area_id": area.id},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.device_id }}"},
+                    },
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    # The TV is not in the targeted area yet, so no turn on action is attached
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
+
+    assert len(service_calls) == 1
+
+    device_registry.async_update_device(device.id, area_id=area.id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == device.id
+
+    device_registry.async_update_device(device.id, area_id=None)
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
+
+    assert len(service_calls) == 4
+
+
+@pytest.mark.usefixtures("client")
 async def test_unknown_trigger_platform_type(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -113,6 +113,14 @@ async def test_webostv_turn_on_trigger_device_id(
             {"trigger": "webostv.turn_on", "entity_id": ENTITY_ID, "target": {}},
             id="legacy_with_empty_target",
         ),
+        pytest.param(
+            {
+                "trigger": "webostv.turn_on",
+                "entity_id": ENTITY_ID,
+                "target": {"entity_id": []},
+            },
+            id="legacy_with_empty_target_value",
+        ),
     ],
 )
 @pytest.mark.usefixtures("client")
@@ -301,6 +309,49 @@ async def test_unknown_trigger_platform_type(
     )
 
     assert "Invalid trigger 'webostv.unknown' specified" in caplog.text
+
+
+@pytest.mark.usefixtures("client")
+async def test_trigger_target_takes_precedence_over_legacy(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test the target wins over a legacy option selecting a different entity."""
+    await setup_webostv(hass)
+
+    platform = MockEntityPlatform(hass)
+    other_entity = f"{DOMAIN}.other"
+    await platform.async_add_entities([MockEntity(name=other_entity)])
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "trigger": "webostv.turn_on",
+                        "entity_id": ENTITY_ID,
+                        "target": {"entity_id": other_entity},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ENTITY_ID},
+                    },
+                },
+            ],
+        },
+    )
+
+    # The target selects another entity, so the legacy entity_id is not used
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
+
+    assert len(service_calls) == 1
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -1,5 +1,7 @@
 """The tests for LG webOS TV automation triggers."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +11,7 @@ from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import area_registry as ar, device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
@@ -18,11 +20,28 @@ from .const import ENTITY_ID, FAKE_UUID
 from tests.common import MockEntity, MockEntityPlatform
 
 
+@pytest.mark.parametrize(
+    "build_trigger",
+    [
+        pytest.param(
+            lambda device_id: {"trigger": "webostv.turn_on", "device_id": device_id},
+            id="legacy",
+        ),
+        pytest.param(
+            lambda device_id: {
+                "trigger": "webostv.turn_on",
+                "target": {"device_id": device_id},
+            },
+            id="target",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("client")
 async def test_webostv_turn_on_trigger_device_id(
     hass: HomeAssistant,
     service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
-    client,
+    build_trigger: Callable[[str], dict[str, Any]],
 ) -> None:
     """Test for turn_on triggers by device_id firing."""
     await setup_webostv(hass)
@@ -35,10 +54,7 @@ async def test_webostv_turn_on_trigger_device_id(
         {
             automation.DOMAIN: [
                 {
-                    "trigger": {
-                        "platform": "webostv.turn_on",
-                        "device_id": device.id,
-                    },
+                    "trigger": build_trigger(device.id),
                     "action": {
                         "service": "test.automation",
                         "data_template": {
@@ -78,8 +94,27 @@ async def test_webostv_turn_on_trigger_device_id(
     assert len(service_calls) == 1
 
 
+@pytest.mark.parametrize(
+    "trigger_config",
+    [
+        pytest.param(
+            {"trigger": "webostv.turn_on", "entity_id": ENTITY_ID}, id="legacy"
+        ),
+        pytest.param(
+            {"trigger": "webostv.turn_on", "target": {"entity_id": ENTITY_ID}},
+            id="target",
+        ),
+        pytest.param(
+            {"trigger": "webostv.turn_on", "entity_id": ENTITY_ID, "target": {}},
+            id="legacy_with_empty_target",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("client")
 async def test_webostv_turn_on_trigger_entity_id(
-    hass: HomeAssistant, service_calls: list[ServiceCall], client
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    trigger_config: dict[str, Any],
 ) -> None:
     """Test for turn_on triggers by entity_id firing."""
     await setup_webostv(hass)
@@ -90,10 +125,7 @@ async def test_webostv_turn_on_trigger_entity_id(
         {
             automation.DOMAIN: [
                 {
-                    "trigger": {
-                        "platform": "webostv.turn_on",
-                        "entity_id": ENTITY_ID,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {
@@ -118,8 +150,54 @@ async def test_webostv_turn_on_trigger_entity_id(
     assert service_calls[1].data["id"] == 0
 
 
+@pytest.mark.usefixtures("client")
+async def test_webostv_turn_on_trigger_area_id(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test for turn_on triggers targeting an area firing."""
+    await setup_webostv(hass)
+
+    area = area_registry.async_create("Living room")
+    device = device_registry.async_get_device(identifiers={(DOMAIN, FAKE_UUID)})
+    device_registry.async_update_device(device.id, area_id=area.id)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "trigger": "webostv.turn_on",
+                        "target": {"area_id": area.id},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.device_id }}"},
+                    },
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == device.id
+
+
+@pytest.mark.usefixtures("client")
 async def test_unknown_trigger_platform_type(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test unknown trigger platform type."""
     await setup_webostv(hass)
@@ -146,13 +224,14 @@ async def test_unknown_trigger_platform_type(
         },
     )
 
-    assert "Unknown trigger platform: webostv.unknown" in caplog.text
+    assert "Invalid trigger 'webostv.unknown' specified" in caplog.text
 
 
-async def test_trigger_invalid_entity_id(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client
+@pytest.mark.usefixtures("client")
+async def test_trigger_non_webostv_entity_id(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
-    """Test turn on trigger using invalid entity_id."""
+    """Test turn on trigger using an entity_id of another integration."""
     await setup_webostv(hass)
 
     platform = MockEntityPlatform(hass)
@@ -160,26 +239,58 @@ async def test_trigger_invalid_entity_id(
     invalid_entity = f"{DOMAIN}.invalid"
     await platform.async_add_entities([MockEntity(name=invalid_entity)])
 
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: [
                 {
                     "trigger": {
-                        "platform": "webostv.turn_on",
-                        "entity_id": invalid_entity,
+                        "trigger": "webostv.turn_on",
+                        "target": {"entity_id": invalid_entity},
                     },
                     "action": {
                         "service": "test.automation",
-                        "data_template": {
-                            "some": ENTITY_ID,
-                            "id": "{{ trigger.id }}",
-                        },
+                        "data_template": {"some": ENTITY_ID},
                     },
                 },
             ],
         },
     )
 
-    assert f"Entity {invalid_entity} is not a valid webOS TV entity" in caplog.text
+    # The entity is not a webOS TV entity, so no turn on trigger is attached
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
+
+    assert len(service_calls) == 1
+
+
+@pytest.mark.usefixtures("client")
+async def test_trigger_without_target(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test turn on trigger without a target."""
+    await setup_webostv(hass)
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"trigger": "webostv.turn_on", "target": {}},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ENTITY_ID},
+                    },
+                },
+            ],
+        },
+    )
+
+    assert "The LG webOS TV turn on trigger requires a target" in caplog.text

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -123,6 +123,17 @@ async def test_webostv_turn_on_trigger_device_id(
             },
             id="legacy_with_empty_target_value",
         ),
+        pytest.param(
+            {
+                "trigger": "webostv.turn_on",
+                "entity_id": f"{ENTITY_ID},media_player.other",
+            },
+            id="legacy_comma_separated",
+        ),
+        pytest.param(
+            {"trigger": "webostv.turn_on", "entity_id": ENTITY_ID.upper()},
+            id="legacy_uppercase",
+        ),
     ],
 )
 @pytest.mark.usefixtures("client")

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -487,6 +487,48 @@ async def test_trigger_target_takes_precedence_over_legacy(
 
 
 @pytest.mark.usefixtures("client")
+async def test_trigger_unknown_device_id(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test turn on trigger targeting a device that no longer exists."""
+    await setup_webostv(hass)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "trigger": "webostv.turn_on",
+                        "target": {"device_id": "does-not-exist"},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ENTITY_ID},
+                    },
+                },
+            ],
+        },
+    )
+
+    assert "ValueError" not in caplog.text
+
+    # The device does not resolve, so no turn on action is attached
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
+
+    assert len(service_calls) == 1
+
+
+@pytest.mark.usefixtures("client")
 async def test_trigger_non_webostv_entity_id(
     hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `webostv.turn_on` trigger used the legacy trigger platform API, which provides no
description to the frontend. As a result the automation editor showed it as "Unknown
trigger" and offered YAML-only editing.

This migrates it to the modern trigger platform:

- Replace the hand-rolled trigger dispatcher in `trigger.py` with a `Trigger` class and
  `async_get_triggers`.
- Add `triggers.yaml`, plus the `triggers` entries in `strings.json` and `icons.json`, so
  the trigger renders in the automation editor with a target selector.
- Target selection now goes through the standard target helpers. On top of the existing
  entity and device selection this adds area, floor and label targeting, and the selected
  devices stay up to date as the registries change.
- Remove `webostv` from `NON_MIGRATED_INTEGRATIONS` in `script/hassfest/triggers.py`.
- Mark the `repair-issues` quality scale rule as `done`, since the integration now raises
  one.

Existing configurations keep working: the top-level `entity_id` and `device_id` options
are folded into the target during config validation. A config carrying both shapes, which
is what the editor produces when an old automation is saved, uses the target whenever it
selects anything and falls back to the legacy options only when it does not.

**This PR also introduces a deprecation.** A stored configuration using the top-level
options has a different shape from the one now described to the frontend, so such an
automation renders in the editor with an empty target picker. It still triggers correctly,
but rather than leave users with a trigger that looks misconfigured, a repair issue points
them at the change to make. The legacy options are scheduled for removal in 2027.3; happy
to move that date. The repair is fixable through a `ConfirmRepairFlow` so it can be
dismissed once the affected automations are updated, and is recreated on reload if a
legacy configuration is still present.

This affects only configurations written by hand against the documented example.
Automations created through the device page use the `trigger: device` form, which is
described through `device_automation` and is untouched by this PR, those keep rendering
as before and raise no repair issue.

Two behaviour changes worth flagging:

- A target resolving to an entity that is not a webOS TV entity is now filtered out
  silently, where the old code raised `Entity {entity_id} is not a valid webOS TV entity.`
  This matches the other target-based triggers and is what makes area, floor and label
  targeting workable. The `invalid_entity_id` string is removed.
- An unknown `webostv.*` trigger now reports the core `Invalid trigger '...' specified`
  instead of the integration's `unknown_trigger_platform` message, which is removed along
  with the dispatcher that raised it.

### Alternative considered

`calendar`, `sun` and `zwave_js` deliberately keep their legacy trigger key out of
`triggers.yaml`, so the editor keeps treating it as unsupported. webostv cannot do that
and still describe the same key, because a trigger key maps one-to-one onto its platform
name, the modern trigger would have to be renamed, for example to
`webostv.turn_on_requested`.

I prototyped that and it works, but it permanently parks the good name on the deprecated
trigger, leaves "Unknown trigger" in place for exactly the hand-written configs this PR
sets out to fix, and still needs a deprecation to retire the old key. Migrating in place
converges on a single trigger with the right name, at the cost of a one-time bump. Happy
to switch if matching the existing pattern is preferred, that branch is ready to push.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47297
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
