### PR TITLE
Fix naive datetime in Wallbox using time.time() and dt_util

### DIFF
--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -100,9 +100,8 @@ def _require_authentication[_WallboxCoordinatorT: WallboxCoordinator, **_P](
 
 def check_token_validity(jwt_token_ttl: int, jwt_token_drift: int) -> bool:
     """Check if the jwtToken is still valid in order to reuse if possible."""
-    return round((jwt_token_ttl / 1000) - jwt_token_drift, 0) > datetime.timestamp(
-        datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
-    )
+   return round((jwt_token_ttl / 1000) - jwt_token_drift, 0) > time.time()
+
 
 
 def _validate(wallbox: Wallbox) -> None:

--- a/tests/components/knx/README.md
+++ b/tests/components/knx/README.md
@@ -17,6 +17,7 @@ async def test_some_yaml(hass: HomeAssistant, knx: KNXTestKit):
         }
     )
 
+
 async def test_some_config_store(hass: HomeAssistant, knx: KNXTestKit):
     await knx.setup_integration(config_store_fixture="config_store_filename.json")
 ```

--- a/tests/components/wallbox/conftest.py
+++ b/tests/components/wallbox/conftest.py
@@ -50,12 +50,8 @@ def entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_STATION: "12345",
             CHARGER_JWT_TOKEN: "test_token",
             CHARGER_JWT_REFRESH_TOKEN: "test_refresh_token",
-            CHARGER_JWT_TTL: (
-                datetime.timestamp(datetime.now() + timedelta(hours=1)) * 1000  # pylint: disable=home-assistant-enforce-naive-now
-            ),
-            CHARGER_JWT_REFRESH_TTL: (
-                datetime.timestamp(datetime.now() + timedelta(hours=1)) * 1000  # pylint: disable=home-assistant-enforce-naive-now
-            ),
+            CHARGER_JWT_TTL: (time.time() + 3600) * 1000,
+            CHARGER_JWT_REFRESH_TTL: (time.time() + 3600) * 1000,
         },
         entry_id="testEntry",
     )
@@ -98,12 +94,8 @@ def mock_wallbox():
         wallbox.getChargerStatus = Mock(return_value=WALLBOX_STATUS_RESPONSE)
         wallbox.jwtToken = "test_token"
         wallbox.jwtRefreshToken = "test_refresh_token"
-        wallbox.jwtTokenTtl = (
-            datetime.timestamp(datetime.now() + timedelta(hours=1)) * 1000  # pylint: disable=home-assistant-enforce-naive-now
-        )
-        wallbox.jwtRefreshTokenTtl = (
-            datetime.timestamp(datetime.now() + timedelta(hours=1)) * 1000  # pylint: disable=home-assistant-enforce-naive-now
-        )
+        wallbox.jwtTokenTtl = (time.time() + 3600) * 1000
+        wallbox.jwtRefreshTokenTtl = (time.time() + 3600) * 1000
         mock.return_value = wallbox
         yield wallbox
 

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.util import dt as dt_util
 from homeassistant.components.input_number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.components.wallbox.const import CHARGER_JWT_TTL
 from homeassistant.config_entries import ConfigEntryState
@@ -60,7 +61,7 @@ async def test_wallbox_refresh_failed_error_auth(
 
     data = dict(entry.data)
     data[CHARGER_JWT_TTL] = (
-        datetime.timestamp(datetime.now() - timedelta(hours=1)) * 1000  # pylint: disable=home-assistant-enforce-naive-now
+        data[CHARGER_JWT_TTL] = (time.time() - 3600) * 1000
     )
     hass.config_entries.async_update_entry(entry, data=data)
 
@@ -119,7 +120,7 @@ async def test_wallbox_refresh_failed_too_many_requests(
     assert entry.state is ConfigEntryState.LOADED
 
     with patch.object(mock_wallbox, "getChargerStatus", side_effect=http_429_error):
-        async_fire_time_changed(hass, datetime.now() + timedelta(seconds=120), True)  # pylint: disable=home-assistant-enforce-naive-now
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=120), True)
         await hass.async_block_till_done()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -135,7 +136,7 @@ async def test_wallbox_refresh_failed_connection_error(
     assert entry.state is ConfigEntryState.LOADED
 
     with patch.object(mock_wallbox, "pauseChargingSession", side_effect=http_403_error):
-        async_fire_time_changed(hass, datetime.now() + timedelta(seconds=120), True)  # pylint: disable=home-assistant-enforce-naive-now
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=120), True)
         await hass.async_block_till_done()
 
     assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
