### PR TITLE
Fix Mikrotik health sensors matching by name

### DIFF
--- a/homeassistant/components/mikrotik/sensor.py
+++ b/homeassistant/components/mikrotik/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from math import isfinite
 from typing import Any, Final, override
 
 from homeassistant.components.sensor import (
@@ -62,9 +63,12 @@ def _health_numeric_value(data: dict[str, Any]) -> float | None:
     if value is None:
         return None
     try:
-        return float(value)
+        numeric = float(value)
     except TypeError, ValueError:
         return None
+    if not isfinite(numeric):
+        return None
+    return numeric
 
 
 def _calculate_uptime(data: dict[str, Any]) -> datetime | None:

--- a/homeassistant/components/mikrotik/sensor.py
+++ b/homeassistant/components/mikrotik/sensor.py
@@ -1,6 +1,6 @@
 """Support for Mikrotik routers sensors."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Final, override
@@ -35,7 +35,36 @@ class MikrotikSensorEntityDescription(SensorEntityDescription):
 
     value: Callable[[dict[str, Any]], StateType | datetime]
     type: str
-    index: int
+    # Resource sensors are a single dict; health sensors are matched by name.
+    index: int = 0
+    # Preferred health metric names in priority order (first match wins).
+    data_names: tuple[str, ...] | None = None
+
+
+def _find_named_entry(
+    data_list: Sequence[dict[str, Any]], names: tuple[str, ...]
+) -> dict[str, Any] | None:
+    """Return the first health entry whose name is in names."""
+    by_name = {
+        entry["name"]: entry
+        for entry in data_list
+        if isinstance(entry.get("name"), str)
+    }
+    for name in names:
+        if name in by_name:
+            return by_name[name]
+    return None
+
+
+def _health_numeric_value(data: dict[str, Any]) -> float | None:
+    """Return a numeric health value, or None if not numeric."""
+    value = data.get("value")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except TypeError, ValueError:
+        return None
 
 
 def _calculate_uptime(data: dict[str, Any]) -> datetime | None:
@@ -79,18 +108,19 @@ SENSORS: Final = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value=lambda _data: _data["value"],
+        value=_health_numeric_value,
         type=HEALTH,
-        index=1,
+        # Newer boards expose cpu-temperature instead of temperature.
+        data_names=("temperature", "cpu-temperature"),
     ),
     MikrotikSensorEntityDescription(
         key="voltage",
         device_class=SensorDeviceClass.VOLTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        value=lambda _data: _data["value"],
+        value=_health_numeric_value,
         type=HEALTH,
-        index=0,
+        data_names=("voltage",),
     ),
     MikrotikSensorEntityDescription(
         key="cpu-load",
@@ -143,6 +173,17 @@ SENSORS: Final = (
 )
 
 
+def _sensor_data_available(
+    sensors: dict[str, Any], description: MikrotikSensorEntityDescription
+) -> bool:
+    """Return whether the coordinator has data for this sensor description."""
+    data_list = sensors.get(description.type, [])
+    if description.data_names is not None:
+        entry = _find_named_entry(data_list, description.data_names)
+        return entry is not None and _health_numeric_value(entry) is not None
+    return len(data_list) >= description.index + 1
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: MikrotikConfigEntry,
@@ -155,8 +196,7 @@ async def async_setup_entry(
     sensors_list = [
         MikrotikSensorEntity(coordinator, sensor_desc)
         for sensor_desc in SENSORS
-        if len(coordinator.api.sensors.get(sensor_desc.type, []))
-        >= (sensor_desc.index + 1)
+        if _sensor_data_available(coordinator.api.sensors, sensor_desc)
     ]
 
     async_add_entities(sensors_list)
@@ -172,6 +212,13 @@ class MikrotikSensorEntity(MikrotikEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         data_list = self.coordinator.api.sensors[self.entity_description.type]
-        data_entry = data_list[self.entity_description.index]
+        if self.entity_description.data_names is not None:
+            data_entry = _find_named_entry(
+                data_list, self.entity_description.data_names
+            )
+            if data_entry is None:
+                return None
+        else:
+            data_entry = data_list[self.entity_description.index]
 
         return self.entity_description.value(data_entry)

--- a/tests/components/mikrotik/test_sensor.py
+++ b/tests/components/mikrotik/test_sensor.py
@@ -87,15 +87,30 @@ async def test_sensor_named_health_metrics(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.mikrotik_voltage") is None
 
 
-async def test_sensor_non_numeric_health_value(hass: HomeAssistant) -> None:
-    """Test non-numeric health values do not create temperature/voltage sensors."""
-    await setup_mikrotik_entry(
-        hass,
-        health_data=[
-            {"name": "temperature", "value": "ok"},
-            {"name": "voltage", "value": "ok"},
-        ],
-    )
+@pytest.mark.parametrize(
+    "health_data",
+    [
+        pytest.param(
+            [
+                {"name": "temperature", "value": "ok"},
+                {"name": "voltage", "value": "ok"},
+            ],
+            id="non_numeric_string",
+        ),
+        pytest.param(
+            [
+                {"name": "temperature", "value": "nan"},
+                {"name": "voltage", "value": "inf"},
+            ],
+            id="non_finite",
+        ),
+    ],
+)
+async def test_sensor_invalid_health_value(
+    hass: HomeAssistant, health_data: list[dict[str, str]]
+) -> None:
+    """Test invalid health values do not create temperature/voltage sensors."""
+    await setup_mikrotik_entry(hass, health_data=health_data)
 
     assert hass.states.get("sensor.mikrotik_temperature") is None
     assert hass.states.get("sensor.mikrotik_voltage") is None

--- a/tests/components/mikrotik/test_sensor.py
+++ b/tests/components/mikrotik/test_sensor.py
@@ -64,6 +64,43 @@ async def test_sensor_wrong_data(hass: HomeAssistant) -> None:
     assert (state := hass.states.get("sensor.mikrotik_uptime")) is None
 
 
+async def test_sensor_named_health_metrics(hass: HomeAssistant) -> None:
+    """Test health sensors match by name, not list position.
+
+    Newer RouterOS boards expose cpu-temperature and status strings like
+    fan-state=ok at positions that older boards used for temperature/voltage.
+    """
+    await setup_mikrotik_entry(
+        hass,
+        health_data=[
+            {"name": "cpu-temperature", "value": 57, "type": "C"},
+            {"name": "fan-state", "value": "ok", "type": ""},
+            {"name": "fan1-speed", "value": 3855, "type": "RPM"},
+            {"name": "board-temperature1", "value": 38, "type": "C"},
+            {"name": "psu1-state", "value": "ok", "type": ""},
+        ],
+    )
+
+    assert (state := hass.states.get("sensor.mikrotik_temperature"))
+    assert state.state == "57.0"
+
+    assert hass.states.get("sensor.mikrotik_voltage") is None
+
+
+async def test_sensor_non_numeric_health_value(hass: HomeAssistant) -> None:
+    """Test non-numeric health values do not create temperature/voltage sensors."""
+    await setup_mikrotik_entry(
+        hass,
+        health_data=[
+            {"name": "temperature", "value": "ok"},
+            {"name": "voltage", "value": "ok"},
+        ],
+    )
+
+    assert hass.states.get("sensor.mikrotik_temperature") is None
+    assert hass.states.get("sensor.mikrotik_voltage") is None
+
+
 @pytest.mark.parametrize(
     "uptime_api",
     [


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mikrotik health sensors were matched by fixed list index (`voltage` at 0, `temperature` at 1). On newer RouterOS boards (e.g. CCR2004, CRS804), `/system/health/print` returns named metrics in a different order, so index 1 can be `fan-state: ok` instead of temperature. That caused:

```
ValueError: Sensor sensor.ccr2004_temperature has device class 'temperature' ... non-numeric value: 'ok'
```

This change matches health metrics by `name` (with fallbacks such as `temperature` → `cpu-temperature`), skips non-numeric values, and keeps resource sensors index-based.

Verified against live CCR2004 and CRS804 devices and existing mikrotik tests.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr