### PR TITLE
Add available property to hortimax entities

### DIFF
--- a/homeassistant/components/hortimax/entity.py
+++ b/homeassistant/components/hortimax/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Ridder HortiMaX Pro (HortOS) integration."""
 
+from typing import override
+
 from aiohortos import Readout
 
 from homeassistant.helpers import device_registry as dr
@@ -45,6 +47,12 @@ class HortimaxEntity(CoordinatorEntity[HortimaxCoordinator]):
                 config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the controller this readout belongs to is known."""
+        return super().available and self._device_id in self.coordinator.data
 
     @property
     def readout(self) -> Readout | None:

--- a/tests/components/hortimax/test_sensor.py
+++ b/tests/components/hortimax/test_sensor.py
@@ -161,6 +161,25 @@ async def test_disappearing_readout_becomes_unknown(
 
 
 @pytest.mark.usefixtures("mock_hortos_client")
+async def test_disappearing_device_becomes_unavailable(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test an entity whose controller drops out of coordinator data is unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    assert (
+        hass.states.get("sensor.weerstation_outside_temperature").state == "18.203125"
+    )
+
+    mock_config_entry.runtime_data.async_set_updated_data({})
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.weerstation_outside_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+
+@pytest.mark.usefixtures("mock_hortos_client")
 @pytest.mark.parametrize(
     ("code", "expected"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an `available` property to `hortimax`'s base entity, per [review feedback
on #177247][comment]:

> don't we need an available property to check if self._device_id is in the coordinator data?

Follows the same `super().available and <id> in self.coordinator.data`
pattern already used in `alexa_devices`, `data_grand_lyon`, `duco`, and `fyta`.

With hortimax's controller list being fixed at setup and updates being
all-or-nothing across every controller, `self._device_id` can't currently go
missing from `coordinator.data` through the public API client, so I added a
test that reaches it through `coordinator.async_set_updated_data(...)` (a
public coordinator API) rather than the mocked client, to keep this covered
without relying on API behavior that isn't reachable today.

[comment]: https://github.com/home-assistant/core/pull/177247#discussion_r3719795289

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
