### PR TITLE
Avoid a naive datetime.now() in radarr

### DIFF
--- a/homeassistant/components/radarr/coordinator.py
+++ b/homeassistant/components/radarr/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER
 
@@ -171,7 +172,7 @@ class CalendarUpdateCoordinator(RadarrDataUpdateCoordinator[None]):
     async def _fetch_data(self) -> None:
         """Fetch the calendar."""
         self.event = None
-        _date = datetime.today()
+        _date = dt_util.now()
         while self.event is None:
             await self.async_get_events(_date, _date + timedelta(days=1))
             for event in self._events:
@@ -179,7 +180,7 @@ class CalendarUpdateCoordinator(RadarrDataUpdateCoordinator[None]):
                     self.event = event
                     break
             # Prevent infinite loop in case there is nothing recent in the calendar
-            if (_date - datetime.today()).days > 45:
+            if (_date - dt_util.now()).days > 45:
                 break
             _date = _date + timedelta(days=1)
 
@@ -191,7 +192,7 @@ class CalendarUpdateCoordinator(RadarrDataUpdateCoordinator[None]):
         self._events = [
             e
             for e in self._events
-            if e.start >= datetime.now().date() - timedelta(days=30)  # pylint: disable=home-assistant-enforce-naive-now
+            if e.start >= dt_util.now().date() - timedelta(days=30)
         ]
         _days = (end_date - start_date).days
         await asyncio.gather(


### PR DESCRIPTION
﻿## Proposed change

The Radarr calendar deals in local dates, so the naive `datetime.now().date()`
flagged by the issue becomes `dt_util.now().date()`.

### Why two extra lines changed

`_fetch_data` builds its scan cursor with `datetime.today()`, twice. The checker
does not flag that spelling, but it is the same naive local time, and the date
derived from it is compared against exactly the events that the changed line
filters.

Converting only the flagged line would have put the two sides of that
comparison on different time zones for any instance where the configured zone
differs from the host's. Both are converted here for that reason. Happy to drop
them into a separate PR if you would rather keep this one to the single line the
issue lists.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177822
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


