### PR TITLE
Add SpaceXAI Conversation integration.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1738,6 +1738,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/soundtouch/ @kroimon
 /homeassistant/components/spaceapi/ @fabaff
 /tests/components/spaceapi/ @fabaff
+/homeassistant/components/spacexai/ @jeffglousher
+/tests/components/spacexai/ @jeffglousher
 /homeassistant/components/speedtestdotnet/ @rohankapoorcom @engrbm87
 /tests/components/speedtestdotnet/ @rohankapoorcom @engrbm87
 /homeassistant/components/splunk/ @Bre77

--- a/homeassistant/components/spacexai/__init__.py
+++ b/homeassistant/components/spacexai/__init__.py
@@ -1,0 +1,318 @@
+"""The SpaceXAI integration."""
+
+from dataclasses import dataclass
+from typing import cast
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import CONF_MODEL, Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
+from homeassistant.helpers import entity_platform, issue_registry as ir
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
+    LocalOAuth2Implementation,
+    OAuth2Session,
+    async_get_config_entry_implementation,
+)
+from homeassistant.helpers.json import json_dumps
+
+from .client import (
+    OAuthAccessTokenProvider,
+    ProviderSnapshot,
+    SpaceXAIClient,
+    StaticAccessTokenProvider,
+)
+from .const import DEFAULT_MODEL_PLACEHOLDER, DOMAIN, ISSUE_MODEL_NOT_ENTITLED, LOGGER
+from .errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    ErrorContext,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    RateLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    RequestTimeoutError,
+    SpaceXAIError,
+    SubscriptionNotEntitledError,
+    TransientProviderError,
+)
+from .issue import (
+    async_create_model_not_entitled_issue,
+    async_create_subscription_issue,
+    async_delete_model_not_entitled_issue,
+    async_delete_subscription_issue,
+)
+
+PLATFORMS = (Platform.CONVERSATION,)
+
+
+@dataclass(slots=True)
+class SpaceXAIData:
+    """Runtime data for one SpaceXAI account."""
+
+    client: SpaceXAIClient
+    snapshot: ProviderSnapshot
+    subentries: tuple[tuple[str, str, str], ...]
+
+
+type SpaceXAIConfigEntry = ConfigEntry[SpaceXAIData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: SpaceXAIConfigEntry) -> bool:
+    """Set up SpaceXAI from a config entry."""
+    if _async_update_entry not in entry.update_listeners:
+        entry.add_update_listener(_async_update_entry)
+    try:
+        implementation = await async_get_config_entry_implementation(hass, entry)
+    except (ImplementationUnavailableError, ValueError) as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="oauth_implementation_unavailable",
+        ) from err
+
+    client = SpaceXAIClient(
+        hass,
+        OAuthAccessTokenProvider(OAuth2Session(hass, entry, implementation)),
+        runtime_session=True,
+    )
+    try:
+        snapshot = await client.async_validate(expected_subject=entry.unique_id)
+    except AccountMismatchError as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="account_mismatch",
+        ) from err
+    except (
+        AuthenticationRejectedError,
+        ReauthenticationRequiredError,
+        RefreshRejectedError,
+    ) as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="reauthentication_required",
+        ) from err
+    except (
+        ConnectionFailureError,
+        RateLimitedError,
+        RequestTimeoutError,
+        TransientProviderError,
+    ) as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="provider_unavailable",
+        ) from err
+    except SubscriptionNotEntitledError as err:
+        async_create_subscription_issue(hass, entry)
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="subscription_not_entitled",
+        ) from err
+    except NoConversationModelsError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="no_conversation_models",
+        ) from err
+    except QuotaLimitedError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="quota_limited",
+            translation_placeholders={"model": DEFAULT_MODEL_PLACEHOLDER},
+        ) from err
+    except ModelNotEntitledError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="model_not_entitled",
+            translation_placeholders={
+                "model": err.context.model or DEFAULT_MODEL_PLACEHOLDER
+            },
+        ) from err
+    except PermanentProviderError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="permanent_provider_failure",
+            translation_placeholders={
+                "model": err.context.model or DEFAULT_MODEL_PLACEHOLDER
+            },
+        ) from err
+    except SpaceXAIError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="malformed_provider_response",
+            translation_placeholders={"model": DEFAULT_MODEL_PLACEHOLDER},
+        ) from err
+
+    entry.runtime_data = SpaceXAIData(
+        client=client,
+        snapshot=snapshot,
+        subentries=_subentry_fingerprint(entry),
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    async_clear_orphaned_model_repairs(hass, entry)
+    async_reconcile_snapshot(hass, entry, snapshot)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: SpaceXAIConfigEntry) -> bool:
+    """Unload a SpaceXAI config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: SpaceXAIConfigEntry) -> None:
+    """Revoke the OAuth refresh token when an entry is removed."""
+    async_delete_subscription_issue(hass, entry.entry_id)
+    async_clear_orphaned_model_repairs(hass, entry, include_current=True)
+
+    token = entry.data.get("token")
+    if not isinstance(token, dict) or not isinstance(
+        refresh_token := token.get("refresh_token"), str
+    ):
+        LOGGER.warning(
+            "Unable to revoke SpaceXAI OAuth token: reason=missing_refresh_token"
+        )
+        return
+
+    try:
+        implementation = await async_get_config_entry_implementation(hass, entry)
+    except ImplementationUnavailableError, ValueError:
+        LOGGER.warning(
+            "Unable to revoke SpaceXAI OAuth token: reason=implementation_unavailable"
+        )
+        return
+    if not isinstance(implementation, LocalOAuth2Implementation):
+        LOGGER.warning(
+            "Unable to revoke SpaceXAI OAuth token: reason=foreign_implementation"
+        )
+        return
+
+    client = SpaceXAIClient(
+        hass,
+        StaticAccessTokenProvider(""),
+        runtime_session=False,
+    )
+    try:
+        await client.async_revoke(
+            refresh_token,
+            implementation.client_id,
+            implementation.client_secret,
+        )
+    except SpaceXAIError as err:
+        LOGGER.warning(
+            "Unable to revoke SpaceXAI OAuth token: category=%s operation=%s "
+            "status=%s request_id=%s retryable=%s",
+            err.category,
+            err.context.operation,
+            err.context.status,
+            err.context.request_id,
+            err.retryable,
+        )
+
+
+@callback
+def async_mark_subscription_not_entitled(
+    hass: HomeAssistant,
+    entry: SpaceXAIConfigEntry,
+    *,
+    operation: Operation = Operation.MODELS,
+) -> None:
+    """Create the subscription repair and mark loaded conversation entities down."""
+    async_create_subscription_issue(hass, entry)
+    err = SubscriptionNotEntitledError(
+        "Account is not entitled for subscription-backed Grok access",
+        context=ErrorContext(operation=operation),
+    )
+    for platform in entity_platform.async_get_platforms(hass, DOMAIN):
+        for entity in platform.entities.values():
+            if getattr(entity, "entry", None) is not entry:
+                continue
+            mark = getattr(entity, "_mark_unavailable", None)
+            if mark is None:
+                continue
+            mark(err, account_wide=True)
+
+
+@callback
+def async_reconcile_snapshot(
+    hass: HomeAssistant,
+    entry: SpaceXAIConfigEntry,
+    snapshot: ProviderSnapshot,
+) -> None:
+    """Apply a fresh snapshot to repairs and loaded conversation entities."""
+    entry.runtime_data.snapshot = snapshot
+    async_delete_subscription_issue(hass, entry.entry_id)
+    for subentry in entry.subentries.values():
+        if CONF_MODEL not in subentry.data:
+            continue
+        model = cast(str, subentry.data[CONF_MODEL])
+        if snapshot.has_model(model):
+            async_delete_model_not_entitled_issue(hass, subentry.subentry_id)
+        else:
+            async_create_model_not_entitled_issue(
+                hass,
+                entry,
+                subentry_id=subentry.subentry_id,
+                model=model,
+            )
+
+    for platform in entity_platform.async_get_platforms(hass, DOMAIN):
+        for entity in platform.entities.values():
+            apply = getattr(entity, "async_apply_model_entitlement", None)
+            if apply is None or getattr(entity, "entry", None) is not entry:
+                continue
+            apply()
+
+
+def _subentry_fingerprint(
+    entry: SpaceXAIConfigEntry,
+) -> tuple[tuple[str, str, str], ...]:
+    """Return the stored subentry configuration fingerprint."""
+    return tuple(
+        sorted(
+            (
+                subentry.subentry_id,
+                subentry.title,
+                json_dumps(dict(subentry.data)),
+            )
+            for subentry in entry.subentries.values()
+        )
+    )
+
+
+@callback
+def async_clear_orphaned_model_repairs(
+    hass: HomeAssistant,
+    entry: SpaceXAIConfigEntry,
+    *,
+    include_current: bool = False,
+) -> None:
+    """Delete model repairs whose subentry is no longer on this entry."""
+    current_ids: set[str] = set() if include_current else set(entry.subentries)
+    for issue in list(ir.async_get(hass).issues.values()):
+        if issue.domain != DOMAIN or not issue.issue_id.startswith(
+            f"{ISSUE_MODEL_NOT_ENTITLED}_"
+        ):
+            continue
+        data = issue.data or {}
+        if data.get("entry_id") != entry.entry_id:
+            continue
+        if data.get("subentry_id") in current_ids:
+            continue
+        ir.async_delete_issue(hass, DOMAIN, issue.issue_id)
+
+
+async def _async_update_entry(hass: HomeAssistant, entry: SpaceXAIConfigEntry) -> None:
+    """Clear removed-subentry repairs and reload when loaded config changes."""
+    async_clear_orphaned_model_repairs(hass, entry)
+    if entry.state is not ConfigEntryState.LOADED:
+        return
+    if _subentry_fingerprint(entry) == entry.runtime_data.subentries:
+        return
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/spacexai/application_credentials.py
+++ b/homeassistant/components/spacexai/application_credentials.py
@@ -1,0 +1,39 @@
+"""Application credentials for SpaceXAI."""
+
+from typing import override
+
+from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    LocalOAuth2ImplementationWithPkce,
+)
+
+from .const import AUTHORIZE_URL, OAUTH_SCOPES, TOKEN_URL
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant,
+    auth_domain: str,
+    credential: ClientCredential,
+) -> SpaceXAIOAuth2Implementation:
+    """Return the SpaceXAI OAuth implementation."""
+    return SpaceXAIOAuth2Implementation(
+        hass,
+        auth_domain,
+        credential.client_id,
+        AUTHORIZE_URL,
+        TOKEN_URL,
+        credential.client_secret,
+    )
+
+
+class SpaceXAIOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
+    """Authorization Code + PKCE implementation for SpaceXAI."""
+
+    @property
+    @override
+    def extra_authorize_data(self) -> dict[str, str]:
+        """Add least-privilege subscription access scopes."""
+        return super().extra_authorize_data | {
+            "scope": " ".join(OAUTH_SCOPES),
+        }

--- a/homeassistant/components/spacexai/client.py
+++ b/homeassistant/components/spacexai/client.py
@@ -1,0 +1,556 @@
+"""Async client boundary for SpaceXAI."""
+
+import asyncio
+from asyncio import Lock
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+from aiohttp import ClientError, ClientTimeout, ContentTypeError
+import openai
+from openai import AsyncStream
+from openai.types import Model as OpenAIModel
+from openai.types.responses import ResponseInputParam, ResponseStreamEvent
+from pydantic import ValidationError
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.httpx_client import get_async_client
+
+from .const import (
+    API_BASE_URL,
+    CREATE_TIMEOUT,
+    HTTP_TIMEOUT_SECONDS,
+    REVOCATION_URL,
+    USERINFO_URL,
+)
+from .errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    ErrorContext,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    RateLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    RequestTimeoutError,
+    SpaceXAIError,
+    SubscriptionNotEntitledError,
+    TransientProviderError,
+)
+
+HTTP_TIMEOUT = ClientTimeout(total=HTTP_TIMEOUT_SECONDS)
+
+
+class AccessTokenProvider(Protocol):
+    """Provide a valid OAuth access token."""
+
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token."""
+
+
+@dataclass(frozen=True, slots=True)
+class StaticAccessTokenProvider:
+    """Access token provider used while configuring the integration."""
+
+    access_token: str
+
+    async def async_get_access_token(self) -> str:
+        """Return the configuration-flow access token."""
+        return self.access_token
+
+
+@dataclass(slots=True)
+class OAuthAccessTokenProvider:
+    """Access token provider backed by Home Assistant OAuth."""
+
+    session: OAuth2Session
+
+    async def async_get_access_token(self) -> str:
+        """Refresh if needed and return the current access token."""
+        try:
+            await self.session.async_ensure_token_valid()
+        except OAuth2TokenRequestReauthError as err:
+            raise RefreshRejectedError(
+                "OAuth refresh was rejected",
+                context=ErrorContext(operation=Operation.REFRESH),
+            ) from err
+        except OAuth2TokenRequestTransientError as err:
+            raise TransientProviderError(
+                "OAuth refresh failed transiently",
+                context=ErrorContext(
+                    operation=Operation.REFRESH,
+                    status=err.status,
+                ),
+            ) from err
+        except TimeoutError as err:
+            raise RequestTimeoutError(
+                "OAuth refresh timed out",
+                context=ErrorContext(operation=Operation.REFRESH),
+            ) from err
+        except (ClientError, OAuth2TokenRequestError) as err:
+            raise ConnectionFailureError(
+                "OAuth refresh could not be completed",
+                context=ErrorContext(operation=Operation.REFRESH),
+            ) from err
+
+        access_token = self.session.token.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise MalformedProviderResponseError(
+                "OAuth token response omitted access_token",
+                context=ErrorContext(operation=Operation.REFRESH),
+            )
+        return access_token
+
+
+@dataclass(frozen=True, slots=True)
+class AccountInfo:
+    """Parsed account identity."""
+
+    subject: str
+    name: str | None
+    email: str | None
+
+    @property
+    def display_name(self) -> str:
+        """Return a safe display name for the config entry."""
+        return self.name or self.email or "SpaceXAI"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelInfo:
+    """Model available to the authenticated account."""
+
+    id: str
+    owner: str
+    aliases: tuple[str, ...] = ()
+
+    @property
+    def selectable_ids(self) -> tuple[str, ...]:
+        """Return requestable model identifiers for this catalog entry."""
+        return (self.id, *self.aliases)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSnapshot:
+    """Validated provider state cached in runtime data."""
+
+    account: AccountInfo
+    models: tuple[ModelInfo, ...]
+
+    def has_model(self, model: str) -> bool:
+        """Return whether the account is entitled to a model."""
+        return any(model in item.selectable_ids for item in self.models)
+
+
+class SpaceXAIClient:
+    """Narrow async wrapper around the OAuth and Responses APIs."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        token_provider: AccessTokenProvider,
+        *,
+        runtime_session: bool,
+    ) -> None:
+        """Initialize the client."""
+        self._hass = hass
+        self._token_provider = token_provider
+        self._runtime_session = runtime_session
+        self._sdk_client: openai.AsyncOpenAI | None = None
+        self._sdk_lock = Lock()
+
+    async def async_get_account(self) -> AccountInfo:
+        """Fetch and parse the current account identity."""
+        token = await self._token_provider.async_get_access_token()
+        session = async_get_clientsession(self._hass)
+        context = ErrorContext(operation=Operation.ACCOUNT)
+        try:
+            async with session.get(
+                USERINFO_URL,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=HTTP_TIMEOUT,
+            ) as response:
+                if response.status >= 400:
+                    body = await _safe_json(response)
+                    raise self._error_for_status(
+                        response.status,
+                        ErrorContext(
+                            operation=Operation.ACCOUNT,
+                            status=response.status,
+                            provider_code=_provider_error_code(body),
+                        ),
+                        body=body,
+                    )
+                payload = await response.json()
+        except SpaceXAIError:
+            raise
+        except (ContentTypeError, TypeError, ValueError) as err:
+            raise MalformedProviderResponseError(
+                "Account endpoint returned invalid JSON", context=context
+            ) from err
+        except TimeoutError as err:
+            raise RequestTimeoutError(
+                "Account endpoint request timed out", context=context
+            ) from err
+        except ClientError as err:
+            raise ConnectionFailureError(
+                "Could not connect to the account endpoint", context=context
+            ) from err
+
+        if not isinstance(payload, Mapping):
+            raise MalformedProviderResponseError(
+                "Account endpoint returned a non-object response", context=context
+            )
+        subject = payload.get("sub")
+        name = payload.get("name")
+        email = payload.get("email")
+        if (
+            not isinstance(subject, str)
+            or not subject
+            or (name is not None and not isinstance(name, str))
+            or (email is not None and not isinstance(email, str))
+        ):
+            raise MalformedProviderResponseError(
+                "Account endpoint returned invalid identity fields", context=context
+            )
+        return AccountInfo(subject=subject, name=name, email=email)
+
+    async def async_get_models(self) -> tuple[ModelInfo, ...]:
+        """Return the OAuth-entitled Grok language models."""
+        token = await self._token_provider.async_get_access_token()
+        context = ErrorContext(operation=Operation.MODELS)
+        try:
+            async with self._sdk_lock:
+                client = await self._async_sdk_client(token)
+                page = await client.models.list(timeout=float(HTTP_TIMEOUT_SECONDS))
+                models = [
+                    ModelInfo(
+                        id=model.id,
+                        owner=model.owned_by,
+                        aliases=_model_aliases(model),
+                    )
+                    async for model in page
+                    if _is_conversation_model(model)
+                ]
+        except (openai.OpenAIError, ValidationError) as err:
+            raise self.translate_sdk_error(err, context) from err
+
+        models.sort(key=lambda model: model.id)
+        if not models:
+            raise NoConversationModelsError(
+                "The account has no available conversation models",
+                context=ErrorContext(operation=Operation.MODELS),
+            )
+        return tuple(models)
+
+    async def async_validate(
+        self, *, expected_subject: str | None = None
+    ) -> ProviderSnapshot:
+        """Validate identity and discover entitled language models."""
+        account = await self.async_get_account()
+        if expected_subject is not None and account.subject != expected_subject:
+            raise AccountMismatchError(
+                "OAuth account does not match the config entry",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            )
+        models = await self.async_get_models()
+        return ProviderSnapshot(account=account, models=models)
+
+    async def async_stream_response(
+        self,
+        *,
+        model: str,
+        input: ResponseInputParam,
+        tools: Sequence[Mapping[str, Any]],
+        max_output_tokens: int,
+        prompt_cache_key: str,
+    ) -> AsyncStream[ResponseStreamEvent]:
+        """Start a streaming Responses API request."""
+        token = await self._token_provider.async_get_access_token()
+        context = ErrorContext(operation=Operation.RESPONSE, model=model)
+        try:
+            async with self._sdk_lock:
+                client = await self._async_sdk_client(token)
+                create_args: dict[str, Any] = {
+                    "model": model,
+                    "input": input,
+                    "tools": list(tools),
+                    "max_output_tokens": max_output_tokens,
+                    "parallel_tool_calls": False,
+                    "prompt_cache_key": prompt_cache_key,
+                    "store": False,
+                    "include": ["reasoning.encrypted_content"],
+                    "stream": True,
+                }
+                try:
+                    async with asyncio.timeout(CREATE_TIMEOUT):
+                        return cast(
+                            AsyncStream[ResponseStreamEvent],
+                            await client.responses.create(**create_args),
+                        )
+                except TimeoutError as err:
+                    raise RequestTimeoutError(
+                        "Provider response timed out", context=context
+                    ) from err
+        except SpaceXAIError:
+            raise
+        except (openai.OpenAIError, ValidationError) as err:
+            raise self.translate_sdk_error(err, context) from err
+
+    async def async_revoke(
+        self,
+        refresh_token: str,
+        client_id: str,
+        client_secret: str = "",
+    ) -> None:
+        """Revoke a refresh token when the config entry is removed."""
+        session = async_get_clientsession(self._hass)
+        context = ErrorContext(operation=Operation.REVOCATION)
+        data = {
+            "token": refresh_token,
+            "token_type_hint": "refresh_token",
+            "client_id": client_id,
+        }
+        if client_secret:
+            data["client_secret"] = client_secret
+        try:
+            async with session.post(
+                REVOCATION_URL,
+                data=data,
+                timeout=HTTP_TIMEOUT,
+            ) as response:
+                if response.status >= 400:
+                    raise self._error_for_status(
+                        response.status,
+                        ErrorContext(
+                            operation=Operation.REVOCATION,
+                            status=response.status,
+                        ),
+                    )
+        except SpaceXAIError:
+            raise
+        except TimeoutError as err:
+            raise RequestTimeoutError(
+                "Revocation endpoint request timed out", context=context
+            ) from err
+        except ClientError as err:
+            raise ConnectionFailureError(
+                "Could not connect to the revocation endpoint", context=context
+            ) from err
+
+    async def _async_sdk_client(self, access_token: str) -> openai.AsyncOpenAI:
+        """Return a reusable SDK client with the current OAuth token."""
+        if self._sdk_client is None:
+            self._sdk_client = openai.AsyncOpenAI(
+                api_key=access_token,
+                base_url=API_BASE_URL,
+                http_client=get_async_client(self._hass),
+            )
+            await self._hass.async_add_executor_job(self._sdk_client.platform_headers)
+        else:
+            self._sdk_client.api_key = access_token
+        return self._sdk_client
+
+    def translate_sdk_error(
+        self,
+        err: openai.OpenAIError | ValidationError,
+        context: ErrorContext,
+    ) -> SpaceXAIError:
+        """Translate SDK failures at the provider boundary."""
+        if isinstance(err, ValidationError):
+            return MalformedProviderResponseError(
+                "Provider response did not match the SDK schema", context=context
+            )
+        if isinstance(err, openai.APITimeoutError):
+            return RequestTimeoutError("Provider request timed out", context=context)
+        if isinstance(err, openai.APIConnectionError):
+            return ConnectionFailureError(
+                "Could not connect to the provider", context=context
+            )
+        if isinstance(err, openai.APIStatusError):
+            provider_code = _provider_error_code(err.body)
+            status_context = ErrorContext(
+                operation=context.operation,
+                model=context.model,
+                status=err.status_code,
+                provider_code=provider_code,
+                request_id=err.request_id,
+            )
+            return self._error_for_status(
+                err.status_code,
+                status_context,
+                body=err.body,
+            )
+        return PermanentProviderError(
+            "Provider SDK rejected the operation", context=context
+        )
+
+    def _error_for_status(
+        self,
+        status: int,
+        context: ErrorContext,
+        *,
+        body: object | None = None,
+    ) -> SpaceXAIError:
+        """Classify provider status codes without exposing response content."""
+        if status == 401 or _is_credential_rejection(
+            status, context.provider_code, body
+        ):
+            error_type = (
+                ReauthenticationRequiredError
+                if self._runtime_session
+                else AuthenticationRejectedError
+            )
+            return error_type("Provider rejected authentication", context=context)
+        if status == 402:
+            return QuotaLimitedError(
+                "Provider reported a quota or billing limitation", context=context
+            )
+        if status == 403:
+            if _is_subscription_denial(status, context.provider_code, body) or (
+                context.operation
+                in (Operation.ACCOUNT, Operation.MODELS, Operation.RESPONSE)
+                and not _is_permission_denial(context.provider_code, body)
+            ):
+                return SubscriptionNotEntitledError(
+                    "Account is not entitled for subscription-backed Grok access",
+                    context=context,
+                )
+            return PermanentProviderError(
+                "Provider denied permission for the operation", context=context
+            )
+        if status == 404 and context.model is not None:
+            return ModelNotEntitledError(
+                "Configured model is not available to this account", context=context
+            )
+        if status == 408:
+            return RequestTimeoutError("Provider request timed out", context=context)
+        if status == 429:
+            return RateLimitedError("Provider rate limit reached", context=context)
+        if 500 <= status <= 599:
+            return TransientProviderError(
+                "Provider reported a transient failure", context=context
+            )
+        return PermanentProviderError(
+            "Provider rejected the operation", context=context
+        )
+
+
+def _provider_error_code(body: object) -> str | None:
+    """Extract a provider error code from an SDK response body."""
+    if not isinstance(body, Mapping):
+        return None
+    error = body.get("error")
+    if isinstance(error, Mapping):
+        code = error.get("code") or error.get("type")
+    else:
+        code = body.get("code")
+    return code if isinstance(code, str) else None
+
+
+def _provider_error_message(body: object) -> str | None:
+    """Extract a provider error message used only for classification."""
+    if not isinstance(body, Mapping):
+        return None
+    error = body.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+    elif isinstance(error, str):
+        message = error
+    else:
+        message = body.get("error")
+        if not isinstance(message, str):
+            message = body.get("message")
+    return message if isinstance(message, str) else None
+
+
+def _is_credential_rejection(
+    status: int,
+    provider_code: str | None,
+    body: object | None,
+) -> bool:
+    """Return whether the provider rejected credentials with a non-401 status."""
+    if status != 400:
+        return False
+    code = (provider_code or "").lower()
+    if code.startswith("unauthenticated") or code == "invalid_token":
+        return True
+    message = (_provider_error_message(body) or "").lower()
+    return "incorrect api key" in message or "no credentials" in message
+
+
+def _is_subscription_denial(
+    status: int,
+    provider_code: str | None,
+    body: object | None,
+) -> bool:
+    """Return whether a response explicitly signals subscription ineligibility."""
+    if status != 403:
+        return False
+    code = (provider_code or "").lower()
+    if code in {
+        "subscription_required",
+        "subscription_not_entitled",
+        "not_entitled",
+        "insufficient_permissions",
+    }:
+        return True
+    message = (_provider_error_message(body) or "").lower()
+    return "subscription" in message and (
+        "entitled" in message or "required" in message or "inactive" in message
+    )
+
+
+def _is_permission_denial(
+    provider_code: str | None,
+    body: object | None,
+) -> bool:
+    """Return whether a 403 is an explicit non-subscription permission denial."""
+    code = (provider_code or "").lower()
+    if code in {"permission_denied", "access_denied", "forbidden"}:
+        return True
+    message = (_provider_error_message(body) or "").lower()
+    return "permission denied" in message or "access denied" in message
+
+
+def _model_aliases(model: OpenAIModel) -> tuple[str, ...]:
+    """Extract provider aliases that can be used as request model IDs."""
+    extra = model.model_extra or {}
+    aliases = extra.get("aliases")
+    if not isinstance(aliases, list):
+        return ()
+    return tuple(
+        alias
+        for alias in aliases
+        if isinstance(alias, str) and alias and alias != model.id
+    )
+
+
+def _is_conversation_model(model: OpenAIModel) -> bool:
+    """Return whether xAI model metadata identifies text output."""
+    extra = model.model_extra or {}
+    output_modalities = extra.get("output_modalities")
+    if isinstance(output_modalities, list):
+        return "text" in output_modalities
+    return isinstance(extra.get("completion_text_token_price"), int)
+
+
+async def _safe_json(response: Any) -> object | None:
+    """Best-effort JSON body used only for error classification."""
+    try:
+        payload: object = await response.json(content_type=None)
+    except ContentTypeError, TypeError, ValueError:
+        return None
+    return payload

--- a/homeassistant/components/spacexai/config_flow.py
+++ b/homeassistant/components/spacexai/config_flow.py
@@ -1,0 +1,472 @@
+"""Config flow for SpaceXAI."""
+
+from collections.abc import Mapping
+from logging import Logger
+from typing import Any, override
+
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntryState,
+    ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
+from homeassistant.const import CONF_LLM_HASS_API, CONF_MODEL, CONF_PROMPT
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import llm
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    AbstractOAuth2FlowHandler,
+    ImplementationUnavailableError,
+    async_get_implementations,
+)
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    TemplateSelector,
+)
+from homeassistant.loader import async_get_application_credentials
+
+from . import (
+    SpaceXAIConfigEntry,
+    async_create_subscription_issue,
+    async_mark_subscription_not_entitled,
+    async_reconcile_snapshot,
+)
+from .client import ProviderSnapshot, SpaceXAIClient, StaticAccessTokenProvider
+from .const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    DEFAULT_CONVERSATION_NAME,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MODEL,
+    DOMAIN,
+    LOGGER,
+)
+from .errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    QuotaLimitedError,
+    RateLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    RequestTimeoutError,
+    SpaceXAIError,
+    SubscriptionNotEntitledError,
+    TransientProviderError,
+)
+
+
+class SpaceXAIConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
+    """Handle SpaceXAI OAuth configuration."""
+
+    DOMAIN = DOMAIN
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        super().__init__()
+        self._oauth_data: dict[str, Any] | None = None
+        self._snapshot: ProviderSnapshot | None = None
+
+    @property
+    @override
+    def logger(self) -> Logger:
+        """Return the logger used by the OAuth flow."""
+        return LOGGER
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Start Authorization Code + PKCE once Application Credentials exist."""
+        if err := await self._async_ensure_oauth_implementation():
+            return err
+        return await self.async_step_pick_implementation(user_input)
+
+    async def _async_ensure_oauth_implementation(self) -> ConfigFlowResult | None:
+        """Resolve Application Credentials into the active OAuth implementation."""
+        try:
+            implementations = await async_get_implementations(self.hass, self.DOMAIN)
+        except ImplementationUnavailableError:
+            return self.async_abort(reason="oauth_implementation_unavailable")
+        if not implementations:
+            if self.DOMAIN in await async_get_application_credentials(self.hass):
+                return self.async_abort(reason="missing_credentials")
+            return self.async_abort(reason="missing_configuration")
+        self.flow_impl = next(iter(implementations.values()))
+        return None
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Start reauthentication for an invalid OAuth session."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm that the user wants to sign in again."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm")
+        return await self.async_step_user()
+
+    @override
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+        """Validate the OAuth account before creating an entry."""
+        self._oauth_data = data
+        return await self.async_step_validate()
+
+    async def _async_refresh_snapshot(
+        self, *, retry_step: str | None
+    ) -> ConfigFlowResult | None:
+        """Validate with the current OAuth token and store a fresh snapshot."""
+        assert self._oauth_data is not None
+
+        token_data = self._oauth_data.get("token")
+        if (
+            not isinstance(token_data, Mapping)
+            or not isinstance(access_token := token_data.get("access_token"), str)
+            or not access_token
+            or not isinstance(token_data.get("refresh_token"), str)
+            or not token_data["refresh_token"]
+        ):
+            return self.async_abort(reason="oauth_error")
+
+        client = SpaceXAIClient(
+            self.hass,
+            StaticAccessTokenProvider(access_token),
+            runtime_session=False,
+        )
+        expected_subject = (
+            self._get_reauth_entry().unique_id if self.source == SOURCE_REAUTH else None
+        )
+        try:
+            self._snapshot = await client.async_validate(
+                expected_subject=expected_subject
+            )
+        except AccountMismatchError:
+            return self.async_abort(reason="account_mismatch")
+        except AuthenticationRejectedError:
+            return self.async_abort(reason="oauth_unauthorized")
+        except SubscriptionNotEntitledError:
+            if self.source == SOURCE_REAUTH:
+                entry = self._get_reauth_entry()
+                if entry.state is ConfigEntryState.LOADED:
+                    async_mark_subscription_not_entitled(self.hass, entry)
+                else:
+                    async_create_subscription_issue(self.hass, entry)
+            return self.async_abort(reason="subscription_not_entitled")
+        except NoConversationModelsError:
+            return self.async_abort(reason="no_conversation_models")
+        except ModelNotEntitledError:
+            return self.async_abort(reason="model_not_entitled")
+        except QuotaLimitedError:
+            return self.async_abort(reason="quota_limited")
+        except (
+            ConnectionFailureError,
+            RateLimitedError,
+            RequestTimeoutError,
+            TransientProviderError,
+        ) as err:
+            LOGGER.warning(
+                "Unable to validate SpaceXAI account: category=%s operation=%s "
+                "status=%s request_id=%s retryable=%s",
+                err.category,
+                err.context.operation,
+                err.context.status,
+                err.context.request_id,
+                err.retryable,
+            )
+            if retry_step is None:
+                return self.async_abort(reason="cannot_connect")
+            return self.async_show_form(
+                step_id=retry_step,
+                data_schema=vol.Schema({}),
+                errors={"base": "cannot_connect"},
+            )
+        except MalformedProviderResponseError:
+            return self.async_abort(reason="malformed_provider_response")
+        except SpaceXAIError as err:
+            LOGGER.warning(
+                "Unexpected classified SpaceXAI setup failure: category=%s "
+                "operation=%s status=%s request_id=%s retryable=%s",
+                err.category,
+                err.context.operation,
+                err.context.status,
+                err.context.request_id,
+                err.retryable,
+            )
+            return self.async_abort(reason="unknown")
+        return None
+
+    async def async_step_validate(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Validate identity and available language models."""
+        if err := await self._async_refresh_snapshot(retry_step="validate"):
+            return err
+        assert self._snapshot is not None
+        assert self._oauth_data is not None
+
+        await self.async_set_unique_id(self._snapshot.account.subject)
+        if self.source == SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch(reason="account_mismatch")
+            entry = self._get_reauth_entry()
+            result = self.async_update_and_abort(
+                entry,
+                data=self._oauth_data,
+            )
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
+            return result
+
+        self._abort_if_unique_id_configured()
+        return await self.async_step_conversation()
+
+    async def async_step_conversation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure the initial Grok conversation entity."""
+        assert self._snapshot is not None
+        assert self._oauth_data is not None
+
+        if user_input is not None:
+            if err := await self._async_refresh_snapshot(retry_step=None):
+                return err
+            assert self._snapshot is not None
+            if CONF_MODEL in user_input and not self._snapshot.has_model(
+                user_input[CONF_MODEL]
+            ):
+                return self.async_abort(reason="model_not_entitled")
+            return self.async_create_entry(
+                title=self._snapshot.account.display_name,
+                data=self._oauth_data,
+                subentries=[
+                    {
+                        "subentry_type": "conversation",
+                        "data": user_input,
+                        "title": DEFAULT_CONVERSATION_NAME,
+                        "unique_id": None,
+                    }
+                ],
+            )
+
+        return self.async_show_form(
+            step_id="conversation",
+            data_schema=_conversation_schema(
+                self._snapshot,
+                _llm_api_options(self.hass),
+                user_input,
+            ),
+        )
+
+    @classmethod
+    @callback
+    @override
+    def async_get_supported_subentry_types(
+        cls, config_entry: SpaceXAIConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return supported subentry flow handlers."""
+        return {"conversation": SpaceXAIConversationSubentryFlow}
+
+
+class SpaceXAIConversationSubentryFlow(ConfigSubentryFlow):
+    """Add or reconfigure a SpaceXAI conversation entity."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Add a conversation subentry."""
+        return await self._async_configure(user_input, is_new=True)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reconfigure a conversation subentry."""
+        return await self._async_configure(user_input, is_new=False)
+
+    async def _async_configure(
+        self,
+        user_input: dict[str, Any] | None,
+        *,
+        is_new: bool,
+    ) -> SubentryFlowResult:
+        """Create or update a conversation subentry."""
+        entry = self._get_entry()
+        if entry.state is not ConfigEntryState.LOADED:
+            return self.async_abort(reason="entry_not_loaded")
+
+        try:
+            snapshot = await entry.runtime_data.client.async_validate(
+                expected_subject=entry.unique_id
+            )
+        except (
+            AccountMismatchError,
+            AuthenticationRejectedError,
+            ReauthenticationRequiredError,
+            RefreshRejectedError,
+        ):
+            entry.async_start_reauth(self.hass)
+            return self.async_abort(reason="oauth_unauthorized")
+        except SubscriptionNotEntitledError:
+            async_mark_subscription_not_entitled(self.hass, entry)
+            return self.async_abort(reason="subscription_not_entitled")
+        except NoConversationModelsError:
+            return self.async_abort(reason="no_conversation_models")
+        except QuotaLimitedError:
+            return self.async_abort(reason="quota_limited")
+        except ModelNotEntitledError:
+            return self.async_abort(reason="model_not_entitled")
+        except (
+            ConnectionFailureError,
+            RateLimitedError,
+            RequestTimeoutError,
+            TransientProviderError,
+        ):
+            return self.async_abort(reason="cannot_connect")
+        except MalformedProviderResponseError:
+            return self.async_abort(reason="malformed_provider_response")
+        except SpaceXAIError:
+            return self.async_abort(reason="unknown")
+
+        async_reconcile_snapshot(self.hass, entry, snapshot)
+        if user_input is not None:
+            if CONF_MODEL in user_input and not snapshot.has_model(
+                user_input[CONF_MODEL]
+            ):
+                return self.async_abort(reason="model_not_entitled")
+            if is_new:
+                return self.async_create_entry(
+                    title=DEFAULT_CONVERSATION_NAME,
+                    data=user_input,
+                )
+            return self.async_update_and_abort(
+                entry,
+                self._get_reconfigure_subentry(),
+                data=user_input,
+            )
+
+        suggested = None if is_new else dict(self._get_reconfigure_subentry().data)
+        return self.async_show_form(
+            step_id="user" if is_new else "reconfigure",
+            data_schema=_conversation_schema(
+                snapshot,
+                _llm_api_options(self.hass),
+                user_input or suggested,
+            ),
+        )
+
+
+def _model_selector_defaults(
+    snapshot: ProviderSnapshot,
+    suggested: Mapping[str, Any] | None,
+) -> tuple[str, int, list[SelectOptionDict]]:
+    """Return default model, token limit, and model options."""
+    model_ids = {
+        model_id for model in snapshot.models for model_id in model.selectable_ids
+    }
+    default_model = (
+        DEFAULT_MODEL
+        if DEFAULT_MODEL in model_ids
+        else snapshot.models[0].selectable_ids[0]
+    )
+    suggested_max_tokens = DEFAULT_MAX_OUTPUT_TOKENS
+    if suggested is not None:
+        if (
+            isinstance(suggested_model := suggested.get(CONF_MODEL), str)
+            and suggested_model in model_ids
+        ):
+            default_model = suggested_model
+        suggested_max_tokens = int(
+            suggested.get(CONF_MAX_OUTPUT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS)
+        )
+    options = [
+        SelectOptionDict(value=model_id, label=model_id)
+        for model in snapshot.models
+        for model_id in model.selectable_ids
+    ]
+    return default_model, suggested_max_tokens, options
+
+
+def _conversation_schema(
+    snapshot: ProviderSnapshot,
+    llm_apis: list[SelectOptionDict],
+    suggested: Mapping[str, Any] | None,
+) -> vol.Schema:
+    """Build the conversation configuration schema."""
+    default_model, suggested_max_tokens, model_options = _model_selector_defaults(
+        snapshot, suggested
+    )
+    available_api_ids = {option["value"] for option in llm_apis}
+    if suggested is not None:
+        if CONF_LLM_HASS_API in suggested:
+            raw_apis = suggested[CONF_LLM_HASS_API]
+            if isinstance(raw_apis, str):
+                raw_apis = [raw_apis]
+            if isinstance(raw_apis, list):
+                suggested_apis = [
+                    api_id for api_id in raw_apis if api_id in available_api_ids
+                ]
+            else:
+                suggested_apis = []
+        else:
+            suggested_apis = []
+        suggested_prompt = suggested.get(CONF_PROMPT)
+    else:
+        suggested_apis = [
+            api_id for api_id in (llm.LLM_API_ASSIST,) if api_id in available_api_ids
+        ]
+        suggested_prompt = None
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_MODEL, default=default_model): SelectSelector(
+                SelectSelectorConfig(options=model_options)
+            ),
+            vol.Optional(
+                CONF_LLM_HASS_API,
+                default=suggested_apis,
+            ): SelectSelector(SelectSelectorConfig(options=llm_apis, multiple=True)),
+            vol.Optional(
+                CONF_PROMPT,
+                description={"suggested_value": suggested_prompt},
+            ): TemplateSelector(),
+            **_max_output_tokens_schema(suggested_max_tokens),
+        }
+    )
+
+
+def _max_output_tokens_schema(default: int) -> dict[Any, Any]:
+    """Return the shared max-output-tokens field schema."""
+    return {
+        vol.Required(
+            CONF_MAX_OUTPUT_TOKENS,
+            default=default,
+        ): vol.All(
+            NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=131072,
+                    step=1,
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Coerce(int),
+        )
+    }
+
+
+@callback
+def _llm_api_options(hass: HomeAssistant) -> list[SelectOptionDict]:
+    """Return currently registered Home Assistant LLM APIs."""
+    return [
+        SelectOptionDict(value=api.id, label=api.name)
+        for api in llm.async_get_apis(hass)
+    ]

--- a/homeassistant/components/spacexai/const.py
+++ b/homeassistant/components/spacexai/const.py
@@ -1,0 +1,36 @@
+"""Constants for the SpaceXAI integration."""
+
+from logging import Logger, getLogger
+
+DOMAIN = "spacexai"
+LOGGER: Logger = getLogger(__package__)
+
+AUTHORIZE_URL = "https://auth.x.ai/oauth2/authorize"
+TOKEN_URL = "https://auth.x.ai/oauth2/token"
+USERINFO_URL = "https://auth.x.ai/oauth2/userinfo"
+REVOCATION_URL = "https://auth.x.ai/oauth2/revoke"
+API_BASE_URL = "https://api.x.ai/v1"
+
+OAUTH_SCOPES = (
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "grok-cli:access",
+    "api:access",
+)
+
+CONF_MAX_OUTPUT_TOKENS = "max_output_tokens"
+
+ISSUE_MODEL_NOT_ENTITLED = "model_not_entitled"
+ISSUE_SUBSCRIPTION_NOT_ENTITLED = "subscription_not_entitled"
+
+DEFAULT_CONVERSATION_NAME = "Grok"
+DEFAULT_MAX_OUTPUT_TOKENS = 2048
+DEFAULT_MODEL = "grok-4.5"
+DEFAULT_MODEL_PLACEHOLDER = "Grok"
+HTTP_TIMEOUT_SECONDS = 30
+MAX_TOOL_ITERATIONS = 10
+CREATE_TIMEOUT = 30
+RESPONSE_TIMEOUT = 300
+CONVERSE_TIMEOUT = 600

--- a/homeassistant/components/spacexai/conversation.py
+++ b/homeassistant/components/spacexai/conversation.py
@@ -1,0 +1,138 @@
+"""Conversation platform for SpaceXAI."""
+
+from typing import Literal, cast, override
+
+from homeassistant.components import conversation
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.const import (
+    CONF_LLM_HASS_API,
+    CONF_MODEL,
+    CONF_PROMPT,
+    MATCH_ALL,
+    __version__ as HA_VERSION,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_platform, llm
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import SpaceXAIConfigEntry
+from .const import DOMAIN
+from .entity import SpaceXAIBaseLLMEntity
+from .errors import SpaceXAIError
+from .issue import async_delete_subscription_issue
+
+PARALLEL_UPDATES = 0
+
+_RUNTIME_IDENTITY_PROMPT = (
+    "Runtime identity (answer truthfully when asked about versions):\n"
+    "- Home Assistant Core: {ha_version}\n"
+    "- Provider: SpaceXAI (Grok)\n"
+    "- Conversation model: {model}"
+)
+
+
+def _prompt_safe_literal(value: str) -> str:
+    """Strip Jinja delimiter characters from provider-controlled literals."""
+    return value.replace("{", "").replace("}", "").replace("%", "").replace("#", "")
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: SpaceXAIConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up SpaceXAI conversation entities."""
+    for subentry in config_entry.subentries.values():
+        if subentry.subentry_type != "conversation":
+            continue
+        async_add_entities(
+            [SpaceXAIConversationEntity(config_entry, subentry)],
+            config_subentry_id=subentry.subentry_id,
+        )
+
+
+class SpaceXAIConversationEntity(
+    conversation.ConversationEntity,
+    conversation.AbstractConversationAgent,
+    SpaceXAIBaseLLMEntity,
+):
+    """SpaceXAI Grok conversation agent."""
+
+    _attr_supports_streaming = False
+    _attr_translation_key = "conversation"
+
+    def __init__(self, entry: SpaceXAIConfigEntry, subentry: ConfigSubentry) -> None:
+        """Initialize the conversation entity."""
+        super().__init__(entry, subentry)
+        if subentry.data.get(CONF_LLM_HASS_API):
+            self._attr_supported_features = (
+                conversation.ConversationEntityFeature.CONTROL
+            )
+
+    @property
+    @override
+    def supported_languages(self) -> list[str] | Literal["*"]:
+        """Return supported languages."""
+        return MATCH_ALL
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register the conversation agent when the entity is added."""
+        await super().async_added_to_hass()
+        conversation.async_set_agent(self.hass, self.entry, self)
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Keep an entry-id agent alias when sibling conversation entities remain."""
+        conversation.async_unset_agent(self.hass, self.entry)
+        for platform in entity_platform.async_get_platforms(self.hass, DOMAIN):
+            for entity in platform.entities.values():
+                if (
+                    entity is not self
+                    and isinstance(entity, conversation.AbstractConversationAgent)
+                    and getattr(entity, "entry", None) is self.entry
+                ):
+                    conversation.async_set_agent(self.hass, self.entry, entity)
+                    break
+        await super().async_will_remove_from_hass()
+
+    @override
+    async def _async_handle_message(
+        self,
+        user_input: conversation.ConversationInput,
+        chat_log: conversation.ChatLog,
+    ) -> conversation.ConversationResult:
+        """Process a message using Home Assistant-owned chat state."""
+        base_prompt = (
+            self.subentry.data.get(CONF_PROMPT) or llm.DEFAULT_INSTRUCTIONS_PROMPT
+        )
+        identity = _RUNTIME_IDENTITY_PROMPT.format(
+            ha_version=HA_VERSION,
+            model=_prompt_safe_literal(cast(str, self.subentry.data[CONF_MODEL])),
+        )
+        prompt = f"{base_prompt}\n\n{identity}"
+
+        try:
+            await chat_log.async_provide_llm_data(
+                user_input.as_llm_context(DOMAIN),
+                self.subentry.data.get(CONF_LLM_HASS_API),
+                prompt,
+                user_input.extra_system_prompt,
+            )
+        except conversation.ConverseError as err:
+            return err.as_conversation_result()
+
+        try:
+            await self._async_handle_chat_log(chat_log)
+        except SpaceXAIError as err:
+            self._raise_provider_home_assistant_error(err)
+        except HomeAssistantError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            self._raise_unexpected_provider_failure(err)
+
+        if self._mark_available():
+            async_delete_subscription_issue(self.hass, self.entry.entry_id)
+            self._restore_entitled_entry_agents()
+        return conversation.async_get_result_from_chat_log(user_input, chat_log)

--- a/homeassistant/components/spacexai/entity.py
+++ b/homeassistant/components/spacexai/entity.py
@@ -1,0 +1,791 @@
+"""Shared SpaceXAI LLM entity helpers."""
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterable, Callable, Iterable
+import json
+import traceback
+from typing import Any, Literal, NoReturn, cast
+
+import httpx
+import openai
+from openai.types.responses import (
+    EasyInputMessageParam,
+    FunctionToolParam,
+    ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent,
+    ResponseCreatedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
+    ResponseFunctionToolCallParam,
+    ResponseIncompleteEvent,
+    ResponseInProgressEvent,
+    ResponseInputParam,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+    ResponseOutputTextAnnotationAddedEvent,
+    ResponseQueuedEvent,
+    ResponseReasoningItem,
+    ResponseReasoningItemParam,
+    ResponseReasoningSummaryPartAddedEvent,
+    ResponseReasoningSummaryPartDoneEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+    ResponseReasoningSummaryTextDoneEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseReasoningTextDoneEvent,
+    ResponseRefusalDeltaEvent,
+    ResponseRefusalDoneEvent,
+    ResponseStreamEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
+)
+from openai.types.responses.response_input_param import FunctionCallOutput
+from pydantic import ValidationError
+from voluptuous_openapi import convert
+
+from homeassistant.components import conversation
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.const import CONF_MODEL
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_platform, llm
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import json_dumps
+
+from . import SpaceXAIConfigEntry, async_mark_subscription_not_entitled
+from .const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    CONVERSE_TIMEOUT,
+    DOMAIN,
+    LOGGER,
+    MAX_TOOL_ITERATIONS,
+    RESPONSE_TIMEOUT,
+)
+from .errors import (
+    ConnectionFailureError,
+    ErrorCategory,
+    ErrorContext,
+    InvalidModelToolRequestError,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    Operation,
+    OutputLimitError,
+    PermanentProviderError,
+    QuotaLimitedError,
+    RateLimitedError,
+    RequestTimeoutError,
+    SpaceXAIError,
+    SubscriptionNotEntitledError,
+    ToolLoopLimitError,
+    TransientProviderError,
+)
+from .issue import (
+    async_create_model_not_entitled_issue,
+    async_delete_model_not_entitled_issue,
+)
+
+
+def _format_tool(
+    tool: llm.Tool, custom_serializer: Callable[[Any], Any] | None
+) -> FunctionToolParam:
+    """Convert a Home Assistant LLM tool to a Responses API tool."""
+    unsupported_keys = {"oneOf", "anyOf", "allOf", "enum", "not"}
+    schema = convert(tool.parameters, custom_serializer=custom_serializer)
+    if unsupported_keys.intersection(schema):
+        schema = {
+            key: value for key, value in schema.items() if key not in unsupported_keys
+        }
+    return FunctionToolParam(
+        type="function",
+        name=tool.name,
+        description=tool.description,
+        parameters=schema,
+        strict=False,
+    )
+
+
+def _convert_content(
+    chat_content: Iterable[conversation.Content],
+) -> ResponseInputParam:
+    """Convert Home Assistant-owned history to Responses API input."""
+    messages: ResponseInputParam = []
+    reasoning_summary: list[str] = []
+    for content in chat_content:
+        if isinstance(content, conversation.ToolResultContent):
+            reasoning_summary = []
+            messages.append(
+                FunctionCallOutput(
+                    type="function_call_output",
+                    call_id=content.tool_call_id,
+                    output=json_dumps(content.tool_result),
+                )
+            )
+            continue
+
+        if isinstance(content, conversation.AssistantContent):
+            if content.thinking_content:
+                reasoning_summary.append(content.thinking_content)
+            if isinstance(content.native, ResponseReasoningItem):
+                messages.append(
+                    ResponseReasoningItemParam(
+                        type="reasoning",
+                        id=content.native.id,
+                        summary=(
+                            [
+                                {"type": "summary_text", "text": summary}
+                                for summary in reasoning_summary
+                            ]
+                            if content.thinking_content
+                            else []
+                        ),
+                        encrypted_content=content.native.encrypted_content,
+                    )
+                )
+                reasoning_summary = []
+            if content.content:
+                messages.append(
+                    EasyInputMessageParam(
+                        type="message",
+                        role="assistant",
+                        content=content.content,
+                    )
+                )
+            for tool_call in content.tool_calls or ():
+                messages.append(
+                    ResponseFunctionToolCallParam(
+                        type="function_call",
+                        call_id=tool_call.id,
+                        name=tool_call.tool_name,
+                        arguments=json_dumps(tool_call.tool_args),
+                    )
+                )
+            continue
+
+        reasoning_summary = []
+        role: Literal["system", "user"] = content.role
+        messages.append(
+            EasyInputMessageParam(
+                type="message",
+                role=role,
+                content=content.content,
+            )
+        )
+    return messages
+
+
+def _stream_failure(
+    code: str | None,
+    *,
+    model: str,
+    request_id: str | None = None,
+) -> SpaceXAIError:
+    """Classify a valid provider failure event."""
+    context = ErrorContext(
+        operation=Operation.RESPONSE,
+        model=model,
+        provider_code=code,
+        request_id=request_id,
+    )
+    normalized = (code or "").lower()
+    if normalized in ("insufficient_quota", "billing_hard_limit_reached"):
+        return QuotaLimitedError(
+            "Provider reported a quota or billing limitation", context=context
+        )
+    if normalized in ("model_not_found", "model_not_available"):
+        return ModelNotEntitledError(
+            "Configured model is not available to this account", context=context
+        )
+    if normalized in (
+        "subscription_required",
+        "subscription_not_entitled",
+        "not_entitled",
+        "insufficient_permissions",
+    ):
+        return SubscriptionNotEntitledError(
+            "Account is not entitled for subscription-backed Grok access",
+            context=context,
+        )
+    if normalized == "rate_limit_exceeded":
+        return RateLimitedError("Provider rate limit reached", context=context)
+    if normalized == "max_output_tokens":
+        return OutputLimitError(
+            "Provider reached the configured output limit", context=context
+        )
+    if normalized in ("server_error", "vector_store_timeout"):
+        return TransientProviderError(
+            "Provider reported a transient failure", context=context
+        )
+    return PermanentProviderError("Provider rejected the response", context=context)
+
+
+async def _transform_stream(  # noqa: C901
+    chat_log: conversation.ChatLog,
+    stream: AsyncIterable[ResponseStreamEvent],
+    *,
+    model: str,
+) -> AsyncGenerator[
+    conversation.AssistantContentDeltaDict | conversation.ToolResultContentDeltaDict
+]:
+    """Transform a Responses API stream into Home Assistant chat deltas."""
+    assistant_open = False
+    reasoning_native_set = False
+    last_summary_index: int | None = None
+    announced_tool_calls: dict[str, tuple[str, str]] = {}
+    call_ids: set[str] = set()
+    pending_deltas: list[conversation.AssistantContentDeltaDict] = []
+    content_parts: list[str] = []
+    thinking_parts: list[str] = []
+    terminal = False
+    produced_user_visible_output = False
+
+    def _flush_text_parts() -> None:
+        if content_parts:
+            pending_deltas.append({"content": "".join(content_parts)})
+            content_parts.clear()
+        if thinking_parts:
+            pending_deltas.append({"thinking_content": "".join(thinking_parts)})
+            thinking_parts.clear()
+
+    def _emit(delta: conversation.AssistantContentDeltaDict) -> None:
+        content = delta.get("content")
+        if set(delta) == {"content"} and isinstance(content, str):
+            if thinking_parts:
+                _flush_text_parts()
+            content_parts.append(content)
+            return
+        thinking = delta.get("thinking_content")
+        if set(delta) == {"thinking_content"} and isinstance(thinking, str):
+            if content_parts:
+                _flush_text_parts()
+            thinking_parts.append(thinking)
+            return
+        _flush_text_parts()
+        pending_deltas.append(delta)
+
+    async for event in stream:
+        if terminal:
+            raise MalformedProviderResponseError(
+                "Provider emitted data after the terminal event",
+                context=ErrorContext(operation=Operation.RESPONSE, model=model),
+            )
+
+        if isinstance(event, ResponseOutputItemAddedEvent):
+            if isinstance(event.item, ResponseFunctionToolCall):
+                if not assistant_open:
+                    _emit({"role": "assistant"})
+                    assistant_open = True
+                if event.item.id is None:
+                    raise MalformedProviderResponseError(
+                        "Provider tool call omitted its item ID",
+                        context=ErrorContext(operation=Operation.RESPONSE, model=model),
+                    )
+                if not event.item.call_id or not event.item.name:
+                    raise InvalidModelToolRequestError(
+                        "Provider tool call omitted call_id or name",
+                        context=ErrorContext(operation=Operation.TOOL, model=model),
+                    )
+                if (
+                    event.item.id in announced_tool_calls
+                    or event.item.call_id in call_ids
+                ):
+                    raise InvalidModelToolRequestError(
+                        "Provider emitted a duplicate tool-call identifier",
+                        context=ErrorContext(operation=Operation.TOOL, model=model),
+                    )
+                if announced_tool_calls or call_ids:
+                    raise InvalidModelToolRequestError(
+                        "Provider emitted multiple tool calls in one response",
+                        context=ErrorContext(operation=Operation.TOOL, model=model),
+                    )
+                announced_tool_calls[event.item.id] = (
+                    event.item.call_id,
+                    event.item.name,
+                )
+                call_ids.add(event.item.call_id)
+                continue
+            if isinstance(event.item, ResponseOutputMessage):
+                _emit({"role": "assistant"})
+                assistant_open = True
+                continue
+            if isinstance(event.item, ResponseReasoningItem):
+                if not assistant_open or reasoning_native_set:
+                    _emit({"role": "assistant"})
+                    assistant_open = True
+                reasoning_native_set = False
+                last_summary_index = None
+                continue
+            raise MalformedProviderResponseError(
+                f"Unexpected output item type {type(event.item)!r}",
+                context=ErrorContext(operation=Operation.RESPONSE, model=model),
+            )
+
+        if isinstance(event, ResponseFunctionCallArgumentsDoneEvent):
+            announced = announced_tool_calls.pop(event.item_id, None)
+            if announced is None:
+                raise MalformedProviderResponseError(
+                    "Tool arguments did not match an announced tool call",
+                    context=ErrorContext(operation=Operation.RESPONSE, model=model),
+                )
+            call_id, tool_name = announced
+            if event.name and event.name != tool_name:
+                raise InvalidModelToolRequestError(
+                    "Provider changed the announced tool name",
+                    context=ErrorContext(operation=Operation.TOOL, model=model),
+                )
+            try:
+                tool_args = json.loads(event.arguments)
+            except json.JSONDecodeError as err:
+                raise InvalidModelToolRequestError(
+                    "Model emitted malformed tool arguments",
+                    context=ErrorContext(operation=Operation.TOOL, model=model),
+                ) from err
+            if not isinstance(tool_args, dict):
+                raise InvalidModelToolRequestError(
+                    "Model tool arguments were not an object",
+                    context=ErrorContext(operation=Operation.TOOL, model=model),
+                )
+            _emit(
+                {
+                    "tool_calls": [
+                        llm.ToolInput(
+                            id=call_id,
+                            tool_name=tool_name,
+                            tool_args=tool_args,
+                        )
+                    ]
+                }
+            )
+            produced_user_visible_output = True
+            continue
+
+        if isinstance(event, ResponseTextDeltaEvent):
+            if not assistant_open:
+                _emit({"role": "assistant"})
+                assistant_open = True
+            if event.delta:
+                _emit({"content": event.delta})
+                produced_user_visible_output = True
+            continue
+
+        if isinstance(event, ResponseReasoningSummaryTextDeltaEvent):
+            if not assistant_open or reasoning_native_set:
+                _emit({"role": "assistant"})
+                assistant_open = True
+                reasoning_native_set = False
+                last_summary_index = None
+            if (
+                last_summary_index is not None
+                and event.summary_index != last_summary_index
+            ):
+                _emit({"role": "assistant"})
+                assistant_open = True
+            last_summary_index = event.summary_index
+            if event.delta:
+                _emit({"thinking_content": event.delta})
+            continue
+
+        if isinstance(event, ResponseOutputItemDoneEvent):
+            if isinstance(event.item, ResponseReasoningItem):
+                _emit({"native": event.item})
+                reasoning_native_set = True
+            continue
+
+        if isinstance(event, ResponseCompletedEvent):
+            if announced_tool_calls:
+                raise InvalidModelToolRequestError(
+                    "Provider completed with unfinished tool calls",
+                    context=ErrorContext(operation=Operation.TOOL, model=model),
+                )
+            terminal = True
+            if event.response.usage is not None:
+                chat_log.async_trace(
+                    {
+                        "stats": {
+                            "input_tokens": event.response.usage.input_tokens,
+                            "cached_input_tokens": (
+                                event.response.usage.input_tokens_details.cached_tokens
+                            ),
+                            "output_tokens": event.response.usage.output_tokens,
+                        }
+                    }
+                )
+            continue
+
+        if isinstance(event, ResponseIncompleteEvent):
+            reason = (
+                event.response.incomplete_details.reason
+                if event.response.incomplete_details
+                else "unknown"
+            )
+            raise _stream_failure(
+                reason,
+                model=model,
+                request_id=event.response.id,
+            )
+
+        if isinstance(event, ResponseFailedEvent):
+            raise _stream_failure(
+                event.response.error.code if event.response.error else None,
+                model=model,
+                request_id=event.response.id,
+            )
+
+        if isinstance(event, ResponseErrorEvent):
+            raise _stream_failure(event.code, model=model)
+
+        if isinstance(event, (ResponseRefusalDeltaEvent, ResponseRefusalDoneEvent)):
+            raise PermanentProviderError(
+                "Provider refused the response",
+                context=ErrorContext(operation=Operation.RESPONSE, model=model),
+            )
+
+        if isinstance(
+            event,
+            (
+                ResponseContentPartAddedEvent,
+                ResponseContentPartDoneEvent,
+                ResponseCreatedEvent,
+                ResponseFunctionCallArgumentsDeltaEvent,
+                ResponseInProgressEvent,
+                ResponseOutputTextAnnotationAddedEvent,
+                ResponseQueuedEvent,
+                ResponseReasoningSummaryPartAddedEvent,
+                ResponseReasoningSummaryPartDoneEvent,
+                ResponseReasoningSummaryTextDoneEvent,
+                ResponseReasoningTextDeltaEvent,
+                ResponseReasoningTextDoneEvent,
+                ResponseTextDoneEvent,
+            ),
+        ):
+            continue
+
+        raise MalformedProviderResponseError(
+            f"Unexpected stream event type {event.type}",
+            context=ErrorContext(operation=Operation.RESPONSE, model=model),
+        )
+
+    if not terminal:
+        raise MalformedProviderResponseError(
+            "Provider stream ended without a terminal event",
+            context=ErrorContext(operation=Operation.RESPONSE, model=model),
+        )
+    if not produced_user_visible_output:
+        raise MalformedProviderResponseError(
+            "Provider completed without user-visible assistant content",
+            context=ErrorContext(operation=Operation.RESPONSE, model=model),
+        )
+    _flush_text_parts()
+    for delta in pending_deltas:
+        yield delta
+
+
+class SpaceXAIBaseLLMEntity(Entity):
+    """Shared SpaceXAI LLM entity behavior."""
+
+    _attr_has_entity_name = True
+    _attr_name: str | None = None
+
+    def __init__(self, entry: SpaceXAIConfigEntry, subentry: ConfigSubentry) -> None:
+        """Initialize the shared LLM entity."""
+        self.entry = entry
+        self.subentry = subentry
+        self._unavailable_logged = False
+        self._account_wide_unavailable = False
+        model = cast(str, subentry.data[CONF_MODEL])
+        self._attr_available = entry.runtime_data.snapshot.has_model(model)
+        self._attr_unique_id = subentry.subentry_id
+        self._attr_device_info = dr.DeviceInfo(
+            identifiers={(DOMAIN, subentry.subentry_id)},
+            name=subentry.title,
+            manufacturer="SpaceXAI",
+            model=model,
+            model_id=model,
+            entry_type=dr.DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def _model(self) -> str:
+        """Return the configured model."""
+        return cast(str, self.subentry.data[CONF_MODEL])
+
+    @property
+    def _max_output_tokens(self) -> int:
+        """Return the configured model output limit."""
+        return cast(int, self.subentry.data[CONF_MAX_OUTPUT_TOKENS])
+
+    def _raise_provider_home_assistant_error(self, err: SpaceXAIError) -> NoReturn:
+        """Apply runtime side effects and raise a translated Home Assistant error."""
+        self._handle_provider_error(err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=err.category.value,
+            translation_placeholders={"model": err.context.model or self._model},
+        ) from err
+
+    def _raise_unexpected_provider_failure(self, err: Exception) -> NoReturn:
+        """Log and raise for unexpected provider-path failures."""
+        LOGGER.error(
+            "Unexpected SpaceXAI failure: operation=%s model=%s\n%s",
+            Operation.RESPONSE,
+            self._model,
+            "".join(traceback.format_tb(err.__traceback__)),
+        )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="unexpected_provider_failure",
+            translation_placeholders={"model": self._model},
+        ) from err
+
+    async def _async_handle_chat_log(
+        self,
+        chat_log: conversation.ChatLog,
+        *,
+        max_iterations: int = MAX_TOOL_ITERATIONS,
+    ) -> None:
+        """Run the bounded provider/tool loop."""
+        model = self._model
+        messages = _convert_content(chat_log.content)
+        tools: list[dict[str, Any]] = []
+        if chat_log.llm_api:
+            tools = [
+                dict(_format_tool(tool, chat_log.llm_api.custom_serializer))
+                for tool in chat_log.llm_api.tools
+            ]
+
+        try:
+            async with asyncio.timeout(CONVERSE_TIMEOUT):
+                for _iteration in range(max_iterations):
+                    stream = await self.entry.runtime_data.client.async_stream_response(
+                        model=model,
+                        input=messages,
+                        tools=tools,
+                        max_output_tokens=self._max_output_tokens,
+                        prompt_cache_key=chat_log.conversation_id,
+                    )
+
+                    async with stream:
+                        deadline = asyncio.get_running_loop().time() + RESPONSE_TIMEOUT
+                        try:
+                            async with asyncio.timeout_at(deadline):
+                                try:
+                                    deltas = [
+                                        delta
+                                        async for delta in _transform_stream(
+                                            chat_log, stream, model=model
+                                        )
+                                    ]
+                                except httpx.TimeoutException as err:
+                                    raise RequestTimeoutError(
+                                        "Provider response timed out",
+                                        context=ErrorContext(
+                                            operation=Operation.RESPONSE,
+                                            model=model,
+                                        ),
+                                    ) from err
+                                except httpx.TransportError as err:
+                                    raise ConnectionFailureError(
+                                        "Could not read the provider response stream",
+                                        context=ErrorContext(
+                                            operation=Operation.RESPONSE,
+                                            model=model,
+                                        ),
+                                    ) from err
+                                except (openai.OpenAIError, ValidationError) as err:
+                                    raise self.entry.runtime_data.client.translate_sdk_error(
+                                        err,
+                                        ErrorContext(
+                                            operation=Operation.RESPONSE,
+                                            model=model,
+                                        ),
+                                    ) from err
+                        except TimeoutError as err:
+                            raise RequestTimeoutError(
+                                "Provider response timed out",
+                                context=ErrorContext(
+                                    operation=Operation.RESPONSE,
+                                    model=model,
+                                ),
+                            ) from err
+
+                        async def _replay_deltas(
+                            deltas_to_replay: list[
+                                conversation.AssistantContentDeltaDict
+                                | conversation.ToolResultContentDeltaDict
+                            ] = deltas,
+                        ) -> AsyncIterable[
+                            conversation.AssistantContentDeltaDict
+                            | conversation.ToolResultContentDeltaDict
+                        ]:
+                            for delta in deltas_to_replay:
+                                yield delta
+
+                        try:
+                            async with asyncio.timeout_at(deadline):
+                                new_content = [
+                                    content
+                                    async for content in chat_log.async_add_delta_content_stream(
+                                        self.entity_id,
+                                        _replay_deltas(),
+                                    )
+                                ]
+                        except TimeoutError as err:
+                            raise HomeAssistantError(
+                                translation_domain=DOMAIN,
+                                translation_key="home_assistant_tool_failure",
+                                translation_placeholders={"model": model},
+                            ) from err
+
+                    for content in new_content:
+                        if (
+                            isinstance(content, conversation.ToolResultContent)
+                            and "error" in content.tool_result
+                        ):
+                            LOGGER.warning(
+                                "SpaceXAI tool failure: category=%s operation=%s "
+                                "model=%s tool=%s call_id=%s retryable=%s",
+                                ErrorCategory.HOME_ASSISTANT_TOOL_FAILURE,
+                                Operation.TOOL,
+                                model,
+                                content.tool_name,
+                                content.tool_call_id,
+                                False,
+                            )
+
+                    messages.extend(_convert_content(new_content))
+                    if not chat_log.unresponded_tool_results:
+                        return
+        except TimeoutError as err:
+            raise RequestTimeoutError(
+                "Provider response timed out",
+                context=ErrorContext(operation=Operation.RESPONSE, model=model),
+            ) from err
+
+        raise ToolLoopLimitError(
+            f"Model exceeded the {max_iterations}-iteration tool limit",
+            context=ErrorContext(operation=Operation.TOOL, model=model),
+        )
+
+    def _handle_provider_error(self, err: SpaceXAIError) -> None:
+        """Map an expected provider failure to runtime and logging behavior."""
+        if err.category in (
+            ErrorCategory.AUTHENTICATION_REJECTED,
+            ErrorCategory.REFRESH_REJECTED,
+            ErrorCategory.REAUTHENTICATION_REQUIRED,
+            ErrorCategory.ACCOUNT_MISMATCH,
+        ):
+            self.entry.async_start_reauth(self.hass)
+            self._mark_entry_agents_unavailable(err)
+            return
+
+        if err.category is ErrorCategory.MODEL_NOT_ENTITLED:
+            async_create_model_not_entitled_issue(
+                self.hass,
+                self.entry,
+                subentry_id=self.subentry.subentry_id,
+                model=err.context.model or self._model,
+            )
+            self._mark_unavailable(err)
+            return
+
+        if err.category is ErrorCategory.SUBSCRIPTION_NOT_ENTITLED:
+            async_mark_subscription_not_entitled(
+                self.hass,
+                self.entry,
+                operation=err.context.operation,
+            )
+            return
+
+        if err.category is ErrorCategory.QUOTA_LIMITED:
+            self._mark_entry_agents_unavailable(err)
+            return
+
+        if err.retryable:
+            self._mark_unavailable(err)
+            return
+
+        LOGGER.error(
+            "SpaceXAI request failed: category=%s operation=%s model=%s "
+            "status=%s provider_code=%s request_id=%s retryable=%s",
+            err.category,
+            err.context.operation,
+            err.context.model,
+            err.context.status,
+            err.context.provider_code,
+            err.context.request_id,
+            err.retryable,
+        )
+
+    def _mark_entry_agents_unavailable(self, err: SpaceXAIError) -> None:
+        """Mark every conversation agent on this config entry unavailable."""
+        for platform in entity_platform.async_get_platforms(self.hass, DOMAIN):
+            for entity in platform.entities.values():
+                if getattr(entity, "entry", None) is not self.entry:
+                    continue
+                mark = getattr(entity, "_mark_unavailable", None)
+                if mark is not None:
+                    mark(err, account_wide=True)
+
+    def _mark_unavailable(
+        self, err: SpaceXAIError, *, account_wide: bool = False
+    ) -> None:
+        """Mark unavailable and log the transition once."""
+        self._account_wide_unavailable = account_wide and (
+            err.category is not ErrorCategory.MODEL_NOT_ENTITLED
+        )
+        self._attr_available = False
+        if self.hass and self.entity_id:
+            self.async_write_ha_state()
+        if not self._unavailable_logged:
+            LOGGER.info(
+                "SpaceXAI is unavailable: category=%s operation=%s model=%s "
+                "status=%s request_id=%s retryable=%s",
+                err.category,
+                err.context.operation,
+                err.context.model,
+                err.context.status,
+                err.context.request_id,
+                err.retryable,
+            )
+            self._unavailable_logged = True
+
+    def _mark_available(self) -> bool:
+        """Recover only when the configured model is still entitled."""
+        if not self.entry.runtime_data.snapshot.has_model(self._model):
+            return False
+        self._attr_available = True
+        self._account_wide_unavailable = False
+        if self.hass and self.entity_id:
+            self.async_write_ha_state()
+        async_delete_model_not_entitled_issue(self.hass, self.subentry.subentry_id)
+        if self._unavailable_logged:
+            LOGGER.info("SpaceXAI is available again")
+            self._unavailable_logged = False
+        return True
+
+    def _restore_entitled_entry_agents(self) -> None:
+        """Restore siblings that were down only for a shared account outage."""
+        for platform in entity_platform.async_get_platforms(self.hass, DOMAIN):
+            for entity in platform.entities.values():
+                if entity is self or getattr(entity, "entry", None) is not self.entry:
+                    continue
+                if not getattr(entity, "_account_wide_unavailable", False):
+                    continue
+                getattr(entity, "_mark_available")()  # noqa: B009
+
+    @callback
+    def async_apply_model_entitlement(self) -> None:
+        """Sync availability with whether the configured model remains entitled."""
+        if self.entry.runtime_data.snapshot.has_model(self._model):
+            self._mark_available()
+            return
+        if self.available:
+            self._mark_unavailable(
+                ModelNotEntitledError(
+                    "Configured model is not available to this account",
+                    context=ErrorContext(operation=Operation.MODELS, model=self._model),
+                )
+            )

--- a/homeassistant/components/spacexai/errors.py
+++ b/homeassistant/components/spacexai/errors.py
@@ -1,0 +1,167 @@
+"""Typed errors for the SpaceXAI integration."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ErrorCategory(StrEnum):
+    """Closed set of failures exposed by the integration."""
+
+    AUTHENTICATION_REJECTED = "authentication_rejected"
+    REFRESH_REJECTED = "refresh_rejected"
+    REAUTHENTICATION_REQUIRED = "reauthentication_required"
+    ACCOUNT_MISMATCH = "account_mismatch"
+    SUBSCRIPTION_NOT_ENTITLED = "subscription_not_entitled"
+    NO_CONVERSATION_MODELS = "no_conversation_models"
+    MODEL_NOT_ENTITLED = "model_not_entitled"
+    RATE_LIMITED = "rate_limited"
+    QUOTA_LIMITED = "quota_limited"
+    TIMEOUT = "timeout"
+    CONNECTION_FAILURE = "connection_failure"
+    TRANSIENT_PROVIDER_FAILURE = "transient_provider_failure"
+    MALFORMED_PROVIDER_RESPONSE = "malformed_provider_response"
+    INVALID_MODEL_TOOL_REQUEST = "invalid_model_tool_request"
+    HOME_ASSISTANT_TOOL_FAILURE = "home_assistant_tool_failure"
+    TOOL_LOOP_LIMIT = "tool_loop_limit"
+    OUTPUT_LIMIT = "output_limit"
+    PERMANENT_PROVIDER_FAILURE = "permanent_provider_failure"
+
+
+class Operation(StrEnum):
+    """Provider operation associated with a failure."""
+
+    ACCOUNT = "account"
+    MODELS = "models"
+    RESPONSE = "response"
+    REFRESH = "refresh"
+    REVOCATION = "revocation"
+    TOOL = "tool"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ErrorContext:
+    """Sanitized provider error context."""
+
+    operation: Operation
+    model: str | None = None
+    status: int | None = None
+    provider_code: str | None = None
+    request_id: str | None = None
+
+
+class SpaceXAIError(Exception):
+    """Base class for expected SpaceXAI failures."""
+
+    category: ErrorCategory
+    retryable: bool = False
+
+    def __init__(self, message: str, *, context: ErrorContext) -> None:
+        """Initialize a provider failure."""
+        super().__init__(message)
+        self.context = context
+
+
+class AuthenticationRejectedError(SpaceXAIError):
+    """The provider rejected credentials during initial authentication."""
+
+    category = ErrorCategory.AUTHENTICATION_REJECTED
+
+
+class RefreshRejectedError(SpaceXAIError):
+    """The provider rejected the refresh token."""
+
+    category = ErrorCategory.REFRESH_REJECTED
+
+
+class ReauthenticationRequiredError(SpaceXAIError):
+    """The active session must be reauthenticated."""
+
+    category = ErrorCategory.REAUTHENTICATION_REQUIRED
+
+
+class AccountMismatchError(SpaceXAIError):
+    """The authenticated account does not match the config entry."""
+
+    category = ErrorCategory.ACCOUNT_MISMATCH
+
+
+class SubscriptionNotEntitledError(SpaceXAIError):
+    """The account lacks subscription-backed API access."""
+
+    category = ErrorCategory.SUBSCRIPTION_NOT_ENTITLED
+
+
+class NoConversationModelsError(SpaceXAIError):
+    """The account has no entitled text/conversation models."""
+
+    category = ErrorCategory.NO_CONVERSATION_MODELS
+
+
+class ModelNotEntitledError(SpaceXAIError):
+    """The account is not entitled to the configured model."""
+
+    category = ErrorCategory.MODEL_NOT_ENTITLED
+
+
+class RateLimitedError(SpaceXAIError):
+    """The provider rate limited the request."""
+
+    category = ErrorCategory.RATE_LIMITED
+    retryable = True
+
+
+class QuotaLimitedError(SpaceXAIError):
+    """The subscription allowance or quota is exhausted."""
+
+    category = ErrorCategory.QUOTA_LIMITED
+
+
+class RequestTimeoutError(SpaceXAIError):
+    """The provider operation timed out."""
+
+    category = ErrorCategory.TIMEOUT
+    retryable = True
+
+
+class ConnectionFailureError(SpaceXAIError):
+    """The provider could not be reached."""
+
+    category = ErrorCategory.CONNECTION_FAILURE
+    retryable = True
+
+
+class TransientProviderError(SpaceXAIError):
+    """The provider reported a transient failure."""
+
+    category = ErrorCategory.TRANSIENT_PROVIDER_FAILURE
+    retryable = True
+
+
+class MalformedProviderResponseError(SpaceXAIError):
+    """The provider returned data that did not match its contract."""
+
+    category = ErrorCategory.MALFORMED_PROVIDER_RESPONSE
+
+
+class InvalidModelToolRequestError(SpaceXAIError):
+    """The model emitted an invalid tool request."""
+
+    category = ErrorCategory.INVALID_MODEL_TOOL_REQUEST
+
+
+class ToolLoopLimitError(SpaceXAIError):
+    """The bounded model/tool loop reached its limit."""
+
+    category = ErrorCategory.TOOL_LOOP_LIMIT
+
+
+class OutputLimitError(SpaceXAIError):
+    """The provider reached the configured output-token limit."""
+
+    category = ErrorCategory.OUTPUT_LIMIT
+
+
+class PermanentProviderError(SpaceXAIError):
+    """The provider permanently rejected a validly formed operation."""
+
+    category = ErrorCategory.PERMANENT_PROVIDER_FAILURE

--- a/homeassistant/components/spacexai/issue.py
+++ b/homeassistant/components/spacexai/issue.py
@@ -1,0 +1,60 @@
+"""Repair issue helpers for the SpaceXAI integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN, ISSUE_MODEL_NOT_ENTITLED, ISSUE_SUBSCRIPTION_NOT_ENTITLED
+
+
+@callback
+def async_create_model_not_entitled_issue(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    subentry_id: str,
+    model: str,
+) -> None:
+    """Create a repair for a withdrawn conversation model."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{ISSUE_MODEL_NOT_ENTITLED}_{subentry_id}",
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key=ISSUE_MODEL_NOT_ENTITLED,
+        translation_placeholders={"model": model},
+        data={
+            "entry_id": entry.entry_id,
+            "subentry_id": subentry_id,
+        },
+    )
+
+
+@callback
+def async_create_subscription_issue(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Create an account-scoped subscription entitlement repair."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{ISSUE_SUBSCRIPTION_NOT_ENTITLED}_{entry.entry_id}",
+        is_fixable=False,
+        learn_more_url="https://console.x.ai/",
+        severity=ir.IssueSeverity.ERROR,
+        translation_key=ISSUE_SUBSCRIPTION_NOT_ENTITLED,
+    )
+
+
+@callback
+def async_delete_model_not_entitled_issue(
+    hass: HomeAssistant,
+    subentry_id: str,
+) -> None:
+    """Delete the model-not-entitled repair for a subentry if present."""
+    ir.async_delete_issue(hass, DOMAIN, f"{ISSUE_MODEL_NOT_ENTITLED}_{subentry_id}")
+
+
+@callback
+def async_delete_subscription_issue(hass: HomeAssistant, entry_id: str) -> None:
+    """Delete the subscription-not-entitled repair for an entry if present."""
+    ir.async_delete_issue(hass, DOMAIN, f"{ISSUE_SUBSCRIPTION_NOT_ENTITLED}_{entry_id}")

--- a/homeassistant/components/spacexai/manifest.json
+++ b/homeassistant/components/spacexai/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "spacexai",
+  "name": "SpaceXAI",
+  "after_dependencies": ["assist_pipeline", "intent"],
+  "codeowners": ["@jeffglousher"],
+  "config_flow": true,
+  "dependencies": ["application_credentials", "conversation"],
+  "documentation": "https://www.home-assistant.io/integrations/spacexai",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "quality_scale": "silver",
+  "requirements": ["openai==2.45.0"]
+}

--- a/homeassistant/components/spacexai/quality_scale.yaml
+++ b/homeassistant/components/spacexai/quality_scale.yaml
@@ -1,0 +1,98 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration has no actions.
+  appropriate-polling:
+    status: exempt
+    comment: Integration does not poll.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration has no actions.
+  docs-conditions:
+    status: exempt
+    comment: Integration does not provide conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: Integration does not provide triggers.
+  entity-event-setup:
+    status: exempt
+    comment: Conversation entities do not subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration has no actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Service integration, no discovery.
+  discovery:
+    status: exempt
+    comment: Service integration, no discovery.
+  docs-data-update:
+    status: exempt
+    comment: On-demand LLM responses, no polling cadence.
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices:
+    status: exempt
+    comment: Service integration, no physical devices.
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: Service integration, no discovered devices.
+  entity-category:
+    status: exempt
+    comment: Conversation entities are primary service entities.
+  entity-device-class:
+    status: exempt
+    comment: Conversation entities do not have device classes.
+  entity-disabled-by-default:
+    status: exempt
+    comment: The conversation entity is the primary feature.
+  entity-translations:
+    status: exempt
+    comment: Entities set `_attr_name` to `None`.
+  exception-translations: done
+  icon-translations: todo
+  reconfiguration-flow:
+    status: exempt
+    comment: Parent OAuth entry has no user-editable settings; agents use subentry flows.
+  repair-issues: done
+  stale-devices:
+    status: exempt
+    comment: Service integration, no discovered devices.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/spacexai/strings.json
+++ b/homeassistant/components/spacexai/strings.json
@@ -1,0 +1,194 @@
+{
+  "config": {
+    "abort": {
+      "account_mismatch": "The signed-in account does not match the account configured in Home Assistant. Sign in with the original SpaceXAI account.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "malformed_provider_response": "SpaceXAI returned an unexpected response while validating the account. Try again later.",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "missing_credentials": "[%key:common::config_flow::abort::oauth2_missing_credentials%]",
+      "model_not_entitled": "The configured Grok model is no longer available to this account.",
+      "no_conversation_models": "This SpaceXAI account has no entitled text/conversation models available.",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "quota_limited": "SpaceXAI reported an account quota or billing limitation. Review the account in SpaceXAI before trying again.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "subscription_not_entitled": "This SpaceXAI account is not eligible for subscription-backed third-party Grok access.",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "conversation": {
+        "data": {
+          "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
+          "max_output_tokens": "Maximum response tokens",
+          "model": "[%key:common::generic::model%]",
+          "prompt": "[%key:common::config_flow::data::prompt%]"
+        },
+        "data_description": {
+          "llm_hass_api": "Home Assistant APIs that Grok may use. Only explicitly exposed entities and tools are available.",
+          "max_output_tokens": "Maximum number of tokens Grok may generate for one response.",
+          "model": "Grok model discovered for the signed-in subscription.",
+          "prompt": "Instructions that define how Grok should respond. This can be a template."
+        },
+        "description": "Configure the Grok conversation agent for this SpaceXAI account."
+      },
+      "pick_implementation": {
+        "data": {
+          "implementation": "[%key:common::config_flow::data::implementation%]"
+        },
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "description": "The SpaceXAI integration needs you to sign in again.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "user": {
+        "description": "Sign in with a SpaceXAI subscription account using Authorization Code + PKCE."
+      },
+      "validate": {
+        "description": "Home Assistant could not validate the SpaceXAI account. Submit to try again."
+      }
+    }
+  },
+  "config_subentries": {
+    "conversation": {
+      "abort": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "entry_not_loaded": "The SpaceXAI account must be loaded before conversation agents can be configured.",
+        "malformed_provider_response": "[%key:component::spacexai::config::abort::malformed_provider_response%]",
+        "model_not_entitled": "[%key:component::spacexai::config::abort::model_not_entitled%]",
+        "no_conversation_models": "[%key:component::spacexai::config::abort::no_conversation_models%]",
+        "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+        "quota_limited": "[%key:component::spacexai::config::abort::quota_limited%]",
+        "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+        "subscription_not_entitled": "[%key:component::spacexai::config::abort::subscription_not_entitled%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "entry_type": "Conversation agent",
+      "initiate_flow": {
+        "reconfigure": "Reconfigure conversation agent",
+        "user": "Add conversation agent"
+      },
+      "step": {
+        "reconfigure": {
+          "data": {
+            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
+            "max_output_tokens": "[%key:component::spacexai::config::step::conversation::data::max_output_tokens%]",
+            "model": "[%key:common::generic::model%]",
+            "prompt": "[%key:common::config_flow::data::prompt%]"
+          },
+          "data_description": {
+            "llm_hass_api": "[%key:component::spacexai::config::step::conversation::data_description::llm_hass_api%]",
+            "max_output_tokens": "[%key:component::spacexai::config::step::conversation::data_description::max_output_tokens%]",
+            "model": "[%key:component::spacexai::config::step::conversation::data_description::model%]",
+            "prompt": "[%key:component::spacexai::config::step::conversation::data_description::prompt%]"
+          }
+        },
+        "user": {
+          "data": {
+            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
+            "max_output_tokens": "[%key:component::spacexai::config::step::conversation::data::max_output_tokens%]",
+            "model": "[%key:common::generic::model%]",
+            "prompt": "[%key:common::config_flow::data::prompt%]"
+          },
+          "data_description": {
+            "llm_hass_api": "[%key:component::spacexai::config::step::conversation::data_description::llm_hass_api%]",
+            "max_output_tokens": "[%key:component::spacexai::config::step::conversation::data_description::max_output_tokens%]",
+            "model": "[%key:component::spacexai::config::step::conversation::data_description::model%]",
+            "prompt": "[%key:component::spacexai::config::step::conversation::data_description::prompt%]"
+          }
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "account_mismatch": {
+      "message": "The SpaceXAI account does not match the account configured in Home Assistant."
+    },
+    "authentication_rejected": {
+      "message": "SpaceXAI rejected authentication. Reauthenticate the integration."
+    },
+    "connection_failure": {
+      "message": "Home Assistant could not connect to SpaceXAI while using {model}."
+    },
+    "home_assistant_tool_failure": {
+      "message": "A Home Assistant tool requested by {model} failed."
+    },
+    "invalid_model_tool_request": {
+      "message": "{model} requested a Home Assistant tool with invalid arguments."
+    },
+    "malformed_provider_response": {
+      "message": "SpaceXAI returned an unexpected response from {model}."
+    },
+    "model_not_entitled": {
+      "message": "The SpaceXAI account is not entitled to use {model}."
+    },
+    "no_conversation_models": {
+      "message": "This SpaceXAI account has no entitled text/conversation models available."
+    },
+    "oauth_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
+    "output_limit": {
+      "message": "SpaceXAI reached the configured output-token limit for {model}."
+    },
+    "permanent_provider_failure": {
+      "message": "SpaceXAI rejected the request to {model}."
+    },
+    "provider_unavailable": {
+      "message": "SpaceXAI is temporarily unavailable."
+    },
+    "quota_limited": {
+      "message": "SpaceXAI reported an account quota or billing limitation for {model}."
+    },
+    "rate_limited": {
+      "message": "SpaceXAI is rate limiting requests to {model}. Try again later."
+    },
+    "reauthentication_required": {
+      "message": "The SpaceXAI session is no longer valid. Reauthenticate the integration."
+    },
+    "refresh_rejected": {
+      "message": "SpaceXAI rejected the session refresh. Reauthenticate the integration."
+    },
+    "subscription_not_entitled": {
+      "message": "This SpaceXAI account is not eligible for subscription-backed Grok access."
+    },
+    "timeout": {
+      "message": "SpaceXAI did not finish the response from {model} in time."
+    },
+    "tool_loop_limit": {
+      "message": "{model} reached the Home Assistant tool-call limit."
+    },
+    "transient_provider_failure": {
+      "message": "SpaceXAI encountered a temporary error while using {model}. Try again later."
+    },
+    "unexpected_provider_failure": {
+      "message": "An unexpected error occurred while communicating with SpaceXAI using {model}."
+    }
+  },
+  "issues": {
+    "model_not_entitled": {
+      "description": "The conversation agent is configured to use `{model}`, which is not available to this SpaceXAI account. Assist cannot use this agent until a currently entitled model is selected.\n\n1. Open the conversation agent settings for this SpaceXAI entry.\n2. Choose a replacement from the models currently entitled to the account.\n3. Save the conversation agent.\n\nThe agent becomes available after a currently entitled model is saved.",
+      "title": "Configured SpaceXAI model is unavailable"
+    },
+    "subscription_not_entitled": {
+      "description": "The SpaceXAI account connected to Home Assistant is not eligible for subscription-backed third-party Grok access, so conversation agents for this account cannot be used.\n\n1. Open the SpaceXAI console (link below) and confirm the signed-in account has an active eligible subscription.\n2. If the subscription belongs to a different account, remove this integration entry and add it again with the eligible account.\n3. After the subscription is eligible, reload the integration or sign in again.\n\nConversation agents for this account become available once SpaceXAI accepts the account.",
+      "title": "SpaceXAI subscription access is unavailable"
+    }
+  }
+}

--- a/homeassistant/generated/application_credentials.py
+++ b/homeassistant/generated/application_credentials.py
@@ -40,6 +40,7 @@ APPLICATION_CREDENTIALS = [
     "point",
     "senz",
     "smartthings",
+    "spacexai",
     "spotify",
     "tesla_fleet",
     "teslemetry",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -733,6 +733,7 @@ FLOWS = {
         "songpal",
         "sonos",
         "soundtouch",
+        "spacexai",
         "speedtestdotnet",
         "splunk",
         "spotify",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6822,6 +6822,12 @@
       "config_flow": false,
       "iot_class": "calculated"
     },
+    "spacexai": {
+      "name": "SpaceXAI",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "spc": {
       "name": "Vanderbilt SPC",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1781,6 +1781,7 @@ open-meteo==0.3.2
 # homeassistant.components.open_router
 # homeassistant.components.openai_conversation
 # homeassistant.components.ovhcloud_ai_endpoints
+# homeassistant.components.spacexai
 openai==2.45.0
 
 # homeassistant.components.openerz

--- a/tests/components/spacexai/__init__.py
+++ b/tests/components/spacexai/__init__.py
@@ -1,0 +1,305 @@
+"""Test helpers for SpaceXAI."""
+
+from collections.abc import AsyncIterator, Iterable, Sequence
+from typing import Any, Self
+
+from openai.types import Model
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
+    ResponseIncompleteEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputMessage,
+    ResponseStreamEvent,
+    ResponseTextDeltaEvent,
+)
+
+from homeassistant.components import conversation
+from homeassistant.components.conversation import ConversationResult
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.core import Context, HomeAssistant
+
+AGENT_ID = "conversation.grok"
+
+
+class AsyncModelPage:
+    """Async-iterable models page that can span multiple SDK pages."""
+
+    def __init__(self, *pages: Sequence[Model]) -> None:
+        """Store page batches; `.data` mirrors the first page only."""
+        self._pages = pages or ((),)
+        self.data = list(self._pages[0])
+
+    def __aiter__(self) -> AsyncIterator[Model]:
+        """Yield every model across all pages."""
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[Model]:
+        """Yield models in page order."""
+        for page in self._pages:
+            for model in page:
+                yield model
+
+
+def conversation_subentry(entry: ConfigEntry) -> ConfigSubentry:
+    """Return the conversation subentry on a SpaceXAI config entry."""
+    return next(
+        subentry
+        for subentry in entry.subentries.values()
+        if subentry.subentry_type == "conversation"
+    )
+
+
+async def converse(
+    hass: HomeAssistant,
+    text: str,
+    conversation_id: str | None = None,
+    *,
+    agent_id: str = AGENT_ID,
+) -> ConversationResult:
+    """Run a SpaceXAI conversation turn against the default test agent."""
+    return await conversation.async_converse(
+        hass,
+        text,
+        conversation_id,
+        Context(),
+        agent_id=agent_id,
+    )
+
+
+class EventStream:
+    """Deterministic async event stream matching the SDK context-manager shape."""
+
+    def __init__(self, events: Iterable[ResponseStreamEvent]) -> None:
+        """Initialize the stream."""
+        self._events = iter(events)
+        self.closed = False
+
+    async def __aenter__(self) -> Self:
+        """Enter the stream context used by the entity chat loop."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Close the stream after consumption or failure."""
+        self.closed = True
+
+    def __aiter__(self) -> AsyncIterator[ResponseStreamEvent]:
+        """Return the event iterator."""
+        return self
+
+    async def __anext__(self) -> ResponseStreamEvent:
+        """Return the next event."""
+        try:
+            return next(self._events)
+        except StopIteration as err:
+            raise StopAsyncIteration from err
+
+
+def response_payload(**changes: Any) -> Response:
+    """Build a minimal Responses API response object."""
+    data: dict[str, Any] = {
+        "id": "response-123",
+        "created_at": 1,
+        "model": "grok-4.5",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "status": "completed",
+        "usage": None,
+    }
+    data.update(changes)
+    return Response.model_validate(data)
+
+
+def completed_event(
+    sequence_number: int = 2,
+    **response_changes: Any,
+) -> ResponseCompletedEvent:
+    """Build a terminal completed response event."""
+    return ResponseCompletedEvent(
+        response=response_payload(**response_changes),
+        sequence_number=sequence_number,
+        type="response.completed",
+    )
+
+
+def incomplete_event(
+    *,
+    reason: str | None = "max_output_tokens",
+    sequence_number: int = 0,
+) -> ResponseIncompleteEvent:
+    """Build an incomplete terminal response event."""
+    details = None if reason is None else {"reason": reason}
+    return ResponseIncompleteEvent(
+        response=response_payload(status="incomplete", incomplete_details=details),
+        sequence_number=sequence_number,
+        type="response.incomplete",
+    )
+
+
+def failed_event(
+    code: str,
+    message: str,
+    *,
+    sequence_number: int = 0,
+) -> ResponseFailedEvent:
+    """Build a failed terminal response event."""
+    return ResponseFailedEvent(
+        response=response_payload(
+            status="failed",
+            error={"code": code, "message": message},
+        ),
+        sequence_number=sequence_number,
+        type="response.failed",
+    )
+
+
+def error_event(
+    code: str,
+    message: str,
+    *,
+    sequence_number: int = 0,
+) -> ResponseErrorEvent:
+    """Build a mid-stream error event."""
+    return ResponseErrorEvent(
+        code=code,
+        message=message,
+        sequence_number=sequence_number,
+        type="error",
+    )
+
+
+def message_events(text: str, *, complete: bool = True) -> list[ResponseStreamEvent]:
+    """Build a streaming assistant text response."""
+    events: list[ResponseStreamEvent] = [
+        ResponseOutputItemAddedEvent(
+            item=ResponseOutputMessage(
+                id="msg_1",
+                content=[],
+                role="assistant",
+                status="in_progress",
+                type="message",
+            ),
+            output_index=0,
+            sequence_number=0,
+            type="response.output_item.added",
+        ),
+        ResponseTextDeltaEvent(
+            content_index=0,
+            delta=text,
+            item_id="msg_1",
+            logprobs=[],
+            output_index=0,
+            sequence_number=1,
+            type="response.output_text.delta",
+        ),
+    ]
+    if complete:
+        events.append(completed_event(2))
+    return events
+
+
+def tool_call_added(
+    *,
+    item_id: str | None,
+    call_id: str,
+    name: str,
+    output_index: int = 0,
+    sequence_number: int = 0,
+) -> ResponseOutputItemAddedEvent:
+    """Announce a function tool call on the stream."""
+    return ResponseOutputItemAddedEvent(
+        item=ResponseFunctionToolCall(
+            id=item_id,
+            arguments="",
+            call_id=call_id,
+            name=name,
+            status="in_progress",
+            type="function_call",
+        ),
+        output_index=output_index,
+        sequence_number=sequence_number,
+        type="response.output_item.added",
+    )
+
+
+def tool_args_done(
+    *,
+    item_id: str,
+    name: str | None,
+    arguments: str,
+    output_index: int = 0,
+    sequence_number: int = 1,
+) -> ResponseFunctionCallArgumentsDoneEvent:
+    """Finish tool-call arguments, optionally omitting name like xAI sometimes does."""
+    return ResponseFunctionCallArgumentsDoneEvent.model_construct(
+        arguments=arguments,
+        item_id=item_id,
+        name=name,
+        output_index=output_index,
+        sequence_number=sequence_number,
+        type="response.function_call_arguments.done",
+    )
+
+
+def tool_events(
+    *calls: tuple[str, str, str],
+    complete: bool = True,
+) -> list[ResponseStreamEvent]:
+    """Build one assistant response containing one or more tool calls."""
+    events: list[ResponseStreamEvent] = []
+    for index, (call_id, name, arguments) in enumerate(calls):
+        item_id = f"item_{index}"
+        events.extend(
+            (
+                tool_call_added(
+                    item_id=item_id,
+                    call_id=call_id,
+                    name=name,
+                    output_index=index,
+                    sequence_number=index * 2,
+                ),
+                tool_args_done(
+                    item_id=item_id,
+                    name=name,
+                    arguments=arguments,
+                    output_index=index,
+                    sequence_number=index * 2 + 1,
+                ),
+            )
+        )
+    if complete:
+        events.append(completed_event(len(calls) * 2))
+    return events
+
+
+def usage_completed_events(
+    text: str,
+    *,
+    input_tokens: int,
+    cached_tokens: int,
+    output_tokens: int,
+) -> list[ResponseStreamEvent]:
+    """Build a completed text stream that includes usage for Assist tracing."""
+    return [
+        *message_events(text, complete=False),
+        completed_event(
+            2,
+            usage={
+                "input_tokens": input_tokens,
+                "input_tokens_details": {
+                    "cached_tokens": cached_tokens,
+                    "cache_write_tokens": 0,
+                },
+                "output_tokens": output_tokens,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": input_tokens + output_tokens,
+            },
+        ),
+    ]

--- a/tests/components/spacexai/conftest.py
+++ b/tests/components/spacexai/conftest.py
@@ -1,0 +1,151 @@
+"""Fixtures for SpaceXAI tests."""
+
+from collections.abc import Generator
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.application_credentials import (
+    DOMAIN as APPLICATION_CREDENTIALS_DOMAIN,
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.components.spacexai.client import (
+    AccountInfo,
+    ModelInfo,
+    ProviderSnapshot,
+)
+from homeassistant.components.spacexai.const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MODEL,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.const import CONF_LLM_HASS_API, CONF_MODEL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+from . import EventStream, message_events
+
+from tests.common import MockConfigEntry
+
+ACCOUNT_ID = "account-123"
+ACCESS_TOKEN = "access-token"
+REFRESH_TOKEN = "refresh-token"
+
+
+@pytest.fixture
+def provider_snapshot() -> ProviderSnapshot:
+    """Return a valid provider snapshot."""
+    return ProviderSnapshot(
+        account=AccountInfo(
+            subject=ACCOUNT_ID,
+            name="Home User",
+            email="home@example.com",
+        ),
+        models=(
+            ModelInfo(id=DEFAULT_MODEL, owner="xai"),
+            ModelInfo(id="grok-4.3", owner="xai"),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a configured SpaceXAI entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home User",
+        unique_id=ACCOUNT_ID,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": ACCESS_TOKEN,
+                "refresh_token": REFRESH_TOKEN,
+                "expires_at": time.time() + 3600,
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        },
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    CONF_MODEL: DEFAULT_MODEL,
+                    CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+                    CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+                },
+                subentry_type="conversation",
+                title="Grok",
+                unique_id=None,
+            ),
+        ],
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_validate(provider_snapshot: ProviderSnapshot) -> Generator[AsyncMock]:
+    """Mock provider account validation."""
+    with patch(
+        "homeassistant.components.spacexai.client.SpaceXAIClient.async_validate",
+        new_callable=AsyncMock,
+        return_value=provider_snapshot,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_stream() -> Generator[AsyncMock]:
+    """Mock a successful streaming provider response."""
+    with patch(
+        "homeassistant.components.spacexai.client.SpaceXAIClient.async_stream_response",
+        new_callable=AsyncMock,
+        return_value=EventStream(message_events("Hello from Grok")),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    setup_credentials: None,
+) -> MockConfigEntry:
+    """Set up SpaceXAI."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Prevent config flow tests from setting up a created entry."""
+    with patch(
+        "homeassistant.components.spacexai.async_setup_entry",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+async def setup_credentials(hass: HomeAssistant) -> None:
+    """Register a legitimate test OAuth client identity."""
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential("home-assistant-client", ""),
+        DOMAIN,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def setup_homeassistant(hass: HomeAssistant) -> None:
+    """Set up the Home Assistant LLM API."""
+    assert await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/spacexai/snapshots/test_conversation.ambr
+++ b/tests/components/spacexai/snapshots/test_conversation.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_continuation_reuses_history_and_prompt_cache_key
+  list([
+    dict({
+      'content': 'Hello',
+      'role': 'user',
+      'type': 'message',
+    }),
+    dict({
+      'content': 'Hello from Grok',
+      'role': 'assistant',
+      'type': 'message',
+    }),
+    dict({
+      'content': 'Remember me?',
+      'role': 'user',
+      'type': 'message',
+    }),
+    dict({
+      'content': 'Welcome back',
+      'role': 'assistant',
+      'type': 'message',
+    }),
+  ])
+# ---
+# name: test_lifecycle_stream_errors_are_translated[error]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI rejected the request to grok-4.5',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[failed]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI encountered a temporary error while using grok-4.5. Try again later',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[incomplete-unknown]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI rejected the request to grok-4.5',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[max-output-tokens]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI reached the configured output-token limit for grok-4.5',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[rate-limit]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI is rate limiting requests to grok-4.5. Try again later',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[refusal]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI rejected the request to grok-4.5',
+    }),
+  })
+# ---
+# name: test_lifecycle_stream_errors_are_translated[vector-store-timeout]
+  dict({
+    'plain': dict({
+      'extra_data': None,
+      'speech': 'SpaceXAI encountered a temporary error while using grok-4.5. Try again later',
+    }),
+  })
+# ---
+# name: test_system_prompt_includes_runtime_identity
+  '''
+  You are a voice assistant for Home Assistant.
+  Answer questions about the world truthfully.
+  Answer in plain text. Keep it simple and to the point.
+  
+  
+  Runtime identity (answer truthfully when asked about versions):
+  - Home Assistant Core: 2026.9.0.dev0
+  - Provider: SpaceXAI (Grok)
+  - Conversation model: grok-4.5
+  Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
+  '''
+# ---

--- a/tests/components/spacexai/test_client.py
+++ b/tests/components/spacexai/test_client.py
@@ -1,0 +1,844 @@
+"""Tests for the typed SpaceXAI client boundary."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiohttp import ClientConnectionError
+import httpx
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAIError
+from openai.types import Model
+from openai.types.responses import ResponseErrorEvent
+from pydantic import ValidationError
+import pytest
+
+from homeassistant.components.spacexai.client import (
+    AccountInfo,
+    OAuthAccessTokenProvider,
+    ProviderSnapshot,
+    SpaceXAIClient,
+    StaticAccessTokenProvider,
+    _is_permission_denial,
+    _is_subscription_denial,
+    _safe_json,
+)
+from homeassistant.components.spacexai.const import REVOCATION_URL, USERINFO_URL
+from homeassistant.components.spacexai.errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    ErrorCategory,
+    ErrorContext,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    RateLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    RequestTimeoutError,
+    SpaceXAIError,
+    SubscriptionNotEntitledError,
+    TransientProviderError,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+
+from . import AsyncModelPage, EventStream
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+def _client(hass: HomeAssistant, *, runtime: bool = False) -> SpaceXAIClient:
+    """Create a test client."""
+    return SpaceXAIClient(
+        hass,
+        StaticAccessTokenProvider("access-token"),
+        runtime_session=runtime,
+    )
+
+
+def _status_error(status: int, body: object | None = None) -> APIStatusError:
+    """Build an SDK status error for classification tests."""
+    return APIStatusError(
+        message="failure",
+        response=httpx.Response(
+            status,
+            request=httpx.Request("POST", "https://api.x.ai/v1/responses"),
+        ),
+        body=body,
+    )
+
+
+async def test_account_identity(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Parse account identity and send a Bearer authorization header."""
+    aioclient_mock.get(
+        USERINFO_URL,
+        json={
+            "sub": "account-123",
+            "name": "Home User",
+            "email": "home@example.com",
+        },
+    )
+    account = await _client(hass).async_get_account()
+    assert account.subject == "account-123"
+    assert account.display_name == "Home User"
+    assert aioclient_mock.mock_calls[0][3]["Authorization"] == "Bearer access-token"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param([], id="not-an-object"),
+        pytest.param({"name": "Missing subject"}, id="missing-subject"),
+        pytest.param({"sub": "id", "email": 42}, id="invalid-email"),
+    ],
+)
+async def test_malformed_account(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    payload: object,
+) -> None:
+    """Reject malformed provider identity data."""
+    aioclient_mock.get(USERINFO_URL, json=payload)
+    with pytest.raises(MalformedProviderResponseError):
+        await _client(hass).async_get_account()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error_type"),
+    [
+        pytest.param(ClientConnectionError(), ConnectionFailureError, id="connection"),
+        pytest.param(TimeoutError(), RequestTimeoutError, id="timeout"),
+    ],
+)
+async def test_account_transport_errors(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    side_effect: Exception,
+    error_type: type[Exception],
+) -> None:
+    """Map account endpoint transport failures to typed errors."""
+    aioclient_mock.get(USERINFO_URL, exc=side_effect)
+    with pytest.raises(error_type):
+        await _client(hass).async_get_account()
+
+
+async def test_model_discovery_and_filtering(hass: HomeAssistant) -> None:
+    """Return only entitled Grok language models, including request aliases."""
+    page = AsyncModelPage(
+        [
+            Model(
+                id="grok-4.5",
+                created=1,
+                object="model",
+                owned_by="xai",
+                completion_text_token_price=25000,
+            ),
+            Model(
+                id="latest",
+                created=1,
+                object="model",
+                owned_by="xai",
+                output_modalities=["text"],
+                aliases=["grok-4.3-latest", "grok-latest"],
+            ),
+            Model(
+                id="grok-imagine-1",
+                created=1,
+                object="model",
+                owned_by="xai",
+                image_price=1,
+            ),
+            Model(id="unrelated", created=1, object="model", owned_by="other"),
+        ]
+    )
+    with patch(
+        "openai.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
+        return_value=page,
+    ):
+        models = await _client(hass).async_get_models()
+    assert [model.id for model in models] == ["grok-4.5", "latest"]
+    assert models[1].aliases == ("grok-4.3-latest", "grok-latest")
+    snapshot = ProviderSnapshot(
+        account=AccountInfo("sub", "Name", None),
+        models=models,
+    )
+    assert snapshot.has_model("grok-4.3-latest")
+    assert not snapshot.has_model("grok-imagine-1")
+
+
+async def test_model_discovery_iterates_every_page(hass: HomeAssistant) -> None:
+    """Discover conversation models beyond the first SDK page."""
+    page = AsyncModelPage(
+        [
+            Model(
+                id="grok-page-1",
+                created=1,
+                object="model",
+                owned_by="xai",
+                completion_text_token_price=1,
+            )
+        ],
+        [
+            Model(
+                id="grok-page-2",
+                created=1,
+                object="model",
+                owned_by="xai",
+                completion_text_token_price=1,
+            )
+        ],
+    )
+    with patch(
+        "openai.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
+        return_value=page,
+    ):
+        models = await _client(hass).async_get_models()
+    assert [model.id for model in models] == ["grok-page-1", "grok-page-2"]
+
+
+async def test_model_discovery_translates_pagination_errors(
+    hass: HomeAssistant,
+) -> None:
+    """Keep later-page SDK failures inside the typed client boundary."""
+
+    class _FailingPage:
+        data: list[Model] = []
+
+        def __aiter__(self) -> object:
+            return self
+
+        async def __anext__(self) -> Model:
+            raise _status_error(503)
+
+    with (
+        patch(
+            "openai.resources.models.AsyncModels.list",
+            new_callable=AsyncMock,
+            return_value=_FailingPage(),
+        ),
+        pytest.raises(TransientProviderError),
+    ):
+        await _client(hass).async_get_models()
+
+
+async def test_no_entitled_models(hass: HomeAssistant) -> None:
+    """Treat an empty conversation-model catalog as a distinct entitlement gap."""
+    with (
+        patch(
+            "openai.resources.models.AsyncModels.list",
+            new_callable=AsyncMock,
+            return_value=AsyncModelPage(),
+        ),
+        pytest.raises(NoConversationModelsError),
+    ):
+        await _client(hass).async_get_models()
+
+
+async def test_refresh_rejected() -> None:
+    """Map a rejected refresh grant separately from inference authentication."""
+    session = MagicMock(spec=OAuth2Session)
+    session.async_ensure_token_valid = AsyncMock(
+        side_effect=OAuth2TokenRequestReauthError(
+            request_info=MagicMock(),
+            history=(),
+            status=400,
+            message="invalid_grant",
+            headers=None,
+            domain="spacexai",
+        )
+    )
+    with pytest.raises(RefreshRejectedError) as raised:
+        await OAuthAccessTokenProvider(session).async_get_access_token()
+    assert raised.value.category is ErrorCategory.REFRESH_REJECTED
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error_type"),
+    [
+        pytest.param(TimeoutError(), RequestTimeoutError, id="timeout"),
+        pytest.param(
+            OAuth2TokenRequestTransientError(
+                request_info=MagicMock(),
+                history=(),
+                status=503,
+                message="unavailable",
+                headers=None,
+                domain="spacexai",
+            ),
+            TransientProviderError,
+            id="transient",
+        ),
+        pytest.param(
+            ClientConnectionError(),
+            ConnectionFailureError,
+            id="client-error",
+        ),
+        pytest.param(
+            OAuth2TokenRequestError(
+                request_info=MagicMock(),
+                history=(),
+                status=500,
+                message="failed",
+                headers=None,
+                domain="spacexai",
+            ),
+            ConnectionFailureError,
+            id="token-request-error",
+        ),
+    ],
+)
+async def test_refresh_transport_errors(
+    side_effect: Exception,
+    error_type: type[SpaceXAIError],
+) -> None:
+    """Map refresh transport failures to typed connection/transient errors."""
+    session = MagicMock(spec=OAuth2Session)
+    session.async_ensure_token_valid = AsyncMock(side_effect=side_effect)
+    with pytest.raises(error_type):
+        await OAuthAccessTokenProvider(session).async_get_access_token()
+
+
+async def test_refresh_missing_access_token() -> None:
+    """Reject a refreshed token payload that omits access_token."""
+    session = MagicMock(spec=OAuth2Session)
+    session.async_ensure_token_valid = AsyncMock()
+    session.token = {"token_type": "Bearer"}
+    with pytest.raises(MalformedProviderResponseError):
+        await OAuthAccessTokenProvider(session).async_get_access_token()
+
+
+async def test_refresh_returns_access_token() -> None:
+    """Return the access token after a successful OAuth refresh."""
+    session = MagicMock(spec=OAuth2Session)
+    session.async_ensure_token_valid = AsyncMock()
+    session.token = {"access_token": "rotated-token", "token_type": "Bearer"}
+    assert (
+        await OAuthAccessTokenProvider(session).async_get_access_token()
+        == "rotated-token"
+    )
+
+
+async def test_account_http_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Classify account HTTP entitlement failures through the JSON error body."""
+    aioclient_mock.get(USERINFO_URL, status=403, json={"error": {"code": "denied"}})
+    with pytest.raises(SubscriptionNotEntitledError):
+        await _client(hass).async_get_account()
+
+
+async def test_account_invalid_json(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Treat invalid account JSON as a malformed provider response."""
+    aioclient_mock.get(USERINFO_URL, text="not-json")
+    with pytest.raises(MalformedProviderResponseError):
+        await _client(hass).async_get_account()
+
+
+async def test_account_http_error_with_unreadable_body(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Classify account HTTP errors even when the body cannot be parsed."""
+    aioclient_mock.get(USERINFO_URL, status=401, text="plain")
+    with pytest.raises(AuthenticationRejectedError):
+        await _client(hass).async_get_account()
+
+
+async def test_models_sdk_error(hass: HomeAssistant) -> None:
+    """Translate SDK failures while listing models."""
+    with (
+        patch(
+            "openai.resources.models.AsyncModels.list",
+            new_callable=AsyncMock,
+            side_effect=_status_error(403),
+        ),
+        pytest.raises(SubscriptionNotEntitledError),
+    ):
+        await _client(hass).async_get_models()
+
+
+async def test_async_validate(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Compose account identity and model discovery into one snapshot."""
+    aioclient_mock.get(
+        USERINFO_URL,
+        json={"sub": "account-123", "name": "Home User"},
+    )
+    page = AsyncModelPage(
+        [
+            Model(
+                id="grok-4.5",
+                created=1,
+                object="model",
+                owned_by="xai",
+                completion_text_token_price=1,
+            )
+        ]
+    )
+    with patch(
+        "openai.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
+        return_value=page,
+    ):
+        snapshot = await _client(hass).async_validate()
+    assert snapshot.account.subject == "account-123"
+    assert snapshot.has_model("grok-4.5")
+
+
+async def test_async_validate_checks_subject_before_models(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Fail account mismatch before discovering models for the wrong subject."""
+    aioclient_mock.get(
+        USERINFO_URL,
+        json={"sub": "other-account", "name": "Other"},
+    )
+    with (
+        patch(
+            "openai.resources.models.AsyncModels.list",
+            new_callable=AsyncMock,
+        ) as mock_models,
+        pytest.raises(AccountMismatchError),
+    ):
+        await _client(hass).async_validate(expected_subject="account-123")
+    mock_models.assert_not_awaited()
+
+
+async def test_sdk_client_reuses_and_updates_token(hass: HomeAssistant) -> None:
+    """Reuse one SDK client and rotate its API key across requests."""
+
+    class _FakeSDK:
+        def __init__(self) -> None:
+            self.api_key = "unset"
+            self.models = MagicMock()
+            self.platform_headers = MagicMock()
+
+    page = AsyncModelPage(
+        [
+            Model(
+                id="grok-4.5",
+                created=1,
+                object="model",
+                owned_by="xai",
+                completion_text_token_price=1,
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.async_get_access_token = AsyncMock(side_effect=["token-a", "token-b"])
+    client = SpaceXAIClient(hass, provider, runtime_session=False)
+    sdk = _FakeSDK()
+    sdk.models.list = AsyncMock(return_value=page)
+
+    def _build_sdk(**kwargs: object) -> _FakeSDK:
+        sdk.api_key = kwargs["api_key"]  # type: ignore[assignment]
+        return sdk
+
+    with (
+        patch(
+            "homeassistant.components.spacexai.client.openai.AsyncOpenAI",
+            side_effect=_build_sdk,
+        ) as mock_ctor,
+        patch.object(hass, "async_add_executor_job", new_callable=AsyncMock),
+    ):
+        await client.async_get_models()
+        assert client._sdk_client is sdk
+        assert sdk.api_key == "token-a"
+        assert mock_ctor.call_count == 1
+        await client.async_get_models()
+        assert client._sdk_client is sdk
+        assert sdk.api_key == "token-b"
+        assert mock_ctor.call_count == 1
+
+
+async def test_stream_request_options(hass: HomeAssistant) -> None:
+    """Use streaming, local history, parallel tools, caching, and explicit limits."""
+    stream = EventStream(
+        [
+            ResponseErrorEvent(
+                message="unused",
+                sequence_number=0,
+                type="error",
+            )
+        ]
+    )
+    with patch(
+        "openai.resources.responses.AsyncResponses.create",
+        new_callable=AsyncMock,
+        return_value=stream,
+    ) as create:
+        returned = await _client(hass).async_stream_response(
+            model="grok-4.5",
+            input=[],
+            tools=[],
+            max_output_tokens=2048,
+            prompt_cache_key="conversation-id",
+        )
+    assert returned is stream
+    assert create.call_args.kwargs["stream"] is True
+    assert create.call_args.kwargs["store"] is False
+    assert create.call_args.kwargs["include"] == ["reasoning.encrypted_content"]
+    assert create.call_args.kwargs["parallel_tool_calls"] is False
+    assert create.call_args.kwargs["prompt_cache_key"] == "conversation-id"
+    assert "timeout" not in create.call_args.kwargs
+    assert "text" not in create.call_args.kwargs
+
+
+async def test_stream_create_timeout_is_typed(hass: HomeAssistant) -> None:
+    """Translate a TTFB asyncio timeout into RequestTimeoutError."""
+    with (
+        patch(
+            "openai.resources.responses.AsyncResponses.create",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError(),
+        ),
+        pytest.raises(RequestTimeoutError),
+    ):
+        await _client(hass).async_stream_response(
+            model="grok-4.5",
+            input=[],
+            tools=[],
+            max_output_tokens=2048,
+            prompt_cache_key="conversation-id",
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "model", "body", "runtime", "operation", "error_type"),
+    [
+        pytest.param(
+            401,
+            None,
+            {},
+            False,
+            Operation.RESPONSE,
+            AuthenticationRejectedError,
+            id="401",
+        ),
+        pytest.param(
+            401,
+            None,
+            {},
+            True,
+            Operation.RESPONSE,
+            ReauthenticationRequiredError,
+            id="runtime-401",
+        ),
+        pytest.param(
+            402, None, {}, False, Operation.RESPONSE, QuotaLimitedError, id="402"
+        ),
+        pytest.param(
+            403,
+            None,
+            {},
+            False,
+            Operation.RESPONSE,
+            SubscriptionNotEntitledError,
+            id="403-response",
+        ),
+        pytest.param(
+            403,
+            None,
+            {},
+            False,
+            Operation.MODELS,
+            SubscriptionNotEntitledError,
+            id="403-models",
+        ),
+        pytest.param(
+            403,
+            None,
+            {},
+            False,
+            Operation.ACCOUNT,
+            SubscriptionNotEntitledError,
+            id="403-account",
+        ),
+        pytest.param(
+            403,
+            None,
+            {},
+            False,
+            Operation.REVOCATION,
+            PermanentProviderError,
+            id="403-revocation",
+        ),
+        pytest.param(
+            403,
+            None,
+            {"error": {"code": "subscription_required", "message": "inactive"}},
+            False,
+            Operation.REVOCATION,
+            SubscriptionNotEntitledError,
+            id="403-revocation-subscription-code",
+        ),
+        pytest.param(
+            403,
+            None,
+            {"error": {"code": "permission_denied"}},
+            False,
+            Operation.RESPONSE,
+            PermanentProviderError,
+            id="403-response-permission-denied",
+        ),
+        pytest.param(
+            403,
+            None,
+            {
+                "error": {
+                    "message": "Subscription inactive; account is not entitled",
+                }
+            },
+            False,
+            Operation.REVOCATION,
+            SubscriptionNotEntitledError,
+            id="403-revocation-subscription-message",
+        ),
+        pytest.param(
+            404,
+            "grok-4.5",
+            {"code": "model"},
+            False,
+            Operation.RESPONSE,
+            ModelNotEntitledError,
+            id="404",
+        ),
+        pytest.param(
+            408, None, {}, False, Operation.RESPONSE, RequestTimeoutError, id="408"
+        ),
+        pytest.param(
+            429, None, {}, False, Operation.RESPONSE, RateLimitedError, id="429"
+        ),
+        pytest.param(
+            500, None, {}, False, Operation.RESPONSE, TransientProviderError, id="5xx"
+        ),
+        pytest.param(
+            400,
+            None,
+            {
+                "code": "invalid-argument",
+                "error": (
+                    "Incorrect API key provided. You can obtain an API key "
+                    "from https://console.x.ai."
+                ),
+            },
+            False,
+            Operation.RESPONSE,
+            AuthenticationRejectedError,
+            id="400-credential",
+        ),
+        pytest.param(
+            400,
+            None,
+            {"code": "invalid_token"},
+            False,
+            Operation.RESPONSE,
+            AuthenticationRejectedError,
+            id="400-invalid-token-code",
+        ),
+        pytest.param(
+            400,
+            None,
+            {"error": {"message": "Incorrect API key provided"}},
+            False,
+            Operation.RESPONSE,
+            AuthenticationRejectedError,
+            id="400-nested-error-message",
+        ),
+        pytest.param(
+            400,
+            None,
+            {"error": 1, "message": "Incorrect API key provided"},
+            False,
+            Operation.RESPONSE,
+            AuthenticationRejectedError,
+            id="400-fallback-message",
+        ),
+        pytest.param(
+            400,
+            None,
+            {
+                "code": "invalid-argument",
+                "error": "Request mentioned an api key field incorrectly",
+            },
+            False,
+            Operation.RESPONSE,
+            PermanentProviderError,
+            id="400-bare-api-key-not-credential",
+        ),
+        pytest.param(
+            400,
+            None,
+            None,
+            False,
+            Operation.RESPONSE,
+            PermanentProviderError,
+            id="400-non-mapping-body",
+        ),
+    ],
+)
+def test_status_classification(
+    hass: HomeAssistant,
+    status: int,
+    model: str | None,
+    body: object,
+    runtime: bool,
+    operation: Operation,
+    error_type: type[SpaceXAIError],
+) -> None:
+    """Classify provider status families, including runtime reauthentication."""
+    error = _client(hass, runtime=runtime).translate_sdk_error(
+        _status_error(status, body),
+        ErrorContext(operation=operation, model=model),
+    )
+    assert isinstance(error, error_type)
+    assert error.context.operation is operation
+    assert error.context.model == model
+
+
+async def test_revoke(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
+    """Send refresh-token revocation data on success."""
+    aioclient_mock.post(REVOCATION_URL, status=200)
+    await _client(hass).async_revoke("refresh", "client", "secret")
+    assert aioclient_mock.mock_calls[0][2]["token"] == "refresh"
+    assert aioclient_mock.mock_calls[0][2]["client_secret"] == "secret"
+
+
+async def test_revoke_timeout(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Surface TimeoutError while revoking a refresh token."""
+    aioclient_mock.post(REVOCATION_URL, exc=TimeoutError())
+    with pytest.raises(RequestTimeoutError):
+        await _client(hass).async_revoke("refresh-token", "client-id")
+
+
+async def test_revoke_http_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Classify revocation HTTP failures."""
+    aioclient_mock.post(REVOCATION_URL, status=401)
+    with pytest.raises(AuthenticationRejectedError):
+        await _client(hass).async_revoke("refresh-token", "client-id")
+
+
+async def test_revoke_connection_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Surface connection failures while revoking a refresh token."""
+    aioclient_mock.post(REVOCATION_URL, exc=ClientConnectionError())
+    with pytest.raises(ConnectionFailureError):
+        await _client(hass).async_revoke("refresh-token", "client-id")
+
+
+@pytest.mark.parametrize(
+    ("err", "error_type"),
+    [
+        pytest.param(
+            APITimeoutError(request=httpx.Request("GET", "https://api.x.ai/v1")),
+            RequestTimeoutError,
+            id="timeout",
+        ),
+        pytest.param(
+            APIConnectionError(request=httpx.Request("GET", "https://api.x.ai/v1")),
+            ConnectionFailureError,
+            id="connection",
+        ),
+        pytest.param(OpenAIError("denied"), PermanentProviderError, id="generic"),
+    ],
+)
+def test_translate_non_status_sdk_errors(
+    hass: HomeAssistant,
+    err: Exception,
+    error_type: type[SpaceXAIError],
+) -> None:
+    """Translate non-status SDK failures at the client boundary."""
+    assert isinstance(
+        _client(hass).translate_sdk_error(
+            err, ErrorContext(operation=Operation.RESPONSE)
+        ),
+        error_type,
+    )
+
+
+def test_provider_error_helpers_accept_non_mapping_bodies(hass: HomeAssistant) -> None:
+    """Ignore non-mapping provider bodies while classifying failures."""
+    error = _client(hass).translate_sdk_error(
+        _status_error(400, "not-a-mapping"),
+        ErrorContext(operation=Operation.RESPONSE),
+    )
+    assert isinstance(error, PermanentProviderError)
+
+
+def test_subscription_and_permission_denial_helpers() -> None:
+    """Keep body/code helpers tight for subscription vs permission 403s."""
+    assert not _is_subscription_denial(400, None, None)
+    assert _is_subscription_denial(
+        403, None, {"error": {"message": "Subscription required for access"}}
+    )
+    assert _is_permission_denial(
+        None, {"error": {"message": "Permission denied for this resource"}}
+    )
+
+
+async def test_safe_json_returns_none_on_decode_error() -> None:
+    """Ignore unreadable error bodies while classifying HTTP failures."""
+    response = AsyncMock()
+    response.json = AsyncMock(side_effect=ValueError("bad json"))
+    assert await _safe_json(response) is None
+
+
+async def test_sdk_schema_violation_is_malformed(hass: HomeAssistant) -> None:
+    """Treat an SDK schema violation on create as a malformed provider response."""
+    with (
+        patch(
+            "openai.resources.responses.AsyncResponses.create",
+            new_callable=AsyncMock,
+            side_effect=ValidationError.from_exception_data("Response", []),
+        ),
+        pytest.raises(MalformedProviderResponseError),
+    ):
+        await _client(hass).async_stream_response(
+            model="grok-4.5",
+            input=[],
+            tools=[],
+            max_output_tokens=2048,
+            prompt_cache_key="conversation-id",
+        )
+
+
+def test_error_category_values_match_translation_keys() -> None:
+    """Ensure every closed error category value is a strings.json exception key."""
+    assert {category.value for category in ErrorCategory} == {
+        "authentication_rejected",
+        "refresh_rejected",
+        "reauthentication_required",
+        "account_mismatch",
+        "subscription_not_entitled",
+        "no_conversation_models",
+        "model_not_entitled",
+        "rate_limited",
+        "quota_limited",
+        "timeout",
+        "connection_failure",
+        "transient_provider_failure",
+        "malformed_provider_response",
+        "invalid_model_tool_request",
+        "home_assistant_tool_failure",
+        "tool_loop_limit",
+        "output_limit",
+        "permanent_provider_failure",
+    }

--- a/tests/components/spacexai/test_config_flow.py
+++ b/tests/components/spacexai/test_config_flow.py
@@ -1,0 +1,959 @@
+"""Tests for the SpaceXAI config flow."""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.application_credentials import (
+    DOMAIN as APPLICATION_CREDENTIALS_DOMAIN,
+)
+from homeassistant.components.spacexai.client import (
+    AccountInfo,
+    ModelInfo,
+    ProviderSnapshot,
+)
+from homeassistant.components.spacexai.const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MODEL,
+    DOMAIN,
+    OAUTH_SCOPES,
+    TOKEN_URL,
+)
+from homeassistant.components.spacexai.errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    ErrorContext,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    SubscriptionNotEntitledError,
+)
+from homeassistant.const import (
+    CONF_LLM_HASS_API,
+    CONF_MODEL,
+    CONF_PROMPT,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er, issue_registry as ir, llm
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
+)
+from homeassistant.setup import async_setup_component
+
+from . import AGENT_ID, conversation_subentry
+from .conftest import ACCESS_TOKEN, ACCOUNT_ID
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
+
+REDIRECT_URI = "https://example.com/auth/external/callback"
+CONVERSATION_DATA = {
+    CONF_MODEL: DEFAULT_MODEL,
+    CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+    CONF_PROMPT: "Be concise.",
+    CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+}
+
+
+async def _start_flow(hass: HomeAssistant) -> config_entries.ConfigFlowResult:
+    """Start a user OAuth flow."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+
+async def _complete_oauth(
+    hass: HomeAssistant,
+    result: config_entries.ConfigFlowResult,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    token_response: dict[str, object] | None = None,
+) -> config_entries.ConfigFlowResult:
+    """Complete the browser callback and exchange the authorization code."""
+    query = parse_qs(urlparse(result["url"]).query)
+    client = await hass_client_no_auth()
+    response = await client.get(
+        f"/auth/external/callback?code=authorization-code&state={query['state'][0]}"
+    )
+    assert response.status == HTTPStatus.OK
+    aioclient_mock.post(
+        TOKEN_URL,
+        json=token_response
+        or {
+            "access_token": ACCESS_TOKEN,
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+    return await hass.config_entries.flow.async_configure(result["flow_id"])
+
+
+async def test_missing_credentials(hass: HomeAssistant) -> None:
+    """Abort when SpaceXAI has not issued a Home Assistant OAuth identity."""
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    result = await _start_flow(hass)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_credentials"
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_oauth_implementation_unavailable(hass: HomeAssistant) -> None:
+    """Abort when Application Credentials cannot resolve an OAuth implementation."""
+    with patch(
+        "homeassistant.components.spacexai.config_flow.async_get_implementations",
+        side_effect=ImplementationUnavailableError,
+    ):
+        result = await _start_flow(hass)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_implementation_unavailable"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_full_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+) -> None:
+    """Complete Authorization Code + PKCE and configure Grok."""
+    result = await _start_flow(hass)
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    parsed = urlparse(result["url"])
+    query = {key: value[0] for key, value in parse_qs(parsed.query).items()}
+    assert parsed.geturl().startswith("https://auth.x.ai/oauth2/authorize")
+    assert query["client_id"] == "home-assistant-client"
+    assert query["redirect_uri"] == REDIRECT_URI
+    assert query["scope"] == " ".join(OAUTH_SCOPES)
+    assert query["code_challenge_method"] == "S256"
+    assert "code_challenge" in query
+
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "conversation"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], CONVERSATION_DATA
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Home User"
+    assert result["result"].unique_id == ACCOUNT_ID
+    assert result["data"]["token"]["access_token"] == ACCESS_TOKEN
+    subentries = list(result["result"].subentries.values())
+    assert len(subentries) == 1
+    assert subentries[0].subentry_type == "conversation"
+    assert subentries[0].data == CONVERSATION_DATA
+    assert mock_validate.await_count == 2
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_initial_conversation_rejects_withdrawn_model(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+) -> None:
+    """Abort create_entry when the selected model disappears before save."""
+    result = await _start_flow(hass)
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "conversation"
+
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-fresh", "xai"),),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], CONVERSATION_DATA
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "model_not_entitled"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_initial_conversation_refresh_cannot_connect(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+) -> None:
+    """Abort create_entry when the pre-save catalog refresh cannot connect."""
+    result = await _start_flow(hass)
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "conversation"
+
+    mock_validate.side_effect = ConnectionFailureError(
+        "offline",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], CONVERSATION_DATA
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+@pytest.mark.parametrize(
+    "token_response",
+    [
+        pytest.param(
+            {
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+            id="access-token",
+        ),
+        pytest.param(
+            {
+                "access_token": ACCESS_TOKEN,
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+            id="refresh-token",
+        ),
+    ],
+)
+async def test_oauth_token_missing_required_token(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    token_response: dict[str, object],
+) -> None:
+    """Abort if the provider token response violates the OAuth contract."""
+    result = await _start_flow(hass)
+    result = await _complete_oauth(
+        hass,
+        result,
+        hass_client_no_auth,
+        aioclient_mock,
+        token_response,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_error"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "setup_credentials",
+    "mock_setup_entry",
+    "mock_validate",
+)
+async def test_duplicate_account(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Reject a duplicate account."""
+    result = await _start_flow(hass)
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        pytest.param(
+            AuthenticationRejectedError(
+                "rejected",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            "oauth_unauthorized",
+            id="authentication",
+        ),
+        pytest.param(
+            SubscriptionNotEntitledError(
+                "not entitled",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "subscription_not_entitled",
+            id="subscription",
+        ),
+        pytest.param(
+            QuotaLimitedError(
+                "quota",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "quota_limited",
+            id="quota",
+        ),
+        pytest.param(
+            MalformedProviderResponseError(
+                "malformed",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            "malformed_provider_response",
+            id="malformed",
+        ),
+        pytest.param(
+            ModelNotEntitledError(
+                "no models",
+                context=ErrorContext(operation=Operation.MODELS, model="Grok"),
+            ),
+            "model_not_entitled",
+            id="models",
+        ),
+        pytest.param(
+            NoConversationModelsError(
+                "none",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "no_conversation_models",
+            id="no-conversation-models",
+        ),
+        pytest.param(
+            PermanentProviderError(
+                "permanent",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "unknown",
+            id="unexpected-classified",
+        ),
+    ],
+)
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_validation_abort(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    error: Exception,
+    reason: str,
+) -> None:
+    """Map permanent account validation failures to translated aborts."""
+    mock_validate.side_effect = error
+    result = await _start_flow(hass)
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_validation_recovers(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    provider_snapshot: ProviderSnapshot,
+) -> None:
+    """Allow retrying a transient provider validation failure."""
+    mock_validate.side_effect = [
+        ConnectionFailureError(
+            "offline",
+            context=ErrorContext(operation=Operation.MODELS),
+        ),
+        provider_snapshot,
+    ]
+    result = await _start_flow(hass)
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "validate"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "conversation"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "setup_credentials",
+    "mock_setup_entry",
+    "mock_validate",
+)
+async def test_reauth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Update OAuth tokens after reauthentication."""
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data["token"]["access_token"] == ACCESS_TOKEN
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_reauth_account_mismatch(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Reject reauthentication with a different account before model discovery."""
+    mock_validate.side_effect = AccountMismatchError(
+        "mismatch",
+        context=ErrorContext(operation=Operation.ACCOUNT),
+    )
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "account_mismatch"
+    mock_validate.assert_awaited()
+    assert mock_validate.await_args.kwargs.get("expected_subject") == ACCOUNT_ID
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_reauth_subscription_failure_creates_repair(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Create the entry-scoped subscription repair when reauth is denied."""
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "subscription_not_entitled"
+    assert issue_registry.async_get_issue(
+        DOMAIN, f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    )
+
+
+@pytest.mark.usefixtures("current_request_with_host", "setup_credentials")
+async def test_reauth_subscription_failure_marks_loaded_entities(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Mark loaded conversation entities unavailable on reauth subscription denial."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "subscription_not_entitled"
+    assert issue_registry.async_get_issue(
+        DOMAIN, f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    )
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_reauth_with_withdrawn_model(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_validate: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Complete reauthentication even when a configured model was withdrawn."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await _complete_oauth(hass, result, hass_client_no_auth, aioclient_mock)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data["token"]["access_token"] == ACCESS_TOKEN
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_creating_conversation_subentry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Create an additional conversation subentry with its own entity."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    original_subentry = conversation_subentry(mock_config_entry)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "grok-4.3",
+            CONF_MAX_OUTPUT_TOKENS: 1024,
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(mock_config_entry.subentries) == 2
+    added_subentry = next(
+        subentry
+        for subentry in mock_config_entry.subentries.values()
+        if subentry.subentry_type == "conversation"
+        and subentry.subentry_id != original_subentry.subentry_id
+    )
+    assert added_subentry.title == "Grok"
+    assert added_subentry.data == {
+        CONF_MODEL: "grok-4.3",
+        CONF_MAX_OUTPUT_TOKENS: 1024,
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+    }
+    await hass.async_block_till_done()
+    assert {
+        entity.config_subentry_id
+        for entity in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    } == {subentry.subentry_id for subentry in mock_config_entry.subentries.values()}
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_reconfigure_conversation_subentry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+) -> None:
+    """Update model settings on an existing conversation subentry."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    subentry = conversation_subentry(mock_config_entry)
+    mock_validate.reset_mock()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": "reconfigure", "subentry_id": subentry.subentry_id},
+    )
+    assert mock_validate.await_args.kwargs.get("expected_subject") == ACCOUNT_ID
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "grok-4.3",
+            CONF_MAX_OUTPUT_TOKENS: 4096,
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert subentry.data[CONF_MAX_OUTPUT_TOKENS] == 4096
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_reconfigure_withdrawn_model(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Allow model replacement while the configured model is unavailable."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    subentry = conversation_subentry(mock_config_entry)
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": "reconfigure", "subentry_id": subentry.subentry_id},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "grok-other",
+            CONF_MAX_OUTPUT_TOKENS: 2048,
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert subentry.data[CONF_MODEL] == "grok-other"
+    await hass.async_block_till_done()
+    assert not issue_registry.async_get_issue(
+        DOMAIN, f"model_not_entitled_{subentry.subentry_id}"
+    )
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subentry_refreshes_model_catalog(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+) -> None:
+    """Refresh the provider model catalog before showing the subentry form."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-fresh", "xai"),),
+    )
+    mock_validate.reset_mock()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    mock_validate.assert_awaited()
+    assert mock_config_entry.runtime_data.snapshot.has_model("grok-fresh")
+    model_options = result["data_schema"].schema[CONF_MODEL].config["options"]
+    assert {option["value"] for option in model_options} == {"grok-fresh"}
+
+
+@pytest.mark.usefixtures("setup_credentials")
+@pytest.mark.parametrize(
+    ("error", "reason", "starts_reauth"),
+    [
+        pytest.param(
+            ConnectionFailureError(
+                "offline",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "cannot_connect",
+            False,
+            id="cannot-connect",
+        ),
+        pytest.param(
+            ReauthenticationRequiredError(
+                "reauth",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            "oauth_unauthorized",
+            True,
+            id="reauth-required",
+        ),
+        pytest.param(
+            RefreshRejectedError(
+                "refresh",
+                context=ErrorContext(operation=Operation.REFRESH),
+            ),
+            "oauth_unauthorized",
+            True,
+            id="refresh-rejected",
+        ),
+        pytest.param(
+            AccountMismatchError(
+                "mismatch",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            "oauth_unauthorized",
+            True,
+            id="account-mismatch",
+        ),
+        pytest.param(
+            SubscriptionNotEntitledError(
+                "sub",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "subscription_not_entitled",
+            False,
+            id="subscription",
+        ),
+        pytest.param(
+            NoConversationModelsError(
+                "none",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "no_conversation_models",
+            False,
+            id="no-models",
+        ),
+        pytest.param(
+            QuotaLimitedError(
+                "quota",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "quota_limited",
+            False,
+            id="quota",
+        ),
+        pytest.param(
+            ModelNotEntitledError(
+                "model",
+                context=ErrorContext(operation=Operation.MODELS, model="grok-old"),
+            ),
+            "model_not_entitled",
+            False,
+            id="model-not-entitled",
+        ),
+        pytest.param(
+            MalformedProviderResponseError(
+                "bad",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "malformed_provider_response",
+            False,
+            id="malformed",
+        ),
+        pytest.param(
+            PermanentProviderError(
+                "denied",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            "unknown",
+            False,
+            id="unknown",
+        ),
+    ],
+)
+async def test_subentry_aborts_when_catalog_refresh_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    error: Exception,
+    reason: str,
+    starts_reauth: bool,
+) -> None:
+    """Abort subentry configuration with the classified catalog-refresh reason."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    mock_validate.side_effect = error
+    with patch.object(mock_config_entry, "async_start_reauth") as start_reauth:
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, "conversation"),
+            context={"source": config_entries.SOURCE_USER},
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+    assert start_reauth.called is starts_reauth
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subentry_subscription_failure_creates_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Surface a subscription repair when subentry catalog refresh is denied."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "sub",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "subscription_not_entitled"
+    assert issue_registry.async_get_issue(
+        DOMAIN, f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    )
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subentry_submit_rejects_withdrawn_model(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+) -> None:
+    """Abort when a submitted model disappears from the refreshed catalog."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-fresh", "xai"),),
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: DEFAULT_MODEL,
+            CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+            CONF_PROMPT: "Be concise.",
+            CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "model_not_entitled"
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_successful_subentry_refresh_clears_subscription_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Clear a stale subscription repair after a successful catalog snapshot."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    issue_id = f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="subscription_not_entitled",
+    )
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo(DEFAULT_MODEL, "xai"),),
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_reconfigure_filters_stale_llm_apis(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Drop stored LLM API ids that are no longer registered."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    subentry = conversation_subentry(mock_config_entry)
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        subentry,
+        data={
+            **subentry.data,
+            CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, "missing-api"],
+        },
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": "reconfigure", "subentry_id": subentry.subentry_id},
+    )
+    assert result["type"] is FlowResultType.FORM
+    llm_key = next(
+        key for key in result["data_schema"].schema if key == CONF_LLM_HASS_API
+    )
+    assert llm_key.default() == [llm.LLM_API_ASSIST]
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_reconfigure_preserves_cleared_llm_api(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Do not re-select Assist when the stored subentry has no LLM APIs."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    subentry = conversation_subentry(mock_config_entry)
+    data = dict(subentry.data)
+    data.pop(CONF_LLM_HASS_API)
+    hass.config_entries.async_update_subentry(mock_config_entry, subentry, data=data)
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": "reconfigure", "subentry_id": subentry.subentry_id},
+    )
+    assert result["type"] is FlowResultType.FORM
+    llm_key = next(
+        key for key in result["data_schema"].schema if key == CONF_LLM_HASS_API
+    )
+    assert llm_key.default() == []
+
+
+async def test_subentry_requires_loaded_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Abort subentry changes while the parent entry is not loaded."""
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_not_loaded"
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+@pytest.mark.parametrize(
+    ("stored_api", "expected"),
+    [
+        pytest.param(llm.LLM_API_ASSIST, [llm.LLM_API_ASSIST], id="string"),
+        pytest.param(1, [], id="non-list"),
+    ],
+)
+async def test_reconfigure_defaults_non_list_llm_api(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    stored_api: str | int,
+    expected: list[str],
+) -> None:
+    """Normalize stored LLM API values that are not a list of ids."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    subentry = conversation_subentry(mock_config_entry)
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        subentry,
+        data={
+            **subentry.data,
+            CONF_LLM_HASS_API: stored_api,
+        },
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "conversation"),
+        context={"source": "reconfigure", "subentry_id": subentry.subentry_id},
+    )
+    assert result["type"] is FlowResultType.FORM
+    llm_key = next(
+        key for key in result["data_schema"].schema if key == CONF_LLM_HASS_API
+    )
+    assert llm_key.default() == expected
+
+
+async def test_missing_configuration(hass: HomeAssistant) -> None:
+    """Abort when the integration exposes no Application Credentials platform."""
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    with patch(
+        "homeassistant.components.spacexai.config_flow.async_get_application_credentials",
+        return_value=[],
+    ):
+        result = await _start_flow(hass)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_configuration"

--- a/tests/components/spacexai/test_conversation.py
+++ b/tests/components/spacexai/test_conversation.py
@@ -1,0 +1,1385 @@
+"""Tests for SpaceXAI Conversation."""
+
+import asyncio
+import contextlib
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from freezegun import freeze_time
+import httpx
+from openai import OpenAIError
+from openai.types.responses import (
+    ResponseInProgressEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+    ResponseReasoningItem,
+    ResponseReasoningSummaryTextDeltaEvent,
+    ResponseRefusalDeltaEvent,
+    ResponseStreamEvent,
+    ResponseTextDeltaEvent,
+)
+from pydantic import ValidationError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components import conversation
+from homeassistant.components.conversation import trace
+from homeassistant.components.spacexai.client import (
+    AccountInfo,
+    ModelInfo,
+    ProviderSnapshot,
+)
+from homeassistant.components.spacexai.const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MODEL,
+    MAX_TOOL_ITERATIONS,
+)
+from homeassistant.components.spacexai.conversation import SpaceXAIConversationEntity
+from homeassistant.components.spacexai.entity import _format_tool, _stream_failure
+from homeassistant.components.spacexai.errors import (
+    ErrorContext,
+    ModelNotEntitledError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    ReauthenticationRequiredError,
+    SubscriptionNotEntitledError,
+)
+from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.const import (
+    CONF_LLM_HASS_API,
+    CONF_MODEL,
+    CONF_PROMPT,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    device_registry as dr,
+    intent,
+    issue_registry as ir,
+    llm,
+)
+
+from . import (
+    AGENT_ID,
+    EventStream,
+    completed_event,
+    conversation_subentry,
+    converse,
+    error_event,
+    failed_event,
+    incomplete_event,
+    message_events,
+    response_payload,
+    tool_args_done,
+    tool_call_added,
+    tool_events,
+    usage_completed_events,
+)
+from .conftest import ACCESS_TOKEN, ACCOUNT_ID
+
+from tests.common import MockConfigEntry
+from tests.components.conversation import (
+    MockChatLog,
+    mock_chat_log,  # noqa: F401
+)
+
+PRIMARY_AGENT_ID = "conversation.grok_primary"
+SECONDARY_AGENT_ID = "conversation.grok_secondary"
+
+
+def _two_agent_entry(template: MockConfigEntry) -> MockConfigEntry:
+    """Build an entry with two conversation agents from a fixture template."""
+    return MockConfigEntry(
+        domain="spacexai",
+        title="Home User",
+        unique_id=ACCOUNT_ID,
+        data=dict(template.data),
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    CONF_MODEL: DEFAULT_MODEL,
+                    CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+                    CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+                },
+                subentry_type="conversation",
+                title="Grok Primary",
+                unique_id=None,
+            ),
+            ConfigSubentryData(
+                data={
+                    CONF_MODEL: "grok-4.3",
+                    CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+                    CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+                },
+                subentry_type="conversation",
+                title="Grok Secondary",
+                unique_id=None,
+            ),
+        ],
+    )
+
+
+async def test_conversation_entity_registers_service_device(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Expose a control-capable Conversation entity backed by a service device."""
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert (
+        state.attributes["supported_features"]
+        == conversation.ConversationEntityFeature.CONTROL
+    )
+
+    subentry = conversation_subentry(setup_integration)
+    device = device_registry.async_get_device_by_identifier(
+        ("spacexai", subentry.subentry_id), setup_integration.entry_id
+    )
+    assert device is not None
+    assert device.manufacturer == "SpaceXAI"
+    assert device.model_id == DEFAULT_MODEL
+    assert device.entry_type is dr.DeviceEntryType.SERVICE
+    assert (
+        conversation.agent_manager.async_get_agent(hass, AGENT_ID).supported_languages
+        == "*"
+    )
+
+
+@freeze_time("2026-01-15 12:00:00")
+@pytest.mark.usefixtures("setup_integration")
+async def test_system_prompt_includes_runtime_identity(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Seed Assist instructions with HA version, model, and provider identity."""
+    with patch(
+        "homeassistant.components.spacexai.conversation.HA_VERSION",
+        "2026.9.0.dev0",
+    ):
+        await converse(hass, "What versions are you?")
+    system_message = next(
+        item
+        for item in mock_stream.call_args.kwargs["input"]
+        if item.get("type") == "message" and item.get("role") == "system"
+    )
+    assert system_message["content"] == snapshot
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_completed_stream_traces_usage_and_closes(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Close the SDK stream and publish token usage on a completed response."""
+    trace.async_clear_traces()
+    stream = EventStream(
+        usage_completed_events(
+            "Hello from Grok",
+            input_tokens=11,
+            cached_tokens=3,
+            output_tokens=7,
+        )
+    )
+    mock_stream.return_value = stream
+
+    result = await converse(hass, "Hello")
+
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech["plain"]["speech"] == "Hello from Grok"
+    assert stream.closed
+    stats = next(
+        (
+            event["data"]["stats"]
+            for trace_obj in trace.async_get_traces()
+            for event in trace_obj.as_dict().get("events", [])
+            if event.get("event_type") == "agent_detail"
+            and event.get("data", {}).get("stats")
+        ),
+        None,
+    )
+    assert stats == {
+        "input_tokens": 11,
+        "cached_input_tokens": 3,
+        "output_tokens": 7,
+    }
+
+
+@freeze_time("2026-01-15 12:00:00")
+@pytest.mark.usefixtures("setup_integration")
+async def test_continuation_reuses_history_and_prompt_cache_key(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Continue a chat with prior turns and the conversation id as cache key."""
+    mock_stream.return_value = EventStream(message_events("Hello from Grok"))
+    first = await converse(hass, "Hello")
+
+    mock_stream.return_value = EventStream(message_events("Welcome back"))
+    second = await converse(hass, "Remember me?", first.conversation_id)
+
+    assert second.conversation_id == first.conversation_id
+    assert second.response.speech["plain"]["speech"] == "Welcome back"
+    assert mock_stream.call_args.kwargs["prompt_cache_key"] == first.conversation_id
+    assert mock_stream.call_args.kwargs["max_output_tokens"] == 2048
+    assert mock_stream.call_args.kwargs["input"][1:] == snapshot
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_tool_arguments_done_without_name_uses_announced_tool(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Accept xAI streams that omit name on function_call_arguments.done."""
+    mock_stream.side_effect = [
+        EventStream(
+            [
+                tool_call_added(
+                    item_id="item_0",
+                    call_id="call_1",
+                    name="test_tool",
+                ),
+                tool_args_done(
+                    item_id="item_0",
+                    name=None,
+                    arguments='{"value": 1}',
+                ),
+                completed_event(2),
+            ]
+        ),
+        EventStream(message_events("Done")),
+    ]
+    mock_chat_log.mock_tool_results({"call_1": {"result": "ok"}})
+
+    result = await converse(hass, "Run tool", mock_chat_log.conversation_id)
+
+    assert result.response.speech["plain"]["speech"] == "Done"
+    outputs = [
+        item
+        for item in mock_stream.call_args.kwargs["input"]
+        if item["type"] == "function_call_output"
+    ]
+    assert [item["call_id"] for item in outputs] == ["call_1"]
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_failed_stream_does_not_execute_buffered_tool_calls(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Do not run Assist tools when the provider stream fails after tool args."""
+    mock_stream.return_value = EventStream(
+        [
+            *tool_events(("call_1", "test_tool", '{"value": 1}'), complete=False),
+            failed_event("server_error", "failed"),
+        ]
+    )
+    mock_chat_log.mock_tool_results({"call_1": {"result": "should-not-run"}})
+
+    result = await converse(hass, "Run tool", mock_chat_log.conversation_id)
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert mock_stream.await_count == 1
+    assert not any(
+        isinstance(item, conversation.ToolResultContent)
+        for item in mock_chat_log.content
+    )
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_tool_then_text_preserves_provider_output_order(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Keep tool calls ahead of later text when buffering until stream end."""
+    mock_stream.return_value = EventStream(
+        [
+            *tool_events(("call_1", "test_tool", '{"value": 1}'), complete=False),
+            *message_events("After the tool", complete=True),
+        ]
+    )
+    mock_chat_log.mock_tool_results({"call_1": {"result": "one"}})
+
+    result = await converse(hass, "Use a tool", mock_chat_log.conversation_id)
+
+    assert result.response.speech["plain"]["speech"] == "After the tool"
+    tool_index = next(
+        index
+        for index, item in enumerate(mock_chat_log.content)
+        if isinstance(item, conversation.AssistantContent) and item.tool_calls
+    )
+    text_index = next(
+        index
+        for index, item in enumerate(mock_chat_log.content)
+        if isinstance(item, conversation.AssistantContent)
+        and item.content == "After the tool"
+    )
+    assert tool_index < text_index
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_multiple_tool_calls_in_one_response_are_rejected(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Reject multi-tool responses until ChatLog cancels sibling tool tasks."""
+    mock_stream.return_value = EventStream(
+        tool_events(
+            ("call_1", "test_tool", '{"value": 1}'),
+            ("call_2", "test_tool", '{"value": 2}'),
+        )
+    )
+    mock_chat_log.mock_tool_results(
+        {
+            "call_1": {"result": "one"},
+            "call_2": {"result": "two"},
+        }
+    )
+
+    result = await converse(hass, "Run tools", mock_chat_log.conversation_id)
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert mock_stream.await_count == 1
+    assert not any(
+        isinstance(item, conversation.ToolResultContent)
+        for item in mock_chat_log.content
+    )
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_tool_failure_is_returned_to_provider(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keep a Home Assistant tool failure explicit in the model loop."""
+    mock_stream.side_effect = [
+        EventStream(tool_events(("call_1", "missing_tool", "{}"))),
+        EventStream(message_events("The tool failed")),
+    ]
+    mock_chat_log.mock_tool_results(
+        {"call_1": {"error": "HomeAssistantError", "error_text": "Tool not found"}}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = await converse(hass, "Use missing", mock_chat_log.conversation_id)
+
+    assert result.response.speech["plain"]["speech"] == "The tool failed"
+    assert "category=home_assistant_tool_failure" in caplog.text
+    assert "tool=missing_tool" in caplog.text
+    outputs = [
+        item
+        for item in mock_stream.call_args.kwargs["input"]
+        if item["type"] == "function_call_output"
+    ]
+    assert json.loads(outputs[0]["output"]) == {
+        "error": "HomeAssistantError",
+        "error_text": "Tool not found",
+    }
+
+
+def test_format_tool_strips_unsupported_top_level_schema_keys() -> None:
+    """Strip Assist schema keys that the provider rejects at the top level."""
+    tool = MagicMock(spec=llm.Tool)
+    tool.name = "test_tool"
+    tool.description = "desc"
+    tool.parameters = MagicMock()
+    with patch(
+        "homeassistant.components.spacexai.entity.convert",
+        return_value={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "oneOf": [{"required": ["value"]}],
+            "enum": ["a"],
+        },
+    ):
+        formatted = _format_tool(tool, None)
+    assert formatted["parameters"] == {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+    }
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_tool_loop_is_bounded(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Stop after MAX_TOOL_ITERATIONS tool rounds without a final answer."""
+    mock_stream.side_effect = [
+        EventStream(tool_events((f"call_{index}", "test_tool", "{}")))
+        for index in range(MAX_TOOL_ITERATIONS)
+    ]
+    mock_chat_log.mock_tool_results(
+        {f"call_{index}": {"result": "ok"} for index in range(MAX_TOOL_ITERATIONS)}
+    )
+
+    result = await converse(hass, "Loop", mock_chat_log.conversation_id)
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert mock_stream.await_count == MAX_TOOL_ITERATIONS
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_auth_error_starts_reauthentication(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Mark the entity unavailable and start reauth on runtime auth failure."""
+    mock_stream.side_effect = ReauthenticationRequiredError(
+        "expired",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    flows = hass.config_entries.flow.async_progress_by_handler("spacexai")
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_quota_limited_marks_entity_unavailable(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mark the entity unavailable when the subscription quota is exhausted."""
+    mock_stream.side_effect = QuotaLimitedError(
+        "quota",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    with caplog.at_level(logging.INFO):
+        result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert "SpaceXAI is unavailable:" in caplog.text
+    assert "category=quota_limited" in caplog.text
+
+
+async def test_subscription_not_entitled_marks_entity_unavailable(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_stream: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mark the entity unavailable and raise the subscription repair on denial."""
+    mock_stream.side_effect = SubscriptionNotEntitledError(
+        "subscription",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    with caplog.at_level(logging.INFO):
+        result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert issue_registry.async_get_issue(
+        "spacexai", f"subscription_not_entitled_{setup_integration.entry_id}"
+    )
+    assert "SpaceXAI is unavailable:" in caplog.text
+    assert "category=subscription_not_entitled" in caplog.text
+
+
+async def test_model_not_entitled_creates_repair_once(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_stream: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mark the entity unavailable and log the model repair only once."""
+    mock_stream.side_effect = ModelNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    issue_id = (
+        f"model_not_entitled_{conversation_subentry(setup_integration).subentry_id}"
+    )
+
+    with caplog.at_level(logging.INFO):
+        await converse(hass, "Hello")
+        await converse(hass, "Again")
+
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+    assert caplog.text.count("SpaceXAI is unavailable:") == 1
+
+
+async def test_model_not_entitled_recovers_and_clears_repair(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_stream: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Clear the model repair after a later successful converse."""
+    mock_stream.side_effect = ModelNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    issue_id = (
+        f"model_not_entitled_{conversation_subentry(setup_integration).subentry_id}"
+    )
+    await converse(hass, "Hello")
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+
+    mock_stream.side_effect = None
+    mock_stream.return_value = EventStream(message_events("Recovered"))
+    with caplog.at_level(logging.INFO):
+        result = await converse(hass, "Hello again")
+
+    assert result.response.speech["plain"]["speech"] == "Recovered"
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert not issue_registry.async_get_issue("spacexai", issue_id)
+    assert "SpaceXAI is available again" in caplog.text
+
+
+async def test_subscription_not_entitled_recovers_and_clears_repair(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_stream: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Clear the subscription repair after a later successful converse."""
+    mock_stream.side_effect = SubscriptionNotEntitledError(
+        "subscription",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    subscription_issue = f"subscription_not_entitled_{setup_integration.entry_id}"
+    await converse(hass, "Hello")
+    assert issue_registry.async_get_issue("spacexai", subscription_issue)
+
+    mock_stream.side_effect = None
+    mock_stream.return_value = EventStream(message_events("Recovered"))
+    result = await converse(hass, "Hello again")
+
+    assert result.response.speech["plain"]["speech"] == "Recovered"
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert not issue_registry.async_get_issue("spacexai", subscription_issue)
+
+
+async def test_catalog_restore_marks_entity_available_without_chat(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    provider_snapshot: ProviderSnapshot,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Restore availability from catalog refresh without requiring a successful chat."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    with caplog.at_level(logging.INFO):
+        result = await hass.config_entries.subentries.async_init(
+            (setup_integration.entry_id, "conversation"),
+            context={"source": "user"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    issue_id = (
+        f"model_not_entitled_{conversation_subentry(setup_integration).subentry_id}"
+    )
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert "SpaceXAI is unavailable:" in caplog.text
+    assert "category=model_not_entitled" in caplog.text
+
+    mock_validate.return_value = provider_snapshot
+    with caplog.at_level(logging.INFO):
+        result = await hass.config_entries.subentries.async_init(
+            (setup_integration.entry_id, "conversation"),
+            context={"source": "user"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert not issue_registry.async_get_issue("spacexai", issue_id)
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert "SpaceXAI is available again" in caplog.text
+
+
+async def test_conversation_agent_registers_for_config_entry(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+) -> None:
+    """Expose the conversation agent by config entry id while loaded."""
+    agent = conversation.agent_manager.async_get_agent(hass, setup_integration.entry_id)
+    assert isinstance(agent, conversation.AbstractConversationAgent)
+
+    assert await hass.config_entries.async_unload(setup_integration.entry_id)
+    await hass.async_block_till_done()
+    assert (
+        conversation.agent_manager.async_get_agent(hass, setup_integration.entry_id)
+        is None
+    )
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_removing_conversation_keeps_sibling_entry_agent(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Re-register a remaining sibling as the entry-id conversation agent."""
+    await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    entry = _two_agent_entry(mock_config_entry)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    agent = conversation.agent_manager.async_get_agent(hass, entry.entry_id)
+    assert isinstance(agent, conversation.AbstractConversationAgent)
+
+    primary = next(
+        subentry
+        for subentry in entry.subentries.values()
+        if subentry.title == "Grok Primary"
+    )
+    hass.config_entries.async_remove_subentry(entry, primary.subentry_id)
+    await hass.async_block_till_done()
+
+    agent = conversation.agent_manager.async_get_agent(hass, entry.entry_id)
+    assert isinstance(agent, conversation.AbstractConversationAgent)
+    assert hass.states.get(SECONDARY_AGENT_ID) is not None
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_runtime_identity_strips_jinja_from_model_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    mock_stream: AsyncMock,
+) -> None:
+    """Neutralize Jinja delimiter characters in provider-controlled model IDs."""
+    dangerous_model = "grok-{}}{ 7*7 }{%}-x"
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo(dangerous_model, "xai"),),
+    )
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        conversation_subentry(mock_config_entry),
+        data={
+            **conversation_subentry(mock_config_entry).data,
+            CONF_MODEL: dangerous_model,
+        },
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await converse(hass, "Who are you?")
+    system_message = next(
+        item
+        for item in mock_stream.call_args.kwargs["input"]
+        if item.get("type") == "message" and item.get("role") == "system"
+    )
+    content = system_message["content"]
+    assert "{" not in content
+    assert "}" not in content
+    assert "%" not in content
+    assert "Conversation model: grok- 7*7 -x" in content
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_response_timeout_covers_stream_and_tool_awaits(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Budget one deadline per iteration for stream reads and tool awaits."""
+    timeout_enters = 0
+    real_timeout_at = asyncio.timeout_at
+
+    @contextlib.asynccontextmanager
+    async def counting_timeout_at(when: float) -> Any:
+        nonlocal timeout_enters
+        timeout_enters += 1
+        async with real_timeout_at(when):
+            yield
+
+    class ProgressThenStall(EventStream):
+        def __init__(self) -> None:
+            super().__init__([])
+            self._sent = False
+
+        async def __anext__(self) -> ResponseStreamEvent:
+            if not self._sent:
+                self._sent = True
+                return ResponseTextDeltaEvent(
+                    content_index=0,
+                    delta="Hi",
+                    item_id="msg_1",
+                    logprobs=[],
+                    output_index=0,
+                    sequence_number=0,
+                    type="response.output_text.delta",
+                )
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+    mock_stream.return_value = ProgressThenStall()
+    with (
+        patch("homeassistant.components.spacexai.entity.RESPONSE_TIMEOUT", 0.05),
+        patch(
+            "homeassistant.components.spacexai.entity.asyncio.timeout_at",
+            counting_timeout_at,
+        ),
+    ):
+        result = await converse(hass, "Wait")
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert (
+        result.response.speech["plain"]["speech"]
+        == f"SpaceXAI did not finish the response from {DEFAULT_MODEL} in time"
+    )
+    assert timeout_enters == 1
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_cancellation_propagates(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Do not convert task cancellation into a user-facing provider error."""
+    mock_stream.side_effect = asyncio.CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await converse(hass, "Cancel")
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    ("side_effect", "expected_fragments"),
+    [
+        pytest.param(
+            RuntimeError(f"Authorization: Bearer {ACCESS_TOKEN}; refresh-token"),
+            ("_async_handle_chat_log",),
+            id="runtime",
+        ),
+        pytest.param(
+            PermanentProviderError(
+                f"denied Bearer {ACCESS_TOKEN}",
+                context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+            ),
+            ("category=permanent_provider_failure",),
+            id="permanent",
+        ),
+    ],
+)
+async def test_error_logging_is_sanitized(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+    side_effect: Exception,
+    expected_fragments: tuple[str, ...],
+) -> None:
+    """Keep error logs free of credential material."""
+    mock_stream.side_effect = side_effect
+    with caplog.at_level(logging.ERROR):
+        result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert ACCESS_TOKEN not in caplog.text
+    assert "refresh-token" not in caplog.text
+    for fragment in expected_fragments:
+        assert fragment in caplog.text
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    "events",
+    [
+        pytest.param([incomplete_event()], id="max-output-tokens"),
+        pytest.param([incomplete_event(reason=None)], id="incomplete-unknown"),
+        pytest.param([failed_event("server_error", "failed")], id="failed"),
+        pytest.param(
+            [failed_event("vector_store_timeout", "timeout")],
+            id="vector-store-timeout",
+        ),
+        pytest.param([error_event("stream_error", "failed")], id="error"),
+        pytest.param(
+            [error_event("rate_limit_exceeded", "limited")],
+            id="rate-limit",
+        ),
+        pytest.param(
+            [
+                ResponseRefusalDeltaEvent(
+                    content_index=0,
+                    delta="refused",
+                    item_id="message",
+                    output_index=0,
+                    sequence_number=0,
+                    type="response.refusal.delta",
+                )
+            ],
+            id="refusal",
+        ),
+    ],
+)
+async def test_lifecycle_stream_errors_are_translated(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    events: list[ResponseStreamEvent],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Surface provider lifecycle failures as translated Assist errors."""
+    mock_stream.return_value = EventStream(events)
+    result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.speech == snapshot
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_ignored_progress_events_are_skipped(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Skip protocol progress events and non-reasoning output-item completions."""
+    mock_stream.return_value = EventStream(
+        [
+            ResponseInProgressEvent(
+                response=response_payload(status="in_progress"),
+                sequence_number=0,
+                type="response.in_progress",
+            ),
+            *message_events("Ready", complete=False),
+            ResponseOutputItemDoneEvent(
+                item=ResponseOutputMessage(
+                    id="msg_1",
+                    content=[],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                ),
+                output_index=0,
+                sequence_number=3,
+                type="response.output_item.done",
+            ),
+            completed_event(4),
+        ]
+    )
+    result = await converse(hass, "Hello")
+    assert result.response.speech["plain"]["speech"] == "Ready"
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    "events",
+    [
+        pytest.param(message_events("Hi", complete=False), id="truncated"),
+        pytest.param([completed_event()], id="completed-without-content"),
+        pytest.param(
+            [
+                *message_events("Hi"),
+                ResponseTextDeltaEvent(
+                    content_index=0,
+                    delta="late",
+                    item_id="msg_1",
+                    logprobs=[],
+                    output_index=0,
+                    sequence_number=99,
+                    type="response.output_text.delta",
+                ),
+            ],
+            id="post-terminal",
+        ),
+        pytest.param(
+            [SimpleNamespace(type="response.totally_unknown")],
+            id="unknown-event",
+        ),
+        pytest.param(
+            [
+                ResponseOutputItemAddedEvent.model_construct(
+                    type="response.output_item.added",
+                    output_index=0,
+                    sequence_number=0,
+                    item=SimpleNamespace(type="web_search_call", id="ws_1"),
+                )
+            ],
+            id="unexpected-output-item",
+        ),
+    ],
+)
+async def test_malformed_stream_is_unexpected_response(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    events: list[Any],
+) -> None:
+    """Surface truncated, empty, late, and unknown streams as unexpected responses."""
+    mock_stream.return_value = EventStream(events)
+    result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert (
+        result.response.speech["plain"]["speech"]
+        == f"SpaceXAI returned an unexpected response from {DEFAULT_MODEL}"
+    )
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    ("events", "speech"),
+    [
+        pytest.param(
+            [
+                tool_call_added(item_id=None, call_id="call_1", name="test_tool"),
+                completed_event(),
+            ],
+            f"SpaceXAI returned an unexpected response from {DEFAULT_MODEL}",
+            id="null-item-id",
+        ),
+        pytest.param(
+            [
+                tool_args_done(item_id="fc_1", name="test_tool", arguments="{}"),
+                completed_event(),
+            ],
+            f"SpaceXAI returned an unexpected response from {DEFAULT_MODEL}",
+            id="unannounced-args",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="", name="test_tool"),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="empty-call-id",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name=""),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="empty-name",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name="test_tool"),
+                tool_call_added(item_id="fc_1", call_id="call_2", name="test_tool"),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="duplicate-id",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name="test_tool"),
+                tool_args_done(item_id="fc_1", name="other_tool", arguments="{}"),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="name-mismatch",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name="test_tool"),
+                tool_args_done(
+                    item_id="fc_1",
+                    name="test_tool",
+                    arguments='{"broken"',
+                ),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="malformed-json",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name="test_tool"),
+                tool_args_done(item_id="fc_1", name="test_tool", arguments="[]"),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="non-object-args",
+        ),
+        pytest.param(
+            [
+                tool_call_added(item_id="fc_1", call_id="call_1", name="test_tool"),
+                completed_event(),
+            ],
+            f"{DEFAULT_MODEL} requested a Home Assistant tool with invalid arguments",
+            id="unfinished-tool",
+        ),
+    ],
+)
+async def test_invalid_tool_stream_is_rejected(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    events: list[Any],
+    speech: str,
+) -> None:
+    """Reject incomplete, duplicate, and malformed tool-call streams."""
+    mock_stream.return_value = EventStream(events)
+    result = await converse(hass, "Run tool")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.speech["plain"]["speech"] == speech
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    ("error", "speech"),
+    [
+        pytest.param(
+            httpx.TimeoutException("read timeout"),
+            f"SpaceXAI did not finish the response from {DEFAULT_MODEL} in time",
+            id="httpx-timeout",
+        ),
+        pytest.param(
+            httpx.ConnectError("refused"),
+            f"Home Assistant could not connect to SpaceXAI while using {DEFAULT_MODEL}",
+            id="httpx-connect",
+        ),
+        pytest.param(
+            OpenAIError("schema"),
+            f"SpaceXAI rejected the request to {DEFAULT_MODEL}",
+            id="sdk-error",
+        ),
+        pytest.param(
+            ValidationError.from_exception_data("Response", []),
+            f"SpaceXAI returned an unexpected response from {DEFAULT_MODEL}",
+            id="validation",
+        ),
+    ],
+)
+async def test_stream_body_errors_are_typed(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    error: Exception,
+    speech: str,
+) -> None:
+    """Map stream-body httpx and SDK failures onto typed Assist errors."""
+
+    class RaisingStream(EventStream):
+        async def __anext__(self) -> ResponseStreamEvent:
+            raise error
+
+    mock_stream.return_value = RaisingStream(())
+    result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.speech["plain"]["speech"] == speech
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_reasoning_summary_opens_and_splits_assistant_turns(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Start a turn for a leading summary and split when summary_index changes."""
+    mock_stream.return_value = EventStream(
+        [
+            ResponseReasoningSummaryTextDeltaEvent(
+                delta="First",
+                item_id="reasoning-1",
+                output_index=0,
+                sequence_number=0,
+                summary_index=0,
+                type="response.reasoning_summary_text.delta",
+            ),
+            ResponseReasoningSummaryTextDeltaEvent(
+                delta="Second",
+                item_id="reasoning-1",
+                output_index=0,
+                sequence_number=1,
+                summary_index=1,
+                type="response.reasoning_summary_text.delta",
+            ),
+            *message_events("Done"),
+        ]
+    )
+    result = await converse(hass, "Hello")
+    assert result.response.speech["plain"]["speech"] == "Done"
+    chat_log = hass.data[conversation.chat_log.DATA_CHAT_LOGS][result.conversation_id]
+    thinking = [
+        content.thinking_content
+        for content in chat_log.content
+        if isinstance(content, conversation.AssistantContent)
+        and content.thinking_content
+    ]
+    assert thinking == ["First", "Second"]
+
+
+@pytest.mark.parametrize(
+    ("code", "error_type"),
+    [
+        pytest.param("insufficient_quota", QuotaLimitedError, id="quota"),
+        pytest.param("model_not_found", ModelNotEntitledError, id="model"),
+        pytest.param(
+            "subscription_required",
+            SubscriptionNotEntitledError,
+            id="subscription",
+        ),
+    ],
+)
+def test_stream_failure_classifies_entitlement_codes(
+    code: str, error_type: type[Exception]
+) -> None:
+    """Map stream failure codes onto the same typed entitlement errors as HTTP."""
+    error = _stream_failure(code, model=DEFAULT_MODEL)
+    assert isinstance(error, error_type)
+    assert error.context.model == DEFAULT_MODEL
+
+
+async def test_template_error_skips_provider(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_stream: AsyncMock,
+) -> None:
+    """Return the ChatLog error when prompt rendering fails."""
+    subentry = conversation_subentry(setup_integration)
+    hass.config_entries.async_update_subentry(
+        setup_integration,
+        subentry,
+        data={**subentry.data, CONF_PROMPT: "{{ invalid("},
+    )
+    await hass.config_entries.async_reload(setup_integration.entry_id)
+
+    result = await converse(hass, "Hello")
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    mock_stream.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("setup_integration", "mock_stream")
+async def test_homeassistant_error_from_chat_loop_is_preserved(
+    hass: HomeAssistant,
+) -> None:
+    """Preserve translated Home Assistant errors from the chat loop."""
+    with patch.object(
+        SpaceXAIConversationEntity,
+        "_async_handle_chat_log",
+        side_effect=HomeAssistantError("already translated"),
+    ):
+        result = await converse(hass, "Hello")
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_tool_timeout_is_not_provider_outage(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Do not mark SpaceXAI unavailable when the shared tool-phase deadline expires."""
+    mock_stream.return_value = EventStream(message_events("Hello"))
+    phase = {"n": 0}
+    real_timeout_at = asyncio.timeout_at
+
+    @contextlib.asynccontextmanager
+    async def timeout_at_tool_deadline(when: float) -> Any:
+        phase["n"] += 1
+        if phase["n"] == 1:
+            async with real_timeout_at(when):
+                yield
+            return
+        try:
+            yield
+        finally:
+            raise TimeoutError
+
+    with patch(
+        "homeassistant.components.spacexai.entity.asyncio.timeout_at",
+        timeout_at_tool_deadline,
+    ):
+        result = await converse(hass, "Hello")
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert (
+        result.response.speech["plain"]["speech"]
+        == f"A Home Assistant tool requested by {DEFAULT_MODEL} failed"
+    )
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_auth_and_quota_failures_mark_sibling_agents(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_stream: AsyncMock,
+) -> None:
+    """Shared account failures mark every agent; model denials stay local."""
+    await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    entry = _two_agent_entry(mock_config_entry)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_stream.side_effect = QuotaLimitedError(
+        "quota",
+        context=ErrorContext(operation=Operation.RESPONSE, model=DEFAULT_MODEL),
+    )
+    await converse(hass, "Hello", agent_id=PRIMARY_AGENT_ID)
+    assert hass.states.get(PRIMARY_AGENT_ID).state == STATE_UNAVAILABLE
+    assert hass.states.get(SECONDARY_AGENT_ID).state == STATE_UNAVAILABLE
+
+    mock_stream.side_effect = None
+    mock_stream.return_value = EventStream(message_events("Recovered"))
+    result = await converse(hass, "Hello", agent_id=PRIMARY_AGENT_ID)
+    assert result.response.speech["plain"]["speech"] == "Recovered"
+    assert hass.states.get(PRIMARY_AGENT_ID).state != STATE_UNAVAILABLE
+    assert hass.states.get(SECONDARY_AGENT_ID).state != STATE_UNAVAILABLE
+
+    mock_stream.side_effect = ModelNotEntitledError(
+        "gone",
+        context=ErrorContext(operation=Operation.RESPONSE, model="grok-4.3"),
+    )
+    await converse(hass, "Hello", agent_id=SECONDARY_AGENT_ID)
+    mock_stream.side_effect = None
+    mock_stream.return_value = EventStream(message_events("Still ok"))
+    await converse(hass, "Hello", agent_id=PRIMARY_AGENT_ID)
+    assert hass.states.get(PRIMARY_AGENT_ID).state != STATE_UNAVAILABLE
+    assert hass.states.get(SECONDARY_AGENT_ID).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_reasoning_summary_is_replayed_on_tool_continuation(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Rebuild reasoning input from encrypted content plus streamed summary text."""
+    reasoning = ResponseReasoningItem(
+        id="reasoning-1",
+        summary=[],
+        encrypted_content="encrypted-plan",
+        type="reasoning",
+    )
+    mock_stream.side_effect = [
+        EventStream(
+            [
+                ResponseOutputItemAddedEvent(
+                    item=reasoning,
+                    output_index=0,
+                    sequence_number=0,
+                    type="response.output_item.added",
+                ),
+                ResponseReasoningSummaryTextDeltaEvent(
+                    delta="Plan the tool",
+                    item_id="reasoning-1",
+                    output_index=0,
+                    sequence_number=1,
+                    summary_index=0,
+                    type="response.reasoning_summary_text.delta",
+                ),
+                ResponseOutputItemDoneEvent(
+                    item=reasoning,
+                    output_index=0,
+                    sequence_number=2,
+                    type="response.output_item.done",
+                ),
+                *tool_events(("call_1", "test_tool", '{"value": 1}')),
+            ]
+        ),
+        EventStream(message_events("Tool finished")),
+    ]
+    mock_chat_log.mock_tool_results({"call_1": {"result": "one"}})
+
+    result = await converse(hass, "Use a tool", mock_chat_log.conversation_id)
+
+    assert result.response.speech["plain"]["speech"] == "Tool finished"
+    assert mock_stream.await_count == 2
+    reasoning_inputs = [
+        item
+        for item in mock_stream.call_args.kwargs["input"]
+        if item.get("type") == "reasoning"
+    ]
+    assert reasoning_inputs == [
+        {
+            "type": "reasoning",
+            "id": "reasoning-1",
+            "summary": [{"type": "summary_text", "text": "Plan the tool"}],
+            "encrypted_content": "encrypted-plan",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_adjacent_stream_deltas_are_coalesced(
+    hass: HomeAssistant,
+    mock_stream: AsyncMock,
+) -> None:
+    """Merge adjacent text/thinking deltas while buffering the validated stream."""
+    mock_stream.return_value = EventStream(
+        [
+            ResponseTextDeltaEvent(
+                content_index=0,
+                delta="He",
+                item_id="msg_1",
+                logprobs=[],
+                output_index=0,
+                sequence_number=0,
+                type="response.output_text.delta",
+            ),
+            ResponseTextDeltaEvent(
+                content_index=0,
+                delta="llo ",
+                item_id="msg_1",
+                logprobs=[],
+                output_index=0,
+                sequence_number=1,
+                type="response.output_text.delta",
+            ),
+            ResponseReasoningSummaryTextDeltaEvent(
+                delta="Think ",
+                item_id="reasoning-1",
+                output_index=1,
+                sequence_number=2,
+                summary_index=0,
+                type="response.reasoning_summary_text.delta",
+            ),
+            ResponseReasoningSummaryTextDeltaEvent(
+                delta="twice",
+                item_id="reasoning-1",
+                output_index=1,
+                sequence_number=3,
+                summary_index=0,
+                type="response.reasoning_summary_text.delta",
+            ),
+            ResponseTextDeltaEvent(
+                content_index=0,
+                delta="world",
+                item_id="msg_2",
+                logprobs=[],
+                output_index=2,
+                sequence_number=4,
+                type="response.output_text.delta",
+            ),
+            completed_event(5),
+        ]
+    )
+    result = await converse(hass, "Hello")
+    assert result.response.speech["plain"]["speech"] == "Hello world"
+    chat_log = hass.data[conversation.chat_log.DATA_CHAT_LOGS][result.conversation_id]
+    thinking = [
+        content.thinking_content
+        for content in chat_log.content
+        if isinstance(content, conversation.AssistantContent)
+        and content.thinking_content
+    ]
+    assert thinking == ["Think twice"]

--- a/tests/components/spacexai/test_init.py
+++ b/tests/components/spacexai/test_init.py
@@ -1,0 +1,651 @@
+"""Tests for SpaceXAI setup and lifecycle."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.spacexai import (
+    async_reconcile_snapshot,
+    async_remove_entry,
+)
+from homeassistant.components.spacexai.client import (
+    AccountInfo,
+    ModelInfo,
+    ProviderSnapshot,
+)
+from homeassistant.components.spacexai.const import (
+    CONF_MAX_OUTPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MODEL,
+    DOMAIN,
+)
+from homeassistant.components.spacexai.errors import (
+    AccountMismatchError,
+    AuthenticationRejectedError,
+    ConnectionFailureError,
+    ErrorContext,
+    MalformedProviderResponseError,
+    ModelNotEntitledError,
+    NoConversationModelsError,
+    Operation,
+    PermanentProviderError,
+    QuotaLimitedError,
+    RateLimitedError,
+    ReauthenticationRequiredError,
+    RefreshRejectedError,
+    RequestTimeoutError,
+    SubscriptionNotEntitledError,
+    TransientProviderError,
+)
+from homeassistant.config_entries import ConfigEntryState, ConfigSubentryData
+from homeassistant.const import CONF_LLM_HASS_API, CONF_MODEL, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir, llm
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    ImplementationUnavailableError,
+)
+
+from . import AGENT_ID, conversation_subentry
+from .conftest import ACCESS_TOKEN, ACCOUNT_ID, REFRESH_TOKEN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_setup_and_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Set up and unload the Conversation platform."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(AGENT_ID) is not None
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_oauth_token_update_does_not_reload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+) -> None:
+    """Do not reload entities for normal OAuth refresh-token rotation."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={
+            **mock_config_entry.data,
+            "token": {
+                **mock_config_entry.data["token"],
+                "access_token": "rotated-access-token",
+                "refresh_token": "rotated-refresh-token",
+            },
+        },
+    )
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_validate.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_state"),
+    [
+        pytest.param(
+            ReauthenticationRequiredError(
+                "expired",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="reauthentication",
+        ),
+        pytest.param(
+            AuthenticationRejectedError(
+                "rejected",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="authentication_rejected",
+        ),
+        pytest.param(
+            RefreshRejectedError(
+                "refresh rejected",
+                context=ErrorContext(operation=Operation.REFRESH),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="refresh_rejected",
+        ),
+        pytest.param(
+            ConnectionFailureError(
+                "offline",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_RETRY,
+            id="connection",
+        ),
+        pytest.param(
+            RateLimitedError(
+                "limited",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_RETRY,
+            id="rate_limited",
+        ),
+        pytest.param(
+            RequestTimeoutError(
+                "timeout",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_RETRY,
+            id="timeout",
+        ),
+        pytest.param(
+            TransientProviderError(
+                "transient",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_RETRY,
+            id="transient",
+        ),
+        pytest.param(
+            SubscriptionNotEntitledError(
+                "not entitled",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="subscription",
+        ),
+        pytest.param(
+            NoConversationModelsError(
+                "none",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="no-models",
+        ),
+        pytest.param(
+            QuotaLimitedError(
+                "quota",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="quota",
+        ),
+        pytest.param(
+            PermanentProviderError(
+                "denied",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="permanent",
+        ),
+        pytest.param(
+            ModelNotEntitledError(
+                "model",
+                context=ErrorContext(operation=Operation.MODELS),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="model",
+        ),
+        pytest.param(
+            MalformedProviderResponseError(
+                "malformed",
+                context=ErrorContext(operation=Operation.ACCOUNT),
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="malformed",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    side_effect: Exception,
+    expected_state: ConfigEntryState,
+) -> None:
+    """Map provider failures into config-entry setup behavior."""
+    mock_validate.side_effect = side_effect
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is expected_state
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_account_mismatch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+) -> None:
+    """Reject setup when the OAuth account no longer matches the entry."""
+    mock_validate.side_effect = AccountMismatchError(
+        "mismatch",
+        context=ErrorContext(operation=Operation.ACCOUNT),
+    )
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_model_not_entitled(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Load with a repair so the user can reconfigure a replacement model."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    state = hass.states.get(AGENT_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    issue = issue_registry.async_get_issue(
+        "spacexai",
+        f"model_not_entitled_{conversation_subentry(mock_config_entry).subentry_id}",
+    )
+    assert issue is not None
+    assert issue.is_fixable is False
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_validate")
+async def test_reconcile_skips_subentries_without_model(
+    hass: HomeAssistant,
+    provider_snapshot: ProviderSnapshot,
+) -> None:
+    """Ignore non-model subentries while reconciling catalog entitlement."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home User",
+        unique_id=ACCOUNT_ID,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": ACCESS_TOKEN,
+                "refresh_token": REFRESH_TOKEN,
+                "expires_at": time.time() + 3600,
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        },
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    CONF_MODEL: DEFAULT_MODEL,
+                    CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+                    CONF_MAX_OUTPUT_TOKENS: DEFAULT_MAX_OUTPUT_TOKENS,
+                },
+                subentry_type="conversation",
+                title="Grok",
+                unique_id=None,
+            ),
+            ConfigSubentryData(
+                data={},
+                subentry_type="metadata",
+                title="No model",
+                unique_id=None,
+            ),
+        ],
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    async_reconcile_snapshot(hass, entry, provider_snapshot)
+    assert hass.states.get(AGENT_ID) is not None
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subscription_repair_is_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Create an actionable repair for an ineligible subscription."""
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    issue = issue_registry.async_get_issue(
+        "spacexai", f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    )
+    assert issue is not None
+    assert issue.learn_more_url == "https://console.x.ai/"
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subscription_repair_is_entry_scoped(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    provider_snapshot: ProviderSnapshot,
+) -> None:
+    """Keep subscription repairs isolated across config entries."""
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    issue_id = f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    other_issue_id = "subscription_not_entitled_other-entry"
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        other_issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="subscription_not_entitled",
+    )
+
+    mock_validate.side_effect = None
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo("healthy-account", "Healthy", None),
+        models=provider_snapshot.models,
+    )
+    healthy_entry = MockConfigEntry(
+        domain="spacexai",
+        title="Healthy",
+        unique_id="healthy-account",
+        data=dict(mock_config_entry.data),
+    )
+    healthy_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(healthy_entry.entry_id)
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+    assert issue_registry.async_get_issue("spacexai", other_issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subscription_repair_persists_across_transient_setup_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Keep a subscription repair until setup positively validates the account."""
+    mock_validate.side_effect = SubscriptionNotEntitledError(
+        "not entitled",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    issue_id = f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    other_issue_id = "subscription_not_entitled_other-entry"
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        other_issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="subscription_not_entitled",
+    )
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    mock_validate.side_effect = ConnectionFailureError(
+        "offline",
+        context=ErrorContext(operation=Operation.MODELS),
+    )
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+    assert issue_registry.async_get_issue("spacexai", other_issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_subscription_repair_clears_on_successful_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+    provider_snapshot: ProviderSnapshot,
+) -> None:
+    """Clear a subscription repair only after a successful catalog snapshot."""
+    issue_id = f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="subscription_not_entitled",
+    )
+    mock_validate.return_value = provider_snapshot
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert not issue_registry.async_get_issue("spacexai", issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_revokes_refresh_token(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Revoke the provider refresh token when the entry is removed."""
+    with patch(
+        "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+        new_callable=AsyncMock,
+    ) as revoke:
+        await async_remove_entry(hass, mock_config_entry)
+    revoke.assert_awaited_once_with(REFRESH_TOKEN, "home-assistant-client", "")
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_skips_without_refresh_token(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log and skip revocation when the entry has no refresh token."""
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={
+            **mock_config_entry.data,
+            "token": {"access_token": ACCESS_TOKEN, "token_type": "Bearer"},
+        },
+    )
+    with (
+        patch(
+            "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+            new_callable=AsyncMock,
+        ) as revoke,
+        caplog.at_level("WARNING"),
+    ):
+        await async_remove_entry(hass, mock_config_entry)
+    revoke.assert_not_called()
+    assert "reason=missing_refresh_token" in caplog.text
+    assert ACCESS_TOKEN not in caplog.text
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_skips_unavailable_implementation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log and skip revocation when the OAuth implementation cannot be loaded."""
+    with (
+        patch(
+            "homeassistant.components.spacexai.async_get_config_entry_implementation",
+            side_effect=ImplementationUnavailableError(),
+        ),
+        patch(
+            "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+            new_callable=AsyncMock,
+        ) as revoke,
+        caplog.at_level("WARNING"),
+    ):
+        await async_remove_entry(hass, mock_config_entry)
+    revoke.assert_not_called()
+    assert "reason=implementation_unavailable" in caplog.text
+    assert REFRESH_TOKEN not in caplog.text
+    assert ACCESS_TOKEN not in caplog.text
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_skips_foreign_implementation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Skip token revocation when the implementation is not a local OAuth client."""
+    with (
+        patch(
+            "homeassistant.components.spacexai.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+            new_callable=AsyncMock,
+        ) as revoke,
+        caplog.at_level("WARNING"),
+    ):
+        await async_remove_entry(hass, mock_config_entry)
+    revoke.assert_not_called()
+    assert "reason=foreign_implementation" in caplog.text
+    assert REFRESH_TOKEN not in caplog.text
+    assert ACCESS_TOKEN not in caplog.text
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_logs_revocation_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Do not block removal when provider revocation fails."""
+    with (
+        patch(
+            "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+            new_callable=AsyncMock,
+            side_effect=ConnectionFailureError(
+                "offline",
+                context=ErrorContext(operation=Operation.REVOCATION),
+            ),
+        ),
+        caplog.at_level("WARNING"),
+    ):
+        await async_remove_entry(hass, mock_config_entry)
+    assert "category=connection_failure" in caplog.text
+    assert REFRESH_TOKEN not in caplog.text
+    assert ACCESS_TOKEN not in caplog.text
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_subentry_cleans_model_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Delete model repair issues when their subentry is removed."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    issue_id = (
+        f"model_not_entitled_{conversation_subentry(mock_config_entry).subentry_id}"
+    )
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+
+    hass.config_entries.async_remove_subentry(
+        mock_config_entry, conversation_subentry(mock_config_entry).subentry_id
+    )
+    await hass.async_block_till_done()
+    assert not issue_registry.async_get_issue("spacexai", issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_subentry_while_unloaded_cleans_model_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_validate: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Clear model repairs when a subentry is deleted while the entry is unloaded."""
+    mock_validate.return_value = ProviderSnapshot(
+        account=AccountInfo(ACCOUNT_ID, "Home User", None),
+        models=(ModelInfo("grok-other", "xai"),),
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    subentry = conversation_subentry(mock_config_entry)
+    issue_id = f"model_not_entitled_{subentry.subentry_id}"
+    foreign_issue_id = "model_not_entitled_foreign-subentry"
+    assert issue_registry.async_get_issue("spacexai", issue_id)
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        foreign_issue_id,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="model_not_entitled",
+        translation_placeholders={"model": "grok-foreign"},
+        data={
+            "entry_id": "other-entry",
+            "subentry_id": "foreign-subentry",
+        },
+    )
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    hass.config_entries.async_remove_subentry(mock_config_entry, subentry.subentry_id)
+    await hass.async_block_till_done()
+    assert not issue_registry.async_get_issue("spacexai", issue_id)
+    assert issue_registry.async_get_issue("spacexai", foreign_issue_id)
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_remove_cleans_account_repairs(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Remove only the repair issues belonging to the removed account."""
+    subentry = conversation_subentry(mock_config_entry)
+    subscription_issue = f"subscription_not_entitled_{mock_config_entry.entry_id}"
+    model_issue = f"model_not_entitled_{subentry.subentry_id}"
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        subscription_issue,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="subscription_not_entitled",
+    )
+    ir.async_create_issue(
+        hass,
+        "spacexai",
+        model_issue,
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="model_not_entitled",
+        translation_placeholders={"model": "grok-old"},
+        data={
+            "entry_id": mock_config_entry.entry_id,
+            "subentry_id": subentry.subentry_id,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.spacexai.client.SpaceXAIClient.async_revoke",
+        new_callable=AsyncMock,
+    ):
+        await async_remove_entry(hass, mock_config_entry)
+    assert not issue_registry.async_get_issue("spacexai", subscription_issue)
+    assert not issue_registry.async_get_issue("spacexai", model_issue)
+
+
+async def test_setup_without_oauth_implementation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Retry setup until the configured OAuth implementation is available."""
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new **SpaceXAI** integration providing a Grok Conversation agent for Home Assistant.

Users sign in with a SpaceXAI subscription through Application Credentials (OAuth2 Authorization Code + PKCE). The integration talks to the SpaceXAI Responses API with `store=false` and encrypted reasoning continuity, discovers entitled models from the account, and exposes a Conversation entity that can use Assist/`llm_hass_api` tools. It includes typed provider error handling, diagnostics, reauth, and Bronze quality-scale scaffolding.

This PR is Conversation-only. Later stacked PRs will add AI Task, server-side tools, device-code login, Imagine attachments/image generation, and STT/TTS — none of those platforms are in this change.

Brands and docs are opened in parallel:
- Brands: https://github.com/home-assistant/brands/pull/10947
- Docs: https://github.com/home-assistant/home-assistant.io/pull/47349

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47349
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Brands pull request: https://github.com/home-assistant/brands/pull/10947
- Branch: `jeffglousher:cursor/spacexai-up-conversation-2f69` → `dev`
- Dependency note: reuses the existing pinned `openai==2.45.0` (same as `openai_conversation`); `requirements_all.txt` only adds a `# homeassistant.components.spacexai` ownership comment next to that pin (no version bump)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr