### PR TITLE
Avoid a naive datetime.now() in switchbot_cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/image.py
+++ b/homeassistant/components/switchbot_cloud/image.py
@@ -1,6 +1,5 @@
 """Support for the Switchbot Image."""
 
-import datetime
 from typing import override
 
 from switchbot_api import Device, Remote, SwitchBotAPI
@@ -9,6 +8,7 @@ from switchbot_api.utils import get_file_stream_from_cloud
 from homeassistant.components.image import ImageEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from . import SwitchbotCloudConfigEntry, SwitchBotCoordinator
 from .entity import SwitchBotCloudEntity
@@ -60,7 +60,7 @@ class SwitchBotCloudImage(SwitchBotCloudEntity, ImageEntity):
         """Set attributes from coordinator data."""
         if self.coordinator.data is None:
             return
-        self._attr_image_last_updated = datetime.datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+        self._attr_image_last_updated = dt_util.utcnow()
         self._attr_image_url = self.coordinator.data.get("imageUrl")
 
 

--- a/tests/components/switchbot_cloud/test_image.py
+++ b/tests/components/switchbot_cloud/test_image.py
@@ -8,6 +8,7 @@ from homeassistant.components.switchbot_cloud.image import SwitchBotCloudImage
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import configure_integration
 
@@ -81,3 +82,39 @@ async def test_async_image(
         )
         await image_entity.async_image()
         assert image_entity._image_content == mock_get.return_value
+
+
+async def test_image_state_is_timezone_aware(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test the image state carries a timezone.
+
+    The state is image_last_updated serialized, so a naive value would leave
+    consumers of the state without an offset.
+    """
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="ai-art-frame-id-1",
+            deviceName="ai-art-frame-1",
+            deviceType="AI Art Frame",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {
+            "deviceId": "B0E9FEA5D7F0",
+            "deviceType": "AI Art Frame",
+            "hubDeviceId": "B0E9FEA5D7F0",
+            "battery": 0,
+            "displayMode": 1,
+            "imageUrl": "https://example.com/image.jpeg",
+            "version": "V0.0-0.5",
+        }
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get("image.ai_art_frame_1_display")
+    assert state.state != STATE_UNKNOWN
+    assert dt_util.parse_datetime(state.state).tzinfo is not None


### PR DESCRIPTION
﻿## Proposed change

`_attr_image_last_updated` was set from a naive `datetime.now()`.

`ImageEntity` turns that value into the entity state through `isoformat()`, so a
naive one produces a state string with no UTC offset. Every other image platform
in core sets this with `dt_util.utcnow()`, so this one now does the same and the
`home-assistant-enforce-naive-now` suppression goes away.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177832
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

