### PR TITLE
Use the input label configured on the TV in Bravia TV

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -150,7 +150,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             if not name or not uri:
                 continue
             self.source_map[uri] = {**item, "name": name, "type": source_type}
-            if add_to_list and name not in self.source_list:
+            if add_to_list and not any(
+                name.lower() == existing.lower() for existing in self.source_list
+            ):
                 self.source_list.append(name)
 
     @override
@@ -294,6 +296,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         if query.startswith(("extInput:", "tv:", "com.sony.dtv.")):
             return await self.async_source_start(query, source_type)
         coarse_uri = None
+        label_uri = None
         is_numeric_search = source_type == SourceType.CHANNEL and query.isnumeric()
         for uri, item in self.source_map.items():
             if item["type"] == source_type:
@@ -302,14 +305,19 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    # The generic name keeps working after a rename.
-                    for name in (item.get("name"), item.get("title")):
-                        if not name:
-                            continue
-                        if query.lower() == name.lower():
-                            return await self.async_source_start(uri, source_type)
-                        if query.lower() in name.lower():
-                            coarse_uri = uri
+                    folded = query.lower()
+                    title = (item.get("title") or "").lower()
+                    name = (item.get("name") or "").lower()
+                    # A generic name wins over a label, so labelling an input with
+                    # another one's name cannot capture it from an automation.
+                    if folded == title:
+                        return await self.async_source_start(uri, source_type)
+                    if folded == name:
+                        label_uri = label_uri or uri
+                    elif folded in title or folded in name:
+                        coarse_uri = uri
+        if label_uri:
+            return await self.async_source_start(label_uri, source_type)
         if coarse_uri:
             return await self.async_source_start(coarse_uri, source_type)
         raise ValueError(f"Not found {source_type}: {query}")

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -149,11 +149,17 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             name = item.get("label") or title
             if not name or not uri:
                 continue
+            if add_to_list:
+                # Reuse the spelling already listed, so the source reported while
+                # playing is always one of the names offered in the list.
+                known = next(
+                    (s for s in self.source_list if s.lower() == name.lower()), None
+                )
+                if known is None:
+                    self.source_list.append(name)
+                else:
+                    name = known
             self.source_map[uri] = {**item, "name": name, "type": source_type}
-            if add_to_list and not any(
-                name.lower() == existing.lower() for existing in self.source_list
-            ):
-                self.source_list.append(name)
 
     @override
     async def _async_update_data(self) -> None:

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -142,37 +142,15 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         """Extend source map and source list."""
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
-        # A label may repeat another input's generic name and hide it.
-        reserved = {item["title"].casefold() for item in sources if item.get("title")}
-        taken = {name.casefold() for name in self.source_list} if add_to_list else set()
         for item in sources:
             title = item.get("title")
             uri = item.get("uri")
-            # "label" is the name set on the TV, "title" the connector name.
-            label = item.get("label")
-            name = None
-            if label:
-                folded = label.casefold()
-                own = title is not None and folded == title.casefold()
-                if folded not in taken and (own or folded not in reserved):
-                    name = label
-            # Inputs are reported without a title on some models.
-            if name is None:
-                name = title or label
+            # "label" is the name set on the TV, "title" the generic connector name.
+            name = item.get("label") or title
             if not name or not uri:
                 continue
-            own = title.casefold() if title else None
-            base = name
-            suffix = 2
-            while name.casefold() in taken or (
-                name.casefold() in reserved and name.casefold() != own
-            ):
-                name = f"{base} ({suffix})"
-                suffix += 1
-            taken.add(name.casefold())
-            # "title" stays untouched so select_source still takes the generic name.
             self.source_map[uri] = {**item, "name": name, "type": source_type}
-            if add_to_list:
+            if add_to_list and name not in self.source_list:
                 self.source_list.append(name)
 
     @override
@@ -324,15 +302,13 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    # Both names match, so automations written before a rename work.
-                    folded_query = query.casefold()
+                    # The generic name keeps working after a rename.
                     for name in (item.get("name"), item.get("title")):
                         if not name:
                             continue
-                        folded = name.casefold()
-                        if folded_query == folded:
+                        if query.lower() == name.lower():
                             return await self.async_source_start(uri, source_type)
-                        if folded_query in folded:
+                        if query.lower() in name.lower():
                             coarse_uri = uri
         if coarse_uri:
             return await self.async_source_start(coarse_uri, source_type)

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -153,7 +153,8 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 # Reuse the spelling already listed, so the source reported while
                 # playing is always one of the names offered in the list.
                 known = next(
-                    (s for s in self.source_list if s.lower() == name.lower()), None
+                    (s for s in self.source_list if s.casefold() == name.casefold()),
+                    None,
                 )
                 if known is None:
                     self.source_list.append(name)
@@ -311,9 +312,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    folded = query.lower()
-                    title = (item.get("title") or "").lower()
-                    name = (item.get("name") or "").lower()
+                    folded = query.casefold()
+                    title = (item.get("title") or "").casefold()
+                    name = (item.get("name") or "").casefold()
                     # A generic name wins over a label, so labelling an input with
                     # another one's name cannot capture it from an automation.
                     if folded == title:

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -335,12 +335,16 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 else:
                     # Match both the name shown in source_list and the generic
                     # one, so existing automations keep working.
+                    # Casefolded like the uniqueness checks above, so that a
+                    # name reserved as a duplicate also matches as one here.
+                    folded_query = query.casefold()
                     for name in (item.get("name"), item.get("title")):
                         if not name:
                             continue
-                        if query.lower() == name.lower():
+                        folded = name.casefold()
+                        if folded_query == folded:
                             return await self.async_source_start(uri, source_type)
-                        if query.lower() in name.lower():
+                        if folded_query in folded:
                             coarse_uri = uri
         if coarse_uri:
             return await self.async_source_start(coarse_uri, source_type)

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -143,11 +143,16 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
         for item in sources:
-            title = item.get("title")
+            # Sony TVs report the generic connector name in "title" and the name
+            # the user configured on the TV itself in "label". Prefer the latter,
+            # falling back to "title" when no custom name has been set.
+            title = item.get("label") or item.get("title")
             uri = item.get("uri")
             if not title or not uri:
                 continue
-            self.source_map[uri] = {**item, "type": source_type}
+            # Store the resolved name so that lookups in async_source_find match
+            # what is exposed in source_list.
+            self.source_map[uri] = {**item, "title": title, "type": source_type}
             if add_to_list and title not in self.source_list:
                 self.source_list.append(title)
 
@@ -251,7 +256,8 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         if self.media_uri:
             self.media_content_id = self.media_uri
             if self.media_uri[:8] == "extInput":
-                self.source = playing_info.get("title")
+                source = self.source_map.get(self.media_uri, {})
+                self.source = source.get("title") or playing_info.get("title")
             if self.media_uri[:2] == "tv":
                 self.media_content_id = playing_info.get("dispNum")
                 self.media_title = (

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -160,8 +160,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 own = title is not None and folded == title.casefold()
                 if folded not in taken and (own or folded not in reserved):
                     name = label
-            # Otherwise fall back to the generic name, or to the label for the
-            # inputs that are reported without one.
+            # Inputs are reported without a title on some models.
             if name is None:
                 name = title or label
             if not name or not uri:
@@ -333,10 +332,8 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    # Match both the name shown in source_list and the generic
-                    # one, so existing automations keep working.
-                    # Casefolded like the uniqueness checks above, so that a
-                    # name reserved as a duplicate also matches as one here.
+                    # Both names are matched so that automations written
+                    # before an input was renamed keep working.
                     folded_query = query.casefold()
                     for name in (item.get("name"), item.get("title")):
                         if not name:

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -142,19 +142,27 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         """Extend source map and source list."""
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
+        # Reserve every generic connector name up front, so that a custom label
+        # can never shadow another input and leave it unreachable.
+        reserved = {item["title"] for item in sources if item.get("title")}
+        taken = set(self.source_list) if add_to_list else set()
         for item in sources:
             title = item.get("title")
             uri = item.get("uri")
             # Sony TVs report the generic connector name in "title" and the name
             # the user configured on the TV itself in "label". Prefer the latter,
-            # falling back to "title" when no custom name has been set.
-            name = item.get("label") or title
+            # as long as it is free and does not belong to another input.
+            label = item.get("label")
+            name = title
+            if (
+                label
+                and label not in taken
+                and (label == title or label not in reserved)
+            ):
+                name = label
             if not name or not uri:
                 continue
-            # Several inputs are allowed to share the same label, so fall back to
-            # the generic name to keep every input reachable in source_list.
-            if add_to_list and name in self.source_list and title:
-                name = title
+            taken.add(name)
             # "title" is kept untouched so that select_source keeps working with
             # the generic name for anyone already using it.
             self.source_map[uri] = {**item, "name": name, "type": source_type}

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -143,26 +143,37 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
         # Reserve every generic connector name up front, so that a custom label
-        # can never shadow another input and leave it unreachable.
-        reserved = {item["title"] for item in sources if item.get("title")}
-        taken = set(self.source_list) if add_to_list else set()
+        # can never shadow another input and leave it unreachable. Names are
+        # compared casefolded, like async_source_find does.
+        reserved = {item["title"].casefold() for item in sources if item.get("title")}
+        taken = {name.casefold() for name in self.source_list} if add_to_list else set()
         for item in sources:
             title = item.get("title")
             uri = item.get("uri")
             # Sony TVs report the generic connector name in "title" and the name
             # the user configured on the TV itself in "label". Prefer the latter,
-            # as long as it is free and does not belong to another input.
+            # unless it is already used or belongs to a different input.
             label = item.get("label")
-            name = title
-            if (
-                label
-                and label not in taken
-                and (label == title or label not in reserved)
-            ):
-                name = label
+            name = None
+            if label:
+                folded = label.casefold()
+                own = title is not None and folded == title.casefold()
+                if folded not in taken and (own or folded not in reserved):
+                    name = label
+            # Otherwise fall back to the generic name, or to the label for the
+            # inputs that are reported without one.
+            if name is None:
+                name = title or label
             if not name or not uri:
                 continue
-            taken.add(name)
+            # The fallback can collide as well, so make it unique instead of
+            # dropping the input.
+            base = name
+            suffix = 2
+            while name.casefold() in taken:
+                name = f"{base} ({suffix})"
+                suffix += 1
+            taken.add(name.casefold())
             # "title" is kept untouched so that select_source keeps working with
             # the generic name for anyone already using it.
             self.source_map[uri] = {**item, "name": name, "type": source_type}

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -143,18 +143,23 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
         for item in sources:
+            title = item.get("title")
+            uri = item.get("uri")
             # Sony TVs report the generic connector name in "title" and the name
             # the user configured on the TV itself in "label". Prefer the latter,
             # falling back to "title" when no custom name has been set.
-            title = item.get("label") or item.get("title")
-            uri = item.get("uri")
-            if not title or not uri:
+            name = item.get("label") or title
+            if not name or not uri:
                 continue
-            # Store the resolved name so that lookups in async_source_find match
-            # what is exposed in source_list.
-            self.source_map[uri] = {**item, "title": title, "type": source_type}
-            if add_to_list and title not in self.source_list:
-                self.source_list.append(title)
+            # Several inputs are allowed to share the same label, so fall back to
+            # the generic name to keep every input reachable in source_list.
+            if add_to_list and name in self.source_list and title:
+                name = title
+            # "title" is kept untouched so that select_source keeps working with
+            # the generic name for anyone already using it.
+            self.source_map[uri] = {**item, "name": name, "type": source_type}
+            if add_to_list and name not in self.source_list:
+                self.source_list.append(name)
 
     @override
     async def _async_update_data(self) -> None:
@@ -257,7 +262,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             self.media_content_id = self.media_uri
             if self.media_uri[:8] == "extInput":
                 source = self.source_map.get(self.media_uri, {})
-                self.source = source.get("title") or playing_info.get("title")
+                self.source = source.get("name") or playing_info.get("title")
             if self.media_uri[:2] == "tv":
                 self.media_content_id = playing_info.get("dispNum")
                 self.media_title = (
@@ -305,11 +310,15 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    title: str = item["title"]
-                    if query.lower() == title.lower():
-                        return await self.async_source_start(uri, source_type)
-                    if query.lower() in title.lower():
-                        coarse_uri = uri
+                    # Match both the name shown in source_list and the generic
+                    # one, so existing automations keep working.
+                    for name in (item.get("name"), item.get("title")):
+                        if not name:
+                            continue
+                        if query.lower() == name.lower():
+                            return await self.async_source_start(uri, source_type)
+                        if query.lower() in name.lower():
+                            coarse_uri = uri
         if coarse_uri:
             return await self.async_source_start(coarse_uri, source_type)
         raise ValueError(f"Not found {source_type}: {query}")

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -167,10 +167,14 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             if not name or not uri:
                 continue
             # The fallback can collide as well, so make it unique instead of
-            # dropping the input.
+            # dropping the input. A generated name may not take a generic name
+            # that belongs to another input either.
+            own = title.casefold() if title else None
             base = name
             suffix = 2
-            while name.casefold() in taken:
+            while name.casefold() in taken or (
+                name.casefold() in reserved and name.casefold() != own
+            ):
                 name = f"{base} ({suffix})"
                 suffix += 1
             taken.add(name.casefold())

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -142,17 +142,13 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         """Extend source map and source list."""
         if sort_by:
             sources = sorted(sources, key=lambda d: d.get(sort_by, ""))
-        # Reserve every generic connector name up front, so that a custom label
-        # can never shadow another input and leave it unreachable. Names are
-        # compared casefolded, like async_source_find does.
+        # A label may repeat another input's generic name and hide it.
         reserved = {item["title"].casefold() for item in sources if item.get("title")}
         taken = {name.casefold() for name in self.source_list} if add_to_list else set()
         for item in sources:
             title = item.get("title")
             uri = item.get("uri")
-            # Sony TVs report the generic connector name in "title" and the name
-            # the user configured on the TV itself in "label". Prefer the latter,
-            # unless it is already used or belongs to a different input.
+            # "label" is the name set on the TV, "title" the connector name.
             label = item.get("label")
             name = None
             if label:
@@ -165,9 +161,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 name = title or label
             if not name or not uri:
                 continue
-            # The fallback can collide as well, so make it unique instead of
-            # dropping the input. A generated name may not take a generic name
-            # that belongs to another input either.
             own = title.casefold() if title else None
             base = name
             suffix = 2
@@ -177,12 +170,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 name = f"{base} ({suffix})"
                 suffix += 1
             taken.add(name.casefold())
-            # "title" is kept untouched so that select_source keeps working with
-            # the generic name for anyone already using it.
+            # "title" stays untouched so select_source still takes the generic name.
             self.source_map[uri] = {**item, "name": name, "type": source_type}
             if add_to_list:
-                # `taken` starts from source_list, so the loop above already
-                # guarantees the name is not in it.
                 self.source_list.append(name)
 
     @override
@@ -334,8 +324,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    # Both names are matched so that automations written
-                    # before an input was renamed keep working.
+                    # Both names match, so automations written before a rename work.
                     folded_query = query.casefold()
                     for name in (item.get("name"), item.get("title")):
                         if not name:

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -180,7 +180,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             # "title" is kept untouched so that select_source keeps working with
             # the generic name for anyone already using it.
             self.source_map[uri] = {**item, "name": name, "type": source_type}
-            if add_to_list and name not in self.source_list:
+            if add_to_list:
+                # `taken` starts from source_list, so the loop above already
+                # guarantees the name is not in it.
                 self.source_list.append(name)
 
     @override

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -305,6 +305,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         coarse_uri = None
         label_uri = None
         is_numeric_search = source_type == SourceType.CHANNEL and query.isnumeric()
+        folded = query.casefold()
         for uri, item in self.source_map.items():
             if item["type"] == source_type:
                 if is_numeric_search:
@@ -312,7 +313,6 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                     if num and int(query) == int(num):
                         return await self.async_source_start(uri, source_type)
                 else:
-                    folded = query.casefold()
                     title = (item.get("title") or "").casefold()
                     name = (item.get("name") or "").casefold()
                     # A generic name wins over a label, so labelling an input with

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -166,6 +166,7 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         # A partial name still resolves, as it did before.
         ("Streaming", "extInput:cec?type=player&port=1"),
         ("straße", "extInput:scart?port=1"),
+        ("STRASSE", "extInput:scart?port=1"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -40,7 +40,7 @@ INPUTS = [
         "uri": "extInput:hdmi?port=1",
         "title": "HDMI 1",
         "connection": False,
-        "label": "",
+        "label": "HDMI 2",
         "icon": "meta:hdmi",
     },
     {
@@ -54,12 +54,19 @@ INPUTS = [
         "uri": "extInput:hdmi?port=3",
         "title": "HDMI 3",
         "connection": True,
-        "label": "Game console",
+        "label": "game console",
         "icon": "meta:hdmi",
     },
     {
         "uri": "extInput:hdmi?port=4",
         "title": "HDMI 4",
+        "connection": True,
+        "label": "",
+        "icon": "meta:hdmi",
+    },
+    {
+        "uri": "extInput:hdmi?port=5",
+        "title": "HDMI 5",
         "connection": True,
         "icon": "meta:hdmi",
     },
@@ -122,11 +129,12 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_ID)
 
     assert state is not None
-    # HDMI 3 repeats HDMI 2's label, so it does not appear twice.
+    # HDMI 3 repeats HDMI 2's label apart from case, so it does not appear twice.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
-        "HDMI 1",
+        "HDMI 2",
         "Game console",
         "HDMI 4",
+        "HDMI 5",
         "Streaming box",
         "Straße",
     ]
@@ -138,10 +146,13 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     ("source", "expected_uri"),
     [
         ("Game console", "extInput:hdmi?port=2"),
+        ("game console", "extInput:hdmi?port=2"),
+        # HDMI 1 is labelled "HDMI 2": the input that owns that name still wins.
         ("HDMI 2", "extInput:hdmi?port=2"),
-        ("HDMI 3", "extInput:hdmi?port=3"),
         ("HDMI 1", "extInput:hdmi?port=1"),
+        ("HDMI 3", "extInput:hdmi?port=3"),
         ("HDMI 4", "extInput:hdmi?port=4"),
+        ("HDMI 5", "extInput:hdmi?port=5"),
         ("Streaming box", "extInput:cec?type=player&port=1"),
         ("straße", "extInput:scart?port=1"),
     ],

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -77,6 +77,11 @@ INPUTS = [
         "icon": "meta:playbackdevice",
     },
     {
+        "uri": "extInput:widi?port=1",
+        "connection": False,
+        "icon": "meta:wifidisplay",
+    },
+    {
         "uri": "extInput:scart?port=1",
         "title": "AV1",
         "connection": False,
@@ -85,7 +90,7 @@ INPUTS = [
     },
 ]
 
-PLAYING_INFO = {"uri": "extInput:hdmi?port=2", "title": "HDMI 2", "source": "HDMI"}
+PLAYING_INFO = {"uri": "extInput:hdmi?port=3", "title": "HDMI 3", "source": "HDMI"}
 
 
 @pytest.fixture
@@ -138,8 +143,12 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         "Streaming box",
         "Straße",
     ]
-    # The playing input is reported with the same name used in the source list.
+    # HDMI 3 is labelled "game console"; it is reported with the spelling that is
+    # actually in the list, never with one that is missing from it.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
+    assert (
+        state.attributes[ATTR_INPUT_SOURCE] in state.attributes[ATTR_INPUT_SOURCE_LIST]
+    )
 
 
 @pytest.mark.parametrize(
@@ -154,6 +163,8 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         ("HDMI 4", "extInput:hdmi?port=4"),
         ("HDMI 5", "extInput:hdmi?port=5"),
         ("Streaming box", "extInput:cec?type=player&port=1"),
+        # A partial name still resolves, as it did before.
+        ("Streaming", "extInput:cec?type=player&port=1"),
         ("straße", "extInput:scart?port=1"),
     ],
 )

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -33,8 +33,8 @@ BRAVIA_SYSTEM_INFO = {
     "cid": "very_unique_string",
 }
 
-# The TV leaves "label" empty when unset, allows the same label on several
-# inputs, and does not stop one matching another input's "title".
+# The TV leaves "label" empty when unset, omits it on some models, and allows the
+# same label on several inputs.
 INPUTS = [
     {
         "uri": "extInput:hdmi?port=1",
@@ -61,47 +61,19 @@ INPUTS = [
         "uri": "extInput:hdmi?port=4",
         "title": "HDMI 4",
         "connection": True,
-        "label": "HDMI 1",
-        "icon": "meta:hdmi",
-    },
-    {
-        "uri": "extInput:hdmi?port=5",
-        "title": "HDMI 5",
-        "connection": True,
-        "label": "hdmi 1",
-        "icon": "meta:hdmi",
-    },
-    {
-        # Some models leave the key out entirely rather than sending it empty.
-        "uri": "extInput:hdmi?port=6",
-        "title": "HDMI 6",
-        "connection": True,
         "icon": "meta:hdmi",
     },
     {
         "uri": "extInput:cec?type=player&port=1",
         "connection": True,
         "label": "Streaming box",
-        "icon": "meta:cec",
-    },
-    {
-        "uri": "extInput:cec?type=player&port=2",
-        "connection": True,
-        "label": "Streaming box",
-        "icon": "meta:cec",
-    },
-    {
-        "uri": "extInput:composite?port=1",
-        "title": "Streaming box (2)",
-        "connection": False,
-        "label": "",
-        "icon": "meta:composite",
+        "icon": "meta:playbackdevice",
     },
     {
         "uri": "extInput:scart?port=1",
         "title": "AV1",
         "connection": False,
-        "label": "Stra\u00dfe",
+        "label": "Straße",
         "icon": "meta:scart",
     },
 ]
@@ -150,19 +122,13 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_ID)
 
     assert state is not None
-    # "HDMI 3" repeats "HDMI 2"'s label, so it falls back to its own generic
-    # name to stay reachable.
+    # HDMI 3 repeats HDMI 2's label, so it does not appear twice.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
         "HDMI 1",
         "Game console",
-        "HDMI 3",
         "HDMI 4",
-        "HDMI 5",
-        "HDMI 6",
         "Streaming box",
-        "Streaming box (3)",
-        "Streaming box (2)",
-        "Stra\u00dfe",
+        "Straße",
     ]
     # The playing input is reported with the same name used in the source list.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
@@ -176,12 +142,8 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         ("HDMI 3", "extInput:hdmi?port=3"),
         ("HDMI 1", "extInput:hdmi?port=1"),
         ("HDMI 4", "extInput:hdmi?port=4"),
-        ("HDMI 5", "extInput:hdmi?port=5"),
-        ("HDMI 6", "extInput:hdmi?port=6"),
         ("Streaming box", "extInput:cec?type=player&port=1"),
-        ("Streaming box (3)", "extInput:cec?type=player&port=2"),
-        ("Streaming box (2)", "extInput:composite?port=1"),
-        ("STRASSE", "extInput:scart?port=1"),
+        ("straße", "extInput:scart?port=1"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -34,6 +34,7 @@ BRAVIA_SYSTEM_INFO = {
 }
 
 # "title" is the generic connector name, "label" the name set on the TV itself.
+# The TV allows the same label on several inputs, and leaves it empty when unset.
 INPUTS = [
     {
         "uri": "extInput:hdmi?port=1",
@@ -45,6 +46,13 @@ INPUTS = [
     {
         "uri": "extInput:hdmi?port=2",
         "title": "HDMI 2",
+        "connection": True,
+        "label": "Game console",
+        "icon": "meta:hdmi",
+    },
+    {
+        "uri": "extInput:hdmi?port=3",
+        "title": "HDMI 3",
         "connection": True,
         "label": "Game console",
         "icon": "meta:hdmi",
@@ -95,21 +103,39 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_ID)
 
     assert state is not None
-    # "HDMI 1" has no label and keeps the generic name, "HDMI 2" was renamed.
-    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI 1", "Game console"]
+    # "HDMI 1" has no label and keeps the generic name, "HDMI 2" was renamed and
+    # "HDMI 3" repeats the same label, so it falls back to the generic name to
+    # stay reachable.
+    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
+        "HDMI 1",
+        "Game console",
+        "HDMI 3",
+    ]
     # The playing input is reported with the same name used in the source list.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
 
 
-async def test_select_source_by_label(
-    hass: HomeAssistant, set_play_content: AsyncMock
+@pytest.mark.parametrize(
+    ("source", "expected_uri"),
+    [
+        # The label of a renamed input.
+        ("Game console", "extInput:hdmi?port=2"),
+        # The generic name of that same input, still accepted so that existing
+        # automations keep working after the input is renamed on the TV.
+        ("HDMI 2", "extInput:hdmi?port=2"),
+        # An input sharing a label with another one remains selectable.
+        ("HDMI 3", "extInput:hdmi?port=3"),
+    ],
+)
+async def test_select_source(
+    hass: HomeAssistant, set_play_content: AsyncMock, source: str, expected_uri: str
 ) -> None:
-    """Test that selecting a renamed input resolves to the right uri."""
+    """Test selecting an input by label or by generic name."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_SELECT_SOURCE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Game console"},
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: source},
         blocking=True,
     )
 
-    set_play_content.assert_called_once_with("extInput:hdmi?port=2")
+    set_play_content.assert_called_once_with(expected_uri)

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -84,6 +84,13 @@ INPUTS = [
         "label": "Streaming box",
         "icon": "meta:cec",
     },
+    {
+        "uri": "extInput:composite?port=1",
+        "title": "Streaming box (2)",
+        "connection": False,
+        "label": "",
+        "icon": "meta:composite",
+    },
 ]
 
 PLAYING_INFO = {"uri": "extInput:hdmi?port=2", "title": "HDMI 2", "source": "HDMI"}
@@ -134,19 +141,13 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     # "HDMI 3" repeats the same label, so it falls back to the generic name to
     # stay reachable.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
-        # No label, so it keeps its generic name.
         "HDMI 1",
-        # Renamed on the TV.
         "Game console",
-        # Repeats the label of the previous input.
         "HDMI 3",
-        # Labelled with the generic name of another input.
         "HDMI 4",
-        # Same, differing only in case.
         "HDMI 5",
-        # Reported with a label but no generic name at all.
         "Streaming box",
-        # Same, with the label already taken and no generic name to fall back to.
+        "Streaming box (3)",
         "Streaming box (2)",
     ]
     # The playing input is reported with the same name used in the source list.
@@ -156,22 +157,25 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("source", "expected_uri"),
     [
-        # The label of a renamed input.
-        ("Game console", "extInput:hdmi?port=2"),
-        # The generic name of that same input, still accepted so that existing
-        # automations keep working after the input is renamed on the TV.
-        ("HDMI 2", "extInput:hdmi?port=2"),
-        # An input sharing a label with another one remains selectable.
-        ("HDMI 3", "extInput:hdmi?port=3"),
-        # A label may not steal the generic name of a different input.
-        ("HDMI 1", "extInput:hdmi?port=1"),
-        ("HDMI 4", "extInput:hdmi?port=4"),
-        # A label may not steal it in a different case either.
-        ("HDMI 5", "extInput:hdmi?port=5"),
-        # An input reported with a label but no title is selectable too.
-        ("Streaming box", "extInput:cec?type=player&port=1"),
-        # And it keeps a distinct name when that label is already taken.
-        ("Streaming box (2)", "extInput:cec?type=player&port=2"),
+        pytest.param("Game console", "extInput:hdmi?port=2", id="label"),
+        pytest.param("HDMI 2", "extInput:hdmi?port=2", id="generic_name_of_labelled"),
+        pytest.param("HDMI 3", "extInput:hdmi?port=3", id="shared_label"),
+        pytest.param("HDMI 1", "extInput:hdmi?port=1", id="generic_name_not_stolen"),
+        pytest.param("HDMI 4", "extInput:hdmi?port=4", id="label_of_another_input"),
+        pytest.param("HDMI 5", "extInput:hdmi?port=5", id="label_differing_in_case"),
+        pytest.param(
+            "Streaming box", "extInput:cec?type=player&port=1", id="label_without_title"
+        ),
+        pytest.param(
+            "Streaming box (3)",
+            "extInput:cec?type=player&port=2",
+            id="generated_name_avoids_generic_name",
+        ),
+        pytest.param(
+            "Streaming box (2)",
+            "extInput:composite?port=1",
+            id="generic_name_kept_by_its_own_input",
+        ),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -66,7 +66,20 @@ INPUTS = [
         "icon": "meta:hdmi",
     },
     {
+        "uri": "extInput:hdmi?port=5",
+        "title": "HDMI 5",
+        "connection": True,
+        "label": "hdmi 1",
+        "icon": "meta:hdmi",
+    },
+    {
         "uri": "extInput:cec?type=player&port=1",
+        "connection": True,
+        "label": "Streaming box",
+        "icon": "meta:cec",
+    },
+    {
+        "uri": "extInput:cec?type=player&port=2",
         "connection": True,
         "label": "Streaming box",
         "icon": "meta:cec",
@@ -129,8 +142,12 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         "HDMI 3",
         # Labelled with the generic name of another input.
         "HDMI 4",
+        # Same, differing only in case.
+        "HDMI 5",
         # Reported with a label but no generic name at all.
         "Streaming box",
+        # Same, with the label already taken and no generic name to fall back to.
+        "Streaming box (2)",
     ]
     # The playing input is reported with the same name used in the source list.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
@@ -149,8 +166,12 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         # A label may not steal the generic name of a different input.
         ("HDMI 1", "extInput:hdmi?port=1"),
         ("HDMI 4", "extInput:hdmi?port=4"),
+        # A label may not steal it in a different case either.
+        ("HDMI 5", "extInput:hdmi?port=5"),
         # An input reported with a label but no title is selectable too.
         ("Streaming box", "extInput:cec?type=player&port=1"),
+        # And it keeps a distinct name when that label is already taken.
+        ("Streaming box (2)", "extInput:cec?type=player&port=2"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -34,7 +34,8 @@ BRAVIA_SYSTEM_INFO = {
 }
 
 # "title" is the generic connector name, "label" the name set on the TV itself.
-# The TV allows the same label on several inputs, and leaves it empty when unset.
+# The TV leaves the label empty when unset, allows the same label on several
+# inputs, and does not stop a label from matching another input's generic name.
 INPUTS = [
     {
         "uri": "extInput:hdmi?port=1",
@@ -56,6 +57,19 @@ INPUTS = [
         "connection": True,
         "label": "Game console",
         "icon": "meta:hdmi",
+    },
+    {
+        "uri": "extInput:hdmi?port=4",
+        "title": "HDMI 4",
+        "connection": True,
+        "label": "HDMI 1",
+        "icon": "meta:hdmi",
+    },
+    {
+        "uri": "extInput:cec?type=player&port=1",
+        "connection": True,
+        "label": "Streaming box",
+        "icon": "meta:cec",
     },
 ]
 
@@ -107,9 +121,16 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     # "HDMI 3" repeats the same label, so it falls back to the generic name to
     # stay reachable.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
+        # No label, so it keeps its generic name.
         "HDMI 1",
+        # Renamed on the TV.
         "Game console",
+        # Repeats the label of the previous input.
         "HDMI 3",
+        # Labelled with the generic name of another input.
+        "HDMI 4",
+        # Reported with a label but no generic name at all.
+        "Streaming box",
     ]
     # The playing input is reported with the same name used in the source list.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
@@ -125,6 +146,11 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         ("HDMI 2", "extInput:hdmi?port=2"),
         # An input sharing a label with another one remains selectable.
         ("HDMI 3", "extInput:hdmi?port=3"),
+        # A label may not steal the generic name of a different input.
+        ("HDMI 1", "extInput:hdmi?port=1"),
+        ("HDMI 4", "extInput:hdmi?port=4"),
+        # An input reported with a label but no title is selectable too.
+        ("Streaming box", "extInput:cec?type=player&port=1"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -91,6 +91,13 @@ INPUTS = [
         "label": "",
         "icon": "meta:composite",
     },
+    {
+        "uri": "extInput:scart?port=1",
+        "title": "AV1",
+        "connection": False,
+        "label": "Stra\u00dfe",
+        "icon": "meta:scart",
+    },
 ]
 
 PLAYING_INFO = {"uri": "extInput:hdmi?port=2", "title": "HDMI 2", "source": "HDMI"}
@@ -149,6 +156,7 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         "Streaming box",
         "Streaming box (3)",
         "Streaming box (2)",
+        "Stra\u00dfe",
     ]
     # The playing input is reported with the same name used in the source list.
     assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
@@ -176,6 +184,7 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
             "extInput:composite?port=1",
             id="generic_name_kept_by_its_own_input",
         ),
+        pytest.param("STRASSE", "extInput:scart?port=1", id="unicode_case_folding"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -1,0 +1,115 @@
+"""Test the Bravia TV media player."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.braviatv.const import CONF_USE_PSK, DOMAIN
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    ATTR_INPUT_SOURCE_LIST,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOURCE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MAC, CONF_PIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "media_player.bravia_tv_model"
+
+BRAVIA_SYSTEM_INFO = {
+    "product": "TV",
+    "region": "XEU",
+    "language": "pol",
+    "model": "TV-Model",
+    "serial": "serial_number",
+    "macAddr": "AA:BB:CC:DD:EE:FF",
+    "name": "BRAVIA",
+    "generation": "5.2.0",
+    "area": "POL",
+    "cid": "very_unique_string",
+}
+
+# "title" is the generic connector name, "label" the name set on the TV itself.
+INPUTS = [
+    {
+        "uri": "extInput:hdmi?port=1",
+        "title": "HDMI 1",
+        "connection": False,
+        "label": "",
+        "icon": "meta:hdmi",
+    },
+    {
+        "uri": "extInput:hdmi?port=2",
+        "title": "HDMI 2",
+        "connection": True,
+        "label": "Game console",
+        "icon": "meta:hdmi",
+    },
+]
+
+PLAYING_INFO = {"uri": "extInput:hdmi?port=2", "title": "HDMI 2", "source": "HDMI"}
+
+
+@pytest.fixture
+async def set_play_content(hass: HomeAssistant) -> AsyncGenerator[AsyncMock]:
+    """Set up the integration and yield the mocked set_play_content."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="BRAVIA TV-Model",
+        data={
+            CONF_HOST: "localhost",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+            CONF_USE_PSK: True,
+            CONF_PIN: "12345qwerty",
+        },
+        unique_id="very_unique_string",
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch("pybravia.BraviaClient.connect"),
+        patch("pybravia.BraviaClient.pair"),
+        patch("pybravia.BraviaClient.set_wol_mode"),
+        patch("pybravia.BraviaClient.get_system_info", return_value=BRAVIA_SYSTEM_INFO),
+        patch("pybravia.BraviaClient.get_power_status", return_value="active"),
+        patch("pybravia.BraviaClient.get_external_status", return_value=INPUTS),
+        patch("pybravia.BraviaClient.get_volume_info", return_value={}),
+        patch("pybravia.BraviaClient.get_playing_info", return_value=PLAYING_INFO),
+        patch("pybravia.BraviaClient.get_app_list", return_value=[]),
+        patch("pybravia.BraviaClient.get_content_list_all", return_value=[]),
+        patch("pybravia.BraviaClient.get_command_list", return_value=[]),
+        patch("pybravia.BraviaClient.set_play_content") as mock_set_play_content,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        yield mock_set_play_content
+
+
+@pytest.mark.usefixtures("set_play_content")
+async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
+    """Test that an input renamed on the TV is exposed with that name."""
+    state = hass.states.get(ENTITY_ID)
+
+    assert state is not None
+    # "HDMI 1" has no label and keeps the generic name, "HDMI 2" was renamed.
+    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI 1", "Game console"]
+    # The playing input is reported with the same name used in the source list.
+    assert state.attributes[ATTR_INPUT_SOURCE] == "Game console"
+
+
+async def test_select_source_by_label(
+    hass: HomeAssistant, set_play_content: AsyncMock
+) -> None:
+    """Test that selecting a renamed input resolves to the right uri."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Game console"},
+        blocking=True,
+    )
+
+    set_play_content.assert_called_once_with("extInput:hdmi?port=2")

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -33,9 +33,8 @@ BRAVIA_SYSTEM_INFO = {
     "cid": "very_unique_string",
 }
 
-# "title" is the generic connector name, "label" the name set on the TV itself.
-# The TV leaves the label empty when unset, allows the same label on several
-# inputs, and does not stop a label from matching another input's generic name.
+# The TV leaves "label" empty when unset, allows the same label on several
+# inputs, and does not stop one matching another input's "title".
 INPUTS = [
     {
         "uri": "extInput:hdmi?port=1",
@@ -151,9 +150,8 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_ID)
 
     assert state is not None
-    # "HDMI 1" has an empty label and "HDMI 6" no label key at all, so both keep
-    # the generic name. "HDMI 2" was renamed, and "HDMI 3" repeats the same
-    # label, so it falls back to the generic name to stay reachable.
+    # "HDMI 3" repeats "HDMI 2"'s label, so it falls back to its own generic
+    # name to stay reachable.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
         "HDMI 1",
         "Game console",
@@ -173,27 +171,17 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("source", "expected_uri"),
     [
-        pytest.param("Game console", "extInput:hdmi?port=2", id="label"),
-        pytest.param("HDMI 2", "extInput:hdmi?port=2", id="generic_name_of_labelled"),
-        pytest.param("HDMI 3", "extInput:hdmi?port=3", id="shared_label"),
-        pytest.param("HDMI 1", "extInput:hdmi?port=1", id="generic_name_not_stolen"),
-        pytest.param("HDMI 4", "extInput:hdmi?port=4", id="label_of_another_input"),
-        pytest.param("HDMI 5", "extInput:hdmi?port=5", id="label_differing_in_case"),
-        pytest.param("HDMI 6", "extInput:hdmi?port=6", id="no_label_key"),
-        pytest.param(
-            "Streaming box", "extInput:cec?type=player&port=1", id="label_without_title"
-        ),
-        pytest.param(
-            "Streaming box (3)",
-            "extInput:cec?type=player&port=2",
-            id="generated_name_avoids_generic_name",
-        ),
-        pytest.param(
-            "Streaming box (2)",
-            "extInput:composite?port=1",
-            id="generic_name_kept_by_its_own_input",
-        ),
-        pytest.param("STRASSE", "extInput:scart?port=1", id="unicode_case_folding"),
+        ("Game console", "extInput:hdmi?port=2"),
+        ("HDMI 2", "extInput:hdmi?port=2"),
+        ("HDMI 3", "extInput:hdmi?port=3"),
+        ("HDMI 1", "extInput:hdmi?port=1"),
+        ("HDMI 4", "extInput:hdmi?port=4"),
+        ("HDMI 5", "extInput:hdmi?port=5"),
+        ("HDMI 6", "extInput:hdmi?port=6"),
+        ("Streaming box", "extInput:cec?type=player&port=1"),
+        ("Streaming box (3)", "extInput:cec?type=player&port=2"),
+        ("Streaming box (2)", "extInput:composite?port=1"),
+        ("STRASSE", "extInput:scart?port=1"),
     ],
 )
 async def test_select_source(

--- a/tests/components/braviatv/test_media_player.py
+++ b/tests/components/braviatv/test_media_player.py
@@ -73,6 +73,13 @@ INPUTS = [
         "icon": "meta:hdmi",
     },
     {
+        # Some models leave the key out entirely rather than sending it empty.
+        "uri": "extInput:hdmi?port=6",
+        "title": "HDMI 6",
+        "connection": True,
+        "icon": "meta:hdmi",
+    },
+    {
         "uri": "extInput:cec?type=player&port=1",
         "connection": True,
         "label": "Streaming box",
@@ -144,15 +151,16 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_ID)
 
     assert state is not None
-    # "HDMI 1" has no label and keeps the generic name, "HDMI 2" was renamed and
-    # "HDMI 3" repeats the same label, so it falls back to the generic name to
-    # stay reachable.
+    # "HDMI 1" has an empty label and "HDMI 6" no label key at all, so both keep
+    # the generic name. "HDMI 2" was renamed, and "HDMI 3" repeats the same
+    # label, so it falls back to the generic name to stay reachable.
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
         "HDMI 1",
         "Game console",
         "HDMI 3",
         "HDMI 4",
         "HDMI 5",
+        "HDMI 6",
         "Streaming box",
         "Streaming box (3)",
         "Streaming box (2)",
@@ -171,6 +179,7 @@ async def test_source_list_prefers_label(hass: HomeAssistant) -> None:
         pytest.param("HDMI 1", "extInput:hdmi?port=1", id="generic_name_not_stolen"),
         pytest.param("HDMI 4", "extInput:hdmi?port=4", id="label_of_another_input"),
         pytest.param("HDMI 5", "extInput:hdmi?port=5", id="label_differing_in_case"),
+        pytest.param("HDMI 6", "extInput:hdmi?port=6", id="no_label_key"),
         pytest.param(
             "Streaming box", "extInput:cec?type=player&port=1", id="label_without_title"
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Sony Bravia TVs let you rename each external input from the TV's own settings, and
`getCurrentExternalInputsStatus` returns both names:

- `title` — the generic connector name, e.g. `HDMI 4`
- `label` — the name set on the TV, empty when unset

The integration only reads `title`, so a renamed input still shows up as `HDMI 4`.

`_sources_extend` now takes `label` and falls back to `title`, so nothing changes for
anyone who has not renamed an input. Inputs that report only a `label` are exposed
instead of being dropped.

Two related spots keep this consistent:

- The display name is stored in `source_map` as `name`, leaving `title` untouched, and
  `async_source_find` matches either. Automations already calling `select_source` with
  the generic name keep working after a rename.
- `async_update_playing` resolves the current source through `source_map`, because
  `getPlayingContentInfo` always returns the generic name. Otherwise `source` would
  report a value that is not in `source_list`.

When two inputs end up with the same name, the source list keeps one entry rather than
inventing a suffix the TV never shows. This mirrors `webostv`, which keys its source
list by `label`. A generic name always wins over a label, so labelling an input with
another one's name cannot capture it from an automation.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
No new configuration option is introduced: the fallback chain already covers models
that do not report a `label`, and a user who renames an input on the TV is expressing
the name they want to see.

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




