### PR TITLE
Add a device for every Netatmo home

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -150,13 +150,15 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: NetatmoConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
-    data = config_entry.runtime_data
-    modules = [m for h in data.account.homes.values() for m in h.modules]
-    rooms = [r for h in data.account.homes.values() for r in h.rooms]
+    homes = config_entry.runtime_data.account.homes.values()
+    valid_ids = {
+        *(home.entity_id for home in homes),
+        *(module for home in homes for module in home.modules),
+        *(room for home in homes for room in home.rooms),
+    }
 
     return not any(
-        identifier
+        identifier[1] in valid_ids
         for identifier in device_entry.identifiers
-        if (identifier[0] == DOMAIN and identifier[1] in modules)
-        or identifier[1] in rooms
+        if identifier[0] == DOMAIN
     )

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -196,6 +196,11 @@ class NetatmoDataHandler:
 
         await self.subscribe(ACCOUNT, ACCOUNT, None)
 
+        # Parents must exist before a platform links a child to one
+        self.parent_device_ids = async_register_parent_devices(
+            self.hass, self.config_entry, self.account
+        )
+
         await self.hass.config_entries.async_forward_entry_setups(
             self.config_entry, PLATFORMS
         )
@@ -348,10 +353,6 @@ class NetatmoDataHandler:
 
     async def async_dispatch(self) -> None:
         """Dispatch the creation of entities."""
-        self.parent_device_ids = async_register_parent_devices(
-            self.hass, self.config_entry, self.account
-        )
-
         await self.subscribe(WEATHER, WEATHER, None)
         await self.subscribe(AIR_CARE, AIR_CARE, None)
 

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -51,6 +51,7 @@ from .const import (
     WEBHOOK_DEACTIVATION,
     WEBHOOK_PUSH_TYPE,
 )
+from .device import async_register_parent_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,6 +174,7 @@ class NetatmoDataHandler:
         self.device_ids: dict[str, str] = {}
         self.cameras: dict[str, str] = {}
         self.events: dict[str, dict] = {}
+        self.parent_device_ids: dict[str, str] = {}
 
     async def async_setup(self) -> None:
         """Set up the Netatmo data handler."""
@@ -346,6 +348,10 @@ class NetatmoDataHandler:
 
     async def async_dispatch(self) -> None:
         """Dispatch the creation of entities."""
+        self.parent_device_ids = async_register_parent_devices(
+            self.hass, self.config_entry, self.account
+        )
+
         await self.subscribe(WEATHER, WEATHER, None)
         await self.subscribe(AIR_CARE, AIR_CARE, None)
 

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -1,17 +1,21 @@
 """Device registry helpers for the Netatmo integration."""
 
+from typing import TYPE_CHECKING
+
 import pyatmo
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_URL_CONTROL, DOMAIN, MANUFACTURER
 
+if TYPE_CHECKING:
+    from .coordinator import NetatmoConfigEntry
+
 
 @callback
 def async_register_parent_devices(
-    hass: HomeAssistant, entry: ConfigEntry, account: pyatmo.AsyncAccount
+    hass: HomeAssistant, entry: NetatmoConfigEntry, account: pyatmo.AsyncAccount
 ) -> dict[str, str]:
     """Register a device per home and map Netatmo ids to device registry ids."""
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -1,0 +1,31 @@
+"""Device registry helpers for the Netatmo integration."""
+
+import pyatmo
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+
+from .const import CONF_URL_CONTROL, DOMAIN, MANUFACTURER
+
+
+@callback
+def async_register_parent_devices(
+    hass: HomeAssistant, entry: ConfigEntry, account: pyatmo.AsyncAccount
+) -> dict[str, str]:
+    """Register a device per home and map Netatmo ids to device registry ids."""
+    device_registry = dr.async_get(hass)
+    parent_device_ids: dict[str, str] = {}
+
+    for home in account.homes.values():
+        device_entry = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, home.entity_id)},
+            manufacturer=MANUFACTURER,
+            model="Home",
+            name=home.name,
+            configuration_url=CONF_URL_CONTROL,
+        )
+        parent_device_ids[home.entity_id] = device_entry.id
+
+    return parent_device_ids

--- a/homeassistant/components/netatmo/entity.py
+++ b/homeassistant/components/netatmo/entity.py
@@ -123,6 +123,25 @@ class NetatmoDeviceEntity(NetatmoBaseEntity):
         return self.device.home
 
 
+def room_device_info(room: Room, via_device_id: str) -> DeviceInfo:
+    """Return the device info describing a Netatmo room.
+
+    Entities living on a room device must all describe it the same way, or
+    whichever is added last renames the room after itself.
+    """
+    assert room.climate_type
+    manufacturer, model = DEVICE_DESCRIPTION_MAP[room.climate_type]
+    return DeviceInfo(
+        identifiers={(DOMAIN, room.entity_id)},
+        name=room.name,
+        manufacturer=manufacturer,
+        model=model,
+        configuration_url=CONF_URL_ENERGY,
+        suggested_area=room.name,
+        via_device_id=via_device_id,
+    )
+
+
 class NetatmoRoomEntity(NetatmoDeviceEntity):
     """Netatmo room entity base class."""
 
@@ -131,13 +150,9 @@ class NetatmoRoomEntity(NetatmoDeviceEntity):
     def __init__(self, room: NetatmoRoom) -> None:
         """Set up a Netatmo room entity."""
         super().__init__(room.data_handler, room.room)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, room.room.entity_id)},
-            name=room.room.name,
-            manufacturer=self.device_description[0],
-            model=self.device_description[1],
-            configuration_url=CONF_URL_ENERGY,
-            suggested_area=room.room.name,
+        self._attr_device_info = room_device_info(
+            room.room,
+            room.data_handler.parent_device_ids[room.room.home.entity_id],
         )
 
     @override
@@ -171,6 +186,8 @@ class NetatmoModuleEntity(NetatmoDeviceEntity):
             model=self.device_description[1],
             configuration_url=self._attr_configuration_url,
         )
+        if via_device_id := device.data_handler.parent_device_ids.get(device.parent_id):
+            self._attr_device_info["via_device_id"] = via_device_id
 
     @property
     @override

--- a/homeassistant/components/netatmo/select.py
+++ b/homeassistant/components/netatmo/select.py
@@ -9,13 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    CONF_URL_ENERGY,
-    DOMAIN,
-    EVENT_TYPE_SCHEDULE,
-    MANUFACTURER,
-    NETATMO_CREATE_SELECT,
-)
+from .const import DOMAIN, EVENT_TYPE_SCHEDULE, NETATMO_CREATE_SELECT
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoHome
 from .entity import NetatmoBaseEntity
 
@@ -44,7 +38,7 @@ async def async_setup_entry(
 class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
     """Representation a Netatmo thermostat schedule selector."""
 
-    _attr_name = None
+    _attr_translation_key = "schedule"
 
     def __init__(self, netatmo_home: NetatmoHome) -> None:
         """Initialize the select entity."""
@@ -63,10 +57,6 @@ class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.home.entity_id)},
-            name=self.home.name,
-            manufacturer=MANUFACTURER,
-            model="Climate",
-            configuration_url=CONF_URL_ENERGY,
         )
 
         self._attr_unique_id = f"{self.home.entity_id}-schedule-select"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -66,6 +66,7 @@ from .entity import (
     NetatmoModuleEntity,
     NetatmoRoomEntity,
     NetatmoWeatherModuleEntity,
+    room_device_info,
 )
 from .helper import NetatmoArea
 
@@ -794,12 +795,11 @@ class NetatmoClimateBatterySensor(NetatmoLegacySensor):
             f"-{self.device.entity_id}"
             f"-{self.entity_description.key}"
         )
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, netatmo_device.parent_id)},
-            name=netatmo_device.device.name,
-            manufacturer=self.device_description[0],
-            model=self.device_description[1],
-            configuration_url=self._attr_configuration_url,
+        # This sensor lives on the room's device, so it must describe the room
+        # rather than the valve it reads, or it renames the room after the valve
+        self._attr_device_info = room_device_info(
+            self.device.home.rooms[netatmo_device.parent_id],
+            netatmo_device.data_handler.parent_device_ids[self.device.home.entity_id],
         )
 
     @callback

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -83,6 +83,11 @@
         }
       }
     },
+    "select": {
+      "schedule": {
+        "name": "Schedule"
+      }
+    },
     "sensor": {
       "gust_angle": {
         "name": "Gust angle"

--- a/tests/components/netatmo/snapshots/test_init.ambr
+++ b/tests/components/netatmo/snapshots/test_init.ambr
@@ -26,7 +26,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-0009999993]
@@ -56,7 +56,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-00:11:22:33:00:11:45:fe]
@@ -86,7 +86,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-1002003001]
@@ -116,7 +116,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:00:a1:4c:da]
@@ -146,7 +146,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:01:01:01:a1]
@@ -176,7 +176,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#0]
@@ -206,7 +206,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#1]
@@ -236,7 +236,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#2]
@@ -266,7 +266,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#3]
@@ -296,7 +296,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#4]
@@ -326,7 +326,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#5]
@@ -356,7 +356,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#6]
@@ -386,7 +386,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#7]
@@ -416,7 +416,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e#8]
@@ -446,7 +446,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:16:0e]
@@ -476,7 +476,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:86:99]
@@ -506,7 +506,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:00:f1:62]
@@ -536,7 +536,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:03:1b:e4]
@@ -566,7 +566,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:10:b9:0e]
@@ -596,7 +596,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:10:f1:66]
@@ -626,7 +626,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:25:cf:a8]
@@ -806,7 +806,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:80:1c:42]
@@ -836,7 +836,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:80:44:92]
@@ -866,7 +866,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:80:7e:18]
@@ -896,7 +896,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:80:bb:26]
@@ -926,7 +926,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-12:34:56:80:c1:ea]
@@ -956,7 +956,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-222452125]
@@ -982,11 +982,11 @@
     'manufacturer': 'Netatmo',
     'model': 'OpenTherm Modulating Thermostat',
     'model_id': None,
-    'name': 'Bureau Modulate',
+    'name': 'Bureau',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-2746182631]
@@ -1016,7 +1016,7 @@
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-2833524037]
@@ -1042,11 +1042,11 @@
     'manufacturer': 'Netatmo',
     'model': 'Smart Valve',
     'model_id': None,
-    'name': 'Valve1',
+    'name': 'Entrada',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-2940411577]
@@ -1072,11 +1072,11 @@
     'manufacturer': 'Netatmo',
     'model': 'Smart Valve',
     'model_id': None,
-    'name': 'Valve2',
+    'name': 'Cocina',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
-    'via_device_id': None,
+    'via_device_id': <ANY>,
   })
 # ---
 # name: test_devices[netatmo-91763b24c43d3e344f424e8b]
@@ -1084,7 +1084,7 @@
     'area_id': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
-    'configuration_url': 'https://my.netatmo.com/app/energy',
+    'configuration_url': 'https://home.netatmo.com/control',
     'connections': set({
     }),
     'disabled_by': None,
@@ -1100,9 +1100,39 @@
     'labels': set({
     }),
     'manufacturer': 'Netatmo',
-    'model': 'Climate',
+    'model': 'Home',
     'model_id': None,
     'name': 'MYHOME',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_devices[netatmo-91763b24c43d3e344f424e8c]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': 'https://home.netatmo.com/control',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '91763b24c43d3e344f424e8c',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Netatmo',
+    'model': 'Home',
+    'model_id': None,
+    'name': 'Unknown',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,

--- a/tests/components/netatmo/snapshots/test_select.ambr
+++ b/tests/components/netatmo/snapshots/test_select.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entity[select.myhome-entry]
+# name: test_entity[select.myhome_schedule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -18,7 +18,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': None,
-    'entity_id': 'select.myhome',
+    'entity_id': 'select.myhome_schedule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -26,33 +26,33 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Schedule',
     'platform': 'netatmo',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'schedule',
     'unique_id': '91763b24c43d3e344f424e8b-schedule-select',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity[select.myhome-state]
+# name: test_entity[select.myhome_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'MYHOME',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'MYHOME Schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Default',
         'Winter',
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.myhome',
+    'entity_id': 'select.myhome_schedule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/netatmo/snapshots/test_sensor.ambr
+++ b/tests/components/netatmo/snapshots/test_sensor.ambr
@@ -1149,7 +1149,7 @@
     'state': 'High',
   })
 # ---
-# name: test_entity[sensor.bureau_modulate_battery-entry]
+# name: test_entity[sensor.bureau_bureau_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1165,7 +1165,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bureau_modulate_battery',
+    'entity_id': 'sensor.bureau_bureau_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1188,17 +1188,73 @@
     'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
   })
 # ---
-# name: test_entity[sensor.bureau_modulate_battery-state]
+# name: test_entity[sensor.bureau_bureau_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bureau Modulate Battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bureau Battery',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bureau_modulate_battery',
+    'entity_id': 'sensor.bureau_bureau_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '90',
+  })
+# ---
+# name: test_entity[sensor.cocina_cocina_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.cocina_cocina_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2940411577-12:34:56:03:a0:ac-battery',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_entity[sensor.cocina_cocina_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cocina Battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.cocina_cocina_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1471,6 +1527,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'True',
+  })
+# ---
+# name: test_entity[sensor.entrada_entrada_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.entrada_entrada_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2833524037-12:34:56:03:a5:54-battery',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_entity[sensor.entrada_entrada_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Entrada Battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entrada_entrada_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '90',
   })
 # ---
 # name: test_entity[sensor.gas-entry]
@@ -4289,62 +4401,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entity[sensor.livingroom_battery-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.livingroom_battery',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Battery',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'netatmo',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '2746182631-12:34:56:00:01:ae-battery',
-    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
-  })
-# ---
-# name: test_entity[sensor.livingroom_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Livingroom Battery',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.livingroom_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '75',
-  })
-# ---
 # name: test_entity[sensor.livingroom_carbon_dioxide-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -4528,6 +4584,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
+  })
+# ---
+# name: test_entity[sensor.livingroom_livingroom_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.livingroom_livingroom_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2746182631-12:34:56:00:01:ae-battery',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_entity[sensor.livingroom_livingroom_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Livingroom Battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.livingroom_livingroom_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75',
   })
 # ---
 # name: test_entity[sensor.livingroom_noise-entry]
@@ -5606,118 +5718,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'True',
-  })
-# ---
-# name: test_entity[sensor.valve1_battery-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.valve1_battery',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Battery',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'netatmo',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '2833524037-12:34:56:03:a5:54-battery',
-    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
-  })
-# ---
-# name: test_entity[sensor.valve1_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Valve1 Battery',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.valve1_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '90',
-  })
-# ---
-# name: test_entity[sensor.valve2_battery-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.valve2_battery',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Battery',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'netatmo',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '2940411577-12:34:56:03:a0:ac-battery',
-    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
-  })
-# ---
-# name: test_entity[sensor.valve2_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Netatmo',
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Valve2 Battery',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.valve2_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '90',
   })
 # ---
 # name: test_entity[sensor.villa_atmospheric_pressure-entry]

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -642,7 +642,9 @@ async def test_home_devices_registered(
 
         await hass.async_block_till_done()
 
-    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
     assert home_device is not None
     assert home_device.name == "MYHOME"
     assert home_device.manufacturer == "Netatmo"
@@ -651,8 +653,8 @@ async def test_home_devices_registered(
     assert config_entry.runtime_data.parent_device_ids[HOME_ID] == home_device.id
 
     # A home with no rooms and no modules still gets a device
-    empty_home_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "91763b24c43d3e344f424e8c")}
+    empty_home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "91763b24c43d3e344f424e8c"), config_entry.entry_id
     )
     assert empty_home_device is not None
     assert empty_home_device.name == "Unknown"
@@ -670,7 +672,9 @@ async def test_device_hierarchy(
 
         await hass.async_block_till_done()
 
-    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
     assert home_device is not None
 
     device_entries = dr.async_entries_for_config_entry(
@@ -690,8 +694,8 @@ async def test_device_hierarchy(
     assert home_device.via_device_id is None
 
     # Air care modules belong to the account rather than a home, so stay unlinked
-    air_care_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "12:34:56:25:cf:a8")}
+    air_care_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:25:cf:a8"), config_entry.entry_id
     )
     assert air_care_device is not None
     assert air_care_device.via_device_id is None
@@ -722,7 +726,9 @@ async def test_device_remove_devices(
     response = await client.remove_device(device_entry.id, config_entry.entry_id)
     assert not response["success"]
 
-    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
     assert home_device is not None
     response = await client.remove_device(home_device.id, config_entry.entry_id)
     assert not response["success"]

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -630,6 +630,73 @@ async def test_devices(
         assert device_entry == snapshot(name=f"{identifier[0]}-{identifier[1]}")
 
 
+async def test_home_devices_registered(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a device is registered for every home, without the select platform."""
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    assert home_device is not None
+    assert home_device.name == "MYHOME"
+    assert home_device.manufacturer == "Netatmo"
+    assert home_device.model == "Home"
+    assert home_device.configuration_url == "https://home.netatmo.com/control"
+    assert config_entry.runtime_data.parent_device_ids[HOME_ID] == home_device.id
+
+    # A home with no rooms and no modules still gets a device
+    empty_home_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "91763b24c43d3e344f424e8c")}
+    )
+    assert empty_home_device is not None
+    assert empty_home_device.name == "Unknown"
+
+
+async def test_device_hierarchy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test rooms and modules are linked to their home."""
+    with selected_platforms([Platform.CLIMATE, Platform.COVER, Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    assert home_device is not None
+
+    device_entries = dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    )
+    linked = {
+        device.name
+        for device in device_entries
+        if device.via_device_id == home_device.id
+    }
+
+    # Rooms link to the home
+    assert "Livingroom" in linked
+    # Modules link to the home
+    assert "Entrance Blinds" in linked
+    # The home links to nothing
+    assert home_device.via_device_id is None
+
+    # Air care modules belong to the account rather than a home, so stay unlinked
+    air_care_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "12:34:56:25:cf:a8")}
+    )
+    assert air_care_device is not None
+    assert air_care_device.via_device_id is None
+
+
 async def test_device_remove_devices(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -653,6 +720,11 @@ async def test_device_remove_devices(
     device_entry = device_registry.async_get(entity.device_id)
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    assert home_device is not None
+    response = await client.remove_device(home_device.id, config_entry.entry_id)
     assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(

--- a/tests/components/netatmo/test_select.py
+++ b/tests/components/netatmo/test_select.py
@@ -54,7 +54,7 @@ async def test_select_schedule_thermostats(
         await hass.async_block_till_done()
 
     webhook_id = config_entry.data[CONF_WEBHOOK_ID]
-    select_entity = "select.myhome"
+    select_entity = "select.myhome_schedule"
 
     assert hass.states.get(select_entity).state == "Default"
 
@@ -113,7 +113,7 @@ async def test_select_schedule_unknown_schedule_id(
         await hass.async_block_till_done()
 
     webhook_id = config_entry.data[CONF_WEBHOOK_ID]
-    select_entity = "select.myhome"
+    select_entity = "select.myhome_schedule"
     original_state = hass.states.get(select_entity).state
 
     response = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Netatmo device list is flat: rooms, modules and the home are siblings, and nothing says which home a device belongs to. An account with two homes shows one undifferentiated pile.

A home device already existed, but only as a side effect of the schedule select attaching a full DeviceInfo. That meant a home only got a device if it had a climate room, and the device was described as model="Climate" even when the home was cameras and shutters.

This registers a device per home explicitly, from the topology the ACCOUNT publisher already fetches, and links rooms and modules to it with via_device_id. Identifiers are unchanged, so existing home devices are updated in place — no migration.

The schedule select keeps only the link, so home metadata has one source, and is renamed via translation_key instead of taking its device's name. Its friendly name becomes "MYHOME Schedule"; entity_id and unique_id are unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
