### PR TITLE
Nest Netatmo devices under the device they report through

### DIFF
--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -51,7 +51,7 @@ from .const import (
     WEBHOOK_DEACTIVATION,
     WEBHOOK_PUSH_TYPE,
 )
-from .device import async_register_parent_devices
+from .device import async_register_parent_devices, netatmo_module_parents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -175,6 +175,7 @@ class NetatmoDataHandler:
         self.cameras: dict[str, str] = {}
         self.events: dict[str, dict] = {}
         self.parent_device_ids: dict[str, str] = {}
+        self.module_parents: dict[str, str] = {}
 
     async def async_setup(self) -> None:
         """Set up the Netatmo data handler."""
@@ -197,8 +198,9 @@ class NetatmoDataHandler:
         await self.subscribe(ACCOUNT, ACCOUNT, None)
 
         # Parents must exist before a platform links a child to one
+        self.module_parents = netatmo_module_parents(self.account)
         self.parent_device_ids = async_register_parent_devices(
-            self.hass, self.config_entry, self.account
+            self.hass, self.config_entry, self.account, self.module_parents
         )
 
         await self.hass.config_entries.async_forward_entry_setups(

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -1,5 +1,6 @@
 """Device registry helpers for the Netatmo integration."""
 
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import pyatmo
@@ -14,6 +15,27 @@ if TYPE_CHECKING:
     from .coordinator import NetatmoConfigEntry
 
 
+def _bridged_children(home: pyatmo.Home) -> Iterator[tuple[str, str]]:
+    """Yield (module id, parent id) for every child a module lists as bridged."""
+    return (
+        (child_id, module.entity_id)
+        for module in home.modules.values()
+        for child_id in module.modules or ()
+        if child_id in home.modules and child_id != module.entity_id
+    )
+
+
+def _declared_bridges(home: pyatmo.Home) -> Iterator[tuple[str, str]]:
+    """Yield (module id, parent id) for every module that names its bridge."""
+    return (
+        (module.entity_id, bridge)
+        for module in home.modules.values()
+        if (bridge := module.bridge)
+        and bridge in home.modules
+        and bridge != module.entity_id
+    )
+
+
 def netatmo_module_parents(account: pyatmo.AsyncAccount) -> dict[str, str]:
     """Map each module id to the id of the module it reports through.
 
@@ -24,19 +46,9 @@ def netatmo_module_parents(account: pyatmo.AsyncAccount) -> dict[str, str]:
     """
     parents: dict[str, str] = {}
     for home in account.homes.values():
-        for module in home.modules.values():
-            for child_id in module.modules or ():
-                if child_id in home.modules and child_id != module.entity_id:
-                    parents.setdefault(child_id, module.entity_id)
-
-        for module in home.modules.values():
-            bridge = module.bridge
-            if (
-                bridge is not None
-                and bridge in home.modules
-                and bridge != module.entity_id
-            ):
-                parents[module.entity_id] = bridge
+        for child_id, parent_id in _bridged_children(home):
+            parents.setdefault(child_id, parent_id)
+        parents.update(_declared_bridges(home))
 
     return parents
 

--- a/homeassistant/components/netatmo/device.py
+++ b/homeassistant/components/netatmo/device.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 import pyatmo
+from pyatmo.modules.device_types import DEVICE_DESCRIPTION_MAP
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -13,11 +14,88 @@ if TYPE_CHECKING:
     from .coordinator import NetatmoConfigEntry
 
 
+def netatmo_module_parents(account: pyatmo.AsyncAccount) -> dict[str, str]:
+    """Map each module id to the id of the module it reports through.
+
+    The API records the relationship from both ends and neither end is
+    complete: a station lists bridged children that never name it back, and a
+    module can name a bridge that does not list it. `bridge` is single-valued,
+    so it wins wherever the two disagree.
+    """
+    parents: dict[str, str] = {}
+    for home in account.homes.values():
+        for module in home.modules.values():
+            for child_id in module.modules or ():
+                if child_id in home.modules and child_id != module.entity_id:
+                    parents.setdefault(child_id, module.entity_id)
+
+        for module in home.modules.values():
+            bridge = module.bridge
+            if (
+                bridge is not None
+                and bridge in home.modules
+                and bridge != module.entity_id
+            ):
+                parents[module.entity_id] = bridge
+
+    return parents
+
+
+def _register_bridge(
+    device_registry: dr.DeviceRegistry,
+    entry: NetatmoConfigEntry,
+    home: pyatmo.Home,
+    module_id: str,
+    module_parents: dict[str, str],
+    parent_device_ids: dict[str, str],
+    seen: set[str],
+) -> str:
+    """Register a bridging module after its own bridge and return its device id."""
+    if (device_id := parent_device_ids.get(module_id)) is not None:
+        return device_id
+
+    seen.add(module_id)
+    via_device_id = parent_device_ids[home.entity_id]
+    parent_id = module_parents.get(module_id)
+    # `seen` bounds the walk; a cycle in unvalidated API data would not terminate
+    if parent_id is not None and parent_id not in seen:
+        via_device_id = _register_bridge(
+            device_registry,
+            entry,
+            home,
+            parent_id,
+            module_parents,
+            parent_device_ids,
+            seen,
+        )
+
+    module = home.modules[module_id]
+    manufacturer, model = DEVICE_DESCRIPTION_MAP.get(
+        module.device_type, (MANUFACTURER, module.device_type.value)
+    )
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, module_id)},
+        manufacturer=manufacturer,
+        model=model,
+        name=module.name,
+        via_device_id=via_device_id,
+    )
+    parent_device_ids[module_id] = device_entry.id
+    return device_entry.id
+
+
 @callback
 def async_register_parent_devices(
-    hass: HomeAssistant, entry: NetatmoConfigEntry, account: pyatmo.AsyncAccount
+    hass: HomeAssistant,
+    entry: NetatmoConfigEntry,
+    account: pyatmo.AsyncAccount,
+    module_parents: dict[str, str],
 ) -> dict[str, str]:
-    """Register a device per home and map Netatmo ids to device registry ids."""
+    """Register a device per home and per bridging module.
+
+    Maps Netatmo ids to device registry ids.
+    """
     device_registry = dr.async_get(hass)
     parent_device_ids: dict[str, str] = {}
 
@@ -31,5 +109,23 @@ def async_register_parent_devices(
             configuration_url=CONF_URL_CONTROL,
         )
         parent_device_ids[home.entity_id] = device_entry.id
+
+    for home in account.homes.values():
+        bridges = {
+            module_parents[module_id]
+            for module_id in home.modules
+            if module_id in module_parents
+        }
+        for module_id in home.modules:
+            if module_id in bridges:
+                _register_bridge(
+                    device_registry,
+                    entry,
+                    home,
+                    module_id,
+                    module_parents,
+                    parent_device_ids,
+                    set(),
+                )
 
     return parent_device_ids

--- a/homeassistant/components/netatmo/entity.py
+++ b/homeassistant/components/netatmo/entity.py
@@ -186,7 +186,10 @@ class NetatmoModuleEntity(NetatmoDeviceEntity):
             model=self.device_description[1],
             configuration_url=self._attr_configuration_url,
         )
-        if via_device_id := device.data_handler.parent_device_ids.get(device.parent_id):
+        parent_id = device.data_handler.module_parents.get(
+            device.device.entity_id, device.parent_id
+        )
+        if via_device_id := device.data_handler.parent_device_ids.get(parent_id):
             self._attr_device_info["via_device_id"] = via_device_id
 
     @property

--- a/homeassistant/components/netatmo/quality_scale.yaml
+++ b/homeassistant/components/netatmo/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
   test-coverage: todo
 
   # Gold
-  devices: todo
+  devices: done
   diagnostics: done
   discovery-update-info: todo
   discovery: todo

--- a/tests/components/netatmo/snapshots/test_init.ambr
+++ b/tests/components/netatmo/snapshots/test_init.ambr
@@ -1,4 +1,53 @@
 # serializer version: 1
+# name: test_device_hierarchy
+  dict({
+    '0009999992': '12:34:56:30:d5:d4',
+    '0009999993': '12:34:56:30:d5:d4',
+    '00:11:22:33:00:11:45:fe': '12:34:56:80:60:40',
+    '1002003001': '91763b24c43d3e344f424e8b',
+    '12:34:56:00:00:a1:4c:da': '12:34:56:80:60:40',
+    '12:34:56:00:01:01:01:a1': '12:34:56:80:60:40',
+    '12:34:56:00:16:0e': '91763b24c43d3e344f424e8b',
+    '12:34:56:00:16:0e#0': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#1': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#2': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#3': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#4': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#5': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#6': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#7': '12:34:56:00:16:0e',
+    '12:34:56:00:16:0e#8': '12:34:56:00:16:0e',
+    '12:34:56:00:86:99': '12:34:56:00:f1:62',
+    '12:34:56:00:f1:62': '91763b24c43d3e344f424e8b',
+    '12:34:56:00:fa:d0': '91763b24c43d3e344f424e8b',
+    '12:34:56:03:1b:e4': '12:34:56:80:bb:26',
+    '12:34:56:10:b9:0e': '91763b24c43d3e344f424e8b',
+    '12:34:56:10:f1:66': '91763b24c43d3e344f424e8b',
+    '12:34:56:20:f5:44': '91763b24c43d3e344f424e8b',
+    '12:34:56:25:cf:a8': None,
+    '12:34:56:26:65:14': None,
+    '12:34:56:26:68:92': None,
+    '12:34:56:26:69:0c': None,
+    '12:34:56:30:d5:d4': '91763b24c43d3e344f424e8b',
+    '12:34:56:3e:c5:46': None,
+    '12:34:56:80:00:12:ac:f2': '12:34:56:80:60:40',
+    '12:34:56:80:1c:42': '12:34:56:80:bb:26',
+    '12:34:56:80:44:92': '12:34:56:80:bb:26',
+    '12:34:56:80:60:40': '91763b24c43d3e344f424e8b',
+    '12:34:56:80:7e:18': '12:34:56:80:bb:26',
+    '12:34:56:80:bb:26': '91763b24c43d3e344f424e8b',
+    '12:34:56:80:c1:ea': '12:34:56:80:bb:26',
+    '222452125': '91763b24c43d3e344f424e8b',
+    '2746182631': '91763b24c43d3e344f424e8b',
+    '2833524037': '91763b24c43d3e344f424e8b',
+    '2940411577': '91763b24c43d3e344f424e8b',
+    '91763b24c43d3e344f424e8b': None,
+    '91763b24c43d3e344f424e8c': None,
+    'Home avg': None,
+    'Home max': None,
+    'Home min': None,
+  })
+# ---
 # name: test_devices[netatmo-0009999992]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
@@ -539,6 +588,36 @@
     'via_device_id': <ANY>,
   })
 # ---
+# name: test_devices[netatmo-12:34:56:00:fa:d0]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '12:34:56:00:fa:d0',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Netatmo',
+    'model': 'Smart Thermostat Gateway',
+    'model_id': None,
+    'name': 'Thermostat',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
 # name: test_devices[netatmo-12:34:56:03:1b:e4]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
@@ -623,6 +702,36 @@
     'model': 'Smart Video Doorbell',
     'model_id': None,
     'name': 'Netatmo-Doorbell',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
+# name: test_devices[netatmo-12:34:56:20:f5:44]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '12:34:56:20:f5:44',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Netatmo',
+    'model': 'OpenTherm Gateway',
+    'model_id': None,
+    'name': 'Modulating Relay',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
@@ -749,6 +858,36 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[netatmo-12:34:56:30:d5:d4]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '12:34:56:30:d5:d4',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Bubbendorf',
+    'model': 'Gateway',
+    'model_id': None,
+    'name': 'module iDiamant',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
 # name: test_devices[netatmo-12:34:56:3e:c5:46]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
@@ -863,6 +1002,36 @@
     'model': 'Smart Indoor Module',
     'model_id': None,
     'name': 'Villa Bedroom',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
+# name: test_devices[netatmo-12:34:56:80:60:40]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '12:34:56:80:60:40',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Legrand',
+    'model': 'Gateway',
+    'model_id': None,
+    'name': 'Prise Control',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -17,6 +17,10 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import cloud, webhook
 from homeassistant.components.netatmo import DOMAIN, coordinator
+from homeassistant.components.netatmo.device import (
+    async_register_parent_devices,
+    netatmo_module_parents,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_WEBHOOK_ID,
@@ -660,45 +664,221 @@ async def test_home_devices_registered(
     assert empty_home_device.name == "Unknown"
 
 
-async def test_device_hierarchy(
+async def test_module_parents(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test each module is mapped to the module it reports through."""
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    parents = netatmo_module_parents(config_entry.runtime_data.account)
+
+    # A valve reports through the relay that lists it as a bridged module
+    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
+    # "Garden" names its station as its bridge, but the station does not list
+    # it, so a parent-side-only walk would orphan it
+    assert parents["12:34:56:03:1b:e4"] == "12:34:56:80:bb:26"
+    # A gateway itself reports through nothing
+    assert "12:34:56:00:fa:d0" not in parents
+
+
+async def test_bridge_devices_registered(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
     netatmo_auth: AsyncMock,
 ) -> None:
-    """Test rooms and modules are linked to their home."""
-    with selected_platforms([Platform.CLIMATE, Platform.COVER, Platform.SENSOR]):
+    """Test a device is registered for a gateway that has no entities."""
+    with selected_platforms([Platform.CLIMATE]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
+
+    relay = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:00:fa:d0"), config_entry.entry_id
+    )
+    assert relay is not None
+    assert relay.name == "Thermostat"
+    assert relay.manufacturer == "Netatmo"
+    assert relay.model == "Smart Thermostat Gateway"
 
     home_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, HOME_ID), config_entry.entry_id
     )
     assert home_device is not None
+    assert relay.via_device_id == home_device.id
+
+
+async def test_module_links_to_its_bridge(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a module is linked to its gateway rather than to its home."""
+    with selected_platforms([Platform.CLIMATE, Platform.COVER, Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    gateway = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:30:d5:d4"), config_entry.entry_id
+    )
+    assert gateway is not None
+
+    blinds = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "0009999992"), config_entry.entry_id
+    )
+    assert blinds is not None
+    assert blinds.via_device_id == gateway.id
+
+    # "Garden" is reached only through its own `bridge`; its station does not
+    # list it as a bridged module
+    station = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:80:bb:26"), config_entry.entry_id
+    )
+    assert station is not None
+
+    garden = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:03:1b:e4"), config_entry.entry_id
+    )
+    assert garden is not None
+    assert garden.via_device_id == station.id
+
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
+    assert home_device is not None
+    assert station.via_device_id == home_device.id
+
+    # Rooms keep linking to the home
+    livingroom = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "2746182631"), config_entry.entry_id
+    )
+    assert livingroom is not None
+    assert livingroom.via_device_id == home_device.id
+
+
+async def test_nested_bridges(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a gateway that itself reports through another gateway."""
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    account = config_entry.runtime_data.account
+    account.homes[HOME_ID].modules["12:34:56:00:fa:d0"].bridge = "12:34:56:80:60:40"
+
+    parent_device_ids = async_register_parent_devices(
+        hass, config_entry, account, netatmo_module_parents(account)
+    )
+
+    relay = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:00:fa:d0"), config_entry.entry_id
+    )
+    assert relay is not None
+    gateway = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:80:60:40"), config_entry.entry_id
+    )
+    assert gateway is not None
+
+    assert relay.via_device_id == gateway.id
+    assert parent_device_ids["12:34:56:00:fa:d0"] == relay.id
+
+
+async def test_conflicting_claims_resolve_to_the_bridge(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a child claimed by two parents keeps the one its bridge names."""
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    account = config_entry.runtime_data.account
+    camera = account.homes[HOME_ID].modules["12:34:56:00:f1:62"]
+    camera.modules = [*camera.modules, "12:34:56:03:a5:54"]
+
+    parents = netatmo_module_parents(account)
+
+    # Valve1 names the relay as its bridge, so the camera's claim loses
+    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
+
+
+async def test_conflicting_claims_without_a_bridge(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test a child that names no bridge stays with its first claimant."""
+    with selected_platforms([Platform.CLIMATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    account = config_entry.runtime_data.account
+    home = account.homes[HOME_ID]
+    home.modules["12:34:56:03:a5:54"].bridge = None
+    camera = home.modules["12:34:56:00:f1:62"]
+    camera.modules = [*camera.modules, "12:34:56:03:a5:54"]
+
+    parents = netatmo_module_parents(account)
+
+    # The relay is listed before the camera in the API response
+    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
+
+
+async def test_device_hierarchy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test every device is linked to the device it reports through."""
+    with selected_platforms(
+        [
+            Platform.CAMERA,
+            Platform.CLIMATE,
+            Platform.COVER,
+            Platform.LIGHT,
+            Platform.SELECT,
+            Platform.SENSOR,
+            Platform.SWITCH,
+        ]
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
 
     device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )
-    linked = {
-        device.name
+    netatmo_ids = {
+        device.id: next(
+            identifier[1]
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+        )
         for device in device_entries
-        if device.via_device_id == home_device.id
+    }
+    hierarchy = {
+        netatmo_ids[device.id]: netatmo_ids.get(device.via_device_id)
+        for device in device_entries
     }
 
-    # Rooms link to the home
-    assert "Livingroom" in linked
-    # Modules link to the home
-    assert "Entrance Blinds" in linked
-    # The home links to nothing
-    assert home_device.via_device_id is None
-
-    # Air care modules belong to the account rather than a home, so stay unlinked
-    air_care_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "12:34:56:25:cf:a8"), config_entry.entry_id
-    )
-    assert air_care_device is not None
-    assert air_care_device.via_device_id is None
+    assert dict(sorted(hierarchy.items())) == snapshot
 
 
 async def test_device_remove_devices(

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -1,6 +1,7 @@
 """The tests for Netatmo component."""
 
 from collections.abc import Callable, Coroutine, Iterator
+from contextlib import contextmanager
 from datetime import timedelta
 from functools import partial
 from itertools import pairwise
@@ -17,10 +18,6 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import cloud, webhook
 from homeassistant.components.netatmo import DOMAIN, coordinator
-from homeassistant.components.netatmo.device import (
-    async_register_parent_devices,
-    netatmo_module_parents,
-)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_WEBHOOK_ID,
@@ -664,26 +661,33 @@ async def test_home_devices_registered(
     assert empty_home_device.name == "Unknown"
 
 
-async def test_module_parents(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    netatmo_auth: AsyncMock,
-) -> None:
-    """Test each module is mapped to the module it reports through."""
-    with selected_platforms([Platform.CLIMATE]):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
+@contextmanager
+def modified_homesdata(
+    hass: HomeAssistant, modify: Callable[[dict[str, Any]], None]
+) -> Iterator[None]:
+    """Patch the API so /homesdata reports a modified topology.
 
-        await hass.async_block_till_done()
+    `modify` is handed MYHOME's modules keyed by id.
+    """
 
-    parents = netatmo_module_parents(config_entry.runtime_data.account)
+    def modifier(payload: dict[str, Any]) -> None:
+        body = payload.get("body")
+        if not isinstance(body, dict):
+            return
+        for home in body.get("homes", []):
+            if home["id"] == HOME_ID:
+                modify({module["id"]: module for module in home["modules"]})
 
-    # A valve reports through the relay that lists it as a bridged module
-    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
-    # "Garden" names its station as its bridge, but the station does not list
-    # it, so a parent-side-only walk would orphan it
-    assert parents["12:34:56:03:1b:e4"] == "12:34:56:80:bb:26"
-    # A gateway itself reports through nothing
-    assert "12:34:56:00:fa:d0" not in parents
+    async def fake_post(*args: Any, **kwargs: Any):
+        return await fake_post_request(hass, *args, msg_callback=modifier, **kwargs)
+
+    with patch(
+        "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth"
+    ) as mock_auth:
+        mock_auth.return_value.async_post_api_request.side_effect = fake_post
+        mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
+        mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
+        yield
 
 
 async def test_bridge_devices_registered(
@@ -767,20 +771,19 @@ async def test_nested_bridges(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
-    netatmo_auth: AsyncMock,
 ) -> None:
     """Test a gateway that itself reports through another gateway."""
-    with selected_platforms([Platform.CLIMATE]):
+
+    def bridge_the_relay(modules: dict[str, Any]) -> None:
+        modules["12:34:56:00:fa:d0"]["bridge"] = "12:34:56:80:60:40"
+
+    with (
+        modified_homesdata(hass, bridge_the_relay),
+        selected_platforms([Platform.CLIMATE]),
+    ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
-
-    account = config_entry.runtime_data.account
-    account.homes[HOME_ID].modules["12:34:56:00:fa:d0"].bridge = "12:34:56:80:60:40"
-
-    parent_device_ids = async_register_parent_devices(
-        hass, config_entry, account, netatmo_module_parents(account)
-    )
 
     relay = device_registry.async_get_device_by_identifier(
         (DOMAIN, "12:34:56:00:fa:d0"), config_entry.entry_id
@@ -792,51 +795,69 @@ async def test_nested_bridges(
     assert gateway is not None
 
     assert relay.via_device_id == gateway.id
-    assert parent_device_ids["12:34:56:00:fa:d0"] == relay.id
 
 
 async def test_conflicting_claims_resolve_to_the_bridge(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
-    netatmo_auth: AsyncMock,
 ) -> None:
     """Test a child claimed by two parents keeps the one its bridge names."""
-    with selected_platforms([Platform.CLIMATE]):
+
+    def claim_the_blinds(modules: dict[str, Any]) -> None:
+        camera = modules["12:34:56:00:f1:62"]
+        camera["modules_bridged"] = [*camera["modules_bridged"], "0009999992"]
+
+    with (
+        modified_homesdata(hass, claim_the_blinds),
+        selected_platforms([Platform.COVER]),
+    ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
 
-    account = config_entry.runtime_data.account
-    camera = account.homes[HOME_ID].modules["12:34:56:00:f1:62"]
-    camera.modules = [*camera.modules, "12:34:56:03:a5:54"]
-
-    parents = netatmo_module_parents(account)
-
-    # Valve1 names the relay as its bridge, so the camera's claim loses
-    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
+    blinds = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "0009999992"), config_entry.entry_id
+    )
+    assert blinds is not None
+    # The blinds name the iDiamant gateway as their bridge, so the camera loses
+    gateway = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:30:d5:d4"), config_entry.entry_id
+    )
+    assert gateway is not None
+    assert blinds.via_device_id == gateway.id
 
 
 async def test_conflicting_claims_without_a_bridge(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
-    netatmo_auth: AsyncMock,
 ) -> None:
     """Test a child that names no bridge stays with its first claimant."""
-    with selected_platforms([Platform.CLIMATE]):
+
+    def claim_the_bridgeless_blinds(modules: dict[str, Any]) -> None:
+        del modules["0009999992"]["bridge"]
+        camera = modules["12:34:56:00:f1:62"]
+        camera["modules_bridged"] = [*camera["modules_bridged"], "0009999992"]
+
+    with (
+        modified_homesdata(hass, claim_the_bridgeless_blinds),
+        selected_platforms([Platform.COVER]),
+    ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
         await hass.async_block_till_done()
 
-    account = config_entry.runtime_data.account
-    home = account.homes[HOME_ID]
-    home.modules["12:34:56:03:a5:54"].bridge = None
-    camera = home.modules["12:34:56:00:f1:62"]
-    camera.modules = [*camera.modules, "12:34:56:03:a5:54"]
-
-    parents = netatmo_module_parents(account)
-
-    # The relay is listed before the camera in the API response
-    assert parents["12:34:56:03:a5:54"] == "12:34:56:00:fa:d0"
+    blinds = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "0009999992"), config_entry.entry_id
+    )
+    assert blinds is not None
+    # The camera is listed before the iDiamant gateway in the API response
+    camera = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:00:f1:62"), config_entry.entry_id
+    )
+    assert camera is not None
+    assert blinds.via_device_id == camera.id
 
 
 async def test_device_hierarchy(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Register a device for every module that bridges others -- gateways, and weather stations with sub-modules -- and link each module to it instead of to its home. The parent map reads both directions the API records the relationship in: a station lists bridged children that never name it back, and a module can name a bridge that does not list it.

Cameras and the ecometer become parent devices too, since a door tag and a line meter really do report through them.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
