### PR TITLE
Add gateway reboot button to ViCare

### DIFF
--- a/homeassistant/components/vicare/button.py
+++ b/homeassistant/components/vicare/button.py
@@ -9,7 +9,11 @@ from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
-from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -48,10 +52,10 @@ BUTTON_DESCRIPTIONS: tuple[ViCareButtonEntityDescription, ...] = (
 
 def _build_entities(
     device_list: list[ViCareDevice],
-) -> list[ViCareButton]:
+) -> list[ButtonEntity]:
     """Create ViCare button entities for a device."""
 
-    return [
+    entities: list[ButtonEntity] = [
         ViCareButton(
             description,
             device.serial,
@@ -62,6 +66,20 @@ def _build_entities(
         for description in BUTTON_DESCRIPTIONS
         if is_supported(description.key, description.value_getter, device.api)
     ]
+
+    # The gateway is not a device of its own in Home Assistant, so its reboot
+    # button is added to the first device behind it.
+    known_gateways: set[str] = set()
+    for device in device_list:
+        gateway_serial = device.config.getConfig().serial
+        if gateway_serial in known_gateways:
+            continue
+        known_gateways.add(gateway_serial)
+        entities.append(
+            ViCareRebootGatewayButton(device.serial, device.config, device.api)
+        )
+
+    return entities
 
 
 async def async_setup_entry(
@@ -99,3 +117,27 @@ class ViCareButton(ViCareEntity, ButtonEntity):
         """Handle the button press."""
         with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
             self.entity_description.value_setter(self._api)
+
+
+class ViCareRebootGatewayButton(ViCareEntity, ButtonEntity):
+    """Representation of a button rebooting the ViCare gateway."""
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "reboot_gateway"
+
+    def __init__(
+        self,
+        device_serial: str | None,
+        device_config: PyViCareDeviceConfig,
+        device: PyViCareDevice,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__("reboot_gateway", device_serial, device_config, device)
+        self._device = device
+
+    @override
+    def press(self) -> None:
+        """Handle the button press."""
+        with self.vicare_api_handler():
+            self._device.service.reboot_gateway(self._device.accessor)

--- a/homeassistant/components/vicare/button.py
+++ b/homeassistant/components/vicare/button.py
@@ -134,6 +134,9 @@ class ViCareRebootGatewayButton(ViCareEntity, ButtonEntity):
     ) -> None:
         """Initialize the button."""
         super().__init__("reboot_gateway", device_serial, device_config, device)
+        # Keyed on the gateway, not on the device it is attached to: only online
+        # devices enter device_list, so the first one behind a gateway can change.
+        self._attr_unique_id = f"{self._gateway_serial}-reboot_gateway"
         self._device = device
 
     @override

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -82,6 +82,9 @@
       },
       "deactivate_onetimecharge": {
         "name": "Deactivate one-time charge"
+      },
+      "reboot_gateway": {
+        "name": "Reboot gateway"
       }
     },
     "climate": {

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -99,6 +99,7 @@ class MockViCareService:
         self._test_data = load_json_object_fixture(fixture.data_file)
         self.fetch_all_features = Mock(return_value=self._test_data)
         self.setProperty = Mock()
+        self.reboot_gateway = Mock()
         self.roles = fixture.roles
         self.accessor = ViCareDeviceAccessor(installation_id, gateway_id, device_id)
 

--- a/tests/components/vicare/snapshots/test_button.ambr
+++ b/tests/components/vicare/snapshots/test_button.ambr
@@ -99,3 +99,54 @@
     'state': 'unknown',
   })
 # ---
+# name: test_all_entities[button.model0_reboot_gateway-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.model0_reboot_gateway',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reboot gateway',
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Reboot gateway',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'reboot_gateway',
+    'unique_id': 'gateway0_deviceSerialVitodens300W-reboot_gateway',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.model0_reboot_gateway-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'model0 Reboot gateway',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.model0_reboot_gateway',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/vicare/snapshots/test_button.ambr
+++ b/tests/components/vicare/snapshots/test_button.ambr
@@ -132,7 +132,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'reboot_gateway',
-    'unique_id': 'gateway0_deviceSerialVitodens300W-reboot_gateway',
+    'unique_id': 'gateway0-reboot_gateway',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/vicare/test_button.py
+++ b/tests/components/vicare/test_button.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -37,3 +38,69 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_reboot_gateway(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the gateway reboot button."""
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
+    mock_vicare = MockPyViCare(fixtures)
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=mock_vicare.as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.BUTTON]),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.model0_reboot_gateway"},
+        blocking=True,
+    )
+
+    service = mock_vicare.devices[0].service
+    service.reboot_gateway.assert_called_once_with(service.accessor)
+
+
+async def test_reboot_gateway_once_per_gateway(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that devices sharing a gateway get a single reboot button."""
+    fixtures: list[Fixture] = [
+        Fixture({"type:fhtMain"}, "vicare/FHTMain.json", gateway_id="gateway0"),
+        Fixture({"type:fhtChannel"}, "vicare/FHTChannel.json", gateway_id="gateway0"),
+    ]
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=MockPyViCare(fixtures).as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.BUTTON]),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert (
+        len(
+            [
+                entry
+                for entry in er.async_entries_for_config_entry(
+                    entity_registry, mock_config_entry.entry_id
+                )
+                if entry.unique_id.endswith("-reboot_gateway")
+            ]
+        )
+        == 1
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a "Reboot gateway" button that restarts the Viessmann communication module (Vitoconnect / Heatbox) via `ViCareService.reboot_gateway`, available in PyViCare since 2.51.0, so no dependency bump is needed.

A daily reboot is the known workaround for #130273, where the gateway stops pushing the daily/weekly consumption buckets to the Viessmann cloud and the values stay at zero.

The gateway itself is not a device in Home Assistant (`Heatbox1`/`Heatbox2_SRC`/`Heatbox3` are in `UNSUPPORTED_DEVICES`), so the button is added once per gateway, to the first device behind it.

Replaces #152079, which implemented this as an action; @joostlek asked for a button entity there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #130273, #152060
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
