### PR TITLE
Fix prefer internal URL for LOQED webhooks

### DIFF
--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -133,7 +133,9 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
             )
         else:
             webhook_url = webhook.async_generate_url(
-                self.hass, self.config_entry.data[CONF_WEBHOOK_ID]
+                self.hass,
+                self.config_entry.data[CONF_WEBHOOK_ID],
+                prefer_external=False,
             )
 
         _LOGGER.debug("Webhook URL: %s", webhook_url)

--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -150,22 +150,39 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
             await self.lock.registerWebhook(webhook_url)
             webhooks = await self.lock.getWebhooks()
             webhook_index = next(x["id"] for x in webhooks if x["url"] == webhook_url)
+            await self._remove_stale_webhooks(webhook_id, webhook_index, webhooks)
 
             _LOGGER.debug("Webhook got index %s", webhook_index)
+
+    async def _remove_stale_webhooks(
+        self, webhook_id: str, webhook_index: int, webhooks: list[dict]
+    ) -> None:
+        for existing_webhook in webhooks:
+            url = existing_webhook["url"]
+            index = existing_webhook["id"]
+            if webhook_id in url and webhook_index != index:
+                _LOGGER.debug("Removing stale webhook with URL: %s", url)
+                try:
+                    await self.lock.deleteWebhook(index)
+                except (TimeoutError, aiohttp.ClientError) as err:
+                    _LOGGER.warning(
+                        "Could not remove stale webhook from LOQED bridge: %s", err
+                    )
 
     async def remove_webhooks(self) -> None:
         """Remove webhook from LOQED bridge."""
         webhook_id = self.config_entry.data[CONF_WEBHOOK_ID]
 
-        if CONF_CLOUDHOOK_URL in self.config_entry.data:
-            webhook_url = self.config_entry.data[CONF_CLOUDHOOK_URL]
-        else:
-            webhook_url = webhook.async_generate_url(self.hass, webhook_id)
-
-        _LOGGER.debug("Webhook URL: %s", webhook_url)
-
         try:
             webhooks = await self.lock.getWebhooks()
+
+            if CONF_CLOUDHOOK_URL in self.config_entry.data:
+                webhook_url = self.config_entry.data[CONF_CLOUDHOOK_URL]
+            else:
+                webhook_url = next(
+                    (x["url"] for x in webhooks if webhook_id in x["url"]), None
+                )
+                _LOGGER.debug("Webhook URL: %s", webhook_url)
 
             webhook_index = next(
                 (x["id"] for x in webhooks if x["url"] == webhook_url), None

--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -150,9 +150,11 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
             await self.lock.registerWebhook(webhook_url)
             webhooks = await self.lock.getWebhooks()
             webhook_index = next(x["id"] for x in webhooks if x["url"] == webhook_url)
-            await self._remove_stale_webhooks(webhook_id, webhook_index, webhooks)
 
             _LOGGER.debug("Webhook got index %s", webhook_index)
+
+        if webhook_index:
+            await self._remove_stale_webhooks(webhook_id, webhook_index, webhooks)
 
     async def _remove_stale_webhooks(
         self, webhook_id: str, webhook_index: int, webhooks: list[dict]

--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -159,10 +159,16 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
     async def _remove_stale_webhooks(
         self, webhook_id: str, webhook_index: int, webhooks: list[dict]
     ) -> None:
+        cloudhook_url = self.config_entry.data.get(CONF_CLOUDHOOK_URL)
+
         for existing_webhook in webhooks:
             url = existing_webhook["url"]
             index = existing_webhook["id"]
-            if webhook_id in url and webhook_index != index:
+            is_integration_webhook = url.endswith(f"/{webhook_id}") or (
+                cloudhook_url and url == cloudhook_url
+            )
+
+            if is_integration_webhook and webhook_index != index:
                 _LOGGER.debug("Removing stale webhook with URL: %s", url)
                 try:
                     await self.lock.deleteWebhook(index)
@@ -182,7 +188,8 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
                 webhook_url = self.config_entry.data[CONF_CLOUDHOOK_URL]
             else:
                 webhook_url = next(
-                    (x["url"] for x in webhooks if webhook_id in x["url"]), None
+                    (x["url"] for x in webhooks if x["url"].endswith(f"/{webhook_id}")),
+                    None,
                 )
                 _LOGGER.debug("Webhook URL: %s", webhook_url)
 

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -84,9 +84,12 @@ async def test_webhook_prefers_internal_url(
     config_entry.add_to_hass(hass)
 
     lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+
     webhooks_fixture = json.loads(
         await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
     )
+    webhooks_fixture[0]["url"] = f"{hass.config.internal_url}/api/webhook/Webhook_id"
+
     lock.getWebhooks = AsyncMock(side_effect=[[], webhooks_fixture])
 
     with (

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -152,6 +152,50 @@ async def test_ensure_webhooks_removes_stale_webhooks(
     lock.deleteWebhook.assert_has_calls([call(14), call(4)], any_order=True)
 
 
+async def test_ensure_webhooks_handles_bridge_error_on_cleanup(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    lock: loqed.Lock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that stale webhook cleanup handles bridge connection errors smoothly."""
+    await hass.config.async_update(internal_url="http://192.168.1.10:8123")
+
+    config: dict[str, Any] = {DOMAIN: {}}
+    config_entry.add_to_hass(hass)
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+
+    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+
+    stale_webhook = {
+        "id": 14,
+        "url": f"https://this-is-external-url.hass.nabu.casa/api/webhook/{webhook_id}",
+    }
+    new_webhook = {
+        "id": 15,
+        "url": f"{hass.config.internal_url}/api/webhook/{webhook_id}",
+    }
+
+    lock.getWebhooks = AsyncMock(
+        side_effect=[[stale_webhook], [stale_webhook, new_webhook]]
+    )
+
+    lock.deleteWebhook = AsyncMock(side_effect=aiohttp.ClientError)
+
+    with (
+        patch("loqedAPI.loqed.LoqedAPI.async_get_lock", return_value=lock),
+        patch(
+            "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
+        ),
+    ):
+        await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    lock.deleteWebhook.assert_called_once_with(14)
+
+    assert "Could not remove stale webhook from LOQED bridge" in caplog.text
+
+
 async def test_cannot_connect_to_bridge_will_retry(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
 ) -> None:

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -18,7 +18,12 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.network import get_url
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_fixture,
+    async_load_json_object_fixture,
+)
 from tests.typing import ClientSessionGenerator
 
 
@@ -80,10 +85,9 @@ async def test_webhook_prefers_internal_url(
         external_url="https://this-is-external-url.hass.nabu.casa",
     )
 
-    config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     webhooks_fixture = json.loads(
         await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
@@ -98,7 +102,7 @@ async def test_webhook_prefers_internal_url(
             "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
         ),
     ):
-        await async_setup_component(hass, DOMAIN, config)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     lock.registerWebhook.assert_called_with(
@@ -115,11 +119,10 @@ async def test_ensure_webhooks_removes_stale_webhooks(
         external_url="https://this-is-external-url.hass.nabu.casa",
     )
 
-    config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
     webhook_id = config_entry.data[CONF_WEBHOOK_ID]
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     stale_webhook = {
         "id": 14,
@@ -147,7 +150,7 @@ async def test_ensure_webhooks_removes_stale_webhooks(
             "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
         ),
     ):
-        await async_setup_component(hass, DOMAIN, config)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     lock.registerWebhook.assert_called_once()
@@ -164,11 +167,10 @@ async def test_ensure_webhooks_handles_bridge_error_on_cleanup(
     """Test that stale webhook cleanup handles bridge connection errors smoothly."""
     await hass.config.async_update(internal_url="http://192.168.1.10:8123")
 
-    config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
     webhook_id = config_entry.data[CONF_WEBHOOK_ID]
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     stale_webhook = {
         "id": 14,
@@ -191,7 +193,7 @@ async def test_ensure_webhooks_handles_bridge_error_on_cleanup(
             "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
         ),
     ):
-        await async_setup_component(hass, DOMAIN, config)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     lock.deleteWebhook.assert_called_once_with(14)

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory
@@ -101,6 +101,55 @@ async def test_webhook_prefers_internal_url(
     lock.registerWebhook.assert_called_with(
         f"{hass.config.internal_url}/api/webhook/Webhook_id"
     )
+
+
+async def test_ensure_webhooks_removes_stale_webhooks(
+    hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
+) -> None:
+    """Test that stale webhooks with the same ID but different URL are removed."""
+    await hass.config.async_update(
+        internal_url="http://192.168.1.10:8123",
+        external_url="https://this-is-external-url.hass.nabu.casa",
+    )
+
+    config: dict[str, Any] = {DOMAIN: {}}
+    config_entry.add_to_hass(hass)
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+
+    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+
+    stale_webhook = {
+        "id": 14,
+        "url": f"192.168.14.233/api/webhook/{webhook_id}",
+    }
+    another_stale_webhook = {
+        "id": 4,
+        "url": f"{hass.config.external_url}/api/webhook/{webhook_id}",
+    }
+    new_webhook = {
+        "id": 15,
+        "url": f"{hass.config.internal_url}/api/webhook/{webhook_id}",
+    }
+
+    lock.getWebhooks = AsyncMock(
+        side_effect=[
+            [stale_webhook, another_stale_webhook],
+            [stale_webhook, another_stale_webhook, new_webhook],
+        ]
+    )
+
+    with (
+        patch("loqedAPI.loqed.LoqedAPI.async_get_lock", return_value=lock),
+        patch(
+            "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
+        ),
+    ):
+        await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    lock.registerWebhook.assert_called_once()
+    assert lock.deleteWebhook.call_count == 2
+    lock.deleteWebhook.assert_has_calls([call(14), call(4)], any_order=True)
 
 
 async def test_cannot_connect_to_bridge_will_retry(

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -71,6 +71,38 @@ async def test_setup_webhook_in_bridge(
     lock.registerWebhook.assert_called_with(f"{get_url(hass)}/api/webhook/Webhook_id")
 
 
+async def test_webhook_prefers_internal_url(
+    hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
+) -> None:
+    """Test webhook actually prefers internal url."""
+    await hass.config.async_update(
+        internal_url="http://192.168.1.10:8123",
+        external_url="https://this-is-external-url.hass.nabu.casa",
+    )
+
+    config: dict[str, Any] = {DOMAIN: {}}
+    config_entry.add_to_hass(hass)
+
+    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    webhooks_fixture = json.loads(
+        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    )
+    lock.getWebhooks = AsyncMock(side_effect=[[], webhooks_fixture])
+
+    with (
+        patch("loqedAPI.loqed.LoqedAPI.async_get_lock", return_value=lock),
+        patch(
+            "loqedAPI.loqed.LoqedAPI.async_get_lock_details", return_value=lock_status
+        ),
+    ):
+        await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    lock.registerWebhook.assert_called_with(
+        f"{hass.config.internal_url}/api/webhook/Webhook_id"
+    )
+
+
 async def test_cannot_connect_to_bridge_will_retry(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
LOQED [support page](https://support.loqed.com/en/articles/6144029-home-assistant-and-loqed-integration)
states that 'The integration prefers the internal URL over de external one.' which is not the actual behavior.
This PR fixes that.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Default behavior of get_url method is to prefer external url. This PR adds explicitly prefer_external=False
parametrization.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
