### PR TITLE
Disable a Netatmo home via its device

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -16,13 +16,17 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_validation as cv,
+    device_registry as dr,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
     async_get_config_entry_implementation,
 )
-from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_started
@@ -150,10 +154,24 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: NetatmoConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
-    # A disabled home is filtered out of the account, so its rooms and modules
-    # are absent from the inventory below while their devices are still live
-    if device_entry.disabled_by is DeviceEntryDisabler.INTEGRATION:
-        return False
+    account = config_entry.runtime_data.account
+    # A disabled home leaves the account, so everything below it looks stale to
+    # the inventory check. Its descendants keep their own disabler, hence a walk.
+    unpolled_home_ids = account.all_home_names.keys() - account.homes.keys()
+    device_registry = dr.async_get(hass)
+    device: DeviceEntry | None = device_entry
+    while device is not None:
+        if any(
+            identifier[1] in unpolled_home_ids
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+        ):
+            return False
+        device = (
+            device_registry.async_get(device.via_device_id)
+            if device.via_device_id
+            else None
+        )
 
     homes = config_entry.runtime_data.account.homes.values()
     valid_ids = {

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
-from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_started
@@ -150,9 +150,15 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: NetatmoConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
+    # A disabled home is filtered out of the account, so its rooms and modules
+    # are absent from the inventory below while their devices are still live
+    if device_entry.disabled_by is DeviceEntryDisabler.INTEGRATION:
+        return False
+
     homes = config_entry.runtime_data.account.homes.values()
     valid_ids = {
         *config_entry.runtime_data.account.all_home_names,
+        *config_entry.runtime_data.account.modules,
         *(module for home in homes for module in home.modules),
         *(room for home in homes for room in home.rooms),
     }

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -168,7 +168,7 @@ async def async_remove_config_entry_device(
         ):
             return False
         device = (
-            device_registry.async_get(device.via_device_id)
+            device_registry.async_get(device.via_device_id, include_child_devices=False)
             if device.via_device_id
             else None
         )

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -152,7 +152,7 @@ async def async_remove_config_entry_device(
     """Remove a config entry from a device."""
     homes = config_entry.runtime_data.account.homes.values()
     valid_ids = {
-        *(home.entity_id for home in homes),
+        *config_entry.runtime_data.account.all_home_names,
         *(module for home in homes for module in home.modules),
         *(room for home in homes for room in home.rooms),
     }

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -1,10 +1,10 @@
 """The Netatmo data handler."""
 
+import logging
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from itertools import islice
-import logging
 from time import time
 from typing import Any
 
@@ -12,18 +12,24 @@ import aiohttp
 import pyatmo
 from pyatmo.modules.device_types import (
     DeviceCategory as NetatmoDeviceCategory,
+)
+from pyatmo.modules.device_types import (
     DeviceType as NetatmoDeviceType,
 )
 from pyatmo.schedule import Schedule
 
 from homeassistant.components import cloud
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.device_registry import EventDeviceRegistryUpdatedData
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import (
+    async_track_device_registry_updated_event,
+    async_track_time_interval,
+)
 
 from .const import (
     CAMERA_CONNECTION_WEBHOOKS,
@@ -51,7 +57,12 @@ from .const import (
     WEBHOOK_DEACTIVATION,
     WEBHOOK_PUSH_TYPE,
 )
-from .device import async_register_parent_devices, netatmo_module_parents
+from .device import (
+    async_disabled_netatmo_ids,
+    async_register_parent_devices,
+    async_sync_home_disabled_state,
+    netatmo_module_parents,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,6 +187,7 @@ class NetatmoDataHandler:
         self.events: dict[str, dict] = {}
         self.parent_device_ids: dict[str, str] = {}
         self.module_parents: dict[str, str] = {}
+        self.home_device_ids: list[str] = []
 
     async def async_setup(self) -> None:
         """Set up the Netatmo data handler."""
@@ -193,7 +205,10 @@ class NetatmoDataHandler:
             )
         )
 
-        self.account = pyatmo.AsyncAccount(self.auth)
+        self.account = pyatmo.AsyncAccount(
+            self.auth,
+            disabled_homes_ids=async_disabled_netatmo_ids(self.hass, self.config_entry),
+        )
 
         await self.subscribe(ACCOUNT, ACCOUNT, None)
 
@@ -201,6 +216,19 @@ class NetatmoDataHandler:
         self.module_parents = netatmo_module_parents(self.account)
         self.parent_device_ids = async_register_parent_devices(
             self.hass, self.config_entry, self.account, self.module_parents
+        )
+        self.home_device_ids = [
+            self.parent_device_ids[home_id]
+            for home_id in self.account.all_home_names
+            if home_id in self.parent_device_ids
+        ]
+        async_sync_home_disabled_state(
+            self.hass, self.config_entry, self.home_device_ids
+        )
+        self.config_entry.async_on_unload(
+            async_track_device_registry_updated_event(
+                self.hass, self.home_device_ids, self._handle_home_device_update
+            )
         )
 
         await self.hass.config_entries.async_forward_entry_setups(
@@ -376,6 +404,14 @@ class NetatmoDataHandler:
 
         await self.unsubscribe(WEATHER, None)
         await self.unsubscribe(AIR_CARE, None)
+
+    @callback
+    def _handle_home_device_update(
+        self, event: Event[EventDeviceRegistryUpdatedData]
+    ) -> None:
+        """Reload when a home device is enabled or disabled."""
+        if event.data["action"] == "update" and "disabled_by" in event.data["changes"]:
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
     def setup_air_care(self) -> None:
         """Set up home coach/air care modules."""

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -1,10 +1,10 @@
 """The Netatmo data handler."""
 
-import logging
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from itertools import islice
+import logging
 from time import time
 from typing import Any
 
@@ -12,8 +12,6 @@ import aiohttp
 import pyatmo
 from pyatmo.modules.device_types import (
     DeviceCategory as NetatmoDeviceCategory,
-)
-from pyatmo.modules.device_types import (
     DeviceType as NetatmoDeviceType,
 )
 from pyatmo.schedule import Schedule

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -18,12 +18,16 @@ from pyatmo.schedule import Schedule
 
 from homeassistant.components import cloud
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.device_registry import EventDeviceRegistryUpdatedData
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import (
+    async_track_device_registry_updated_event,
+    async_track_time_interval,
+)
 
 from .const import (
     CAMERA_CONNECTION_WEBHOOKS,
@@ -51,7 +55,11 @@ from .const import (
     WEBHOOK_DEACTIVATION,
     WEBHOOK_PUSH_TYPE,
 )
-from .device import async_register_parent_devices
+from .device import (
+    async_disabled_netatmo_ids,
+    async_register_parent_devices,
+    async_sync_home_disabled_state,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -175,6 +183,7 @@ class NetatmoDataHandler:
         self.cameras: dict[str, str] = {}
         self.events: dict[str, dict] = {}
         self.parent_device_ids: dict[str, str] = {}
+        self.home_device_ids: list[str] = []
 
     async def async_setup(self) -> None:
         """Set up the Netatmo data handler."""
@@ -192,13 +201,29 @@ class NetatmoDataHandler:
             )
         )
 
-        self.account = pyatmo.AsyncAccount(self.auth)
+        self.account = pyatmo.AsyncAccount(
+            self.auth,
+            disabled_homes_ids=async_disabled_netatmo_ids(self.hass, self.config_entry),
+        )
 
         await self.subscribe(ACCOUNT, ACCOUNT, None)
 
         # Parents must exist before a platform links a child to one
         self.parent_device_ids = async_register_parent_devices(
             self.hass, self.config_entry, self.account
+        )
+        self.home_device_ids = [
+            self.parent_device_ids[home_id]
+            for home_id in self.account.all_home_names
+            if home_id in self.parent_device_ids
+        ]
+        async_sync_home_disabled_state(
+            self.hass, self.config_entry, self.home_device_ids
+        )
+        self.config_entry.async_on_unload(
+            async_track_device_registry_updated_event(
+                self.hass, self.home_device_ids, self._handle_home_device_update
+            )
         )
 
         await self.hass.config_entries.async_forward_entry_setups(
@@ -374,6 +399,14 @@ class NetatmoDataHandler:
 
         await self.unsubscribe(WEATHER, None)
         await self.unsubscribe(AIR_CARE, None)
+
+    @callback
+    def _handle_home_device_update(
+        self, event: Event[EventDeviceRegistryUpdatedData]
+    ) -> None:
+        """Reload when a home device is enabled or disabled."""
+        if event.data["action"] == "update" and "disabled_by" in event.data["changes"]:
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
     def setup_air_care(self) -> None:
         """Set up home coach/air care modules."""

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -1,6 +1,6 @@
 """Device registry helpers for the Netatmo integration."""
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING
 
 import pyatmo
@@ -98,6 +98,27 @@ def _register_bridge(
 
 
 @callback
+def async_disabled_netatmo_ids(
+    hass: HomeAssistant, entry: NetatmoConfigEntry
+) -> list[str]:
+    """Return the Netatmo ids of every disabled device.
+
+    A superset of the disabled home ids. Module ids never match a home id, so
+    passing them through to pyatmo's denylist is harmless and avoids having to
+    know which devices are homes before the topology has been fetched.
+    """
+    return [
+        identifier[1]
+        for device in dr.async_entries_for_config_entry(
+            dr.async_get(hass), entry.entry_id
+        )
+        if device.disabled_by
+        for identifier in device.identifiers
+        if identifier[0] == DOMAIN
+    ]
+
+
+@callback
 def async_register_parent_devices(
     hass: HomeAssistant,
     entry: NetatmoConfigEntry,
@@ -111,16 +132,16 @@ def async_register_parent_devices(
     device_registry = dr.async_get(hass)
     parent_device_ids: dict[str, str] = {}
 
-    for home in account.homes.values():
+    for home_id, home_name in account.all_home_names.items():
         device_entry = device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, home.entity_id)},
+            identifiers={(DOMAIN, home_id)},
             manufacturer=MANUFACTURER,
             model="Home",
-            name=home.name,
+            name=home_name,
             configuration_url=CONF_URL_CONTROL,
         )
-        parent_device_ids[home.entity_id] = device_entry.id
+        parent_device_ids[home_id] = device_entry.id
 
     for home in account.homes.values():
         bridges = {
@@ -141,3 +162,41 @@ def async_register_parent_devices(
                 )
 
     return parent_device_ids
+
+
+@callback
+def async_sync_home_disabled_state(
+    hass: HomeAssistant, entry: NetatmoConfigEntry, home_device_ids: Iterable[str]
+) -> None:
+    """Mirror each home device's disabled state onto its descendants.
+
+    Devices disabled by the user are left alone in both directions, so toggling a
+    home never undoes a manual choice.
+    """
+    device_registry = dr.async_get(hass)
+
+    children: dict[str, list[dr.DeviceEntry]] = {}
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        if device.via_device_id:
+            children.setdefault(device.via_device_id, []).append(device)
+
+    for home_device_id in home_device_ids:
+        home_device = device_registry.async_get(home_device_id)
+        assert home_device
+
+        disabled = home_device.disabled_by is not None
+        # Walk the whole subtree; a module can be a grandchild via its gateway
+        stack = list(children.get(home_device_id, []))
+        while stack:
+            device = stack.pop()
+            stack.extend(children.get(device.id, []))
+
+            if disabled and device.disabled_by is None:
+                device_registry.async_update_device(
+                    device.id, disabled_by=dr.DeviceEntryDisabler.INTEGRATION
+                )
+            elif (
+                not disabled
+                and device.disabled_by is dr.DeviceEntryDisabler.INTEGRATION
+            ):
+                device_registry.async_update_device(device.id, disabled_by=None)

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -1,5 +1,6 @@
 """Device registry helpers for the Netatmo integration."""
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import pyatmo
@@ -14,6 +15,27 @@ if TYPE_CHECKING:
 
 
 @callback
+def async_disabled_netatmo_ids(
+    hass: HomeAssistant, entry: NetatmoConfigEntry
+) -> list[str]:
+    """Return the Netatmo ids of every disabled device.
+
+    A superset of the disabled home ids. Module ids never match a home id, so
+    passing them through to pyatmo's denylist is harmless and avoids having to
+    know which devices are homes before the topology has been fetched.
+    """
+    return [
+        identifier[1]
+        for device in dr.async_entries_for_config_entry(
+            dr.async_get(hass), entry.entry_id
+        )
+        if device.disabled_by
+        for identifier in device.identifiers
+        if identifier[0] == DOMAIN
+    ]
+
+
+@callback
 def async_register_parent_devices(
     hass: HomeAssistant, entry: NetatmoConfigEntry, account: pyatmo.AsyncAccount
 ) -> dict[str, str]:
@@ -21,15 +43,53 @@ def async_register_parent_devices(
     device_registry = dr.async_get(hass)
     parent_device_ids: dict[str, str] = {}
 
-    for home in account.homes.values():
+    for home_id, home_name in account.all_home_names.items():
         device_entry = device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, home.entity_id)},
+            identifiers={(DOMAIN, home_id)},
             manufacturer=MANUFACTURER,
             model="Home",
-            name=home.name,
+            name=home_name,
             configuration_url=CONF_URL_CONTROL,
         )
-        parent_device_ids[home.entity_id] = device_entry.id
+        parent_device_ids[home_id] = device_entry.id
 
     return parent_device_ids
+
+
+@callback
+def async_sync_home_disabled_state(
+    hass: HomeAssistant, entry: NetatmoConfigEntry, home_device_ids: Iterable[str]
+) -> None:
+    """Mirror each home device's disabled state onto its descendants.
+
+    Devices disabled by the user are left alone in both directions, so toggling a
+    home never undoes a manual choice.
+    """
+    device_registry = dr.async_get(hass)
+
+    children: dict[str, list[dr.DeviceEntry]] = {}
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        if device.via_device_id:
+            children.setdefault(device.via_device_id, []).append(device)
+
+    for home_device_id in home_device_ids:
+        home_device = device_registry.async_get(home_device_id)
+        assert home_device
+
+        disabled = home_device.disabled_by is not None
+        # Walk the whole subtree; a module can be a grandchild via its gateway
+        stack = list(children.get(home_device_id, []))
+        while stack:
+            device = stack.pop()
+            stack.extend(children.get(device.id, []))
+
+            if disabled and device.disabled_by is None:
+                device_registry.async_update_device(
+                    device.id, disabled_by=dr.DeviceEntryDisabler.INTEGRATION
+                )
+            elif (
+                not disabled
+                and device.disabled_by is dr.DeviceEntryDisabler.INTEGRATION
+            ):
+                device_registry.async_update_device(device.id, disabled_by=None)

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -1051,7 +1051,8 @@ async def test_device_remove_devices(
 
     assert await async_setup_component(hass, "config", {})
 
-    with selected_platforms([Platform.CLIMATE]):
+    # The sensor platform is what gives account-owned air care modules a device
+    with selected_platforms([Platform.CLIMATE, Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
@@ -1071,12 +1072,56 @@ async def test_device_remove_devices(
     response = await client.remove_device(home_device.id)
     assert not response["success"]
 
+    # Air care modules belong to the account rather than to a home
+    air_care_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:25:cf:a8"), config_entry.entry_id
+    )
+    assert air_care_device is not None
+    response = await client.remove_device(air_care_device.id, config_entry.entry_id)
+    assert not response["success"]
+
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
     response = await client.remove_device(dead_device_entry.id)
     assert response["success"]
+
+
+async def test_disabled_home_keeps_its_descendants(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home's rooms and modules cannot be removed."""
+    assert await async_setup_component(hass, "config", {})
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom is not None
+
+        home_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, HOME_ID), config_entry.entry_id
+        )
+        assert home_device is not None
+        device_registry.async_update_device(
+            home_device.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+        await hass.async_block_till_done()
+
+    # The home is no longer polled, so its rooms are absent from the account,
+    # but their devices are still live and must keep their customisations
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    assert not response["success"]
 
 
 async def test_oauth_implementation_not_available(

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -902,6 +902,143 @@ async def test_device_hierarchy(
     assert dict(sorted(hierarchy.items())) == snapshot
 
 
+async def test_disabled_home_is_not_polled(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a home whose device is disabled is not set up or polled."""
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, HOME_ID)},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    data_handler = config_entry.runtime_data
+    assert HOME_ID not in data_handler.account.homes
+    assert f"home-{HOME_ID}" not in data_handler.publisher
+    assert hass.states.get("climate.livingroom_livingroom") is None
+
+
+async def test_disabled_home_keeps_its_device(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home keeps a device so it can be re-enabled."""
+    assert await async_setup_component(hass, "config", {})
+
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, HOME_ID)},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
+    assert home_device is not None
+    assert home_device.name == "MYHOME"
+    assert home_device.model == "Home"
+    assert home_device.disabled_by is dr.DeviceEntryDisabler.USER
+
+    # A disabled home is still live, so its device must not be removable
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(config_entry.entry_id)
+    assert not response["success"]
+
+
+async def test_disabled_home_disables_its_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home disables its devices without touching manual choices."""
+    with selected_platforms([Platform.CLIMATE, Platform.COVER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        blinds = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "0009999992"), config_entry.entry_id
+        )
+        assert blinds is not None
+        # A device the user disabled by hand, which must survive a home toggle
+        device_registry.async_update_device(
+            blinds.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom is not None
+        assert livingroom.disabled_by is None
+
+        # A grandchild, as a gateway will produce once bridge nesting lands.
+        # Without this the recursive walk is never exercised and would regress
+        # silently.
+        grandchild = device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, "grandchild-module-id")},
+            via_device_id=livingroom.id,
+        )
+
+        home_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, HOME_ID), config_entry.entry_id
+        )
+        assert home_device is not None
+        device_registry.async_update_device(
+            home_device.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom.disabled_by is dr.DeviceEntryDisabler.INTEGRATION
+        entity = entity_registry.async_get("climate.livingroom_livingroom")
+        assert entity.disabled_by is er.RegistryEntryDisabler.DEVICE
+
+        # The walk reaches a grandchild, not just direct children
+        assert (
+            device_registry.async_get(grandchild.id).disabled_by
+            is dr.DeviceEntryDisabler.INTEGRATION
+        )
+
+        # Re-enabling restores what we disabled, and only what we disabled
+        device_registry.async_update_device(home_device.id, disabled_by=None)
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom.disabled_by is None
+        entity = entity_registry.async_get("climate.livingroom_livingroom")
+        assert entity.disabled_by is None
+
+        blinds = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "0009999992"), config_entry.entry_id
+        )
+        assert blinds.disabled_by is dr.DeviceEntryDisabler.USER
+
+        assert device_registry.async_get(grandchild.id).disabled_by is None
+
+
 async def test_device_remove_devices(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -1117,9 +1117,15 @@ async def test_disabled_home_keeps_its_descendants(
         )
         await hass.async_block_till_done()
 
-    # The home is no longer polled, so its rooms are absent from the account,
-    # but their devices are still live and must keep their customisations
+    # The room is absent from the account now, but its device is still live
     client = await hass_ws_client(hass)
+    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # A hand-disabled device keeps USER, so only the walk up to the home finds it
+    device_registry.async_update_device(
+        livingroom.id, disabled_by=dr.DeviceEntryDisabler.USER
+    )
     response = await client.remove_device(livingroom.id, config_entry.entry_id)
     assert not response["success"]
 

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -957,7 +957,7 @@ async def test_disabled_home_keeps_its_device(
 
     # A disabled home is still live, so its device must not be removable
     client = await hass_ws_client(hass)
-    response = await client.remove_device(config_entry.entry_id)
+    response = await client.remove_device(home_device.id)
     assert not response["success"]
 
 
@@ -1077,7 +1077,7 @@ async def test_device_remove_devices(
         (DOMAIN, "12:34:56:25:cf:a8"), config_entry.entry_id
     )
     assert air_care_device is not None
-    response = await client.remove_device(air_care_device.id, config_entry.entry_id)
+    response = await client.remove_device(air_care_device.id)
     assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
@@ -1119,14 +1119,14 @@ async def test_disabled_home_keeps_its_descendants(
 
     # The room is absent from the account now, but its device is still live
     client = await hass_ws_client(hass)
-    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    response = await client.remove_device(livingroom.id)
     assert not response["success"]
 
     # A hand-disabled device keeps USER, so only the walk up to the home finds it
     device_registry.async_update_device(
         livingroom.id, disabled_by=dr.DeviceEntryDisabler.USER
     )
-    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    response = await client.remove_device(livingroom.id)
     assert not response["success"]
 
 

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -701,6 +701,143 @@ async def test_device_hierarchy(
     assert air_care_device.via_device_id is None
 
 
+async def test_disabled_home_is_not_polled(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a home whose device is disabled is not set up or polled."""
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, HOME_ID)},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    data_handler = config_entry.runtime_data
+    assert HOME_ID not in data_handler.account.homes
+    assert f"home-{HOME_ID}" not in data_handler.publisher
+    assert hass.states.get("climate.livingroom_livingroom") is None
+
+
+async def test_disabled_home_keeps_its_device(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home keeps a device so it can be re-enabled."""
+    assert await async_setup_component(hass, "config", {})
+
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, HOME_ID)},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
+    assert home_device is not None
+    assert home_device.name == "MYHOME"
+    assert home_device.model == "Home"
+    assert home_device.disabled_by is dr.DeviceEntryDisabler.USER
+
+    # A disabled home is still live, so its device must not be removable
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(home_device.id, config_entry.entry_id)
+    assert not response["success"]
+
+
+async def test_disabled_home_disables_its_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home disables its devices without touching manual choices."""
+    with selected_platforms([Platform.CLIMATE, Platform.COVER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        blinds = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "0009999992"), config_entry.entry_id
+        )
+        assert blinds is not None
+        # A device the user disabled by hand, which must survive a home toggle
+        device_registry.async_update_device(
+            blinds.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom is not None
+        assert livingroom.disabled_by is None
+
+        # A grandchild, as a gateway will produce once bridge nesting lands.
+        # Without this the recursive walk is never exercised and would regress
+        # silently.
+        grandchild = device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, "grandchild-module-id")},
+            via_device_id=livingroom.id,
+        )
+
+        home_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, HOME_ID), config_entry.entry_id
+        )
+        assert home_device is not None
+        device_registry.async_update_device(
+            home_device.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom.disabled_by is dr.DeviceEntryDisabler.INTEGRATION
+        entity = entity_registry.async_get("climate.livingroom_livingroom")
+        assert entity.disabled_by is er.RegistryEntryDisabler.DEVICE
+
+        # The walk reaches a grandchild, not just direct children
+        assert (
+            device_registry.async_get(grandchild.id).disabled_by
+            is dr.DeviceEntryDisabler.INTEGRATION
+        )
+
+        # Re-enabling restores what we disabled, and only what we disabled
+        device_registry.async_update_device(home_device.id, disabled_by=None)
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom.disabled_by is None
+        entity = entity_registry.async_get("climate.livingroom_livingroom")
+        assert entity.disabled_by is None
+
+        blinds = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "0009999992"), config_entry.entry_id
+        )
+        assert blinds.disabled_by is dr.DeviceEntryDisabler.USER
+
+        assert device_registry.async_get(grandchild.id).disabled_by is None
+
+
 async def test_device_remove_devices(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -850,7 +850,8 @@ async def test_device_remove_devices(
 
     assert await async_setup_component(hass, "config", {})
 
-    with selected_platforms([Platform.CLIMATE]):
+    # The sensor platform is what gives account-owned air care modules a device
+    with selected_platforms([Platform.CLIMATE, Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
@@ -870,12 +871,56 @@ async def test_device_remove_devices(
     response = await client.remove_device(home_device.id, config_entry.entry_id)
     assert not response["success"]
 
+    # Air care modules belong to the account rather than to a home
+    air_care_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:25:cf:a8"), config_entry.entry_id
+    )
+    assert air_care_device is not None
+    response = await client.remove_device(air_care_device.id, config_entry.entry_id)
+    assert not response["success"]
+
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
     response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
     assert response["success"]
+
+
+async def test_disabled_home_keeps_its_descendants(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a disabled home's rooms and modules cannot be removed."""
+    assert await async_setup_component(hass, "config", {})
+
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        livingroom = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "2746182631"), config_entry.entry_id
+        )
+        assert livingroom is not None
+
+        home_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, HOME_ID), config_entry.entry_id
+        )
+        assert home_device is not None
+        device_registry.async_update_device(
+            home_device.id, disabled_by=dr.DeviceEntryDisabler.USER
+        )
+        await hass.async_block_till_done()
+
+    # The home is no longer polled, so its rooms are absent from the account,
+    # but their devices are still live and must keep their customisations
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    assert not response["success"]
 
 
 async def test_oauth_implementation_not_available(

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -916,9 +916,15 @@ async def test_disabled_home_keeps_its_descendants(
         )
         await hass.async_block_till_done()
 
-    # The home is no longer polled, so its rooms are absent from the account,
-    # but their devices are still live and must keep their customisations
+    # The room is absent from the account now, but its device is still live
     client = await hass_ws_client(hass)
+    response = await client.remove_device(livingroom.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # A hand-disabled device keeps USER, so only the walk up to the home finds it
+    device_registry.async_update_device(
+        livingroom.id, disabled_by=dr.DeviceEntryDisabler.USER
+    )
     response = await client.remove_device(livingroom.id, config_entry.entry_id)
     assert not response["success"]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make disabling a Netatmo home device mean something.

Every home is a device, so the UI already offers to disable one. Home Assistant does not cascade disabled_by down via_device, so today that only disables the home device's own entities: the home is still polled every five minutes and all of its rooms and modules keep their entities. An account with a holiday home, or a home shared by a family member, has no way to stop paying for it in API calls.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
