### PR TITLE
Create hassio config entry during setup instead of deferring to started

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -349,8 +349,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
-            ),
-            eager_start=True,
+            )
         )
     return True
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -349,7 +349,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
-            )
+            ),
+            "hassio system config entry flow",
         )
     return True
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -341,8 +341,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     frontend.async_register_built_in_panel(hass, "app")
 
     if entry is None:
-        discovery_flow.async_create_flow(
-            hass, DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
+        # Create the config entry directly instead of via the discovery flow
+        # helper, which defers flow creation until Home Assistant has started.
+        # All Supervisor data is fetched by the entry's coordinators, so on
+        # first boot deferring would leave system info unavailable during
+        # onboarding and race listeners of the started event.
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
+            ),
+            eager_start=True,
         )
     return True
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -69,7 +69,7 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.hassio import is_hassio
@@ -194,6 +194,27 @@ async def test_setup_api_ping_fails(
     assert is_hassio(hass)
     entry = hass.config_entries.async_entries("hassio")[0]
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_created_before_started(
+    hass: HomeAssistant, supervisor_client: AsyncMock
+) -> None:
+    """Test the entry is created and loaded during startup on first boot.
+
+    Consumers of system info such as onboarding need Supervisor data before
+    Home Assistant has started, so entry creation must not be deferred to the
+    started event.
+    """
+    hass.set_state(CoreState.not_running)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        result = await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert result
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.state is ConfigEntryState.LOADED
+    assert get_core_info(hass)["version_latest"] == "1.0.0"
 
 
 async def test_setup_onboarding_supervisor_update(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -196,9 +196,8 @@ async def test_setup_api_ping_fails(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_entry_created_before_started(
-    hass: HomeAssistant, supervisor_client: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("supervisor_client")
+async def test_setup_entry_created_before_started(hass: HomeAssistant) -> None:
     """Test the entry is created and loaded during startup on first boot.
 
     Consumers of system info such as onboarding need Supervisor data before


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On a fresh installation (first boot, no hassio config entry yet), Supervisor data is unavailable until after Home Assistant has started. The hassio config entry is created via the discovery flow helper, which defers flow creation until `EVENT_HOMEASSISTANT_STARTED` (#112291). Since #169586 removed the eager info fetch from `async_setup`, all Supervisor data (`DATA_INFO`, `DATA_HOST_INFO`, etc.) is only populated by the config entry's coordinators — so on first boot nothing populates it before the started event.

As a result, started-event listeners which call `async_get_system_info` race the entry's first refresh and misdetect the installation type (e.g. a Home Assistant OS system is reported as "Home Assistant Container" or "Home Assistant Supervised"). This affects the deprecation repair check, the SSDP UPnP server and analytics, and logs warnings like:

```
WARNING (MainThread) [homeassistant.helpers.system_info] No Home Assistant Supervisor info available
WARNING (MainThread) [homeassistant.helpers.system_info] No Home Assistant Supervisor host info available
```

Existing installations are not affected because their entry already exists at bootstrap and is set up within `async_setup_component` in stage 1.

This PR creates the config entry directly with an eagerly started `flow.async_init` task in `async_setup` (the pattern used before #112291). The entry is then registered before component setup completes, so it is set up inside bootstrap stage 1 together with its coordinators — making first boot behave exactly like every subsequent boot. Deferring the flow was harmless when it was introduced, since back then `async_setup` fetched all Supervisor data itself; that assumption no longer holds since #169586.

Note that this also means the onboarding Supervisor update check from #171129 now runs during bootstrap stage 1 instead of after the started event, which matches that PR's intent of updating Supervisor before Core loads against it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
