### PR TITLE
Document why hortimax's no-devices retry stays within HortOS's rate limit

### DIFF
--- a/homeassistant/components/hortimax/coordinator.py
+++ b/homeassistant/components/hortimax/coordinator.py
@@ -85,6 +85,12 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
         # The config flow refuses a key with no controllers, so an entry that
         # suddenly has none is a change on the HortOS side. Retrying beats
         # loading an integration with nothing in it.
+        #
+        # HA's setup-retry backoff for the resulting ConfigEntryNotReady is
+        # capped at once per 10 minutes (SETUP_RETRY_MAX_WAIT), reaching that
+        # cap after 7 calls to this endpoint in the first ~10 minutes. aiohortos
+        # documents HortOS's limit as 100 requests per 15 seconds per API key,
+        # so this stays far under it even in that worst case.
         if not self.devices:
             raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_devices")
 

--- a/homeassistant/components/hortimax/coordinator.py
+++ b/homeassistant/components/hortimax/coordinator.py
@@ -86,9 +86,9 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
         # suddenly has none is a change on the HortOS side. Retrying beats
         # loading an integration with nothing in it.
         #
-        # HA's setup-retry backoff for the resulting ConfigEntryNotReady is
-        # capped at once per 10 minutes (SETUP_RETRY_MAX_WAIT), reaching that
-        # cap after 7 calls to this endpoint in the first ~10 minutes. aiohortos
+        # HA's setup-retry backoff for the resulting ConfigEntryNotReady grows
+        # 5, 10, 20, 40, 80, 160, 320 seconds, then caps at 600 (10 minutes,
+        # SETUP_RETRY_MAX_WAIT) forever from the 8th call onward. aiohortos
         # documents HortOS's limit as 100 requests per 15 seconds per API key,
         # so this stays far under it even in that worst case.
         if not self.devices:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Document why `hortimax`'s no-devices retry is safe, per [review feedback on #177247][comment]:

> However, this means if you don't have devices, it will retry forever, with
> expontential backoff, which the API might like less

No behavior change — `ConfigEntryNotReady` is already handled by Home
Assistant's own setup-retry mechanism, which caps backoff at once per 10
minutes (`SETUP_RETRY_MAX_WAIT`). Worked out concretely: that's 7 calls to
`get_devices()` in the first ~10 minutes while backing off, then one every 10
minutes after. `aiohortos`'s docs put HortOS's limit at 100 requests per 15
seconds per API key, so this worst case stays far under it — gentler, in
fact, than normal steady-state polling (one `get_latest_readouts` call per
controller every 60 seconds). Added a comment at the call site with these
numbers so this doesn't need re-deriving later.

[comment]: https://github.com/home-assistant/core/pull/177247#discussion_r3719787920

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
