### PR TITLE
Add PIN recovery test to Subaru config flow

### DIFF
--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -349,7 +349,7 @@ async def test_pin_form_success(hass: HomeAssistant, pin_form) -> None:
 
 
 async def test_pin_form_incorrect_pin(hass: HomeAssistant, pin_form) -> None:
-    """Test we handle invalid pin."""
+    """Test we handle invalid pin, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_TEST_PIN,
@@ -367,6 +367,16 @@ async def test_pin_form_incorrect_pin(hass: HomeAssistant, pin_form) -> None:
     assert len(mock_update_saved_pin.mock_calls) == 1
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "incorrect_pin"}
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_form(options_form) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change

Split out of #178638 per review feedback. Extends `test_pin_form_incorrect_pin` to verify the config flow can still be completed after an incorrect PIN error, not just that the error is shown.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
