### PR TITLE
Avoid a naive datetime.now() in israel_rail

### DIFF
--- a/homeassistant/components/israel_rail/coordinator.py
+++ b/homeassistant/components/israel_rail/coordinator.py
@@ -68,13 +68,14 @@ class IsraelRailDataUpdateCoordinator(DataUpdateCoordinator[list[DataConnection]
 
     @override
     async def _async_update_data(self) -> list[DataConnection]:
+        query_time = dt_util.now()
         try:
             train_routes = await self.hass.async_add_executor_job(
                 self._train_schedule.query,
                 self._start,
                 self._destination,
-                datetime.now().strftime("%Y-%m-%d"),  # pylint: disable=home-assistant-enforce-naive-now
-                datetime.now().strftime("%H:%M"),  # pylint: disable=home-assistant-enforce-naive-now
+                query_time.strftime("%Y-%m-%d"),
+                query_time.strftime("%H:%M"),
             )
         except Exception as e:
             raise UpdateFailed(


### PR DESCRIPTION
﻿## Proposed change

The schedule query is built from the local date and time, which is what
`dt_util.now()` returns. The module already imports it and uses it a few lines
below, to drop routes that have already departed, so the two naive calls were
the odd ones out.

Both strings now come from a single `query_time`. Calling `now()` twice meant
the date and the time could be read from either side of midnight — vanishingly
rare, but free to remove.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177811
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


