### PR TITLE
Add `sync_state` to all KNX YAML entities

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -114,6 +114,7 @@ async def async_setup_entry(
 
 def _create_climate_yaml(xknx: XKNX, config: ConfigType) -> XknxClimate:
     """Return a KNX Climate device to be used within XKNX."""
+    sync_state = config[CONF_SYNC_STATE]
     climate_mode = XknxClimateMode(
         xknx,
         name=f"{config[CONF_NAME]} Mode",
@@ -151,6 +152,7 @@ def _create_climate_yaml(xknx: XKNX, config: ConfigType) -> XknxClimate:
         group_address_heat_cool_state=config.get(
             ClimateSchema.CONF_HEAT_COOL_STATE_ADDRESS
         ),
+        sync_state=sync_state,
         operation_modes=config.get(ClimateConf.OPERATION_MODES),
         controller_modes=config.get(ClimateConf.CONTROLLER_MODES),
     )
@@ -182,6 +184,7 @@ def _create_climate_yaml(xknx: XKNX, config: ConfigType) -> XknxClimate:
         group_address_command_value_state=config.get(
             ClimateSchema.CONF_COMMAND_VALUE_STATE_ADDRESS
         ),
+        sync_state=sync_state,
         min_temp=config.get(ClimateConf.MIN_TEMP),
         max_temp=config.get(ClimateConf.MAX_TEMP),
         mode=climate_mode,

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -261,6 +261,7 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
             invert_updown=config[CoverConf.INVERT_UPDOWN],
             invert_position=config[CoverConf.INVERT_POSITION],
             invert_angle=config[CoverConf.INVERT_ANGLE],
+            sync_state=config[CONF_SYNC_STATE],
         )
         super().__init__(
             knx_module=knx_module,

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -199,6 +199,7 @@ def _create_yaml_light(xknx: XKNX, config: ConfigType) -> XknxLight:
         color_temperature_type=color_temperature_type,
         min_kelvin=config[LightSchema.CONF_MIN_KELVIN],
         max_kelvin=config[LightSchema.CONF_MAX_KELVIN],
+        sync_state=config[CONF_SYNC_STATE],
     )
 
 

--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -118,6 +118,7 @@ class KnxYamlNumber(_KnxNumber, KnxYamlEntity):
             group_address=config[KNX_ADDRESS],
             group_address_state=config.get(CONF_STATE_ADDRESS),
             respond_to_read=config[CONF_RESPOND_TO_READ],
+            sync_state=config[CONF_SYNC_STATE],
             value_type=config[CONF_TYPE],
         )
         super().__init__(

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -77,6 +77,7 @@ from .validation import (
     numeric_type_validator,
     sensor_type_validator,
     string_type_validator,
+    sync_state_no_false_validator,
     sync_state_validator,
     validate_number_attributes,
     validate_sensor_attributes,
@@ -421,6 +422,9 @@ class ClimateSchema(KNXPlatformSchema):
                 vol.Optional(CONF_SWING_HORIZONTAL_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_SWING_HORIZONTAL_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_HUMIDITY_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(
+                    CONF_SYNC_STATE, default=True
+                ): sync_state_no_false_validator,
             }
         ),
     )
@@ -461,6 +465,9 @@ class CoverSchema(KNXPlatformSchema):
                 vol.Optional(CoverConf.INVERT_POSITION, default=False): cv.boolean,
                 vol.Optional(CoverConf.INVERT_ANGLE, default=False): cv.boolean,
                 vol.Optional(CONF_DEVICE_CLASS): COVER_DEVICE_CLASSES_SCHEMA,
+                vol.Optional(
+                    CONF_SYNC_STATE, default=True
+                ): sync_state_no_false_validator,
             }
         ),
         vol.Any(
@@ -703,6 +710,9 @@ class LightSchema(KNXPlatformSchema):
                 vol.Optional(CONF_MAX_KELVIN, default=DEFAULT_MAX_KELVIN): vol.All(
                     vol.Coerce(int), vol.Range(min=1)
                 ),
+                vol.Optional(
+                    CONF_SYNC_STATE, default=True
+                ): sync_state_no_false_validator,
             }
         ),
         vol.Any(
@@ -776,6 +786,9 @@ class NumberSchema(KNXPlatformSchema):
                 vol.Optional(NumberConf.STEP): cv.positive_float,
                 vol.Optional(CONF_DEVICE_CLASS): NUMBER_DEVICE_CLASSES_SCHEMA,
                 vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+                vol.Optional(
+                    CONF_SYNC_STATE, default=True
+                ): sync_state_no_false_validator,
             }
         ),
         _number_limit_sub_validator,
@@ -869,6 +882,7 @@ class SwitchSchema(KNXPlatformSchema):
             vol.Required(KNX_ADDRESS): ga_list_validator,
             vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,
             vol.Optional(CONF_DEVICE_CLASS): SWITCH_DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_SYNC_STATE, default=True): sync_state_no_false_validator,
         }
     )
 
@@ -885,6 +899,7 @@ class TextSchema(KNXPlatformSchema):
             vol.Optional(CONF_MODE, default=TextMode.TEXT): vol.Coerce(TextMode),
             vol.Required(KNX_ADDRESS): ga_list_validator,
             vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,
+            vol.Optional(CONF_SYNC_STATE, default=True): sync_state_no_false_validator,
         }
     )
 

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -117,6 +117,7 @@ class KnxYamlSwitch(_KnxSwitch, KnxYamlEntity):
             group_address=config[KNX_ADDRESS],
             group_address_state=config.get(SwitchSchema.CONF_STATE_ADDRESS),
             respond_to_read=config[CONF_RESPOND_TO_READ],
+            sync_state=config[CONF_SYNC_STATE],
             invert=config[SwitchSchema.CONF_INVERT],
         )
         super().__init__(

--- a/homeassistant/components/knx/text.py
+++ b/homeassistant/components/knx/text.py
@@ -123,6 +123,7 @@ class KnxYamlText(_KnxText, KnxYamlEntity):
             group_address=config[KNX_ADDRESS],
             group_address_state=config.get(CONF_STATE_ADDRESS),
             respond_to_read=config[CONF_RESPOND_TO_READ],
+            sync_state=config[CONF_SYNC_STATE],
             value_type=config[CONF_TYPE],
         )
         super().__init__(

--- a/homeassistant/components/knx/validation.py
+++ b/homeassistant/components/knx/validation.py
@@ -121,6 +121,13 @@ sync_state_validator = vol.Any(
     cv.matches_regex(r"^(init|expire|every)( \d*)?$"),
 )
 
+# entities having a writable group address can omit the state address
+# instead of disabling state updates entirely
+sync_state_no_false_validator = vol.All(
+    sync_state_validator,
+    vol.IsTrue("Sync state can not be disabled for this platform"),
+)
+
 
 def backwards_compatible_xknx_climate_enum_member(enumClass: type[Enum]) -> vol.All:
     """Transform a string to an enum member.

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -3,7 +3,7 @@
 import pytest
 
 from homeassistant.components.climate import HVACMode
-from homeassistant.components.knx.const import ClimateConf
+from homeassistant.components.knx.const import CONF_SYNC_STATE, ClimateConf
 from homeassistant.components.knx.schema import ClimateSchema
 from homeassistant.const import CONF_NAME, STATE_IDLE, Platform
 from homeassistant.core import HomeAssistant
@@ -32,6 +32,7 @@ async def test_climate_basic_temperature_set(
                 ClimateSchema.CONF_TEMPERATURE_ADDRESS: "1/2/3",
                 ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS: "1/2/4",
                 ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS: "1/2/5",
+                CONF_SYNC_STATE: "init",
             }
         }
     )

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -10,6 +10,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
     CoverState,
 )
+from homeassistant.components.knx.const import CONF_SYNC_STATE
 from homeassistant.components.knx.schema import CoverSchema
 from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
@@ -30,6 +31,7 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
                 CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
                 CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+                CONF_SYNC_STATE: "init",
             }
         }
     )

--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -7,7 +7,12 @@ import pytest
 from xknx.core import XknxConnectionState
 from xknx.devices.light import Light as XknxLight
 
-from homeassistant.components.knx.const import CONF_STATE_ADDRESS, KNX_ADDRESS, Platform
+from homeassistant.components.knx.const import (
+    CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
+    KNX_ADDRESS,
+    Platform,
+)
 from homeassistant.components.knx.schema import LightSchema
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -151,6 +156,7 @@ async def test_light_color_temp_absolute(hass: HomeAssistant, knx: KNXTestKit) -
                     LightSchema.CONF_COLOR_TEMP_ADDRESS: test_ct,
                     LightSchema.CONF_COLOR_TEMP_STATE_ADDRESS: test_ct_state,
                     LightSchema.CONF_COLOR_TEMP_MODE: "absolute",
+                    CONF_SYNC_STATE: "init",
                 },
             ]
         }

--- a/tests/components/knx/test_number.py
+++ b/tests/components/knx/test_number.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components.knx.const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import NumberSchema
@@ -139,6 +140,7 @@ async def test_number_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> Non
                 KNX_ADDRESS: test_address,
                 CONF_STATE_ADDRESS: test_state_address,
                 CONF_TYPE: "illuminance",
+                CONF_SYNC_STATE: "init",
             }
         }
     )

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -1,5 +1,7 @@
 """Test KNX switch."""
 
+import pytest
+
 from homeassistant.components.knx.const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -113,6 +115,24 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
     # switch does not respond to read by default
     await knx.receive_read(_ADDRESS)
     await knx.assert_telegram_count(0)
+
+
+async def test_switch_sync_state_false_invalid(
+    hass: HomeAssistant, knx: KNXTestKit, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test entities having a writable address don't allow disabling state updates."""
+    await knx.setup_integration(
+        {
+            SwitchSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: "1/1/1",
+                CONF_STATE_ADDRESS: "2/2/2",
+                CONF_SYNC_STATE: False,
+            },
+        }
+    )
+    assert "Sync state can not be disabled for this platform" in caplog.text
+    assert hass.states.get("switch.test") is None
 
 
 async def test_switch_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -3,6 +3,7 @@
 from homeassistant.components.knx.const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import SwitchSchema
@@ -64,6 +65,7 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
                 CONF_NAME: "test",
                 KNX_ADDRESS: _ADDRESS,
                 CONF_STATE_ADDRESS: _STATE_ADDRESS,
+                CONF_SYNC_STATE: "init",
             },
         }
     )

--- a/tests/components/knx/test_text.py
+++ b/tests/components/knx/test_text.py
@@ -3,6 +3,7 @@
 from homeassistant.components.knx.const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import TextSchema
@@ -120,6 +121,7 @@ async def test_text_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
                 CONF_NAME: "test",
                 KNX_ADDRESS: test_address,
                 CONF_STATE_ADDRESS: test_state_address,
+                CONF_SYNC_STATE: "init",
             }
         }
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
climate, cover, light, number, switch and text

These platforms have state addresses but didn't support the `sync_state` option in YAML yet. Like in the UI schema, disabling state updates entirely is not valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47335
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
