### PR TITLE
Handle Wyoming error events

### DIFF
--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, override
 
 from wyoming.asr import Transcript
 from wyoming.client import AsyncTcpClient
+from wyoming.error import Error
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import HandleProgram, IntentProgram
 from wyoming.intent import Intent, IntentsStart, IntentsStop, NotRecognized
@@ -20,7 +21,7 @@ from homeassistant.util import ulid as ulid_util
 
 from .const import DOMAIN
 from .data import WyomingService
-from .error import WyomingError
+from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -179,6 +180,17 @@ class WyomingConversationEntity(
             event = await client.read_event()
             if event is None:
                 raise WyomingError("Connection lost")
+
+            if Error.is_type(event.type):
+                message = error_event_message(Error.from_event(event))
+                _LOGGER.error(message)
+                intent_response.async_set_error(
+                    intent.IntentResponseErrorCode.UNKNOWN, message
+                )
+
+                # Don't process any intents that were already received
+                intents.clear()
+                break
 
             if IntentsStart.is_type(event.type):
                 # Multiple intents may be present

--- a/homeassistant/components/wyoming/error.py
+++ b/homeassistant/components/wyoming/error.py
@@ -1,7 +1,17 @@
 """Errors for the Wyoming integration."""
 
+from wyoming.error import Error
+
 from homeassistant.exceptions import HomeAssistantError
 
 
 class WyomingError(HomeAssistantError):
     """Base class for Wyoming errors."""
+
+
+def error_event_message(error: Error) -> str:
+    """Return a message for an error event from a Wyoming service."""
+    if error.code is None:
+        return f"Error from Wyoming service: {error.text}"
+
+    return f"Error from Wyoming service: {error.text} (code: {error.code})"

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -7,6 +7,7 @@ from typing import override
 from wyoming.asr import Transcribe, Transcript
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
+from wyoming.error import Error
 
 from homeassistant.components import stt
 from homeassistant.core import HomeAssistant
@@ -14,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
 from .data import WyomingService
-from .error import WyomingError
+from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,6 +127,10 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                     event = await client.read_event()
                     if event is None:
                         _LOGGER.debug("Connection lost")
+                        return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+
+                    if Error.is_type(event.type):
+                        _LOGGER.error(error_event_message(Error.from_event(event)))
                         return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
 
                     if Transcript.is_type(event.type):

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -9,6 +9,7 @@ import wave
 
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
+from wyoming.error import Error
 from wyoming.tts import (
     Synthesize,
     SynthesizeChunk,
@@ -20,6 +21,7 @@ from wyoming.tts import (
 
 from homeassistant.components import tts
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_SPEAKER
@@ -28,6 +30,14 @@ from .error import WyomingError
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _error_message(error: Error) -> str:
+    """Return a message for an error event from the TTS service."""
+    if error.code is None:
+        return f"Error from TTS service: {error.text}"
+
+    return f"Error from TTS service: {error.text} (code: {error.code})"
 
 
 async def async_setup_entry(
@@ -116,6 +126,11 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
                         if event is None:
                             _LOGGER.debug("Connection lost")
                             return (None, None)
+
+                        if Error.is_type(event.type):
+                            raise HomeAssistantError(
+                                _error_message(Error.from_event(event))
+                            )
 
                         if AudioStop.is_type(event.type):
                             break
@@ -213,6 +228,9 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
 
         try:
             while event := await client.read_event():
+                if Error.is_type(event.type):
+                    raise HomeAssistantError(_error_message(Error.from_event(event)))
+
                 if wav_header_sent and AudioChunk.is_type(event.type):
                     # PCM audio
                     yield AudioChunk.from_event(event).audio

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -26,18 +26,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_SPEAKER
 from .data import WyomingService
-from .error import WyomingError
+from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _error_message(error: Error) -> str:
-    """Return a message for an error event from the TTS service."""
-    if error.code is None:
-        return f"Error from TTS service: {error.text}"
-
-    return f"Error from TTS service: {error.text} (code: {error.code})"
 
 
 async def async_setup_entry(
@@ -129,7 +121,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
 
                         if Error.is_type(event.type):
                             raise HomeAssistantError(
-                                _error_message(Error.from_event(event))
+                                error_event_message(Error.from_event(event))
                             )
 
                         if AudioStop.is_type(event.type):
@@ -229,7 +221,9 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
         try:
             while event := await client.read_event():
                 if Error.is_type(event.type):
-                    raise HomeAssistantError(_error_message(Error.from_event(event)))
+                    raise HomeAssistantError(
+                        error_event_message(Error.from_event(event))
+                    )
 
                 if wav_header_sent and AudioChunk.is_type(event.type):
                     # PCM audio

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -7,6 +7,7 @@ from typing import override
 
 from wyoming.audio import AudioChunk, AudioStart
 from wyoming.client import AsyncTcpClient
+from wyoming.error import Error
 from wyoming.wake import Detect, Detection
 
 from homeassistant.components import wake_word
@@ -14,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .data import WyomingService, load_wyoming_info
-from .error import WyomingError
+from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,6 +123,12 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
                             event = wake_task.result()
                             if event is None:
                                 _LOGGER.debug("Connection lost")
+                                break
+
+                            if Error.is_type(event.type):
+                                _LOGGER.error(
+                                    error_event_message(Error.from_event(event))
+                                )
                                 break
 
                             if Detection.is_type(event.type):

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
+from wyoming.error import Error
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import Info
 from wyoming.intent import Entity, Intent, IntentsStart, IntentsStop, NotRecognized
@@ -401,6 +402,76 @@ async def test_not_handled(
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
+
+
+@pytest.mark.usefixtures("init_wyoming_intent")
+@pytest.mark.parametrize(
+    ("error_code", "expected_message"),
+    [
+        pytest.param(None, "Error from Wyoming service: Boom!", id="without_code"),
+        pytest.param(
+            "IntentError",
+            "Error from Wyoming service: Boom! (code: IntentError)",
+            id="with_code",
+        ),
+    ],
+)
+async def test_error_event(
+    hass: HomeAssistant, error_code: str | None, expected_message: str
+) -> None:
+    """Test that an error event from the service is reported."""
+    agent_id = "conversation.test_intent"
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+        )
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == expected_message
+
+
+@pytest.mark.usefixtures("init_wyoming_intent")
+async def test_error_event_discards_received_intents(hass: HomeAssistant) -> None:
+    """Test that intents received before an error event are not handled."""
+    agent_id = "conversation.test_intent"
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(
+            [
+                IntentsStart().event(),
+                Intent(name="TestIntent").event(),
+                Error(text="Boom!").event(),
+            ]
+        ),
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+        )
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.speech, "No speech"
+    assert (
+        result.response.speech.get("plain", {}).get("speech")
+        == "Error from Wyoming service: Boom!"
+    )
 
 
 async def test_connection_lost(

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -2,8 +2,10 @@
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
+from wyoming.error import Error
 
 from homeassistant.components import stt
 from homeassistant.core import HomeAssistant
@@ -67,6 +69,43 @@ async def test_streaming_audio_connection_lost(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
+@pytest.mark.parametrize(
+    ("error_code", "expected_message"),
+    [
+        pytest.param(None, "Error from Wyoming service: Boom!", id="without_code"),
+        pytest.param(
+            "ModelNotFoundError",
+            "Error from Wyoming service: Boom! (code: ModelNotFoundError)",
+            id="with_code",
+        ),
+    ],
+)
+async def test_streaming_audio_error_event(
+    hass: HomeAssistant,
+    metadata: stt.SpeechMetadata,
+    caplog: pytest.LogCaptureFixture,
+    error_code: str | None,
+    expected_message: str,
+) -> None:
+    """Test that an error event from the service is reported."""
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+
+    async def audio_stream():
+        yield "chunk1"
+
+    with patch(
+        "homeassistant.components.wyoming.stt.AsyncTcpClient",
+        MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
+    ):
+        result = await entity.async_process_audio_stream(metadata, audio_stream())
+
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert expected_message in caplog.text
 
 
 async def test_streaming_audio_oserror(

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -202,10 +202,10 @@ async def test_get_tts_audio_audio_oserror(
 @pytest.mark.parametrize(
     ("error_code", "expected_message"),
     [
-        pytest.param(None, "Error from TTS service: Boom!", id="without_code"),
+        pytest.param(None, "Error from Wyoming service: Boom!", id="without_code"),
         pytest.param(
             "VoiceNotFoundError",
-            "Error from TTS service: Boom! (code: VoiceNotFoundError)",
+            "Error from Wyoming service: Boom! (code: VoiceNotFoundError)",
             id="with_code",
         ),
     ],
@@ -246,7 +246,9 @@ async def test_get_tts_audio_streaming_error_event(hass: HomeAssistant) -> None:
         )
         stream.async_set_message_stream(message_gen())
 
-        with pytest.raises(HomeAssistantError, match="Error from TTS service: Boom!"):
+        with pytest.raises(
+            HomeAssistantError, match="Error from Wyoming service: Boom!"
+        ):
             async for _chunk in stream.async_stream_result():
                 pass
 

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -1,12 +1,14 @@
 """Test tts."""
 
 import io
+import re
 from unittest.mock import patch
 import wave
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.error import Error
 from wyoming.tts import SynthesizeStopped
 
 from homeassistant.components import tts, wyoming
@@ -194,6 +196,59 @@ async def test_get_tts_audio_audio_oserror(
                 hass, "Hello world", "tts.test_tts", hass.config.language
             ),
         )
+
+
+@pytest.mark.usefixtures("init_wyoming_tts")
+@pytest.mark.parametrize(
+    ("error_code", "expected_message"),
+    [
+        pytest.param(None, "Error from TTS service: Boom!", id="without_code"),
+        pytest.param(
+            "VoiceNotFoundError",
+            "Error from TTS service: Boom! (code: VoiceNotFoundError)",
+            id="with_code",
+        ),
+    ],
+)
+async def test_get_tts_audio_error_event(
+    hass: HomeAssistant, error_code: str | None, expected_message: str
+) -> None:
+    """Test that an error event from the service is reported."""
+    with (
+        patch(
+            "homeassistant.components.wyoming.tts.AsyncTcpClient",
+            MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
+        ),
+        pytest.raises(HomeAssistantError, match=re.escape(expected_message)),
+    ):
+        await tts.async_get_media_source_audio(
+            hass,
+            tts.generate_media_source_id(hass, "Hello world", "tts.test_tts", "en-US"),
+        )
+
+
+@pytest.mark.usefixtures("init_wyoming_streaming_tts")
+async def test_get_tts_audio_streaming_error_event(hass: HomeAssistant) -> None:
+    """Test that an error event received while streaming is reported."""
+
+    async def message_gen():
+        yield "Hello world."
+
+    with patch(
+        "homeassistant.components.wyoming.tts.AsyncTcpClient",
+        MockAsyncTcpClient([Error(text="Boom!").event()]),
+    ):
+        stream = tts.async_create_stream(
+            hass,
+            "tts.test_streaming_tts",
+            "en-US",
+            options={tts.ATTR_PREFERRED_FORMAT: "wav"},
+        )
+        stream.async_set_message_stream(message_gen())
+
+        with pytest.raises(HomeAssistantError, match="Error from TTS service: Boom!"):
+            async for _chunk in stream.async_stream_result():
+                pass
 
 
 async def test_voice_speaker(

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -3,8 +3,10 @@
 import asyncio
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
+from wyoming.error import Error
 from wyoming.info import Info, WakeModel, WakeProgram
 from wyoming.wake import Detection
 
@@ -83,6 +85,45 @@ async def test_streaming_audio_connection_lost(
         result = await entity.async_process_audio_stream(audio_stream(), None)
 
     assert result is None
+
+
+@pytest.mark.usefixtures("init_wyoming_wake_word")
+@pytest.mark.parametrize(
+    ("error_code", "expected_message"),
+    [
+        pytest.param(None, "Error from Wyoming service: Boom!", id="without_code"),
+        pytest.param(
+            "ModelNotFoundError",
+            "Error from Wyoming service: Boom! (code: ModelNotFoundError)",
+            id="with_code",
+        ),
+    ],
+)
+async def test_streaming_audio_error_event(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    error_code: str | None,
+    expected_message: str,
+) -> None:
+    """Test that an error event from the service is reported."""
+    entity = wake_word.async_get_wake_word_detection_entity(
+        hass, "wake_word.test_wake_word"
+    )
+    assert entity is not None
+
+    async def audio_stream():
+        # Delay to force a pending audio chunk
+        await asyncio.sleep(0.05)
+        yield b"chunk", 1
+
+    with patch(
+        "homeassistant.components.wyoming.wake_word.AsyncTcpClient",
+        MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
+    ):
+        result = await entity.async_process_audio_stream(audio_stream(), None)
+
+    assert result is None
+    assert expected_message in caplog.text
 
 
 async def test_streaming_audio_oserror(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Properly handle Wyoming `error` events for the various platforms in the integration. These take different forms depending on the platform. For example, `conversation` is able to report an error directly to the user while others like `wake_word` just stop the audio stream.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/178560
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
