### PR TITLE
Make tplink unavailable-entity warning resilient to broken device repr

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -277,9 +277,15 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
             available = self._async_update_attrs()
         except Exception as ex:  # noqa: BLE001
             if self._attr_available:
+                try:
+                    device_repr = str(self._device)
+                except Exception:  # noqa: BLE001
+                    # __repr__ can itself raise if the device's last update
+                    # failed, e.g. a smartcam returning a SmartErrorCode
+                    device_repr = self._device.host
                 _LOGGER.warning(
                     "Unable to read data for %s %s: %s",
-                    self._device,
+                    device_repr,
                     self.entity_id,
                     ex,
                 )

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the TP-Link component."""
 
+from collections.abc import Callable
 import copy
 from datetime import timedelta
 from typing import Any
@@ -344,14 +345,33 @@ async def test_plug_auth_fails(hass: HomeAssistant) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("mock_str", "expected_device_repr"),
+    [
+        pytest.param(lambda _: "MockLight", "MockLight", id="normal_repr"),
+        pytest.param(
+            MagicMock(
+                side_effect=TypeError("'SmartErrorCode' object is not subscriptable")
+            ),
+            IP_ADDRESS,
+            id="broken_repr",
+        ),
+    ],
+)
 async def test_update_attrs_fails_in_init(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
+    mock_str: Callable[[Device], str] | MagicMock,
+    expected_device_repr: str,
 ) -> None:
-    """Test a smart plug auth failure."""
+    """Test a smart plug auth failure.
+
+    Also covers a device whose __str__ raises, e.g. a smartcam device
+    whose __repr__ re-queries the device after a SmartErrorCode response.
+    """
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
     )
     config_entry.add_to_hass(hass)
     features = [
@@ -365,7 +385,7 @@ async def test_update_attrs_fails_in_init(
     light_module = light.modules[Module.Light]
     p = PropertyMock(side_effect=KasaException)
     type(light_module).color_temp = p
-    light.__str__ = lambda _: "MockLight"
+    light.__str__ = mock_str
     with _patch_discovery(device=light), _patch_connect(device=light):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -375,7 +395,7 @@ async def test_update_attrs_fails_in_init(
     assert entity
     state = hass.states.get(entity_id)
     assert state.state == STATE_UNAVAILABLE
-    assert f"Unable to read data for MockLight {entity_id}:" in caplog.text
+    assert f"Unable to read data for {expected_device_repr} {entity_id}:" in caplog.text
 
 
 async def test_update_attrs_fails_on_update(
@@ -428,46 +448,6 @@ async def test_update_attrs_fails_on_update(
     state = hass.states.get(entity_id)
     assert state.state == STATE_UNAVAILABLE
     assert f"Unable to read data for MockLight {entity_id}:" not in caplog.text
-
-
-async def test_update_attrs_fails_with_broken_device_repr(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test the unavailable warning still logs when device __str__ raises.
-
-    This can happen for smartcam devices when a query fails with a
-    SmartErrorCode, since __repr__ itself queries the device.
-    """
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
-    )
-    config_entry.add_to_hass(hass)
-    features = [
-        _mocked_feature("brightness", value=50),
-        _mocked_feature("hsv", value=(10, 30, 5)),
-        _mocked_feature(
-            "color_temp", value=4000, minimum_value=4000, maximum_value=9000
-        ),
-    ]
-    light = _mocked_device(modules=[Module.Light], alias="my_light", features=features)
-    light_module = light.modules[Module.Light]
-    p = PropertyMock(side_effect=KasaException)
-    type(light_module).color_temp = p
-    light.__str__ = MagicMock(
-        side_effect=TypeError("'SmartErrorCode' object is not subscriptable")
-    )
-    with _patch_discovery(device=light), _patch_connect(device=light):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    entity_id = "light.my_light"
-    entity = entity_registry.async_get(entity_id)
-    assert entity
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_UNAVAILABLE
-    assert f"Unable to read data for {IP_ADDRESS} {entity_id}:" in caplog.text
 
 
 async def test_feature_no_category(

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -430,6 +430,46 @@ async def test_update_attrs_fails_on_update(
     assert f"Unable to read data for MockLight {entity_id}:" not in caplog.text
 
 
+async def test_update_attrs_fails_with_broken_device_repr(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the unavailable warning still logs when device __str__ raises.
+
+    This can happen for smartcam devices when a query fails with a
+    SmartErrorCode, since __repr__ itself queries the device.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
+    )
+    config_entry.add_to_hass(hass)
+    features = [
+        _mocked_feature("brightness", value=50),
+        _mocked_feature("hsv", value=(10, 30, 5)),
+        _mocked_feature(
+            "color_temp", value=4000, minimum_value=4000, maximum_value=9000
+        ),
+    ]
+    light = _mocked_device(modules=[Module.Light], alias="my_light", features=features)
+    light_module = light.modules[Module.Light]
+    p = PropertyMock(side_effect=KasaException)
+    type(light_module).color_temp = p
+    light.__str__ = MagicMock(
+        side_effect=TypeError("'SmartErrorCode' object is not subscriptable")
+    )
+    with _patch_discovery(device=light), _patch_connect(device=light):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_light"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert f"Unable to read data for {IP_ADDRESS} {entity_id}:" in caplog.text
+
+
 async def test_feature_no_category(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Proposed change

Fixes an issue where the entity coordinator logs the device object directly with %s. When a smartcam device's last query returned a SmartErrorCode, Device.__repr__ re-queries the device via .model and raises again, breaking the log record's formatting and hiding the real error (home-assistant/core#177650).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177650
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr