### PR TITLE
Add ESPHome sub-device availability

### DIFF
--- a/homeassistant/components/esphome/camera.py
+++ b/homeassistant/components/esphome/camera.py
@@ -42,6 +42,16 @@ class EsphomeCamera(Camera, EsphomeEntity[CameraInfo, CameraState]):
         super()._on_device_update()
         if not self.available:
             self._set_futures(False)
+        elif self._entry_data.available:
+            self.async_write_ha_state()
+
+    @callback
+    @override
+    def _on_availability_update(self) -> None:
+        """Handle sub-device availability changes."""
+        super()._on_availability_update()
+        if not self.available:
+            self._set_futures(False)
 
     @callback
     @override

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -354,9 +354,10 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
         self._states = cast(dict[int, _StateT], entry_data.state[state_type])
         assert entry_data.device_info is not None
         device_info = entry_data.device_info
-        self._on_entry_data_changed()
         self._key = entity_info.key
         self._state_type = state_type
+        self._static_info = cast(_InfoT, entity_info)
+        self._on_entry_data_changed()
         self._on_static_info_update(entity_info)
 
         # Determine the device connection based on whether this
@@ -389,6 +390,12 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
                 self._state_type,
                 self._key,
                 self._on_state_update,
+            )
+        )
+        self.async_on_remove(
+            entry_data.async_subscribe_device_availability(
+                self._static_info.device_id,
+                self._on_availability_update,
             )
         )
         self.async_on_remove(
@@ -480,9 +487,19 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
         if self._device_info.has_deep_sleep:
             # During deep sleep the ESP will not be connectable (by design)
             # For these cases, show it as available
-            self._attr_available = entry_data.expected_disconnect
+            connection_available = entry_data.expected_disconnect
         else:
-            self._attr_available = entry_data.available
+            connection_available = entry_data.available
+        self._attr_available = (
+            connection_available
+            and self._static_info.device_id not in entry_data.unavailable_devices
+        )
+
+    @callback
+    def _on_availability_update(self) -> None:
+        """Call when the sub-device availability changes."""
+        self._on_entry_data_changed()
+        self.async_write_ha_state()
 
     @callback
     def _on_device_update(self) -> None:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -22,6 +22,7 @@ from aioesphomeapi import (
     DateInfo,
     DateTimeInfo,
     DeviceInfo,
+    DeviceState,
     EntityInfo,
     EntityState,
     Event,
@@ -71,6 +72,7 @@ INFO_TO_COMPONENT_TYPE: Final = {v: k for k, v in COMPONENT_TYPE_TO_INFO.items()
 
 _SENTINEL = object()
 SAVE_DELAY = 120
+MIN_VERSION_DEVICE_AVAILABILITY = APIVersion(1, 15)
 _LOGGER = logging.getLogger(__name__)
 
 # Mapping from ESPHome info type to HA platform
@@ -145,6 +147,10 @@ class RuntimeEntryData:
         default_factory=dict
     )
     device_update_subscriptions: set[CALLBACK_TYPE] = field(default_factory=set)
+    device_availability_subscriptions: defaultdict[int, set[CALLBACK_TYPE]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    unavailable_devices: set[int] = field(default_factory=set)
     static_info_update_subscriptions: set[Callable[[list[EntityInfo]], None]] = field(
         default_factory=set
     )
@@ -345,6 +351,15 @@ class RuntimeEntryData:
         return partial(self.device_update_subscriptions.remove, callback_)
 
     @callback
+    def async_subscribe_device_availability(
+        self, device_id: int, callback_: CALLBACK_TYPE
+    ) -> CALLBACK_TYPE:
+        """Subscribe to availability updates for a device."""
+        subscriptions = self.device_availability_subscriptions[device_id]
+        subscriptions.add(callback_)
+        return partial(subscriptions.remove, callback_)
+
+    @callback
     def async_subscribe_static_info_updated(
         self, callback_: Callable[[list[EntityInfo]], None]
     ) -> CALLBACK_TYPE:
@@ -402,6 +417,29 @@ class RuntimeEntryData:
         """Distribute an update of a core device state like availability."""
         for callback_ in self.device_update_subscriptions.copy():
             callback_()
+
+    @callback
+    def async_update_device_availability(self, state: DeviceState) -> None:
+        """Distribute an availability update for a device."""
+        device_id = state.device_id
+        is_unavailable = device_id in self.unavailable_devices
+        if is_unavailable == (not state.available):
+            return
+        if state.available:
+            self.unavailable_devices.remove(device_id)
+        else:
+            self.unavailable_devices.add(device_id)
+        for callback_ in tuple(
+            self.device_availability_subscriptions.get(device_id, ())
+        ):
+            callback_()
+
+    @callback
+    def async_prepare_availability(self, api_version: APIVersion) -> None:
+        """Prepare availability before subscribing after a reconnect."""
+        # Device snapshots report both values, so preserve them across reconnects.
+        if api_version < MIN_VERSION_DEVICE_AVAILABILITY:
+            self.unavailable_devices.clear()
 
     async def async_load_from_store(self) -> tuple[list[EntityInfo], list[UserService]]:
         """Load the retained data from store and return de-serialized data."""

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -673,6 +673,7 @@ class ESPHomeManager:
 
         api_version = cli.api_version
         assert api_version is not None, "API version must be set"
+        entry_data.async_prepare_availability(api_version)
         entry_data.async_on_connect(hass, device_info, api_version)
 
         await self._handle_dynamic_encryption_key(device_info)
@@ -734,6 +735,7 @@ class ESPHomeManager:
             on_service_call=self.async_on_service_call,
             on_state_sub=self.async_on_state_subscription,
             on_state_request=self.async_on_state_request,
+            on_device_state=entry_data.async_update_device_availability,
         )
 
         entry_data.async_save_to_store()

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -12,6 +12,7 @@ from aioesphomeapi import (
     APIVersion,
     BluetoothProxyFeature,
     DeviceInfo,
+    DeviceState,
     EntityInfo,
     EntityState,
     HomeassistantServiceCall,
@@ -240,6 +241,7 @@ class MockESPHomeDevice:
         self.entry = entry
         self.client = client
         self.state_callback: Callable[[EntityState], None]
+        self.device_state_callback: Callable[[DeviceState], None]
         self.service_call_callback: Callable[[HomeassistantServiceCall], None]
         self.on_disconnect: Callable[[bool], None]
         self.on_connect: Callable[[bool], None]
@@ -290,6 +292,10 @@ class MockESPHomeDevice:
     def set_state(self, state: EntityState) -> None:
         """Mock setting state."""
         self.state_callback(state)
+
+    def set_device_state(self, state: DeviceState) -> None:
+        """Mock setting device state."""
+        self.device_state_callback(state)
 
     def set_on_disconnect(self, on_disconnect: Callable[[bool], None]) -> None:
         """Set the disconnect callback."""
@@ -527,9 +533,12 @@ async def _mock_generic_device_entry(
         on_service_call: Callable[[HomeassistantServiceCall], None],
         on_state_sub: Callable[[str, str | None], None],
         on_state_request: Callable[[str, str | None], None],
+        on_device_state: Callable[[DeviceState], None] | None = None,
     ) -> None:
         """Subscribe to states and service calls."""
         mock_device.set_state_callback(on_state)
+        assert on_device_state is not None
+        mock_device.device_state_callback = on_device_state
         mock_device.set_service_call_callback(on_service_call)
         mock_device.set_home_assistant_state_subscription_callback(
             on_state_sub, on_state_request

--- a/tests/components/esphome/test_availability.py
+++ b/tests/components/esphome/test_availability.py
@@ -1,0 +1,94 @@
+"""Test ESPHome sub-device availability."""
+
+from aioesphomeapi import (
+    APIClient,
+    APIVersion,
+    BinarySensorInfo,
+    BinarySensorState,
+    DeviceState,
+    SubDeviceInfo,
+)
+import pytest
+
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockESPHomeDeviceType
+
+
+async def test_sub_device_availability_only_affects_its_entities(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a sub-device availability update is scoped by device id."""
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "devices": [
+                SubDeviceInfo(device_id=1, name="Sub Device 1"),
+                SubDeviceInfo(device_id=2, name="Sub Device 2"),
+            ]
+        },
+        entity_info=[
+            BinarySensorInfo(key=1, name="Main", device_id=0),
+            BinarySensorInfo(key=1, name="Motion", device_id=1),
+            BinarySensorInfo(key=1, name="Motion", device_id=2),
+        ],
+        states=[
+            BinarySensorState(key=1, state=True, device_id=0),
+            BinarySensorState(key=1, state=True, device_id=1),
+            BinarySensorState(key=1, state=True, device_id=2),
+        ],
+    )
+
+    mock_device.set_device_state(DeviceState(device_id=1, available=False))
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("binary_sensor.test_main", STATE_ON)
+    assert hass.states.is_state("binary_sensor.sub_device_1_motion", STATE_UNAVAILABLE)
+    assert hass.states.is_state("binary_sensor.sub_device_2_motion", STATE_ON)
+
+    mock_device.set_device_state(DeviceState(device_id=1, available=True))
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("binary_sensor.sub_device_1_motion", STATE_ON)
+
+
+@pytest.mark.parametrize(
+    ("api_version", "state_after_reconnect"),
+    [
+        pytest.param(APIVersion(1, 14), STATE_ON, id="unsupported"),
+        pytest.param(APIVersion(1, 15), STATE_UNAVAILABLE, id="supported"),
+    ],
+)
+async def test_sub_device_availability_reconnect_behavior_depends_on_api_version(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    api_version: APIVersion,
+    state_after_reconnect: str,
+) -> None:
+    """Test reconnect behavior depends on snapshot support."""
+    mock_client.api_version = api_version
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={"devices": [SubDeviceInfo(device_id=1, name="Sub Device")]},
+        entity_info=[BinarySensorInfo(key=1, name="Motion", device_id=1)],
+        states=[BinarySensorState(key=1, state=True, device_id=1)],
+    )
+
+    mock_device.set_device_state(DeviceState(device_id=1, available=False))
+    await hass.async_block_till_done()
+    assert hass.states.is_state("binary_sensor.sub_device_motion", STATE_UNAVAILABLE)
+
+    await mock_device.mock_disconnect(expected_disconnect=False)
+    await mock_device.mock_connect()
+    await hass.async_block_till_done()
+    assert hass.states.is_state(
+        "binary_sensor.sub_device_motion", state_after_reconnect
+    )
+
+    mock_device.set_device_state(DeviceState(device_id=1, available=True))
+    await hass.async_block_till_done()
+    assert hass.states.is_state("binary_sensor.sub_device_motion", STATE_ON)

--- a/tests/components/esphome/test_camera.py
+++ b/tests/components/esphome/test_camera.py
@@ -1,6 +1,12 @@
 """Test ESPHome cameras."""
 
-from aioesphomeapi import APIClient, CameraInfo, CameraState as ESPHomeCameraState
+from aioesphomeapi import (
+    APIClient,
+    CameraInfo,
+    CameraState as ESPHomeCameraState,
+    DeviceState,
+    SubDeviceInfo,
+)
 
 from homeassistant.components.camera import CameraState
 from homeassistant.const import STATE_UNAVAILABLE
@@ -137,6 +143,34 @@ async def test_camera_single_image_unavailable_during_request(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
+    assert resp.status == 500
+
+
+async def test_camera_single_image_sub_device_unavailable_during_request(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a camera whose sub-device becomes unavailable during a request."""
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={"devices": [SubDeviceInfo(device_id=1, name="Sub Device")]},
+        entity_info=[
+            CameraInfo(object_id="mycamera", key=1, name="my camera", device_id=1)
+        ],
+    )
+
+    def _mock_camera_image() -> None:
+        mock_device.set_device_state(DeviceState(device_id=1, available=False))
+
+    mock_client.request_single_image = _mock_camera_image
+
+    client = await hass_client()
+    resp = await client.get("/api/camera_proxy/camera.sub_device_my_camera")
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("camera.sub_device_my_camera", STATE_UNAVAILABLE)
     assert resp.status == 500
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds ESPHome sub-device availability support. When ESPHome reports a sub-device as unavailable, every entity registered under it becomes unavailable. Cameras also abort any in-flight image request for that sub-device.

The focused ESPHome availability, camera, and entry-data tests pass against the matching aioesphomeapi branch. Ruff formatting, Ruff checks, and pylint also pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Partially addresses https://github.com/esphome/feature-requests/issues/1568
- This PR is related to issue: esphome/esphome#18220, esphome/aioesphomeapi#1856
- Link to documentation pull request: esphome/esphome.io#7147
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
