### PR TITLE
Bump homematicip to 2.14.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.13.4"]
+  "requirements": ["homematicip==2.14.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1293,7 +1293,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.5
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.13.4
+homematicip==2.14.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Bump `homematicip` from 2.13.4 to 2.14.0.

- Changelog diff: https://github.com/hahn-th/homematicip-rest-api/compare/2.13.4...2.14.0
- Release notes: https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.14.0

Relevant to this integration:

- Failing REST calls now log the response body, which is where the HmIP error code (`INVALID_REQUEST`, `CLIENT_ACCESS_DENIED`, ...) is carried. Previously a failure logged only the status code, so reporters could not supply the cause. The logged body is redacted with the same key set as the request and truncated.
- On the request-based alarm panel (`securityZoneActivationMode: ACTIVATION_REQUEST_BASED`), an activation blocked by an open window no longer reports success. `setZonesActivation` answers HTTP 200 without arming, so the library now uses `setExtendedZonesActivation`, marks the result unsuccessful and names the blocking sensors.
- A low battery no longer blocks arming, it logs a warning instead.
- `SecurityZoneGroup.ignorableDevices` was always empty and now resolves correctly.

Note this bump on its own does not yet change what a user sees when arming fails, because the integration does not check the result of `set_security_zones_activation_async`. A follow-up PR will surface the error. The response body logging does take effect immediately.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177173, #178488
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
