### PR TITLE
Improve iZone user Search with progress and handoff to Discovered flows

### DIFF
--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -91,9 +91,6 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         Discovery is started if not yet running, then a fresh discovery cycle is triggered
         and this step waits briefly for replies.
-
-        While this interactive flow is active, runtime integration discovery remains
-        blocked by ``_async_blocks_runtime_integration_discovery`` to avoid UI races.
         """
 
         if self._async_in_progress(include_uninitialized=True):

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -1,16 +1,19 @@
 """Config flow for izone."""
 
+import asyncio
 from collections.abc import Iterable
+from dataclasses import dataclass
 import logging
 from typing import Any, Self, override
 
 import pizone
+from pizone.discovery import SCAN_TIMEOUT
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, FlowType
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.selector import (
     SelectOptionDict,
@@ -28,6 +31,18 @@ _LOGGER = logging.getLogger(__name__)
 
 SELECTED_CONTROLLER_UID = "selected_controller_uid"
 
+# Wait after IASD for ASPort replies (matches pizone discover_all wait).
+USER_SCAN_WAIT_SECONDS = SCAN_TIMEOUT
+
+
+@dataclass(frozen=True, slots=True)
+class _ShelfCandidate:
+    """An in-progress discovery/HomeKit flow on the Discovered shelf."""
+
+    uid: str
+    host: str
+    flow_id: str
+
 
 def _flow_uid_for_matching(flow: ConfigFlow) -> str | None:
     """Return a stable controller UID for deduplicating in-progress flows."""
@@ -42,8 +57,9 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
-    _user_discovered_endpoints: list[pizone.ControllerEndpoint] | None = None
     _discovered_controller_ip: str | None = None
+    _user_discovery_task: asyncio.Task[None] | None = None
+    _user_discovery_failed: bool = False
 
     @override
     def is_matching(self, other_flow: Self) -> bool:
@@ -87,60 +103,85 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, _user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """User-started flow: offer configuration choices for discovered controllers.
+        """User-started flow: search the LAN, then offer discovered controllers."""
+        return await self.async_step_discover()
 
-        Discovery is started if not yet running, then a fresh discovery cycle is triggered
-        and this step waits briefly for replies.
-        """
-
-        if self._async_in_progress(include_uninitialized=True):
-            return self.async_abort(reason="already_in_progress")
-
+    async def _async_run_user_discovery(self) -> None:
+        """Scan and wait for the progress step (no unique_id work here)."""
+        self._user_discovery_failed = False
         try:
-            endpoints = await izone_discovery.async_discover_all_endpoints(self.hass)
+            await izone_discovery.async_scan(self.hass)
+            await asyncio.sleep(USER_SCAN_WAIT_SECONDS)
+            await self.hass.async_block_till_done(wait_background_tasks=True)
         except OSError:
             _LOGGER.debug("Unable to start iZone discovery service", exc_info=True)
+            self._user_discovery_failed = True
+
+    async def async_step_discover(
+        self, _user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Broadcast discovery with a progress UI, then continue to discovery_done."""
+        if not self._user_discovery_task:
+            self._user_discovery_task = self.hass.async_create_task(
+                self._async_run_user_discovery()
+            )
+            # Always leave progress first; the task may already be done (eager).
+            return self.async_show_progress(
+                step_id="discover",
+                progress_action="discover",
+                progress_task=self._user_discovery_task,
+            )
+
+        if not self._user_discovery_task.done():
+            return self.async_show_progress(
+                step_id="discover",
+                progress_action="discover",
+                progress_task=self._user_discovery_task,
+            )
+
+        self._user_discovery_task = None
+        return self.async_show_progress_done(next_step_id="discovery_done")
+
+    async def async_step_discovery_done(
+        self, _user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """After Search scan: abort, hand off the sole shelf flow, or choose."""
+        if self._user_discovery_failed:
             return self.async_abort(reason="discovery_failed")
-        if not endpoints:
-            _LOGGER.debug("No controllers found")
+
+        candidates = self._async_user_candidates()
+        if not candidates:
+            _LOGGER.debug("No controllers found on the Discovered shelf")
             return self.async_abort(reason="no_devices_found")
-
-        self._user_discovered_endpoints = self._async_get_unconfigured_endpoints(
-            endpoints
-        )
-        if not self._user_discovered_endpoints:
-            return self.async_abort(reason="already_configured")
-        if len(self._user_discovered_endpoints) > 1:
-            return await self.async_step_select_controller()
-
-        sole = self._user_discovered_endpoints[0]
-        await self.async_set_unique_id(sole.uid)
-        self._discovered_controller_ip = sole.host
-        return await self.async_step_confirm()
+        if len(candidates) == 1:
+            return self.async_abort(
+                reason="continue_setup",
+                next_flow=(FlowType.CONFIG_FLOW, candidates[0].flow_id),
+            )
+        return await self.async_step_select_controller()
 
     async def async_step_select_controller(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Choose one unconfigured controller after broadcast discovery."""
-        if not self._user_discovered_endpoints:
+        """Choose one shelf controller after Search, then hand off to its confirm."""
+        candidates = self._async_user_candidates()
+        if len(candidates) < 2:
             return self.async_abort(reason="no_devices_found")
 
-        by_uid = {
-            endpoint.uid: endpoint for endpoint in self._user_discovered_endpoints
-        }
+        by_uid = {candidate.uid: candidate for candidate in candidates}
         selection_schema = vol.Schema(
             {
                 vol.Required(
                     SELECTED_CONTROLLER_UID,
-                    default=self._user_discovered_endpoints[0].uid,
+                    default=candidates[0].uid,
                 ): SelectSelector(
                     SelectSelectorConfig(
                         options=[
                             SelectOptionDict(
-                                value=endpoint.uid,
-                                label=f"{endpoint.uid} ({endpoint.host})",
+                                value=candidate.uid,
+                                label=f"{candidate.uid} ({candidate.host})",
                             )
-                            for endpoint in self._user_discovered_endpoints
+                            for candidate in candidates
                         ],
                         mode=SelectSelectorMode.DROPDOWN,
                     )
@@ -150,23 +191,15 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             selected_uid = user_input[SELECTED_CONTROLLER_UID]
-            if (primary := by_uid.get(selected_uid)) is None:
+            if (selected := by_uid.get(selected_uid)) is None:
                 return self.async_abort(reason="no_devices_found")
-
-            for endpoint in self._user_discovered_endpoints:
-                if endpoint.uid == primary.uid:
-                    continue
-                # Using integration_discovery lets HA's deduplication guard prevent stacking
-                # flows for UIDs already in progress or already configured.
-                self._async_schedule_integration_discovery_flow(
-                    endpoint.uid,
-                    endpoint.host,
-                )
-            return await self._async_create_controller_entry(primary)
+            return self.async_abort(
+                reason="continue_setup",
+                next_flow=(FlowType.CONFIG_FLOW, selected.flow_id),
+            )
 
         controllers_lines = "\n".join(
-            f"- {endpoint.uid} ({endpoint.host})"
-            for endpoint in self._user_discovered_endpoints
+            f"- {candidate.uid} ({candidate.host})" for candidate in candidates
         )
         return self.async_show_form(
             step_id="select_controller",
@@ -251,6 +284,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             self.context["title_placeholders"] = {
                 "name": self._entry_title(controller_uid),
+                "host": str(host),
             }
             return self.async_show_form(
                 step_id="confirm",
@@ -267,12 +301,37 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     # -- Private helpers
 
     @callback
+    def _async_user_candidates(self) -> list[_ShelfCandidate]:
+        """Return Discovered-shelf flows (integration discovery and HomeKit)."""
+        candidates: list[_ShelfCandidate] = []
+        for flow in self.hass.config_entries.flow.async_progress_by_handler(
+            DOMAIN, include_uninitialized=True
+        ):
+            if flow["flow_id"] == self.flow_id:
+                continue
+            context = flow["context"]
+            if context.get("source") not in (
+                config_entries.SOURCE_INTEGRATION_DISCOVERY,
+                config_entries.SOURCE_HOMEKIT,
+            ):
+                continue
+            uid = context.get("unique_id")
+            placeholders = context.get("title_placeholders")
+            host = placeholders.get("host") if placeholders is not None else None
+            if not isinstance(uid, str) or not isinstance(host, str):
+                continue
+            candidates.append(
+                _ShelfCandidate(uid=uid, host=host, flow_id=flow["flow_id"])
+            )
+        return sorted(candidates, key=lambda candidate: (candidate.uid, candidate.host))
+
+    @callback
     def _async_schedule_integration_discovery_flow(
         self,
         uid: str,
         host: str,
     ) -> None:
-        """Queue integration discovery (import fan-out or manual discovery pick)."""
+        """Queue integration discovery (import fan-out or HomeKit sibling)."""
         discovery_flow.async_create_flow(
             self.hass,
             DOMAIN,
@@ -287,38 +346,6 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     def _entry_title(device_uid: str) -> str:
         """Standard config entry title for a controller UID."""
         return f"iZone {device_uid}"
-
-    @staticmethod
-    def _filter_yaml_exclude(
-        hass: HomeAssistant, endpoints: dict[str, pizone.ControllerEndpoint]
-    ) -> dict[str, pizone.ControllerEndpoint]:
-        """Remove UIDs listed in deprecated YAML ``exclude``."""
-        excluded = izone_discovery.yaml_excluded_uids(hass)
-        if not excluded:
-            return endpoints
-        return {
-            uid: endpoint
-            for uid, endpoint in endpoints.items()
-            if endpoint.uid not in excluded
-        }
-
-    @callback
-    def _async_get_unconfigured_endpoints(
-        self, endpoints: dict[str, pizone.ControllerEndpoint]
-    ) -> list[pizone.ControllerEndpoint]:
-        """Return sorted unconfigured endpoints for the interactive user flow."""
-        endpoints = self._filter_yaml_exclude(self.hass, endpoints)
-        # include_ignore=True ensures controllers whose entries have been explicitly
-        # ignored by the user (SOURCE_IGNORE) are not re-offered as configurable.
-        configured_uids = self._async_current_ids(include_ignore=True)
-        return sorted(
-            (
-                endpoint
-                for endpoint in endpoints.values()
-                if endpoint.uid not in configured_uids
-            ),
-            key=lambda endpoint: (endpoint.uid, endpoint.host),
-        )
 
     async def _async_create_controller_entry(
         self,

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -207,6 +207,19 @@ async def async_discover_all_endpoints(
     return {endpoint.uid: endpoint for endpoint in await service.discover_all()}
 
 
+async def async_scan(hass: HomeAssistant) -> None:
+    """Broadcast IASD so ASPort replies fill the Discovered shelf.
+
+    Does not wait for replies or run ``discover_all``'s post-wait probe fan-out.
+    Callers that need replies to land should sleep after this (e.g. config flow).
+
+    Raises:
+        OSError: Discovery UDP socket could not be bound.
+    """
+    service = await async_ensure_discovery(hass)
+    await service.scan()
+
+
 async def async_discover_endpoint(
     hass: HomeAssistant, uid: str
 ) -> pizone.ControllerEndpoint | None:

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -75,8 +75,6 @@ def async_note_integration_discovery(
     """Start a config flow when discovery reports an unclaimed endpoint."""
     if endpoint.uid in yaml_excluded_uids(hass):
         return
-    if _async_blocks_runtime_integration_discovery(hass):
-        return
     discovery_flow.async_create_flow(
         hass,
         DOMAIN,
@@ -86,18 +84,6 @@ def async_note_integration_discovery(
         },
         data={CONF_HOST: endpoint.host},
     )
-
-
-@callback
-def _async_blocks_runtime_integration_discovery(hass: HomeAssistant) -> bool:
-    """Return True when an interactive setup flow should own the UI."""
-    for flw in hass.config_entries.flow.async_progress_by_handler(
-        DOMAIN, include_uninitialized=True
-    ):
-        src = flw["context"].get("source")
-        if src == config_entries.SOURCE_USER:
-            return True
-    return False
 
 
 @callback

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -3,11 +3,15 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "continue_setup": "Continue setting up the discovered iZone controller.",
       "discovery_failed": "Failed to start iZone discovery. Make sure your network is properly configured.",
       "discovery_started": "iZone discovery has started. Your controllers will appear as discovered devices under Settings \u003e Devices \u0026 services.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     },
     "flow_title": "{name}",
+    "progress": {
+      "discover": "Searching for iZone controllers on your network"
+    },
     "step": {
       "confirm": {
         "description": "Do you want to set up iZone?\n\nController UID: {controller_uid}\nController IP: {host}"

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -7,9 +7,11 @@ from unittest.mock import AsyncMock, Mock, patch
 from pizone import Controller, ControllerEndpoint, DiscoveryService, Zone
 import pytest
 
+from homeassistant.components.izone import discovery as izone_discovery
 from homeassistant.components.izone.const import DOMAIN
 from homeassistant.const import CONF_EXCLUDE, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult, FlowResultType
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -182,8 +184,11 @@ def create_mock_zone(
 @contextmanager
 def patch_discovered_controllers(
     controllers: Mock | dict[str, Mock] | Iterable[Mock],
-) -> Generator[tuple[AsyncMock, AsyncMock]]:
-    """Patch discovery helpers using mock controllers' uid/ip."""
+) -> Generator[tuple[AsyncMock, AsyncMock, AsyncMock]]:
+    """Patch discovery helpers using mock controllers' uid/ip.
+
+    User Search scan notes each controller onto the Discovered shelf.
+    """
     if isinstance(controllers, dict):
         ctrl_list = list(controllers.values())
     elif isinstance(controllers, Mock):
@@ -200,10 +205,15 @@ def patch_discovered_controllers(
     ) -> dict[str, ControllerEndpoint]:
         return dict(endpoints)
 
+    async def _scan(hass: HomeAssistant) -> None:
+        for endpoint in endpoints.values():
+            izone_discovery.async_note_integration_discovery(hass, endpoint)
+
     async def _discover_one(hass: HomeAssistant, uid: str) -> ControllerEndpoint | None:
         return endpoints.get(uid)
 
     mock_discover_all = AsyncMock(side_effect=_discover_all)
+    mock_scan = AsyncMock(side_effect=_scan)
     mock_discover_one = AsyncMock(side_effect=_discover_one)
     with (
         patch(
@@ -211,11 +221,40 @@ def patch_discovered_controllers(
             new=mock_discover_all,
         ),
         patch(
+            "homeassistant.components.izone.discovery.async_scan",
+            new=mock_scan,
+        ),
+        patch(
             "homeassistant.components.izone.discovery.async_discover_endpoint",
             new=mock_discover_one,
         ),
     ):
-        yield mock_discover_all, mock_discover_one
+        yield mock_discover_all, mock_discover_one, mock_scan
+
+
+async def async_finish_user_discover(
+    hass: HomeAssistant, result: FlowResult
+) -> FlowResult:
+    """Advance a user Search flow past SHOW_PROGRESS discover."""
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["progress_action"] == "discover"
+    await hass.async_block_till_done(wait_background_tasks=True)
+    return await hass.config_entries.flow.async_configure(result["flow_id"])
+
+
+async def async_follow_user_handoff(
+    hass: HomeAssistant, result: FlowResult
+) -> FlowResult:
+    """Follow Search handoff into the shelf confirm form."""
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "continue_setup"
+    next_flow = result["next_flow"]
+    assert next_flow is not None
+    _flow_type, flow_id = next_flow
+    result = await hass.config_entries.flow.async_configure(flow_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    return result
 
 
 async def async_load_yaml_exclude(hass: HomeAssistant, *uids: str) -> None:

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -877,10 +877,10 @@ async def test_runtime_integration_discovery_skips_for_ignored_unique_id(
     assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
 
 
-async def test_runtime_integration_discovery_skips_during_user_select_controller_step(
+async def test_runtime_integration_discovery_allows_during_user_select_controller_step(
     hass: HomeAssistant,
 ) -> None:
-    """Do not stack auto discovery while the user is choosing discovered controllers."""
+    """Runtime discovery may add shelf flows while the user is choosing controllers."""
     MockConfigEntry(
         domain=DOMAIN,
         unique_id="000000001",
@@ -898,22 +898,25 @@ async def test_runtime_integration_discovery_skips_during_user_select_controller
 
     new_ctrl = create_mock_controller("000000002", "192.0.2.2")
 
-    with patch(
-        "homeassistant.helpers.discovery_flow.async_create_flow"
-    ) as mock_create_flow:
-        izone_discovery.async_note_integration_discovery(
-            hass, endpoint_from_controller(new_ctrl)
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
+    izone_discovery.async_note_integration_discovery(
+        hass, endpoint_from_controller(new_ctrl)
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    mock_create_flow.assert_not_called()
+    discovery_flows = [
+        flow
+        for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        if flow["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
+    ]
+    assert len(discovery_flows) == 1
+    assert discovery_flows[0]["context"]["unique_id"] == new_ctrl.device_uid
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
-async def test_runtime_integration_discovery_skips_during_user_confirm(
+async def test_runtime_integration_discovery_allows_during_user_confirm(
     hass: HomeAssistant,
 ) -> None:
-    """Runtime discovery stays suppressed while an interactive user flow is active."""
+    """Runtime discovery may add shelf flows while a user confirm step is open."""
     first = create_mock_controller("000000001", "192.0.2.1")
     second = create_mock_controller("000000002", "192.0.2.2")
     with patch_discovered_controllers(first):
@@ -928,8 +931,12 @@ async def test_runtime_integration_discovery_skips_during_user_confirm(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
-    assert len(progress) == 1
-    assert progress[0]["context"]["source"] == config_entries.SOURCE_USER
+    assert len(progress) == 2
+    sources = {flow["context"]["source"] for flow in progress}
+    assert sources == {
+        config_entries.SOURCE_USER,
+        config_entries.SOURCE_INTEGRATION_DISCOVERY,
+    }
 
 
 async def test_async_setup_starts_import_flow(hass: HomeAssistant) -> None:

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -15,6 +15,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
+    async_finish_user_discover,
+    async_follow_user_handoff,
     async_load_yaml_exclude,
     create_mock_controller,
     endpoint_from_controller,
@@ -31,10 +33,16 @@ def _make_homekit_info(md: str, host: str | None = None) -> SimpleNamespace:
 
 @pytest.fixture(autouse=True)
 def mock_izone_timeouts() -> Generator[None]:
-    """Mock iZone idle-stop delay to speed up tests."""
-    with patch(
-        "homeassistant.components.izone.discovery.DISCOVERY_IDLE_SECONDS",
-        0.04,
+    """Mock iZone discovery waits so tests do not sleep for real scan timeouts."""
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.DISCOVERY_IDLE_SECONDS",
+            0.04,
+        ),
+        patch(
+            "homeassistant.components.izone.config_flow.USER_SCAN_WAIT_SECONDS",
+            0,
+        ),
     ):
         yield
 
@@ -43,14 +51,14 @@ def mock_izone_timeouts() -> Generator[None]:
 async def test_user_discovery_success(
     hass: HomeAssistant,
 ) -> None:
-    """Test user flow confirms and creates an entry for a discovered controller."""
+    """Test user Search hands off to the shelf confirm and creates an entry."""
     controller = create_mock_controller("000000001", "192.0.2.55")
     with patch_discovered_controllers(controller):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -61,18 +69,21 @@ async def test_user_discovery_success(
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
-async def test_user_discovery_default_selects_first_and_queues_other(
+async def test_user_discovery_default_selects_first_and_leaves_other(
     hass: HomeAssistant,
 ) -> None:
-    """Default dropdown selection configures first UID and queues the other for confirm."""
+    """Default dropdown selection hands off to first UID; other stays on shelf."""
     first = create_mock_controller("000000001", "192.0.2.1")
     second = create_mock_controller("000000002", "192.0.2.2")
     with patch_discovered_controllers([first, second]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "select_controller"
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await async_follow_user_handoff(hass, result)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -96,7 +107,7 @@ async def test_user_discovery_default_selects_first_and_queues_other(
 async def test_broadcast_skips_already_configured_controller(
     hass: HomeAssistant,
 ) -> None:
-    """Test broadcast discovery skips configured controllers and sets up an unconfigured one."""
+    """Search shelf omits configured controllers and hands off the unconfigured one."""
     configured_controller = create_mock_controller("000000001", "192.0.2.1")
     unconfigured_controller = create_mock_controller("000000002", "192.0.2.2")
     MockConfigEntry(
@@ -110,8 +121,8 @@ async def test_broadcast_skips_already_configured_controller(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -125,7 +136,7 @@ async def test_broadcast_skips_already_configured_controller(
 async def test_user_discovery_skips_yaml_excluded_controllers(
     hass: HomeAssistant,
 ) -> None:
-    """User flow should not offer controllers excluded by deprecated YAML config."""
+    """User Search should not offer controllers excluded by deprecated YAML config."""
     excluded_controller = create_mock_controller("000000001", "192.0.2.1")
     allowed_controller = create_mock_controller("000000002", "192.0.2.2")
     await async_load_yaml_exclude(hass, excluded_controller.device_uid)
@@ -134,8 +145,8 @@ async def test_user_discovery_skips_yaml_excluded_controllers(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "confirm"
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -149,7 +160,7 @@ async def test_user_discovery_skips_yaml_excluded_controllers(
 async def test_broadcast_multiple_unconfigured_shows_choice(
     hass: HomeAssistant,
 ) -> None:
-    """Test broadcast discovery shows a controller choice when multiple unconfigured controllers are found."""
+    """Search shows a controller choice when multiple shelf flows are present."""
     first_controller = create_mock_controller("000000002", "192.0.2.1")
     second_controller = create_mock_controller("000000001", "192.0.2.2")
 
@@ -157,6 +168,7 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "select_controller"
@@ -164,9 +176,10 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
         assert len(schema_keys) == 1
         assert str(schema_keys[0].schema) == config_flow.SELECTED_CONTROLLER_UID
 
-        # Choose one and queue the other as integration discovery (confirm step).
+        # Default is lowest UID; hand off and leave the other on the shelf.
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
+        result = await async_follow_user_handoff(hass, result)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -188,10 +201,10 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
     assert progress[0]["context"]["unique_id"] == "000000002"
 
 
-async def test_select_controller_aborts_when_choices_missing(
+async def test_select_controller_aborts_when_shelf_emptied(
     hass: HomeAssistant,
 ) -> None:
-    """Controller selection aborts if discovered choices were lost on the flow."""
+    """Controller selection aborts if shelf flows disappear before submit."""
     first_controller = create_mock_controller("000000001", "192.0.2.1")
     second_controller = create_mock_controller("000000002", "192.0.2.2")
 
@@ -199,13 +212,22 @@ async def test_select_controller_aborts_when_choices_missing(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
-    # Public configure cannot clear flow-local discovery state; poke the in-progress
-    # instance so the empty-choices abort path is exercised.
-    flow = hass.config_entries.flow._progress[result["flow_id"]]
-    flow._user_discovered_endpoints = None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_controller"
+    user_flow_id = result["flow_id"]
 
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    for progress in hass.config_entries.flow.async_progress_by_handler(DOMAIN):
+        if progress["flow_id"] == user_flow_id:
+            continue
+        if progress["context"].get("source") in (
+            config_entries.SOURCE_INTEGRATION_DISCOVERY,
+            config_entries.SOURCE_HOMEKIT,
+        ):
+            hass.config_entries.flow.async_abort(progress["flow_id"])
+
+    result = await hass.config_entries.flow.async_configure(user_flow_id)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
@@ -222,9 +244,11 @@ async def test_select_controller_aborts_when_uid_not_in_choices(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
-    # Schema validation rejects unknown UIDs; call the step directly with a UID that
-    # is not in the discovered set to cover the step's own abort.
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_controller"
+
     flow = hass.config_entries.flow._progress[result["flow_id"]]
     result = await flow.async_step_select_controller(
         {config_flow.SELECTED_CONTROLLER_UID: "000000099"}
@@ -235,10 +259,10 @@ async def test_select_controller_aborts_when_uid_not_in_choices(
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
-async def test_select_controller_creates_selected_uid_and_queues_others(
+async def test_select_controller_hands_off_selected_uid_and_leaves_others(
     hass: HomeAssistant,
 ) -> None:
-    """A selected controller is configured and non-selected controllers are queued."""
+    """A selected controller hands off; non-selected shelf flows remain."""
     first_controller = create_mock_controller("000000002", "192.0.2.1")
     second_controller = create_mock_controller("000000001", "192.0.2.2")
 
@@ -246,11 +270,14 @@ async def test_select_controller_creates_selected_uid_and_queues_others(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {config_flow.SELECTED_CONTROLLER_UID: "000000002"},
         )
+        result = await async_follow_user_handoff(hass, result)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -272,7 +299,7 @@ async def test_select_controller_creates_selected_uid_and_queues_others(
 async def test_broadcast_aborts_when_all_discovered_are_configured(
     hass: HomeAssistant,
 ) -> None:
-    """Test broadcast discovery aborts when every discovered controller is configured."""
+    """Search aborts when every noted controller is already configured."""
     configured_controller = create_mock_controller("000000001", "192.0.2.1")
     MockConfigEntry(
         domain=DOMAIN,
@@ -285,20 +312,16 @@ async def test_broadcast_aborts_when_all_discovered_are_configured(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "no_devices_found"
 
 
 async def test_user_flow_aborts_when_all_discovered_are_ignored(
     hass: HomeAssistant,
 ) -> None:
-    """User flow aborts when every discovered controller has been explicitly ignored.
-
-    _async_get_unconfigured_controllers uses include_ignore=True so controllers
-    whose entries carry SOURCE_IGNORE are not re-offered as configurable, respecting
-    the user's earlier choice to dismiss them.
-    """
+    """Search aborts when every noted controller is ignored (no shelf flow)."""
     ignored_controller = create_mock_controller("000000001", "192.0.2.1")
     MockConfigEntry(
         domain=DOMAIN,
@@ -311,9 +334,10 @@ async def test_user_flow_aborts_when_all_discovered_are_ignored(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "no_devices_found"
 
 
 async def test_import_aborts_when_another_izone_flow_in_progress(
@@ -325,8 +349,7 @@ async def test_import_aborts_when_another_izone_flow_in_progress(
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert user_flow["type"] is FlowResultType.FORM
-    assert user_flow["step_id"] == "confirm"
+        assert user_flow["type"] is FlowResultType.SHOW_PROGRESS
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -376,12 +399,13 @@ async def test_import_aborts_when_discovery_bind_fails(hass: HomeAssistant) -> N
 async def test_user_flow_aborts_when_discovery_bind_fails(hass: HomeAssistant) -> None:
     """User flow aborts when discovery cannot bind the UDP socket."""
     with patch(
-        "homeassistant.components.izone.discovery.async_discover_all_endpoints",
+        "homeassistant.components.izone.discovery.async_scan",
         new=AsyncMock(side_effect=OSError("bind failed")),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_failed"
@@ -408,7 +432,10 @@ async def test_homekit_confirm_uses_discovered_host(
             for flow in hass.config_entries.flow.async_progress()
             if flow["flow_id"] == result["flow_id"]
         )
-        assert flow["context"]["title_placeholders"] == {"name": "iZone 000000001"}
+        assert flow["context"]["title_placeholders"] == {
+            "name": "iZone 000000001",
+            "host": "192.0.2.3",
+        }
         assert result["description_placeholders"] == {
             "controller_uid": "000000001",
             "host": "192.0.2.3",
@@ -495,17 +522,19 @@ async def test_homekit_flow_sets_device_uid_once(
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
-async def test_homekit_aborts_while_user_confirm_is_open(
+async def test_homekit_aborts_while_user_select_is_open(
     hass: HomeAssistant,
 ) -> None:
-    """HomeKit onboarding for same UID is blocked while a user flow is already active."""
-    controller = create_mock_controller("000000001", "192.0.2.3")
-    with patch_discovered_controllers(controller):
+    """HomeKit onboarding for same UID is blocked while user Search select is open."""
+    first = create_mock_controller("000000001", "192.0.2.3")
+    second = create_mock_controller("000000002", "192.0.2.4")
+    with patch_discovered_controllers([first, second]):
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        user_flow = await async_finish_user_discover(hass, user_flow)
         assert user_flow["type"] is FlowResultType.FORM
-        assert user_flow["step_id"] == "confirm"
+        assert user_flow["step_id"] == "select_controller"
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -517,12 +546,13 @@ async def test_homekit_aborts_while_user_confirm_is_open(
     assert result["reason"] == "already_in_progress"
 
 
-async def test_user_broadcast_aborts_when_homekit_flow_in_progress(
+async def test_user_search_allowed_while_homekit_flow_in_progress(
     hass: HomeAssistant,
 ) -> None:
-    """Test user broadcast discovery aborts when a HomeKit flow is already active."""
-    controller = create_mock_controller("000000001", "192.0.2.3")
-    with patch_discovered_controllers(controller):
+    """User Search may start while a HomeKit confirm flow is already open."""
+    homekit_controller = create_mock_controller("000000001", "192.0.2.3")
+    other_controller = create_mock_controller("000000002", "192.0.2.4")
+    with patch_discovered_controllers([homekit_controller, other_controller]):
         homekit_flow = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
@@ -532,14 +562,15 @@ async def test_user_broadcast_aborts_when_homekit_flow_in_progress(
         assert homekit_flow["type"] is FlowResultType.FORM
         assert homekit_flow["step_id"] == "confirm"
 
-        user_flow = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
         )
-        result = user_flow
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        result = await async_finish_user_discover(hass, result)
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_in_progress"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_controller"
 
 
 async def test_homekit_aborts_when_uid_already_configured(
@@ -698,6 +729,7 @@ async def test_user_flow_aborts_when_no_controllers_found(hass: HomeAssistant) -
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
@@ -893,13 +925,20 @@ async def test_runtime_integration_discovery_allows_during_user_select_controlle
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        user_flow = await async_finish_user_discover(hass, user_flow)
     assert user_flow["type"] is FlowResultType.FORM
     assert user_flow["step_id"] == "select_controller"
 
-    new_ctrl = create_mock_controller("000000002", "192.0.2.2")
+    discovery_flows = [
+        flow
+        for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        if flow["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
+    ]
+    assert len(discovery_flows) == 2
 
+    # Re-noting an existing shelf UID must not stack another flow.
     izone_discovery.async_note_integration_discovery(
-        hass, endpoint_from_controller(new_ctrl)
+        hass, endpoint_from_controller(first)
     )
     await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -908,21 +947,26 @@ async def test_runtime_integration_discovery_allows_during_user_select_controlle
         for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
         if flow["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
     ]
-    assert len(discovery_flows) == 1
-    assert discovery_flows[0]["context"]["unique_id"] == new_ctrl.device_uid
+    assert len(discovery_flows) == 2
+    assert {flow["context"]["unique_id"] for flow in discovery_flows} == {
+        first.device_uid,
+        second.device_uid,
+    }
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
 async def test_runtime_integration_discovery_allows_during_user_confirm(
     hass: HomeAssistant,
 ) -> None:
-    """Runtime discovery may add shelf flows while a user confirm step is open."""
+    """Runtime discovery may add shelf flows while a shelf confirm step is open."""
     first = create_mock_controller("000000001", "192.0.2.1")
     second = create_mock_controller("000000002", "192.0.2.2")
     with patch_discovered_controllers(first):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
         assert result["step_id"] == "confirm"
 
     izone_discovery.async_note_integration_discovery(
@@ -934,7 +978,6 @@ async def test_runtime_integration_discovery_allows_during_user_confirm(
     assert len(progress) == 2
     sources = {flow["context"]["source"] for flow in progress}
     assert sources == {
-        config_entries.SOURCE_USER,
         config_entries.SOURCE_INTEGRATION_DISCOVERY,
     }
 
@@ -983,6 +1026,8 @@ async def test_confirm_asserts_when_controller_data_is_missing(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
 
     # Corrupt flow-local state that the public path always sets before confirm.
     flow = hass.config_entries.flow._progress[result["flow_id"]]
@@ -1001,6 +1046,8 @@ async def test_confirm_asserts_when_unique_id_is_not_string(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        result = await async_finish_user_discover(hass, result)
+        result = await async_follow_user_handoff(hass, result)
 
     flow = hass.config_entries.flow._progress[result["flow_id"]]
     flow.context["unique_id"] = None

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -519,6 +519,20 @@ async def test_discover_all_endpoints(
     mock_service.discover_all.assert_awaited_once()
 
 
+async def test_scan(
+    hass: HomeAssistant,
+    mock_pizone_create_discovery: tuple[AsyncMock, Mock],
+) -> None:
+    """User Search broadcasts without reading dump_state."""
+    _, mock_service = mock_pizone_create_discovery
+    mock_service.scan = AsyncMock()
+
+    await izone_discovery.async_scan(hass)
+
+    assert mock_service.scan.await_count >= 1
+    mock_service.discover_all.assert_not_called()
+
+
 async def test_discover_endpoint_by_uid(
     hass: HomeAssistant,
     mock_pizone_create_discovery: tuple[AsyncMock, Mock],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
User **Search** for iZone now shows progress while the shared discovery service broadcasts and waits for replies, so controllers can appear on the Discovered shelf during the wait.

After the scan, Search builds choices from in-progress discovery/HomeKit shelf flows and hands off into the selected confirm via `next_flow` (`continue_setup`). The user Search flow does not claim `unique_id` under progress, and it ends after handing off one controller (siblings stay on the shelf). 

Also stops blocking runtime integration discovery while a `SOURCE_USER` flow is open, which is required for the shelf to fill during Search. This does mean multiple user initated flows can be created, and abandoned, however they won't block further discovery or searches so users aren't forced to restart. The abandoned searches may need to be aborted as per #177462, which is a bigger system-wide fix as it affects all integrations.

Split out of the larger draft [#177163](https://github.com/home-assistant/core/pull/177163) which I'm trying to split up to make more reviewable. 

Manual host remains a follow-up. Docs for manual host remain parent-blocked: [home-assistant.io#47026](https://github.com/home-assistant/home-assistant.io/pull/47026).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47026 (parent-blocked; manual host follow-up)
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Related draft / split from: https://github.com/home-assistant/core/pull/177163

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr