### PR TITLE
Bump zhong-hong-hvac to 1.0.18

### DIFF
--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["zhong_hong_hvac"],
   "quality_scale": "legacy",
-  "requirements": ["zhong-hong-hvac==1.0.17"]
+  "requirements": ["zhong-hong-hvac==1.0.18"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3479,7 +3479,7 @@ zha-quirks==2.2.0
 zha==2.1.0
 
 # homeassistant.components.zhong_hong
-zhong-hong-hvac==1.0.17
+zhong-hong-hvac==1.0.18
 
 # homeassistant.components.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.1.0


### PR DESCRIPTION
## Proposed change

Bump `zhong-hong-hvac` from 1.0.17 to 1.0.18, which lets discovery be given a time budget.

`discovery_ac()` asks the gateway which air conditioners are on its bus and retries until it gets an answer, ten rounds of a thirty second receive timeout. An address that accepts the TCP connection but never speaks the protocol therefore takes over five minutes to come back. That is fine for a background reconnect, and far too long for a caller with someone waiting on the answer, which is what the config flow in #178506 is.

The library now takes an optional `timeout` bounding the whole exchange. Without one it behaves exactly as before, so this bump changes nothing on its own — it only makes the bound available.

The bound has to be applied to the gateway object rather than to the socket, because `send()` puts the socket back to the gateway's own receive timeout after every write; a socket level timeout would be undone by the first request that goes out. That is covered by the library's tests.

- Library diff: https://github.com/crhan/ZhongHongHVAC/compare/v1.0.17...v1.0.18
- Release notes: https://github.com/crhan/ZhongHongHVAC/releases/tag/v1.0.18

Split out of #178506 at review request.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178506
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
