### PR TITLE
Identify the joined row by primary key when detecting orphaned rows

### DIFF
--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -93,9 +93,10 @@ def attributes_ids_exist_in_states(
     PostgreSQL does not support skip/loose index scan
     https://wiki.postgresql.org/wiki/Loose_indexscan
 
-    To avoid using distinct, we use a subquery to get the latest last_updated_ts
-    for each attributes_id. This is then used to filter out the attributes_id
-    that no longer exist in the States table.
+    To avoid using distinct, we join against a single arbitrary States row per
+    attributes_id, picked by a correlated subquery. The row is identified by its
+    primary key: any nullable column would make the equality never hold for rows
+    where it is NULL, and report an attributes_id still in use as unused.
 
     This query is fast for older MariaDB, older MySQL, and PostgreSQL.
     """
@@ -107,8 +108,8 @@ def attributes_ids_exist_in_states(
                 States,
                 and_(
                     States.attributes_id == StateAttributes.attributes_id,
-                    States.last_updated_ts
-                    == select(States.last_updated_ts)
+                    States.state_id
+                    == select(States.state_id)
                     .where(States.attributes_id == StateAttributes.attributes_id)
                     .limit(1)
                     .scalar_subquery()
@@ -137,9 +138,10 @@ def data_ids_exist_in_events(
     PostgreSQL does not support skip/loose index scan
     https://wiki.postgresql.org/wiki/Loose_indexscan
 
-    To avoid using distinct, we use a subquery to get the latest time_fired_ts
-    for each data_id. This is then used to filter out the data_id
-    that no longer exist in the Events table.
+    To avoid using distinct, we join against a single arbitrary Events row per
+    data_id, picked by a correlated subquery. The row is identified by its
+    primary key: any nullable column would make the equality never hold for
+    rows where it is NULL, and report a data_id still in use as unused.
 
     This query is fast for older MariaDB, older MySQL, and PostgreSQL.
     """
@@ -151,8 +153,8 @@ def data_ids_exist_in_events(
                 Events,
                 and_(
                     Events.data_id == EventData.data_id,
-                    Events.time_fired_ts
-                    == select(Events.time_fired_ts)
+                    Events.event_id
+                    == select(Events.event_id)
                     .where(Events.data_id == EventData.data_id)
                     .limit(1)
                     .scalar_subquery()

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -93,10 +93,9 @@ def attributes_ids_exist_in_states(
     PostgreSQL does not support skip/loose index scan
     https://wiki.postgresql.org/wiki/Loose_indexscan
 
-    To avoid using distinct, we join against a single arbitrary States row per
-    attributes_id, picked by a correlated subquery. The row is identified by its
-    primary key: any nullable column would make the equality never hold for rows
-    where it is NULL, and report an attributes_id still in use as unused.
+    To avoid using distinct, we use a subquery to get the latest last_updated_ts
+    for each attributes_id. This is then used to filter out the attributes_id
+    that no longer exist in the States table.
 
     This query is fast for older MariaDB, older MySQL, and PostgreSQL.
     """
@@ -108,8 +107,8 @@ def attributes_ids_exist_in_states(
                 States,
                 and_(
                     States.attributes_id == StateAttributes.attributes_id,
-                    States.state_id
-                    == select(States.state_id)
+                    States.last_updated_ts
+                    == select(States.last_updated_ts)
                     .where(States.attributes_id == StateAttributes.attributes_id)
                     .limit(1)
                     .scalar_subquery()
@@ -138,10 +137,9 @@ def data_ids_exist_in_events(
     PostgreSQL does not support skip/loose index scan
     https://wiki.postgresql.org/wiki/Loose_indexscan
 
-    To avoid using distinct, we join against a single arbitrary Events row per
-    data_id, picked by a correlated subquery. The row is identified by its
-    primary key: any nullable column would make the equality never hold for
-    rows where it is NULL, and report a data_id still in use as unused.
+    To avoid using distinct, we use a subquery to get the latest time_fired_ts
+    for each data_id. This is then used to filter out the data_id
+    that no longer exist in the Events table.
 
     This query is fast for older MariaDB, older MySQL, and PostgreSQL.
     """
@@ -153,8 +151,8 @@ def data_ids_exist_in_events(
                 Events,
                 and_(
                     Events.data_id == EventData.data_id,
-                    Events.event_id
-                    == select(Events.event_id)
+                    Events.time_fired_ts
+                    == select(Events.time_fired_ts)
                     .where(Events.data_id == EventData.data_id)
                     .limit(1)
                     .scalar_subquery()

--- a/tests/components/recorder/test_queries.py
+++ b/tests/components/recorder/test_queries.py
@@ -42,9 +42,7 @@ async def test_data_ids_still_referenced_by_events(
         session.flush()
         data_id = data.data_id
         for time_fired_ts in timestamps:
-            session.add(
-                Events(event_type_id=1, data_id=data_id, time_fired_ts=time_fired_ts)
-            )
+            session.add(Events(data_id=data_id, time_fired_ts=time_fired_ts))
         session.flush()
 
         for query in (

--- a/tests/components/recorder/test_queries.py
+++ b/tests/components/recorder/test_queries.py
@@ -1,0 +1,94 @@
+"""Tests for the recorder queries."""
+
+import pytest
+from sqlalchemy import update
+
+from homeassistant.components.recorder.db_schema import (
+    EventData,
+    Events,
+    StateAttributes,
+    States,
+    StatesMeta,
+)
+from homeassistant.components.recorder.queries import (
+    attributes_ids_exist_in_states,
+    attributes_ids_exist_in_states_with_fast_in_distinct,
+    data_ids_exist_in_events,
+    data_ids_exist_in_events_with_fast_in_distinct,
+)
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.core import HomeAssistant
+
+# The subquery variants are used where a range scan is slow, currently
+# PostgreSQL and older MariaDB. The distinct variants are used elsewhere. Both
+# answer the same question and have to agree.
+TIMESTAMPS = [
+    pytest.param([1700000000.0], id="one_row"),
+    pytest.param([None], id="one_row_without_timestamp"),
+    pytest.param([1700000000.0, None], id="timestamp_first"),
+    pytest.param([None, 1700000000.0], id="missing_timestamp_first"),
+]
+
+
+@pytest.mark.parametrize("timestamps", TIMESTAMPS)
+@pytest.mark.usefixtures("recorder_mock")
+async def test_data_ids_still_referenced_by_events(
+    hass: HomeAssistant, timestamps: list[float | None]
+) -> None:
+    """Test a data_id that events still point at is never reported as unused."""
+    with session_scope(hass=hass) as session:
+        data = EventData(hash=1234, shared_data='{"key": "value"}')
+        session.add(data)
+        session.flush()
+        data_id = data.data_id
+        for time_fired_ts in timestamps:
+            session.add(
+                Events(event_type_id=1, data_id=data_id, time_fired_ts=time_fired_ts)
+            )
+        session.flush()
+
+        for query in (
+            data_ids_exist_in_events,
+            data_ids_exist_in_events_with_fast_in_distinct,
+        ):
+            found = [row[0] for row in session.execute(query([data_id])).all()]
+            assert found == [data_id], f"{query.__name__} lost the reference"
+
+
+@pytest.mark.parametrize("timestamps", TIMESTAMPS)
+@pytest.mark.usefixtures("recorder_mock")
+async def test_attributes_ids_still_referenced_by_states(
+    hass: HomeAssistant, timestamps: list[float | None]
+) -> None:
+    """Test an attributes_id that states still point at is not reported unused."""
+    with session_scope(hass=hass) as session:
+        states_meta = StatesMeta(entity_id="sensor.test")
+        attributes = StateAttributes(hash=1234, shared_attrs='{"key": "value"}')
+        session.add_all([states_meta, attributes])
+        session.flush()
+        attributes_id = attributes.attributes_id
+        for last_updated_ts in timestamps:
+            state = States(
+                metadata_id=states_meta.metadata_id,
+                attributes_id=attributes_id,
+                last_updated_ts=last_updated_ts,
+            )
+            session.add(state)
+            session.flush()
+            if last_updated_ts is None:
+                # The column carries a default, so a row without a timestamp
+                # cannot be inserted through the ORM. Databases predating the
+                # timestamp migration do have them, which is what the backfill
+                # in migration.py exists for.
+                session.execute(
+                    update(States)
+                    .where(States.state_id == state.state_id)
+                    .values(last_updated_ts=None)
+                )
+
+        for query in (
+            attributes_ids_exist_in_states,
+            attributes_ids_exist_in_states_with_fast_in_distinct,
+        ):
+            found = [row[0] for row in session.execute(query([attributes_id])).all()]
+            assert found == [attributes_id], f"{query.__name__} lost the reference"


### PR DESCRIPTION
## Proposed change

Before deleting from `event_data` and `state_attributes`, purge subtracts the ids that are still referenced. Where a range scan is slow, currently PostgreSQL and older MariaDB, that question is answered by joining against one arbitrary row per id, picked by a correlated subquery on `Events.time_fired_ts` and `States.last_updated_ts`.

Both columns are nullable. When the picked row has no timestamp the equality never holds, the join matches nothing, and an id that events or states still point at is reported as unused. Purge then deletes it and a database enforcing the foreign key rejects the statement. One such row is enough to hide the id even when other rows with a timestamp reference it, since nothing pins down which row the subquery picks.

Selecting the primary key instead keeps the query shape, the correlation and the indexes it uses, and cannot be null. Rows without a timestamp exist on databases predating the timestamp migration, which is what the `WHERE time_fired_ts is NULL` backfill in `migration.py` is for.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177871
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
