### PR TITLE
Bump lyngdorf to 1.4.8

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.5"],
+  "requirements": ["lyngdorf==1.4.7"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.4"],
+  "requirements": ["lyngdorf==1.4.5"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.7"],
+  "requirements": ["lyngdorf==1.4.8"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.5
+lyngdorf==1.4.7
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.4
+lyngdorf==1.4.5
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.7
+lyngdorf==1.4.8
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps the `lyngdorf` dependency from `1.4.4` to `1.4.8` (supersedes the earlier 1.4.5-only version of this PR — 1.4.6/1.4.7/1.4.8 shipped shortly after).

Fixes idle TDAI connections (TDAI-1120, TDAI-2170, TDAI-3400) being force-disconnected and reconnected every ~6 minutes forever, with a full setup-command replay each time. The connection keep-alive queried `PING`, which the entire TDAI family doesn't implement, so it silently never got sent while the staleness check that triggers a forced reconnect still ran unconditionally.

Reported in #178508 against a real TDAI-1120 as locking up the device's own control subsystem entirely — unresponsive front panel and official Android app, requiring a mains power cycle to recover.

Fix (fishloa/lyngdorf#28, fishloa/lyngdorf#27): the keep-alive command is now a per-model config value (`ModelConfig.keepalive_message`) instead of hardcoded in the API layer, defaulting to `DEVICE` — the one query genuinely universal across every model, including TDAI-2170's more limited protocol subset which doesn't even have `VERBOSE`.

1.4.6/1.4.7 also fix TDAI volume/trim step commands and expose new model capability methods (`has_bass_trim_feature`/`has_treble_trim_feature`, and renamed `has_bass_trim_step_feature`/`has_treble_trim_step_feature`) that this integration doesn't yet use — no HA-side behavior change from those in this PR; follow-up planned separately. 1.4.8 hardens the library's own PyPI publish pipeline with attestation; no code change relevant to this integration.

Compare: https://github.com/fishloa/lyngdorf/compare/v1.4.4...v1.4.8

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178508
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

PyPI: https://pypi.org/project/lyngdorf/1.4.8/

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

