### PR TITLE
Avoid a naive datetime.now() in generic

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -2,8 +2,8 @@
 
 import asyncio
 from collections.abc import Mapping
-from datetime import datetime, timedelta
 import logging
+import time
 from typing import Any, override
 
 import httpx
@@ -75,7 +75,7 @@ class GenericCamera(Camera):
     """A generic implementation of an IP camera."""
 
     _last_image: bytes | None
-    _last_update: datetime
+    _last_update: float
     _update_lock: asyncio.Lock
 
     def __init__(
@@ -114,7 +114,7 @@ class GenericCamera(Camera):
 
         self._last_url = None
         self._last_image = None
-        self._last_update = datetime.min
+        self._last_update = 0.0
         self._update_lock = asyncio.Lock()
 
         self._attr_device_info = DeviceInfo(
@@ -155,13 +155,12 @@ class GenericCamera(Camera):
             if (
                 self._last_image is not None
                 and url == self._last_url
-                and self._last_update + timedelta(0, self._attr_frame_interval)
-                > datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+                and self._last_update + self._attr_frame_interval > time.time()
             ):
                 return self._last_image
 
             try:
-                update_time = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+                update_time = time.time()
                 async_client = get_async_client(self.hass, verify_ssl=self.verify_ssl)
                 response = await async_client.get(
                     url,

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -3,10 +3,10 @@
 import asyncio
 from collections.abc import Mapping
 import contextlib
-from datetime import datetime
 from errno import EHOSTUNREACH, EIO
 import io
 import logging
+import time
 from typing import Any, cast, override
 
 from aiohttp import web
@@ -587,8 +587,7 @@ async def ws_start_preview(
 
     if user_input.get(CONF_STILL_IMAGE_URL):
         ha_still_url = (
-            "/api/generic/preview_flow_image"
-            f"/{msg['flow_id']}?t={datetime.now().isoformat()}"  # pylint: disable=home-assistant-enforce-naive-now
+            f"/api/generic/preview_flow_image/{msg['flow_id']}?t={time.time()}"
         )
         _LOGGER.debug("Got preview still URL: %s", ha_still_url)
 


### PR DESCRIPTION
﻿## Proposed change

Three uses, all of them the relative time case from the issue.

The camera throttles refetching by checking whether `_attr_frame_interval` has
passed since the last successful fetch. `_last_update` is internal, never
rendered or stored, and only ever subtracted from the current time, so it
becomes a `float` from `time.time()`. The sentinel changes from `datetime.min`
to `0.0` and the `timedelta` wrapper is no longer needed, since
`_attr_frame_interval` is already in seconds.

The timestamp appended to the preview URL in the config flow is only there to
bust the browser cache, so `time.time()` serves the same purpose. With the
suppression comment gone the f-string fits on one line, which is what
`ruff format` produces.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177801
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

