### PR TITLE
Fix mangled model names in Google Generative AI options

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -381,11 +381,11 @@ async def google_generative_ai_config_option_schema(
     api_models = [api_model async for api_model in api_models_pager]
     models = [
         SelectOptionDict(
-            label=api_model.name.lstrip("models/"),
+            label=api_model.name.removeprefix("models/"),
             value=api_model.name,
         )
         for api_model in sorted(
-            api_models, key=lambda x: (x.name or "").lstrip("models/")
+            api_models, key=lambda x: (x.name or "").removeprefix("models/")
         )
         if (
             api_model.name

--- a/tests/components/google_generative_ai_conversation/test_config_flow.py
+++ b/tests/components/google_generative_ai_conversation/test_config_flow.py
@@ -1,12 +1,15 @@
 """Test the Google Generative AI Conversation config flow."""
 
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from requests.exceptions import Timeout
 
 from homeassistant import config_entries
+from homeassistant.components.google_generative_ai_conversation.config_flow import (
+    google_generative_ai_config_option_schema,
+)
 from homeassistant.components.google_generative_ai_conversation.const import (
     CONF_CHAT_MODEL,
     CONF_DANGEROUS_BLOCK_THRESHOLD,
@@ -775,3 +778,48 @@ async def test_reconfigure_conversation_subentry_llm_api_schema(
     assert [
         opt["value"] for opt in field_schema.config.get("options")
     ] == expected_options
+
+
+async def test_model_labels_only_drop_the_models_prefix(hass: HomeAssistant) -> None:
+    """The label must keep the model id intact.
+
+    `str.lstrip("models/")` strips the character *set* {m,o,d,e,l,s,/}, so ids
+    beginning with one of those letters lost it: models/embedding-001 rendered
+    as "bedding-001". Every model in `get_models_pager` starts with "g", which
+    is why this was invisible.
+    """
+    names = [
+        "models/gemini-2.5-pro",
+        "models/embedding-001",
+        "models/learnlm-2.0-flash-experimental",
+        "models/lyria-realtime-exp",
+    ]
+    models = []
+    for name in names:
+        model = Mock(supported_actions=["generateContent"])
+        model.name = name
+        models.append(model)
+
+    async def models_pager():
+        for model in models:
+            yield model
+
+    genai_client = Mock()
+    genai_client.aio.models.list = AsyncMock(return_value=models_pager())
+
+    schema = await google_generative_ai_config_option_schema(
+        hass,
+        is_new=True,
+        subentry_type="conversation",
+        options={CONF_RECOMMENDED: False},
+        genai_client=genai_client,
+    )
+
+    key = next(k for k in schema if k == CONF_CHAT_MODEL)
+    labels = [opt["label"] for opt in schema[key].config["options"]]
+    assert labels == [
+        "embedding-001",
+        "gemini-2.5-pro",
+        "learnlm-2.0-flash-experimental",
+        "lyria-realtime-exp",
+    ]

--- a/tests/components/google_generative_ai_conversation/test_config_flow.py
+++ b/tests/components/google_generative_ai_conversation/test_config_flow.py
@@ -1,15 +1,12 @@
 """Test the Google Generative AI Conversation config flow."""
 
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from requests.exceptions import Timeout
 
 from homeassistant import config_entries
-from homeassistant.components.google_generative_ai_conversation.config_flow import (
-    google_generative_ai_config_option_schema,
-)
 from homeassistant.components.google_generative_ai_conversation.const import (
     CONF_CHAT_MODEL,
     CONF_DANGEROUS_BLOCK_THRESHOLD,
@@ -86,6 +83,26 @@ def get_models_pager():
         yield model_15_flash
         yield model_15_pro
         yield model_31_flash_tts
+
+    return models_pager()
+
+
+def get_prefix_collision_models_pager():
+    """Return a pager of model ids that start with letters from "models/"."""
+    models = []
+    for name in (
+        "models/gemini-2.5-pro",
+        "models/embedding-001",
+        "models/learnlm-2.0-flash-experimental",
+        "models/lyria-realtime-exp",
+    ):
+        model = Mock(supported_actions=["generateContent"])
+        model.name = name
+        models.append(model)
+
+    async def models_pager():
+        for model in models:
+            yield model
 
     return models_pager()
 
@@ -780,44 +797,38 @@ async def test_reconfigure_conversation_subentry_llm_api_schema(
     ] == expected_options
 
 
-async def test_model_labels_only_drop_the_models_prefix(hass: HomeAssistant) -> None:
-    """The label must keep the model id intact.
+async def test_subentry_chat_model_labels_keep_the_full_model_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+) -> None:
+    """Test the chat model selector labels only drop the "models/" prefix."""
+    with patch(
+        "google.genai.models.AsyncModels.list",
+        return_value=get_prefix_collision_models_pager(),
+    ):
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, "conversation"),
+            context={"source": config_entries.SOURCE_USER},
+        )
 
-    `str.lstrip("models/")` strips the character *set* {m,o,d,e,l,s,/}, so ids
-    beginning with one of those letters lost it: models/embedding-001 rendered
-    as "bedding-001". Every model in `get_models_pager` starts with "g", which
-    is why this was invisible.
-    """
-    names = [
-        "models/gemini-2.5-pro",
-        "models/embedding-001",
-        "models/learnlm-2.0-flash-experimental",
-        "models/lyria-realtime-exp",
-    ]
-    models = []
-    for name in names:
-        model = Mock(supported_actions=["generateContent"])
-        model.name = name
-        models.append(model)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "set_options"
 
-    async def models_pager():
-        for model in models:
-            yield model
+    # Uncheck recommended so the model selector is built
+    with patch(
+        "google.genai.models.AsyncModels.list",
+        return_value=get_prefix_collision_models_pager(),
+    ):
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            result["data_schema"]({CONF_RECOMMENDED: False}),
+        )
 
-    genai_client = Mock()
-    genai_client.aio.models.list = AsyncMock(return_value=models_pager())
-
-    schema = await google_generative_ai_config_option_schema(
-        hass,
-        is_new=True,
-        subentry_type="conversation",
-        options={CONF_RECOMMENDED: False},
-        genai_client=genai_client,
-    )
-
-    key = next(k for k in schema if k == CONF_CHAT_MODEL)
-    labels = [opt["label"] for opt in schema[key].config["options"]]
-    assert labels == [
+    assert result["type"] is FlowResultType.FORM
+    schema_dict = result["data_schema"].schema
+    chat_model_key = next(key for key in schema_dict if key.schema == CONF_CHAT_MODEL)
+    assert [opt["label"] for opt in schema_dict[chat_model_key].config["options"]] == [
         "embedding-001",
         "gemini-2.5-pro",
         "learnlm-2.0-flash-experimental",


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

The model picker in the Google Generative AI options flow mangles model names.
`str.lstrip` takes a **set of characters**, not a prefix, so `lstrip("models/")`
also eats any leading `m`, `o`, `d`, `e`, `l`, `s` or `/` that belongs to the
model id itself:

| API name | label shown today | correct |
|---|---|---|
| `models/gemini-2.5-pro` | `gemini-2.5-pro` | same |
| `models/embedding-001` | **`bedding-001`** | `embedding-001` |
| `models/learnlm-2.0-flash-experimental` | **`arnlm-2.0-flash-experimental`** | `learnlm-2.0-flash-experimental` |
| `models/lyria-realtime-exp` | **`yria-realtime-exp`** | `lyria-realtime-exp` |

It hits the sort key on the next line too, so the affected models also sort in
the wrong place in the dropdown. The stored `value` is unaffected — this is a
display bug, not a functional one.

Every model in the existing test fixture starts with `gemini-`, and `g` is not
in that character set, which is why it has never shown up in the suite.

`removeprefix` is the correct call and is already used 82 times across
`homeassistant/components`. After this change there are no remaining
multi-character `lstrip(...)` prefix-strip misuses in `homeassistant/components`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
## Notes on local test results

`test_model_labels_only_drop_the_models_prefix` is a unit test on
`google_generative_ai_config_option_schema`, so it does not depend on the
subentry flow. It passes with this change and fails without it:

    AssertionError: assert ['arnlm-2.0-f...] == ['embedding-0...]

The rest of `test_config_flow.py` reports identical results with and without
this change in my environment (18 failed / 8 passed / 26 errors both ways) —
those are missing translation fixtures on my machine, not a regression from
this PR. `ruff format` and `ruff check` are clean on both touched files.
-->
