### PR TITLE
Increase MAX_CLIENT_SIZE to 128MB from 16MB

### DIFF
--- a/homeassistant/components/http/server.py
+++ b/homeassistant/components/http/server.py
@@ -66,7 +66,7 @@ from .web_runner import HomeAssistantUnixSite
 
 _LOGGER: Final = logging.getLogger(__name__)
 
-MAX_CLIENT_SIZE: Final = 1024**2 * 16
+MAX_CLIENT_SIZE: Final = 1024**2 * 128
 MAX_LINE_SIZE: Final = 24570
 
 _HAS_IPV6 = hasattr(socket, "AF_INET6")


### PR DESCRIPTION
This changes `MAX_CLIENT_SIZE` from 16MB to 128MB. Ideally this value would be configurable in the future but at least for the users in https://github.com/home-assistant/core/issues/178574 the issue will be solved for now.

I could not find other PRs touching `MAX_CLIENT_SIZE` and I have not tested the change. I do not anticipate negative impact but have no knowledge of homassistant's inner workings or potential drawbacks of such change.
