### PR TITLE
Add status code sensor to Gatus integration

### DIFF
--- a/homeassistant/components/gatus/sensor.py
+++ b/homeassistant/components/gatus/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -41,6 +41,12 @@ SENSOR_TYPES: tuple[GatusSensorEntityDescription, ...] = (
             if result.duration is not None
             else None
         ),
+    ),
+    GatusSensorEntityDescription(
+        key="status_code",
+        translation_key="status_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda result: result.status,
     ),
 )
 

--- a/homeassistant/components/gatus/strings.json
+++ b/homeassistant/components/gatus/strings.json
@@ -33,6 +33,9 @@
     "sensor": {
       "response_time": {
         "name": "Response time"
+      },
+      "status_code": {
+        "name": "Status code"
       }
     }
   },

--- a/tests/components/gatus/snapshots/test_sensor.ambr
+++ b/tests/components/gatus/snapshots/test_sensor.ambr
@@ -57,3 +57,53 @@
     'state': '23.12',
   })
 # ---
+# name: test_sensor_setup_and_states[sensor.core_backend_service_status_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.core_backend_service_status_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Status code',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Status code',
+    'platform': 'gatus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'status_code',
+    'unique_id': '1234567890abcdef1234567890abcdef_backend_service_status_code',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup_and_states[sensor.core_backend_service_status_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Core Backend Service Status code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.core_backend_service_status_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '200',
+  })
+# ---

--- a/tests/components/gatus/test_sensor.py
+++ b/tests/components/gatus/test_sensor.py
@@ -61,11 +61,15 @@ async def test_sensor_dynamic_update(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that the sensor entity updates when the mock client returns new data."""
+    """Test that sensor entities update when the mock client returns new data."""
     await setup_integration(hass, mock_config_entry)
     state = hass.states.get("sensor.core_backend_service_response_time")
     assert state is not None
     assert state.state == "23.12"
+
+    status_code_state = hass.states.get("sensor.core_backend_service_status_code")
+    assert status_code_state is not None
+    assert status_code_state.state == "200"
 
     mock_data = await async_load_json_array_fixture(hass, "gatus/group.json")
 
@@ -81,13 +85,17 @@ async def test_sensor_dynamic_update(
     assert state is not None
     assert state.state == "45.0"
 
+    status_code_state = hass.states.get("sensor.core_backend_service_status_code")
+    assert status_code_state is not None
+    assert status_code_state.state == "500"
+
 
 async def test_sensor_no_group(
     hass: HomeAssistant,
     mock_gatus_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that the sensor entity is created correctly when an endpoint has no group."""
+    """Test that sensor entities are created correctly when an endpoint has no group."""
     mock_data = await async_load_json_array_fixture(hass, "gatus/no_group.json")
 
     mock_gatus_client.get_endpoints_statuses.return_value = _to_endpoint_statuses(
@@ -99,6 +107,10 @@ async def test_sensor_no_group(
     state = hass.states.get("sensor.backend_service_response_time")
     assert state is not None
     assert state.state == "12.5"
+
+    status_code_state = hass.states.get("sensor.backend_service_status_code")
+    assert status_code_state is not None
+    assert status_code_state.state == "200"
 
 
 async def test_sensor_empty_results(
@@ -122,6 +134,10 @@ async def test_sensor_empty_results(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
+    status_code_state = hass.states.get("sensor.backend_service_status_code")
+    assert status_code_state is not None
+    assert status_code_state.state == STATE_UNAVAILABLE
+
 
 async def test_sensor_missing_duration(
     hass: HomeAssistant,
@@ -141,5 +157,27 @@ async def test_sensor_missing_duration(
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get("sensor.backend_service_response_time")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_sensor_missing_status_code(
+    hass: HomeAssistant,
+    mock_gatus_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a result missing status code evaluates to STATE_UNKNOWN for status code sensor."""
+    mock_gatus_client.get_endpoints_statuses.return_value = [
+        EndpointStatus(
+            key="backend_service",
+            name="Backend Service",
+            group=None,
+            results=[Result(success=True, status=None, duration=12500000)],
+        )
+    ]
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.backend_service_status_code")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/gatus/test_sensor.py
+++ b/tests/components/gatus/test_sensor.py
@@ -61,15 +61,11 @@ async def test_sensor_dynamic_update(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that sensor entities update when the mock client returns new data."""
+    """Test that the sensor entity updates when the mock client returns new data."""
     await setup_integration(hass, mock_config_entry)
     state = hass.states.get("sensor.core_backend_service_response_time")
     assert state is not None
     assert state.state == "23.12"
-
-    status_code_state = hass.states.get("sensor.core_backend_service_status_code")
-    assert status_code_state is not None
-    assert status_code_state.state == "200"
 
     mock_data = await async_load_json_array_fixture(hass, "gatus/group.json")
 
@@ -85,17 +81,13 @@ async def test_sensor_dynamic_update(
     assert state is not None
     assert state.state == "45.0"
 
-    status_code_state = hass.states.get("sensor.core_backend_service_status_code")
-    assert status_code_state is not None
-    assert status_code_state.state == "500"
-
 
 async def test_sensor_no_group(
     hass: HomeAssistant,
     mock_gatus_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that sensor entities are created correctly when an endpoint has no group."""
+    """Test that the sensor entity is created correctly when an endpoint has no group."""
     mock_data = await async_load_json_array_fixture(hass, "gatus/no_group.json")
 
     mock_gatus_client.get_endpoints_statuses.return_value = _to_endpoint_statuses(
@@ -107,10 +99,6 @@ async def test_sensor_no_group(
     state = hass.states.get("sensor.backend_service_response_time")
     assert state is not None
     assert state.state == "12.5"
-
-    status_code_state = hass.states.get("sensor.backend_service_status_code")
-    assert status_code_state is not None
-    assert status_code_state.state == "200"
 
 
 async def test_sensor_empty_results(
@@ -133,10 +121,6 @@ async def test_sensor_empty_results(
     state = hass.states.get("sensor.backend_service_response_time")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
-
-    status_code_state = hass.states.get("sensor.backend_service_status_code")
-    assert status_code_state is not None
-    assert status_code_state.state == STATE_UNAVAILABLE
 
 
 async def test_sensor_missing_duration(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds http status code to Gatus endpoints

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47320
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
