### PR TITLE
Read the recorder database name with the SQLAlchemy URL parser

### DIFF
--- a/homeassistant/components/recorder/system_health/__init__.py
+++ b/homeassistant/components/recorder/system_health/__init__.py
@@ -1,7 +1,8 @@
 """Provide info to system health."""
 
 from typing import Any
-from urllib.parse import urlparse
+
+from sqlalchemy.engine.url import make_url
 
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
@@ -58,7 +59,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     instance = get_instance(hass)
 
     recorder_runs_manager = instance.recorder_runs_manager
-    database_name = urlparse(instance.db_url).path.lstrip("/")
+    database_name = make_url(instance.db_url).database or ""
     db_engine_info = _async_get_db_engine_info(instance)
     db_stats: dict[str, Any] = {}
 

--- a/tests/components/recorder/test_system_health.py
+++ b/tests/components/recorder/test_system_health.py
@@ -128,3 +128,42 @@ async def test_recorder_system_health_crashed_recorder_runs_table(
         "database_engine": SupportedDialect.SQLITE.value,
         "database_version": ANY,
     }
+
+
+@pytest.mark.parametrize("db_engine", [SupportedDialect.POSTGRESQL])
+@pytest.mark.parametrize(
+    "db_url",
+    [
+        "postgresql://homeassistant:secret@192.168.0.2:5432/home_assistant",
+        "postgresql://homeassistant:pa#ss@192.168.0.2:5432/home_assistant",
+        "postgresql://homeassistant:pa?ss@192.168.0.2:5432/home_assistant",
+        "postgresql://homeassistant:pa/ss@192.168.0.2:5432/home_assistant",
+    ],
+    ids=["plain", "hash", "question_mark", "slash"],
+)
+@pytest.mark.usefixtures("recorder_mock")
+async def test_recorder_system_health_db_name_with_special_characters(
+    hass: HomeAssistant,
+    db_engine: SupportedDialect,
+    db_url: str,
+    recorder_dialect_name: None,
+) -> None:
+    """Test the database name is read correctly when the password needs escaping.
+
+    Characters that are structural in a generic URL, such as ``#`` and ``?``,
+    must not be allowed to swallow the database name that follows them.
+    """
+    assert await async_setup_component(hass, "system_health", {})
+    await async_wait_recording_done(hass)
+
+    instance = get_instance(hass)
+    with (
+        patch.object(instance, "db_url", db_url),
+        patch(
+            "sqlalchemy.orm.session.Session.execute",
+            return_value=Mock(scalar=Mock(return_value=("1048576"))),
+        ) as execute_mock,
+    ):
+        await get_system_health_info(hass, "recorder")
+
+    assert execute_mock.call_args.args[1] == {"database_name": "home_assistant"}


### PR DESCRIPTION
## Proposed change

`system_health` builds the database name with `urlparse(instance.db_url).path`. A generic URL parser treats `#` and `?` in the password as structure, so the path — and with it the database name — comes out empty, and `pg_database_size('''')` fails with `database "" does not exist`. A `/` in the password corrupts it instead.

`make_url` is the parser SQLAlchemy already uses to open the connection, so the name now agrees with the connection in every case. Only the MySQL and PostgreSQL helpers use the value; the SQLite one ignores it and reads the size from `pragma_page_count()`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #176077
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
