### PR TITLE
Avoid a naive datetime.now() in huawei_lte

### DIFF
--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -28,6 +28,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 
 from . import HuaweiLteConfigEntry, Router
 from .const import (
@@ -76,11 +77,10 @@ def format_last_reset_elapsed_seconds(value: str | None) -> datetime | None:
     if value is None:
         return None
     try:
-        last_reset = datetime.now() - timedelta(seconds=int(value))  # pylint: disable=home-assistant-enforce-naive-now
-        last_reset.replace(microsecond=0)
+        elapsed = timedelta(seconds=int(value))
     except ValueError:
         return None
-    return last_reset
+    return (dt_util.utcnow() - elapsed).replace(microsecond=0)
 
 
 def format_ipv6(value: StateType) -> tuple[StateType, str | None]:

--- a/tests/components/huawei_lte/test_sensor.py
+++ b/tests/components/huawei_lte/test_sensor.py
@@ -1,5 +1,8 @@
 """Huawei LTE sensor tests."""
 
+from datetime import timedelta
+
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.huawei_lte import sensor
@@ -7,6 +10,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
 )
+from homeassistant.util import dt as dt_util
 
 
 @pytest.mark.parametrize(
@@ -22,3 +26,34 @@ from homeassistant.const import (
 def test_format_default(value, expected) -> None:
     """Test that default formatter copes with expected values."""
     assert sensor.format_default(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_elapsed"),
+    [
+        ("0", timedelta(0)),
+        ("90", timedelta(seconds=90)),
+        ("86400", timedelta(days=1)),
+    ],
+)
+def test_format_last_reset_elapsed_seconds(
+    freezer: FrozenDateTimeFactory, value: str, expected_elapsed: timedelta
+) -> None:
+    """Test elapsed seconds are turned into an aware, truncated reset time."""
+    freezer.move_to("2026-01-02T03:04:05.678901+00:00")
+
+    result = sensor.format_last_reset_elapsed_seconds(value)
+
+    assert result is not None
+    # last_reset feeds long term statistics, which convert it with
+    # dt_util.as_utc, so a naive value would be read in the configured
+    # time zone rather than the host one.
+    assert result.tzinfo is not None
+    assert result.microsecond == 0
+    assert result == dt_util.utcnow().replace(microsecond=0) - expected_elapsed
+
+
+@pytest.mark.parametrize("value", [None, "", "not a number"])
+def test_format_last_reset_elapsed_seconds_invalid(value: str | None) -> None:
+    """Test values that cannot be converted are ignored."""
+    assert sensor.format_last_reset_elapsed_seconds(value) is None

--- a/tests/components/huawei_lte/test_sensor.py
+++ b/tests/components/huawei_lte/test_sensor.py
@@ -45,9 +45,6 @@ def test_format_last_reset_elapsed_seconds(
     result = sensor.format_last_reset_elapsed_seconds(value)
 
     assert result is not None
-    # last_reset feeds long term statistics, which convert it with
-    # dt_util.as_utc, so a naive value would be read in the configured
-    # time zone rather than the host one.
     assert result.tzinfo is not None
     assert result.microsecond == 0
     assert result == dt_util.utcnow().replace(microsecond=0) - expected_elapsed


### PR DESCRIPTION
﻿## Proposed change

`format_last_reset_elapsed_seconds` built `last_reset` from a naive
`datetime.now()`.

This one is not only cosmetic. `last_reset` feeds long term statistics, and
`sensor/recorder.py::_last_reset_as_utc_isoformat` converts it with
`dt_util.as_utc`, which reads a naive datetime as being in the **configured**
time zone. `datetime.now()` returns the **host** one. On an install where those
differ, for example a container running UTC with Home Assistant set to a local
zone, the recorded reset time is shifted by that offset. `dt_util.utcnow()`
removes the ambiguity.

While in there, the microsecond truncation was a no-op:

```python
last_reset = datetime.now() - timedelta(seconds=int(value))
last_reset.replace(microsecond=0)   # result discarded
return last_reset
```

`datetime.replace` returns a new object rather than mutating, so nothing was
ever truncated. The truncation now applies to the returned value, which is what
the line was clearly meant to do. Happy to split that into its own PR if you
would rather keep the two apart, though it is the same four line function.

The helper had no tests, so this adds them: timezone awareness, the truncation,
the elapsed arithmetic under a frozen clock, and the invalid input paths. They
fail on `dev`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177808
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

