### PR TITLE
Add ETag support to camera image proxy

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -8,6 +8,8 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from enum import IntFlag
 from functools import partial
+import hashlib
+from http import HTTPStatus
 import logging
 import os
 from random import SystemRandom
@@ -879,6 +881,17 @@ class CameraView(HomeAssistantView):
         raise NotImplementedError
 
 
+def _etag_matches(request: web.Request, etag: str) -> bool:
+    """Check a request's If-None-Match header against an ETag."""
+    if not (header := request.headers.get(hdrs.IF_NONE_MATCH)):
+        return False
+    if header.strip() == "*":
+        return True
+    return any(
+        candidate.strip().removeprefix("W/") == etag for candidate in header.split(",")
+    )
+
+
 class CameraImageView(CameraView):
     """Camera view to serve an image."""
 
@@ -900,7 +913,17 @@ class CameraImageView(CameraView):
         except (HomeAssistantError, ValueError) as ex:
             raise web.HTTPInternalServerError from ex
 
-        return web.Response(body=image.content, content_type=image.content_type)
+        etag = f'"{hashlib.sha256(image.content).hexdigest()}"'
+        if _etag_matches(request, etag):
+            return web.Response(
+                status=HTTPStatus.NOT_MODIFIED, headers={hdrs.ETAG: etag}
+            )
+
+        return web.Response(
+            body=image.content,
+            content_type=image.content_type,
+            headers={hdrs.ETAG: etag},
+        )
 
 
 class CameraMjpegStream(CameraView):

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -21,7 +21,7 @@ async def test_create_doorbell(
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
 
     with patch.object(
-        doorbell_one, "async_get_doorbell_image", create=False, return_value="image"
+        doorbell_one, "async_get_doorbell_image", create=False, return_value=b"image"
     ):
         await _create_august_with_devices(hass, [doorbell_one], brand=Brand.AUGUST)
 

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -742,6 +742,53 @@ async def test_camera_proxy_authenticated_unknown_entity(
 
 
 @pytest.mark.usefixtures("mock_camera")
+async def test_camera_proxy_not_modified(hass_client: ClientSessionGenerator) -> None:
+    """Test camera_proxy returns 304 with an empty body for an unchanged image."""
+    client = await hass_client()
+
+    resp = await client.get("/api/camera_proxy/camera.demo_camera")
+    assert resp.status == HTTPStatus.OK
+    etag = resp.headers[hdrs.ETAG]
+
+    resp = await client.get(
+        "/api/camera_proxy/camera.demo_camera", headers={hdrs.IF_NONE_MATCH: etag}
+    )
+    assert resp.status == HTTPStatus.NOT_MODIFIED
+    assert resp.headers[hdrs.ETAG] == etag
+    assert await resp.read() == b""
+
+
+@pytest.mark.usefixtures("mock_camera")
+@pytest.mark.parametrize(
+    ("if_none_match", "expected_status"),
+    [
+        pytest.param("{etag}", HTTPStatus.NOT_MODIFIED, id="exact"),
+        pytest.param("W/{etag}", HTTPStatus.NOT_MODIFIED, id="weak"),
+        pytest.param('"other", {etag}', HTTPStatus.NOT_MODIFIED, id="list"),
+        pytest.param("*", HTTPStatus.NOT_MODIFIED, id="any"),
+        pytest.param('"stale"', HTTPStatus.OK, id="mismatch"),
+        pytest.param("", HTTPStatus.OK, id="empty"),
+    ],
+)
+async def test_camera_proxy_if_none_match(
+    hass_client: ClientSessionGenerator,
+    if_none_match: str,
+    expected_status: HTTPStatus,
+) -> None:
+    """Test camera_proxy revalidation against the forms If-None-Match can take."""
+    client = await hass_client()
+
+    resp = await client.get("/api/camera_proxy/camera.demo_camera")
+    etag = resp.headers[hdrs.ETAG]
+
+    resp = await client.get(
+        "/api/camera_proxy/camera.demo_camera",
+        headers={hdrs.IF_NONE_MATCH: if_none_match.format(etag=etag)},
+    )
+    assert resp.status == expected_status
+
+
+@pytest.mark.usefixtures("mock_camera")
 async def test_state_streaming(hass: HomeAssistant) -> None:
     """Camera state."""
     demo_camera = hass.states.get("camera.demo_camera")

--- a/tests/components/yale/test_camera.py
+++ b/tests/components/yale/test_camera.py
@@ -21,7 +21,7 @@ async def test_create_doorbell(
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
 
     with patch.object(
-        doorbell_one, "async_get_doorbell_image", create=False, return_value="image"
+        doorbell_one, "async_get_doorbell_image", create=False, return_value=b"image"
     ):
         await _create_yale_with_devices(hass, [doorbell_one], brand=Brand.YALE_GLOBAL)
 
@@ -50,7 +50,7 @@ async def test_doorbell_refresh_content_token_recover(
         doorbell_two,
         "async_get_doorbell_image",
         create=False,
-        side_effect=[ContentTokenExpired, "image"],
+        side_effect=[ContentTokenExpired, b"image"],
     ):
         await _create_yale_with_devices(
             hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`CameraImageView` serves camera stills with no cache validators at all (no `ETag`, no `Last-Modified`, no `Cache-Control`) so every request transfers the full image body even when the image is byte-for-byte identical to the previous response.

This PR adds a strong `ETag` (SHA-256 of the response body) to `/api/camera_proxy/{entity_id}` and returns `304 Not Modified` when a request carries a matching `If-None-Match`.

The motivation is the frontend's still-camera view, which re-fetches the image on a fixed 10 second timer regardless of how often the camera updates. For a camera backed by a coordinator refreshing every 5 minutes, 29 of every 30 requests transfer bytes the client already has. That is negligible for a small JPEG snapshot but significant for large payloads: an Environment Canada radar loop is a ~2 MB animated GIF, so a single open dashboard pulls roughly 700 MB/hour, almost all of it redundant.

The companion frontend PR sends `If-None-Match` and leaves the rendered image untouched on a 304. That also fixes a visible bug: animated camera images (GIF/WebP) currently restart from the first frame on every poll, so a loop longer than the refresh interval never plays to the end.

Notes for reviewers:

- `If-None-Match` is matched against an exact tag, a weak tag (`W/"…"`), a comma-separated list, and `*`.
- The image is still fetched from the camera before the ETag can be computed, so this saves response bandwidth, not the upstream camera fetch.
- Hashing costs roughly 0.04 ms for a typical 100 KB JPEG and 1 ms for a 2 MB animation.
- No caching headers are added, so behaviour is unchanged for any client that does not send `If-None-Match`.

Measured against a local instance with the companion frontend change, on a camera serving a 96,743 byte animated GIF that changes every 5 minutes: over a ~100 second window the frontend went from 10 full downloads out of 10 polls to 1 out of 13, transferring 96,743 bytes instead of 967,430.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53563

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
