### PR TITLE
Bump evohome-async to v2.1.0

### DIFF
--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -20,7 +20,7 @@ from evohomeasync2.const import (
     SZ_USE_DAYLIGHT_SAVE_SWITCHING,
     SZ_ZONES,
 )
-from evohomeasync2.typedefs import EvoLocStatusResponseT, EvoTcsConfigResponseT
+from evohomeasync2.typedefs import EvoLocStatusT, EvoTcsConfigResponseT
 
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -60,7 +60,7 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.loc_idx = location_idx
 
-        self.data: EvoLocStatusResponseT = None  # type: ignore[assignment]
+        self.data: EvoLocStatusT = None  # type: ignore[assignment]
         self.temps: dict[str, float | None] = {}
 
         self._first_refresh_done = False  # get schedules only after first refresh
@@ -114,8 +114,10 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
                     SZ_USE_DAYLIGHT_SAVE_SWITCHING
                 ],
             }
-            tcs_info: EvoTcsConfigResponseT = self.tcs.config  # type: ignore[assignment]
-            tcs_info[SZ_ZONES] = [zone.config for zone in self.tcs.zones]
+            tcs_info: EvoTcsConfigResponseT = {
+                **self.tcs.config,
+                SZ_ZONES: [zone.config for zone in self.tcs.zones],
+            }
             if self.tcs.hotwater:
                 tcs_info[SZ_DHW] = self.tcs.hotwater.config
             gwy_info = {
@@ -223,7 +225,7 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
                 self.logger.warning("DHW has an invalid/missing schedule: %r", err)
 
     @override
-    async def _async_update_data(self) -> EvoLocStatusResponseT:  # type: ignore[override]
+    async def _async_update_data(self) -> EvoLocStatusT:  # type: ignore[override]
         """Fetch the latest state of an entire TCC Location.
 
         This includes state data for a Controller and all its child devices, such as the

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -64,6 +64,7 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         self.temps: dict[str, float | None] = {}
 
         self._first_refresh_done = False  # get schedules only after first refresh
+        self._v1_temps_warned = False  # only log v1 API faults once, until resolved
 
     # our version of async_config_entry_first_refresh()...
     async def async_first_refresh(self) -> None:
@@ -158,7 +159,7 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.client_v1.update()
 
-        except ec1.BadUserCredentialsError as err:
+        except (ec1.BadUserCredentialsError, ec1.BadApiSchemaError) as err:
             self.logger.warning(
                 (
                     "Unable to obtain high-precision temperatures. "
@@ -169,16 +170,21 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
             self.client_v1 = None
 
         except ec1.EvohomeError as err:
-            self.logger.warning(
-                (
-                    "Unable to obtain the latest high-precision temperatures. "
-                    "They will be ignored this refresh cycle: %r"
-                ),
-                err,
-            )
+            if not self._v1_temps_warned:
+                self.logger.warning(
+                    (
+                        "Unable to obtain the latest high-precision temperatures. "
+                        "They will be ignored until this feature recovers: %r"
+                    ),
+                    err,
+                )
+                self._v1_temps_warned = True
             self.temps = {}  # high-precision temps now considered stale
 
         else:
+            if self._v1_temps_warned:
+                self.logger.warning("High-precision temperatures are available again")
+                self._v1_temps_warned = False
             self.temps = await self.client_v1.location_by_id[
                 self.loc.id
             ].get_temperatures(dont_update_status=True)

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -64,7 +64,6 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         self.temps: dict[str, float | None] = {}
 
         self._first_refresh_done = False  # get schedules only after first refresh
-        self._v1_temps_warned = False  # only log v1 API faults once, until resolved
 
     # our version of async_config_entry_first_refresh()...
     async def async_first_refresh(self) -> None:
@@ -159,7 +158,7 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.client_v1.update()
 
-        except (ec1.BadUserCredentialsError, ec1.BadApiSchemaError) as err:
+        except ec1.BadUserCredentialsError as err:
             self.logger.warning(
                 (
                     "Unable to obtain high-precision temperatures. "
@@ -170,21 +169,16 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
             self.client_v1 = None
 
         except ec1.EvohomeError as err:
-            if not self._v1_temps_warned:
-                self.logger.warning(
-                    (
-                        "Unable to obtain the latest high-precision temperatures. "
-                        "They will be ignored until this feature recovers: %r"
-                    ),
-                    err,
-                )
-                self._v1_temps_warned = True
+            self.logger.warning(
+                (
+                    "Unable to obtain the latest high-precision temperatures. "
+                    "They will be ignored this refresh cycle: %r"
+                ),
+                err,
+            )
             self.temps = {}  # high-precision temps now considered stale
 
         else:
-            if self._v1_temps_warned:
-                self.logger.warning("High-precision temperatures are available again")
-                self._v1_temps_warned = False
             self.temps = await self.client_v1.location_by_id[
                 self.loc.id
             ].get_temperatures(dont_update_status=True)

--- a/homeassistant/components/evohome/entity.py
+++ b/homeassistant/components/evohome/entity.py
@@ -14,7 +14,7 @@ from evohomeasync2.const import (
     ZoneModelType as EvoZoneModelType,
     ZoneType as EvoZoneType,
 )
-from evohomeasync2.typedefs import EvoDayOfWeekDhwT
+from evohomeasync2.typedefs import EvoDhwScheduleDayOfWeekT, EvoZonScheduleDayOfWeekT
 
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -118,7 +118,9 @@ class EvoChild(EvoEntity):
         self._evo_id = evo_device.id
         self._evo_tcs = evo_device.tcs
 
-        self._schedule: list[EvoDayOfWeekDhwT] | None = None
+        self._schedule: (
+            list[EvoDhwScheduleDayOfWeekT] | list[EvoZonScheduleDayOfWeekT] | None
+        ) = None
         self._setpoints: dict[str, Any] = {}
 
     @property

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["evohomeasync", "evohomeasync2"],
   "quality_scale": "legacy",
-  "requirements": ["evohome-async==2.0.1"]
+  "requirements": ["evohome-async==2.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -982,7 +982,7 @@ eurotronic-cometblue-ha==1.4.0
 # evdev==1.9.3
 
 # homeassistant.components.evohome
-evohome-async==2.0.1
+evohome-async==2.1.0
 
 # homeassistant.components.bryant_evolution
 evolutionhttp==0.0.19


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
> Devs, please cherry pick this PR for next point-release as it fixes significant bugs

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `evohome-async` from 2.0.1 to 2.1.0:

- Changelog: https://github.com/zxdavb/evohome-async/releases/tag/v2.1.0
- Diff: https://github.com/zxdavb/evohome-async/compare/v2.0.1...v2.1.0

This upstream release fixes two schema-validation bugs that were causing user-facing errors.

- the v2 API's `active_faults[].fault_type` schema now tolerates unknown/new fault types instead of raising (#178493), which cased evohome to fail to start

- the v1 (high-precision temperature) API's location schema no longer requires a `weather` key, which was rarely absent, falling back to standard precision, and causing logspam (#178510)

The latter bug is not completely addressed by this PR - there is still a matter of logspam to resolve; that will be in a subsequent PR (that can wait until next release).

This PR also updates type hints to match improvements made in the latest evohome client.

The evohome client uses voluptuous schemas to convert JSON values to snake_case. Thus, they are now required, were before they were optional. As a consequence, any validation failure is now a show-stopper (raises an excpetion), where before it merely generated a warning to the user. 

The main change in the client is to make unreferenced keys `vol.Optional` rather than `vol.Required`, whihc handles edge-cases where they are not present (the API is undocumented).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178493
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.


<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
