### PR TITLE
Bump zhong-hong-hvac to 1.0.17

### DIFF
--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["zhong_hong_hvac"],
   "quality_scale": "legacy",
-  "requirements": ["zhong-hong-hvac==1.0.16"]
+  "requirements": ["zhong-hong-hvac==1.0.17"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3479,7 +3479,7 @@ zha-quirks==2.2.0
 zha==2.1.0
 
 # homeassistant.components.zhong_hong
-zhong-hong-hvac==1.0.16
+zhong-hong-hvac==1.0.17
 
 # homeassistant.components.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.1.0


### PR DESCRIPTION
## Proposed change

Bump `zhong-hong-hvac` from 1.0.16 to 1.0.17, which fixes the library reporting a state the air conditioner was never in.

The gateway acknowledges every control command by echoing it back byte for byte, and the library was applying that echo to the device state. The echo is identical whether or not the unit can do what was asked, so setting a fan speed a unit does not have looked exactly like setting one it does: the integration reported the new speed, and only a later status frame quietly corrected it — or nothing did, and it stayed wrong until the next poll.

The library now leaves the state to status frames, which the gateway sends unprompted once a unit really changes.

Confirmed against a live gateway with six indoor units. Setting a three-speed unit to each of the five addressable speeds produced status frames for exactly the three it has, and none for the other two:

```
send >> [0x1 0x34 0x5 0x1 0x0 0x3 0x3e]     # ask for MIDLOW, a speed this unit lacks
recv << [0x1 0x34 0x5 0x1 0x0 0x3 0x3e]     # echoed back in the same millisecond
                                            # ... and no status frame ever follows
```

Library diff: https://github.com/crhan/ZhongHongHVAC/compare/v1.0.16...v1.0.17

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
