### PR TITLE
Add `handle_safe_area` opt-out to `panel_custom` and fix KNX panel

### DIFF
--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -104,6 +104,7 @@ async def register_panel(hass: HomeAssistant) -> None:
             module_url=f"{URL_BASE}/{knx_panel.entrypoint_js}",
             embed_iframe=True,
             require_admin=True,
+            handle_safe_area=True,
         )
 
 

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -90,9 +90,6 @@ async def async_register_panel(
     embed_iframe: bool = DEFAULT_EMBED_IFRAME,
     # Should user be asked for confirmation when loading external source
     trust_external: bool = DEFAULT_TRUST_EXTERNAL,
-    # If your panel handles the safe area insets itself, opting out of the
-    # padding Home Assistant would otherwise add around it
-    handle_safe_area: bool = DEFAULT_HANDLE_SAFE_AREA,
     # Configuration to be passed to the panel
     config: ConfigType | None = None,
     # If your panel should only be shown to admin users
@@ -100,6 +97,9 @@ async def async_register_panel(
     # If your panel is used to configure an integration,
     # needs the domain of the integration
     config_panel_domain: str | None = None,
+    # If your panel handles the safe area insets itself, opting out of the
+    # padding Home Assistant would otherwise add around it
+    handle_safe_area: bool = DEFAULT_HANDLE_SAFE_AREA,
 ) -> None:
     """Register a new custom panel."""
     if js_url is None and module_url is None:

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -23,9 +23,11 @@ CONF_EMBED_IFRAME = "embed_iframe"
 CONF_TRUST_EXTERNAL_SCRIPT = "trust_external_script"
 CONF_URL_EXCLUSIVE_GROUP = "url_exclusive_group"
 CONF_REQUIRE_ADMIN = "require_admin"
+CONF_HANDLE_SAFE_AREA = "handle_safe_area"
 
 DEFAULT_EMBED_IFRAME = False
 DEFAULT_TRUST_EXTERNAL = False
+DEFAULT_HANDLE_SAFE_AREA = False
 
 DEFAULT_ICON = "mdi:bookmark"
 LEGACY_URL = "/api/panel_custom/{}"
@@ -59,6 +61,9 @@ CONFIG_SCHEMA = vol.Schema(
                             default=DEFAULT_TRUST_EXTERNAL,
                         ): cv.boolean,
                         vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
+                        vol.Optional(
+                            CONF_HANDLE_SAFE_AREA, default=DEFAULT_HANDLE_SAFE_AREA
+                        ): cv.boolean,
                     }
                 ),
             ],
@@ -85,6 +90,9 @@ async def async_register_panel(
     embed_iframe: bool = DEFAULT_EMBED_IFRAME,
     # Should user be asked for confirmation when loading external source
     trust_external: bool = DEFAULT_TRUST_EXTERNAL,
+    # If your panel handles the safe area insets itself, opting out of the
+    # padding Home Assistant would otherwise add around it
+    handle_safe_area: bool = DEFAULT_HANDLE_SAFE_AREA,
     # Configuration to be passed to the panel
     config: ConfigType | None = None,
     # If your panel should only be shown to admin users
@@ -103,6 +111,7 @@ async def async_register_panel(
         "name": webcomponent_name,
         "embed_iframe": embed_iframe,
         "trust_external": trust_external,
+        "handle_safe_area": handle_safe_area,
     }
 
     if js_url is not None:
@@ -148,6 +157,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             "trust_external": panel[CONF_TRUST_EXTERNAL_SCRIPT],
             "embed_iframe": panel[CONF_EMBED_IFRAME],
             "require_admin": panel[CONF_REQUIRE_ADMIN],
+            "handle_safe_area": panel[CONF_HANDLE_SAFE_AREA],
         }
 
         if CONF_JS_URL in panel:

--- a/tests/components/panel_custom/test_init.py
+++ b/tests/components/panel_custom/test_init.py
@@ -61,6 +61,7 @@ async def test_js_webcomponent(hass: HomeAssistant) -> None:
             "name": "todo-mvc",
             "embed_iframe": True,
             "trust_external": True,
+            "handle_safe_area": False,
         },
     }
     assert panel.frontend_url_path == "nice_url"
@@ -81,6 +82,7 @@ async def test_module_webcomponent(hass: HomeAssistant) -> None:
             "embed_iframe": True,
             "trust_external_script": True,
             "require_admin": True,
+            "handle_safe_area": True,
         }
     }
 
@@ -102,6 +104,7 @@ async def test_module_webcomponent(hass: HomeAssistant) -> None:
             "name": "todo-mvc",
             "embed_iframe": True,
             "trust_external": True,
+            "handle_safe_area": True,
         },
     }
     assert panel.frontend_url_path == "nice_url"
@@ -136,6 +139,7 @@ async def test_latest_and_es5_build(hass: HomeAssistant) -> None:
             "module_url": "/local/latest.js",
             "embed_iframe": False,
             "trust_external": False,
+            "handle_safe_area": False,
         },
     }
     assert panel.frontend_url_path == "nice_url"
@@ -169,6 +173,7 @@ async def test_register_config_panel(hass: HomeAssistant) -> None:
         embed_iframe=True,
         require_admin=True,
         config_panel_domain="test",
+        handle_safe_area=True,
     )
 
     panels = hass.data.get(frontend.DATA_PANELS, [])
@@ -183,6 +188,7 @@ async def test_register_config_panel(hass: HomeAssistant) -> None:
             "name": "custom-frontend",
             "embed_iframe": True,
             "trust_external": False,
+            "handle_safe_area": True,
         },
     }
     assert panel.frontend_url_path == "config_panel"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The frontend now pads custom panels for device safe areas (notch, home
indicator, status bar) by default, with an opt-out via
`_panel_custom.handle_safe_area` for panels that already handle the
insets themselves (frontend PR linked below). That opt-out was not
reachable from core: `panel_custom.async_register_panel` had no way to
set it, so any integration whose panel already deals with safe areas
would get the padding applied on top, doubling the inset.

This PR:
- Adds a `handle_safe_area` option to `panel_custom.async_register_panel`
  (and the `panel_custom:` YAML schema), defaulting to `False` so
  existing panels keep the current padding behavior.
- Opts the KNX panel into it (`handle_safe_area=True`), since it already
  handles the safe-area insets itself, fixing the doubled-padding
  regression introduced by the frontend change in the 2026.8 release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53127

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
