### PR TITLE
Reduce FFmpeg probe latency for streaming WAV from TTS

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -326,6 +326,10 @@ async def _async_convert_audio(
     if from_extension:
         command.extend(["-f", from_extension])
 
+    if is_input_gen and from_extension == "wav":
+        # The container is known, so minimize probing latency for live TTS audio.
+        command.extend(["-probesize", "32"])
+
     if is_input_gen:
         # Async generator
         command.extend(["-i", "pipe:0"])

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1,12 +1,13 @@
 """The tests for the TTS component."""
 
 import asyncio
+from collections.abc import AsyncGenerator
 from http import HTTPStatus
 import io
 from pathlib import Path
 import tempfile
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import wave
 
 from freezegun.api import FrozenDateTimeFactory
@@ -1854,6 +1855,79 @@ async def test_async_convert_audio_error(hass: HomeAssistant) -> None:
             hass, "wav", bad_data_gen(), "mp3"
         ):
             pass
+
+
+async def _audio_data_gen() -> AsyncGenerator[bytes]:
+    """Yield test audio data."""
+    yield b"audio"
+
+
+@pytest.mark.parametrize(
+    ("from_extension", "audio_input", "expected_input"),
+    [
+        pytest.param(
+            "wav",
+            _audio_data_gen(),
+            ["-f", "wav", "-probesize", "32", "-i", "pipe:0"],
+            id="streaming_wav",
+        ),
+        pytest.param(
+            "wav",
+            Path("input.wav"),
+            ["-f", "wav", "-i", "input.wav"],
+            id="static_wav",
+        ),
+        pytest.param(
+            "mp3",
+            _audio_data_gen(),
+            ["-f", "mp3", "-i", "pipe:0"],
+            id="streaming_mp3",
+        ),
+    ],
+)
+async def test_async_convert_audio_probe_size(
+    hass: HomeAssistant,
+    from_extension: str,
+    audio_input: AsyncGenerator[bytes] | Path,
+    expected_input: list[str],
+) -> None:
+    """Test probe size is limited for streaming WAV conversion only."""
+    assert await async_setup_component(hass, ffmpeg.DOMAIN, {})
+
+    mock_process = MagicMock()
+    mock_process.stdin.drain = AsyncMock()
+    mock_process.stdout.read = AsyncMock(return_value=b"")
+    mock_process.wait = AsyncMock(return_value=0)
+
+    with patch(
+        "asyncio.create_subprocess_exec", return_value=mock_process
+    ) as mock_create_subprocess_exec:
+        async for _chunk in tts._async_convert_audio(
+            hass,
+            from_extension,
+            audio_input,
+            "flac",
+            to_sample_rate=48000,
+            to_sample_channels=1,
+            to_sample_bytes=2,
+        ):
+            pass
+
+    command = list(mock_create_subprocess_exec.call_args.args)
+    input_index = command.index("-i")
+    # FFmpeg input options are positional.
+    assert command[4 : input_index + 2] == expected_input
+    assert command[input_index + 2 :] == [
+        "-f",
+        "flac",
+        "-ar",
+        "48000",
+        "-ac",
+        "1",
+        "-sample_fmt",
+        "s16",
+        "pipe:1",
+    ]
 
 
 async def test_default_engine_prefer_entity(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Currently, when TTS audio comes from Wyoming sources, it is encoded as PCM samples. To be streamed to voice satellites like the Voice PE, audio is transcoded via ffmpeg. However, at the site of transcoding the audio arrives packed as a WAV file, not raw PCM samples.
This means ffmpeg will first probe the WAV file to check if it's encoded properly. By default, this probe is quite long, equivalent to several seconds of audio. If TTS is fast, this doesn't really matter. But if TTS is slow (only a bit faster than realtime), this probing adds several seconds (3-4s in my case) of latency before TTS starts streaming. Actually, this has the annoying side effect that the voice assistant esphome component times out waiting for the stream to start (hardcoded 2 seconds after the response text), and opens the mic again, so when the audio eventually arrives the assistant talks to itself. Funny, but not very helpful.

The simple fix for now is to reduce the probe size of ffmpeg, since for generated audio we know the codec is PCM WAV, we don't need an overly cautious probe. Reducing the probe size to 32 decreases the latency until I hear audio from 3-4 seconds to ~1s. 

The better long-term fix would be keeping more metadata from the TTS stream around so that we can give ffmpeg the raw PCM samples. This would allow ffmpeg to stream basically immediately. Let me know if such a PR would be welcome.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
* This PR fixes or closes issue: fixes #
* This PR is related to issue:
* Link to documentation pull request:
* Link to developer documentation pull request:
* Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
