### PR TITLE
Migrate calls to async_get_device in tests

### DIFF
--- a/tests/components/fritz/test_coordinator.py
+++ b/tests/components/fritz/test_coordinator.py
@@ -724,8 +724,8 @@ async def test_old_discovery_does_not_self_reference_box(
 
     assert entry.state is ConfigEntryState.LOADED
 
-    router = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    router = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert router is not None
     assert router.via_device_id is None

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -1348,7 +1348,9 @@ async def test_entity_device_info_with_via_device(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device_by_identifier(
+        ("mqtt", "helloworld"), mqtt_config_entry.entry_id
+    )
     assert device is not None
     assert device.via_device_id == hub.id
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -3292,7 +3292,9 @@ async def test_discovery_with_late_via_device_discovery(
 
     # The child device links to the stub via device by via_device_id
     stub_id = via_device_entry.id
-    child_device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    child_device_entry = device_registry.async_get_device_by_identifier(
+        ("mqtt", "0AFFD2"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert child_device_entry is not None
     assert child_device_entry.via_device_id == stub_id
 
@@ -3321,7 +3323,9 @@ async def test_discovery_with_late_via_device_discovery(
     # The stub merges into the announced device, keeping its id, so the link
     # from the child device survives
     assert via_device_entry.id == stub_id
-    child_device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    child_device_entry = device_registry.async_get_device_by_identifier(
+        ("mqtt", "0AFFD2"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert child_device_entry is not None
     assert child_device_entry.via_device_id == stub_id
 
@@ -3384,7 +3388,9 @@ async def test_discovery_with_late_via_device_update(
 
     # The discovery update established the via_device_id link on the child device
     stub_id = via_device_entry.id
-    child_device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    child_device_entry = device_registry.async_get_device_by_identifier(
+        ("mqtt", "0AFFD2"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert child_device_entry is not None
     assert child_device_entry.via_device_id == stub_id
 
@@ -3411,7 +3417,9 @@ async def test_discovery_with_late_via_device_update(
     assert via_device_entry is not None
     assert via_device_entry.name == "My Switch"
     assert via_device_entry.id == stub_id
-    child_device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    child_device_entry = device_registry.async_get_device_by_identifier(
+        ("mqtt", "0AFFD2"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert child_device_entry is not None
     assert child_device_entry.via_device_id == stub_id
 
@@ -3447,8 +3455,12 @@ async def test_via_device_relinks_after_parent_removed(
     )
     await hass.async_block_till_done()
 
-    parent = device_registry.async_get_device({("mqtt", "parent-id")})
-    child = device_registry.async_get_device({("mqtt", "child-id")})
+    parent = device_registry.async_get_device_by_identifier(
+        ("mqtt", "parent-id"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
+    child = device_registry.async_get_device_by_identifier(
+        ("mqtt", "child-id"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert parent is not None
     assert child is not None
     assert child.via_device_id == parent.id
@@ -3456,7 +3468,9 @@ async def test_via_device_relinks_after_parent_removed(
     # Removing the parent clears the child's via_device_id
     device_registry.async_remove_device(parent.id)
     await hass.async_block_till_done()
-    child = device_registry.async_get_device({("mqtt", "child-id")})
+    child = device_registry.async_get_device_by_identifier(
+        ("mqtt", "child-id"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert child is not None
     assert child.via_device_id is None
 
@@ -3467,8 +3481,12 @@ async def test_via_device_relinks_after_parent_removed(
     )
     await hass.async_block_till_done()
 
-    parent_stub = device_registry.async_get_device({("mqtt", "parent-id")})
-    child = device_registry.async_get_device({("mqtt", "child-id")})
+    parent_stub = device_registry.async_get_device_by_identifier(
+        ("mqtt", "parent-id"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
+    child = device_registry.async_get_device_by_identifier(
+        ("mqtt", "child-id"), hass.config_entries.async_entries("mqtt")[0].entry_id
+    )
     assert parent_stub is not None
     assert child is not None
     assert child.via_device_id == parent_stub.id
@@ -3496,7 +3514,9 @@ async def test_via_device_across_subentries(
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     subentry_id = next(iter(config_entry.subentries))
-    parent = device_registry.async_get_device({(DOMAIN, subentry_id)})
+    parent = device_registry.async_get_device_by_identifier(
+        (DOMAIN, subentry_id), config_entry.entry_id
+    )
     assert parent is not None
     assert parent.config_subentry_id == subentry_id
 
@@ -3512,7 +3532,9 @@ async def test_via_device_across_subentries(
     )
     await hass.async_block_till_done()
 
-    child = device_registry.async_get_device({(DOMAIN, "child-id")})
+    child = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "child-id"), config_entry.entry_id
+    )
     assert child is not None
     # The parent lives in a subentry and the discovered child does not, yet the
     # link resolves because lookups are scoped to the config entry.

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -554,7 +554,9 @@ async def test_entity_device_info_with_via_device(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
+    device = device_registry.async_get_device_by_identifier(
+        ("mqtt", "helloworld"), mqtt_config_entry.entry_id
+    )
     assert device is not None
     assert device.via_device_id == hub.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
