### PR TITLE
Add `Images` scope to Home Connect 

### DIFF
--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -44,18 +44,10 @@ class OAuth2FlowHandler(
         }
 
     @override
-    async def async_step_auth(
+    async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Create an entry for auth.
-
-        We need to intercede to ask the user if he wants to use the image scope
-        before generating the URL. Otherwise, attempts with application credentials
-        that don't have the image scope will fail.
-        """
-        if user_input is not None:
-            return await super().async_step_auth(user_input)
-
+        """Handle a flow start."""
         return await self.async_step_scopes(user_input)
 
     async def async_step_scopes(
@@ -65,7 +57,7 @@ class OAuth2FlowHandler(
         if user_input is not None:
             self.images_scope = user_input[INPUT_IMAGES_SCOPE]
         if self.images_scope is not None:
-            return await super().async_step_auth(None)
+            return await self.async_step_pick_implementation(None)
 
         return self.async_show_form(
             step_id="scopes",

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DOMAIN
 
-INPUT_IMAGE_SCOPE: Final = "images_scope"
+INPUT_IMAGES_SCOPE: Final = "images_scope"
 
 
 class OAuth2FlowHandler(
@@ -25,7 +25,7 @@ class OAuth2FlowHandler(
 
     MINOR_VERSION = 3
 
-    image_scope: bool | None = None
+    images_scope: bool | None = None
 
     @property
     @override
@@ -37,8 +37,7 @@ class OAuth2FlowHandler(
     @override
     def extra_authorize_data(self) -> dict[str, str]:
         return {
-            "scope": "Control Monitor Settings IdentifyAppliance"
-            + (" Images" if self.image_scope else "")
+            "scope": f"Control Monitor Settings IdentifyAppliance{' Images' if self.images_scope else ''}",
         }
 
     @override
@@ -59,17 +58,17 @@ class OAuth2FlowHandler(
     async def async_step_scopes(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Ask the user if he wants to use the image scope."""
+        """Ask for the scopes to use."""
         if user_input is not None:
-            self.image_scope = user_input[INPUT_IMAGE_SCOPE]
-        if self.image_scope is not None:
+            self.images_scope = user_input[INPUT_IMAGES_SCOPE]
+        if self.images_scope is not None:
             return await super().async_step_auth(None)
 
         return self.async_show_form(
             step_id="scopes",
             data_schema=vol.Schema(
                 {
-                    vol.Required(INPUT_IMAGE_SCOPE): bool,
+                    vol.Required(INPUT_IMAGES_SCOPE): bool,
                 }
             ),
         )

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, override
+from typing import Any, Final, override
 
 import jwt
 import voluptuous as vol
@@ -12,6 +12,8 @@ from homeassistant.helpers import config_entry_oauth2_flow, device_registry as d
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DOMAIN
+
+INPUT_IMAGE_SCOPE: Final = "images_scope"
 
 
 class OAuth2FlowHandler(
@@ -23,6 +25,8 @@ class OAuth2FlowHandler(
 
     MINOR_VERSION = 3
 
+    image_scope: bool | None = None
+
     @property
     @override
     def logger(self) -> logging.Logger:
@@ -32,7 +36,43 @@ class OAuth2FlowHandler(
     @property
     @override
     def extra_authorize_data(self) -> dict[str, str]:
-        return {"scope": "Control Monitor Settings IdentifyAppliance Images"}
+        return {
+            "scope": "Control Monitor Settings IdentifyAppliance"
+            + (" Images" if self.image_scope else "")
+        }
+
+    @override
+    async def async_step_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Create an entry for auth.
+
+        We need to intercede to ask the user if he wants to use the image scope
+        before generating the URL. Otherwise, attempts with application credentials
+        that don't have the image scope will fail.
+        """
+        if user_input is not None:
+            return await super().async_step_auth(user_input)
+
+        return await self.async_step_scopes(user_input)
+
+    async def async_step_scopes(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask the user if he wants to use the image scope."""
+        if user_input is not None:
+            self.image_scope = user_input[INPUT_IMAGE_SCOPE]
+        if self.image_scope is not None:
+            return await super().async_step_auth(None)
+
+        return self.async_show_form(
+            step_id="scopes",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(INPUT_IMAGE_SCOPE): bool,
+                }
+            ),
+        )
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -37,7 +37,10 @@ class OAuth2FlowHandler(
     @override
     def extra_authorize_data(self) -> dict[str, str]:
         return {
-            "scope": f"Control Monitor Settings IdentifyAppliance{' Images' if self.images_scope else ''}",
+            "scope": (
+                "Control Monitor Settings"
+                f" IdentifyAppliance{' Images' if self.images_scope else ''}"
+            ),
         }
 
     @override

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -29,6 +29,11 @@ class OAuth2FlowHandler(
         """Return logger."""
         return logging.getLogger(__name__)
 
+    @property
+    @override
+    def extra_authorize_data(self) -> dict[str, str]:
+        return {"scope": "Control Monitor Settings IdentifyAppliance Images"}
+
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -38,6 +38,16 @@
       "reauth_confirm": {
         "description": "The Home Connect integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "scopes": {
+        "data": {
+          "images_scope": "Images scope"
+        },
+        "data_description": {
+          "images_scope": "Allows Home Assistant to access images from your Home Connect devices."
+        },
+        "description": "Select the optional scopes you want to enable for Home Connect authentication.",
+        "title": "Scopes"
       }
     }
   },

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -17,6 +17,7 @@
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
       "wrong_account": "Please ensure you reconfigure against the same account."
     },
     "create_entry": {

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qsl, urlsplit
 
 from aiohomeconnect.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 from aiohomeconnect.model import HomeAppliance
@@ -24,6 +25,23 @@ from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
+
+
+def assert_authorize_url(url: str, state: str) -> None:
+    """Assert the generated OAuth authorize URL."""
+    split_url = urlsplit(url)
+
+    assert (
+        f"{split_url.scheme}://{split_url.netloc}{split_url.path}" == OAUTH2_AUTHORIZE
+    )
+    assert dict(parse_qsl(split_url.query)) == {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": "https://example.com/auth/external/callback",
+        "state": state,
+        "scope": "Control Monitor Settings IdentifyAppliance Images",
+    }
+
 
 DHCP_DISCOVERY = (
     DhcpServiceInfo(
@@ -115,11 +133,7 @@ async def test_full_flow(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert result["url"] == (
-        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
-        "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}"
-    )
+    assert_authorize_url(result["url"], state)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -170,11 +184,7 @@ async def test_prevent_reconfiguring_same_account(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert result["url"] == (
-        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
-        "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}"
-    )
+    assert_authorize_url(result["url"], state)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -332,11 +342,7 @@ async def test_zeroconf_flow(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert result["url"] == (
-        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
-        "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}"
-    )
+    assert_authorize_url(result["url"], state)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -414,11 +420,7 @@ async def test_dhcp_flow(
         },
     )
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert result["url"] == (
-        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
-        "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}"
-    )
+    assert_authorize_url(result["url"], state)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -27,7 +27,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-def assert_authorize_url(url: str, state: str) -> None:
+def assert_authorize_url(url: str, state: str, images_scope: bool | None) -> None:
     """Assert the generated OAuth authorize URL."""
     split_url = urlsplit(url)
 
@@ -39,7 +39,8 @@ def assert_authorize_url(url: str, state: str) -> None:
         "client_id": CLIENT_ID,
         "redirect_uri": "https://example.com/auth/external/callback",
         "state": state,
-        "scope": "Control Monitor Settings IdentifyAppliance Images",
+        "scope": "Control Monitor Settings IdentifyAppliance"
+        + (" Images" if images_scope else ""),
     }
 
 
@@ -113,16 +114,27 @@ DHCP_DISCOVERY = (
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    "images_scope", [True, False], ids=["images_scope", "no_images_scope"]
+)
 async def test_full_flow(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
+    images_scope: bool,
 ) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(hass, "home_connect", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context=ConfigFlowContext(source=config_entries.SOURCE_USER)
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": images_scope}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -133,7 +145,7 @@ async def test_full_flow(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert_authorize_url(result["url"], state)
+    assert_authorize_url(result["url"], state, images_scope)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -175,6 +187,13 @@ async def test_prevent_reconfiguring_same_account(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context=ConfigFlowContext(source=config_entries.SOURCE_USER)
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": True}
+    )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -184,7 +203,7 @@ async def test_prevent_reconfiguring_same_account(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert_authorize_url(result["url"], state)
+    assert_authorize_url(result["url"], state, True)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -224,6 +243,13 @@ async def test_reauth_flow(
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": False}
+    )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -278,6 +304,13 @@ async def test_reauth_flow_with_different_account(
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": True}
+    )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -333,6 +366,13 @@ async def test_zeroconf_flow(
         result["flow_id"],
         {},
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": True}
+    )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -342,7 +382,7 @@ async def test_zeroconf_flow(
     )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert_authorize_url(result["url"], state)
+    assert_authorize_url(result["url"], state, True)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
@@ -412,6 +452,13 @@ async def test_dhcp_flow(
         result["flow_id"],
         {},
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"images_scope": True}
+    )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -420,7 +467,7 @@ async def test_dhcp_flow(
         },
     )
     assert result["type"] is FlowResultType.EXTERNAL_STEP
-    assert_authorize_url(result["url"], state)
+    assert_authorize_url(result["url"], state, True)
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -39,8 +39,7 @@ def assert_authorize_url(url: str, state: str, images_scope: bool | None) -> Non
         "client_id": CLIENT_ID,
         "redirect_uri": "https://example.com/auth/external/callback",
         "state": state,
-        "scope": "Control Monitor Settings IdentifyAppliance"
-        + (" Images" if images_scope else ""),
+        "scope": f"Control Monitor Settings IdentifyAppliance{' Images' if images_scope else ''}",
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `Image` scope to Home Connect authentication process.
This scope will be added depending on the user desire to allow Home Assistant to access appliance's images (feature that will be added soon). To give that option, a form has been added once the config flow implementation has been selected.
Also, the option has been given (instead of set it by default) because using that scope and a Home Connect application that doesn't have the scope enabled raises an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47307
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
