### PR TITLE
Flush KNX Postgres telegram buffer every second instead of every 10 minutes

### DIFF
--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -58,10 +58,11 @@ FLUSH_INTERVAL_SECONDS_SQLITE = 600
 FLUSH_INTERVAL_SECONDS_POSTGRES = 1
 
 # The buffer drops the oldest telegrams when full. Size it to cover a full
-# flush interval at ~50 telegrams/s, the maximum rate of a KNX TP line, so
-# nothing is dropped while the database is healthy.
-MAX_BUFFER_TELEGRAMS_SQLITE = FLUSH_INTERVAL_SECONDS_SQLITE * 50
-MAX_BUFFER_TELEGRAMS_POSTGRES = FLUSH_INTERVAL_SECONDS_POSTGRES * 50
+# flush interval at ~50 telegrams/s, the maximum rate of a single KNX TP line,
+# times 4 for headroom - routing can record multiple TP lines concurrently -
+# so nothing is dropped while the database is healthy.
+MAX_BUFFER_TELEGRAMS_SQLITE = FLUSH_INTERVAL_SECONDS_SQLITE * 50 * 4
+MAX_BUFFER_TELEGRAMS_POSTGRES = FLUSH_INTERVAL_SECONDS_POSTGRES * 50 * 4
 
 # Timeout for the migration probe and store initialization, so an unreachable
 # database cannot block KNX setup until the driver/OS connection timeout expires.

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -50,12 +50,18 @@ EVICT_EXPIRED_HOUR = 3
 # Interval at which buffered telegram writes are flushed to the database.
 # Websocket queries flush on demand (``flush_first=True``), so the only telegrams
 # at risk from a longer interval are those buffered during an ungraceful shutdown.
-FLUSH_INTERVAL_SECONDS = 600
+# Postgres is additionally used for live views driven directly by the database
+# (e.g. SpectrumKNX's postgres-readonly companion mode, via LISTEN/NOTIFY on
+# insert), which only learn about a telegram once it is actually written - so
+# Postgres flushes much more often than sqlite.
+FLUSH_INTERVAL_SECONDS_SQLITE = 600
+FLUSH_INTERVAL_SECONDS_POSTGRES = 1
 
 # The buffer drops the oldest telegrams when full. Size it to cover a full
 # flush interval at ~50 telegrams/s, the maximum rate of a KNX TP line, so
 # nothing is dropped while the database is healthy.
-MAX_BUFFER_TELEGRAMS = FLUSH_INTERVAL_SECONDS * 50
+MAX_BUFFER_TELEGRAMS_SQLITE = FLUSH_INTERVAL_SECONDS_SQLITE * 50
+MAX_BUFFER_TELEGRAMS_POSTGRES = FLUSH_INTERVAL_SECONDS_POSTGRES * 50
 
 # Timeout for the migration probe and store initialization, so an unreachable
 # database cannot block KNX setup until the driver/OS connection timeout expires.
@@ -127,8 +133,8 @@ class Telegrams:
             self._uninitialized_store = BufferedPostgresStore(
                 self.dsn,
                 retention_days=self.retention_days,
-                flush_interval=FLUSH_INTERVAL_SECONDS,
-                max_buffer_size=MAX_BUFFER_TELEGRAMS,
+                flush_interval=FLUSH_INTERVAL_SECONDS_POSTGRES,
+                max_buffer_size=MAX_BUFFER_TELEGRAMS_POSTGRES,
             )
         else:
             full_path = hass.config.path(STORAGE_DIR, KNX_TELEGRAM_DB_PATH_SQLITE)
@@ -136,8 +142,8 @@ class Telegrams:
             self._uninitialized_store = BufferedSqliteStore(
                 full_path,
                 retention_days=self.retention_days,
-                flush_interval=FLUSH_INTERVAL_SECONDS,
-                max_buffer_size=MAX_BUFFER_TELEGRAMS,
+                flush_interval=FLUSH_INTERVAL_SECONDS_SQLITE,
+                max_buffer_size=MAX_BUFFER_TELEGRAMS_SQLITE,
             )
 
         self._xknx_telegram_cb_handle = (

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -48,12 +48,9 @@ _LOGGER = logging.getLogger(__name__)
 EVICT_EXPIRED_HOUR = 3
 
 # Interval at which buffered telegram writes are flushed to the database.
-# Websocket queries flush on demand (``flush_first=True``), so the only telegrams
-# at risk from a longer interval are those buffered during an ungraceful shutdown.
-# Postgres is additionally used for live views driven directly by the database
-# (e.g. SpectrumKNX's postgres-readonly companion mode, via LISTEN/NOTIFY on
-# insert), which only learn about a telegram once it is actually written - so
-# Postgres flushes much more often than sqlite.
+# Postgres flushes far more often than sqlite: push-based consumers, unlike
+# on-demand-flushed (``flush_first=True``) queries, only see a telegram once
+# it is actually written.
 FLUSH_INTERVAL_SECONDS_SQLITE = 600
 FLUSH_INTERVAL_SECONDS_POSTGRES = 1
 

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -21,6 +21,8 @@ from homeassistant.components.knx.const import (
     REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR,
 )
 from homeassistant.components.knx.telegrams import (
+    FLUSH_INTERVAL_SECONDS_POSTGRES,
+    FLUSH_INTERVAL_SECONDS_SQLITE,
     STORE_INIT_RETRY_BACKOFF,
     TelegramDict,
 )
@@ -684,3 +686,43 @@ async def test_postgres_backend_init_error(
         issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
         is not None
     )
+
+
+async def test_postgres_backend_flushes_more_often_than_sqlite(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Postgres flushes every second; sqlite keeps the original 10 minute interval.
+
+    Sqlite's long interval is safe because the websocket history API already
+    flushes on demand. Postgres consumers that only learn about a telegram
+    once it is written (e.g. a LISTEN/NOTIFY-driven live view) have no such
+    fallback, so they need a much shorter interval.
+    """
+    assert FLUSH_INTERVAL_SECONDS_POSTGRES < FLUSH_INTERVAL_SECONDS_SQLITE
+
+    dsn = "postgresql://user:secret@db.local:5432/knx"
+    knx.mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        knx.mock_config_entry,
+        options=knx.mock_config_entry.options
+        | {
+            CONF_KNX_TELEGRAM_DB_BACKEND: KNX_TELEGRAM_BACKEND_POSTGRES,
+            CONF_KNX_TELEGRAM_DB_POSTGRES_DSN: dsn,
+        },
+    )
+    await knx.setup_integration(add_entry_to_hass=False)
+
+    store = hass.data[KNX_MODULE_KEY].telegrams.store
+    assert store.flush_interval == FLUSH_INTERVAL_SECONDS_POSTGRES
+
+
+async def test_sqlite_backend_keeps_long_flush_interval(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Sqlite's flush interval is unaffected by the Postgres-specific tuning."""
+    await knx.setup_integration()
+
+    store = hass.data[KNX_MODULE_KEY].telegrams.store
+    assert store.flush_interval == FLUSH_INTERVAL_SECONDS_SQLITE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The KNX telegram buffer flush interval (`FLUSH_INTERVAL_SECONDS = 600`, 10 minutes) was tuned for sqlite, where it's safe: the websocket history API already flushes on demand (`flush_first=True`) before every query, so the only telegrams actually at risk from a long interval are those buffered during an ungraceful shutdown.

Postgres consumers that learn about a telegram only when it is *actually written* - notably a `LISTEN`/`NOTIFY`-driven live view (e.g. [SpectrumKNX's postgres-readonly companion mode](https://github.com/martinhoefling/SpectrumKNX/pull/401)) - have no equivalent on-demand flush to fall back on. They inherited the same 10-minute delay, which for a "live" feed is a much bigger deal than for sqlite's on-demand-flushed history queries.

This keeps sqlite's interval and buffer size exactly as they were, and flushes Postgres every second instead. At the documented worst-case KNX TP rate (~50 telegrams/s), that's still only ~50 telegrams per flush - a small, cheap batch for Postgres.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
