### PR TITLE
Select explicit SSE topics for Teslemetry account stream

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -44,7 +44,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CLIENT_ID, DOMAIN, LOGGER, VEHICLE_ISSUE_LEARN_MORE
+from .const import CLIENT_ID, DOMAIN, LOGGER, STREAM_TOPICS, VEHICLE_ISSUE_LEARN_MORE
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
@@ -340,6 +340,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     server=f"{region.lower()}.teslemetry.com",
                     parse_timestamp=True,
                     manual=True,
+                    topics=STREAM_TOPICS,
                 )
 
             # Remove the protobuff 'cached_data' that we do not use to save memory

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -3,6 +3,8 @@
 from enum import StrEnum
 import logging
 
+from teslemetry_stream.const import SseTopic
+
 DOMAIN = "teslemetry"
 
 LOGGER = logging.getLogger(__package__)
@@ -11,6 +13,16 @@ LOGGER = logging.getLogger(__package__)
 AUTHORIZE_URL = "https://teslemetry.com/connect"
 TOKEN_URL = "https://api.teslemetry.com/oauth/token"
 CLIENT_ID = "homeassistant"
+
+# Exact SSE wire topics Home Assistant consumes. Passed to the account-wide
+# stream so unconsumed topics (alerts/errors/config) are never delivered.
+STREAM_TOPICS: tuple[SseTopic, ...] = (
+    SseTopic.STATE,
+    SseTopic.VEHICLE_DATA,
+    SseTopic.DATA,
+    SseTopic.CONNECTIVITY,
+    SseTopic.CREDITS,
+)
 
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -18,9 +18,11 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
+from teslemetry_stream import TeslemetryStream
+from teslemetry_stream.const import SseTopic
 
 from homeassistant.components.teslemetry import _get_access_token
-from homeassistant.components.teslemetry.const import CLIENT_ID, DOMAIN
+from homeassistant.components.teslemetry.const import CLIENT_ID, DOMAIN, STREAM_TOPICS
 
 # Coordinator constants
 from homeassistant.components.teslemetry.coordinator import (
@@ -211,6 +213,47 @@ async def test_vehicle_stream(
     state = hass.states.get("binary_sensor.test_status")
     assert state is not None
     assert state.state == STATE_OFF
+
+
+async def test_stream_topics_selection(hass: HomeAssistant) -> None:
+    """The account stream is created once with only the topics HA consumes."""
+
+    with patch(
+        "homeassistant.components.teslemetry.TeslemetryStream",
+        wraps=TeslemetryStream,
+    ) as mock_stream:
+        await setup_platform(hass)
+
+    mock_stream.assert_called_once()
+    requested = set(mock_stream.call_args.kwargs["topics"])
+    assert requested == {
+        SseTopic.STATE,
+        SseTopic.VEHICLE_DATA,
+        SseTopic.DATA,
+        SseTopic.CONNECTIVITY,
+        SseTopic.CREDITS,
+    }
+    # Guards against accidentally passing SSE_ALL_TOPICS/SSE_VEHICLE_TOPICS.
+    assert not requested & {SseTopic.ALERTS, SseTopic.ERRORS, SseTopic.CONFIG}
+
+
+async def test_consumed_topic_no_regression(hass: HomeAssistant) -> None:
+    """Every requested topic maps to a real HA consumer, and vice versa.
+
+    Couples the allowlist policy to behavior: a listener whose topic was
+    dropped, or an allowlisted topic HA no longer consumes, breaks this test.
+    """
+
+    # Each wire topic paired with the HA effect that consumes it today.
+    consumed_topics = {
+        SseTopic.STATE: "status binary sensor and vehicle coordinator merge",
+        SseTopic.VEHICLE_DATA: "polling-bridge vehicle document merge",
+        SseTopic.DATA: "typed streaming entity field listeners",
+        SseTopic.CONNECTIVITY: "cellular/Wi-Fi connectivity binary sensors",
+        SseTopic.CREDITS: "balance and credits sensors",
+    }
+
+    assert set(STREAM_TOPICS) == set(consumed_topics)
 
 
 async def test_vehicle_asleep_polling(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The account-wide `TeslemetryStream` is now given an explicit allowlist of the five SSE wire topics Home Assistant actually consumes today (`state`, `vehicle_data`, `data`, `connectivity`, `credits`) instead of subscribing to every topic.

This is a protocol uplift, not a behavior change: HA still receives every topic it consumes, so entity and coordinator behavior is unchanged. The only observable difference is less irrelevant stream traffic, as `alerts`, `errors`, and `config` are no longer delivered. Topic definitions, selection validation, and query-string serialization are owned by `teslemetry-stream` (already pinned in `dev`); HA only chooses and passes the policy.

This is the first of three PRs in a Teslemetry SSE protocol uplift.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
