### PR TITLE
Fix loading IP bans without banned_at

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -46,7 +46,7 @@ IP_BANS_FILE: Final = "ip_bans.yaml"
 ATTR_BANNED_AT: Final = "banned_at"
 
 SCHEMA_IP_BAN_ENTRY: Final = vol.Schema(
-    {vol.Optional("banned_at"): vol.Any(None, cv.datetime)}
+    {vol.Optional(ATTR_BANNED_AT, default=None): vol.Any(None, cv.datetime)}
 )
 
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -83,18 +83,19 @@ async def test_access_from_banned_ip_with_partially_broken_yaml_file(
     aiohttp_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test accessing to server from banned IP. Both trusted and not.
-
-    We inject some garbage into the yaml file to make sure it can
-    still load the bans.
-    """
+    """Test loading IP bans from a partially broken YAML file."""
     app = web.Application()
     app[KEY_HASS] = hass
     setup_bans(hass, app, 5)
     set_real_ip = mock_real_ip(app)
 
-    data = {banned_ip: {"banned_at": "2016-11-16T19:20:03"} for banned_ip in BANNED_IPS}
-    data["5.3.3.3"] = {"banned_at": "garbage"}
+    data = {
+        BANNED_IPS[0]: {"banned_at": "2016-11-16T19:20:03"},
+        "5.3.3.3": {"banned_at": "garbage"},
+        "5.3.3.4": {},
+        "5.3.3.5": None,
+        BANNED_IPS[1]: {"banned_at": "2016-11-16T19:20:03"},
+    }
 
     with patch(
         "homeassistant.components.http.ban.load_yaml_config_file",
@@ -102,17 +103,18 @@ async def test_access_from_banned_ip_with_partially_broken_yaml_file(
     ):
         client = await aiohttp_client(app)
 
-    for remote_addr in BANNED_IPS:
+    for remote_addr in (*BANNED_IPS, "5.3.3.4"):
         set_real_ip(remote_addr)
         resp = await client.get("/")
         assert resp.status == HTTPStatus.FORBIDDEN
 
-    # Ensure garbage data is ignored
-    set_real_ip("5.3.3.3")
-    resp = await client.get("/")
-    assert resp.status == HTTPStatus.NOT_FOUND
+    # Ensure malformed data is ignored
+    for remote_addr in ("5.3.3.3", "5.3.3.5"):
+        set_real_ip(remote_addr)
+        resp = await client.get("/")
+        assert resp.status == HTTPStatus.NOT_FOUND
 
-    assert "Failed to load IP ban" in caplog.text
+    assert caplog.text.count("Failed to load IP ban") == 2
 
 
 async def test_access_from_banned_ip_with_invalid_ip_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The IP ban entry schema allowed `banned_at` to be omitted, but the loader accessed the key unconditionally. This could raise a `KeyError` and prevent the HTTP server from starting.

Keep `banned_at` optional and have the schema supply `None` when it is missing. This preserves the existing behavior of assigning the current time while continuing to log and skip non-mapping entries, invalid timestamps, and invalid IP addresses. Valid bans before and after malformed entries continue to load.

Validated with the HTTP IP ban test suite and targeted Ruff and Pylint checks.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178387
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
