### PR TITLE
Fix delayed trains being dropped from Israel Rail departures

### DIFF
--- a/homeassistant/components/israel_rail/coordinator.py
+++ b/homeassistant/components/israel_rail/coordinator.py
@@ -1,7 +1,7 @@
 """DataUpdateCoordinator for the israel rail integration."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import override
 
@@ -36,6 +36,22 @@ def departure_time(train_route: TrainRoute) -> datetime | None:
     """Get departure time."""
     start_datetime = dt_util.parse_datetime(train_route.start_time)
     return start_datetime.astimezone() if start_datetime else None
+
+
+def is_upcoming(train_route: TrainRoute, now: datetime) -> bool:
+    """Return whether the route has not left its origin yet.
+
+    A reported delay pushes back the moment the train actually leaves, so the route
+    stays upcoming until its scheduled departure plus that delay. A negative delay is
+    ignored so an early running train does not disappear before its scheduled time,
+    and a route whose departure cannot be parsed is kept, so an API format change
+    surfaces as an unknown state instead of silently dropping departures.
+    """
+    scheduled = departure_time(train_route)
+    if scheduled is None:
+        return True
+    delay = max(train_route.trains[0].departure_delay, 0)
+    return scheduled + timedelta(minutes=delay) >= now
 
 
 type IsraelRailConfigEntry = ConfigEntry[IsraelRailDataUpdateCoordinator]
@@ -87,8 +103,7 @@ class IsraelRailDataUpdateCoordinator(DataUpdateCoordinator[list[DataConnection]
             route = train_routes[offset]
             if route is None:
                 break
-            route_departure = departure_time(route)
-            if route_departure is None or route_departure >= now:
+            if is_upcoming(route, now):
                 break
             offset += 1
 

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -22,6 +22,17 @@ BEFORE_FIRST_TRAIN = "2021-10-10T10:00:00+00:00"
 
 EXPECTED_ENTITY_COUNT = DEPARTURES_COUNT * 5
 
+# TRAINS[0] (10:10) running 15 minutes late, so it only leaves at 10:25.
+DELAYED_TRAINS = [
+    get_train_route(
+        train_number="1234",
+        departure_time=get_time(10, 10),
+        arrival_time=get_time(10, 30),
+        departure_delay=15,
+    ),
+    *TRAINS[1:],
+]
+
 
 @pytest.fixture(autouse=True)
 def freeze_before_first_train(freezer: FrozenDateTimeFactory) -> FrozenDateTimeFactory:
@@ -148,9 +159,9 @@ async def test_departure_delay(
         *TRAINS[1:],
     ]
 
-    # Refresh while still before TRAINS[0] departs, so the delay-bearing
-    # first route is treated as upcoming and not skipped.
-    freeze_before_first_train.move_to("2021-10-10T10:05:00+00:00")
+    # Refresh past the scheduled 10:10 departure: the 7 minute delay puts the
+    # first route at 10:17, so it is still upcoming and not skipped.
+    freeze_before_first_train.move_to("2021-10-10T10:15:00+00:00")
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -249,3 +260,45 @@ async def test_all_routes_in_past(
     assert hass.states.get("sensor.mock_title_departure").state == STATE_UNKNOWN
     assert hass.states.get("sensor.mock_title_departure_1").state == STATE_UNKNOWN
     assert hass.states.get("sensor.mock_title_departure_2").state == STATE_UNKNOWN
+
+
+async def test_delayed_route_kept_past_scheduled_time(
+    hass: HomeAssistant,
+    freeze_before_first_train: FrozenDateTimeFactory,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A route running late stays in the window until its delay has elapsed."""
+    # TRAINS[0] is scheduled for 10:10 but runs 15 minutes late, so it only
+    # leaves at 10:25 and is still boardable at 10:15.
+    mock_israelrail.query.return_value = DELAYED_TRAINS
+    freeze_before_first_train.move_to("2021-10-10T10:15:00+00:00")
+
+    await init_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.mock_title_departure").state == get_time(10, 10)
+    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 20)
+    assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 30)
+    assert hass.states.get("sensor.mock_title_train_number").state == "1234"
+    # The displayed departure stays the scheduled time; the delay is its own sensor.
+    assert hass.states.get("sensor.mock_title_departure_delay").state == "15"
+
+
+async def test_delayed_route_dropped_once_delay_elapsed(
+    hass: HomeAssistant,
+    freeze_before_first_train: FrozenDateTimeFactory,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A route running late leaves the window once its delayed departure passes."""
+    # TRAINS[0] leaves at 10:25 (10:10 + 15) and TRAINS[1] at 10:20, so by 10:26
+    # the window starts at TRAINS[2].
+    mock_israelrail.query.return_value = DELAYED_TRAINS
+    freeze_before_first_train.move_to("2021-10-10T10:26:00+00:00")
+
+    await init_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.mock_title_departure").state == get_time(10, 30)
+    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 40)
+    assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 50)
+    assert hass.states.get("sensor.mock_title_train_number").state == "1236"

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -34,6 +34,17 @@ DELAYED_TRAINS = [
     *TRAINS[1:],
 ]
 
+# A departure in the "%d/%m/%Y %H:%M:%S" format israelrailapi's own parser expects,
+# which is not ISO 8601 and so cannot be parsed by the coordinator.
+UNPARSABLE_TRAINS = [
+    get_train_route(
+        train_number="1234",
+        departure_time="10/10/2021 10:10:00",
+        arrival_time=get_time(10, 30),
+    ),
+    *TRAINS[1:],
+]
+
 
 @pytest.fixture(autouse=True)
 def freeze_before_first_train(freezer: FrozenDateTimeFactory) -> FrozenDateTimeFactory:
@@ -303,3 +314,40 @@ async def test_delayed_route_dropped_once_delay_elapsed(
     assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 30)
     assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 40)
     assert hass.states.get("sensor.mock_title_train_number").state == "1235"
+
+
+async def test_route_with_unparsable_departure_is_kept(
+    hass: HomeAssistant,
+    freeze_before_first_train: FrozenDateTimeFactory,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A route whose departure cannot be parsed is kept rather than skipped."""
+    # "now" is past the scheduled 10:10, so treating an unparsable departure as
+    # departed would shift the window on to TRAINS[1].
+    mock_israelrail.query.return_value = UNPARSABLE_TRAINS
+    freeze_before_first_train.move_to("2021-10-10T10:15:00+00:00")
+
+    await init_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.mock_title_departure").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.mock_title_train_number").state == "1234"
+    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 20)
+    assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 30)
+
+
+async def test_none_route_ends_the_scan(
+    hass: HomeAssistant,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A None route ends the scan and is dropped from the window."""
+    mock_israelrail.query.return_value = [None, *TRAINS[:3]]
+
+    await init_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.mock_title_departure").state == get_time(10, 10)
+    assert hass.states.get("sensor.mock_title_train_number").state == "1234"
+    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 20)
+    # The None entry takes up a slot in the window, leaving only two routes.
+    assert hass.states.get("sensor.mock_title_departure_2").state == STATE_UNKNOWN

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -22,13 +22,14 @@ BEFORE_FIRST_TRAIN = "2021-10-10T10:00:00+00:00"
 
 EXPECTED_ENTITY_COUNT = DEPARTURES_COUNT * 5
 
-# TRAINS[0] (10:10) running 15 minutes late, so it only leaves at 10:25.
+# TRAINS[0] (10:10) running 8 minutes late, so it only leaves at 10:18. Routes keep
+# their order, so a delay stays shorter than the 10 minute gap to TRAINS[1].
 DELAYED_TRAINS = [
     get_train_route(
         train_number="1234",
         departure_time=get_time(10, 10),
         arrival_time=get_time(10, 30),
-        departure_delay=15,
+        departure_delay=8,
     ),
     *TRAINS[1:],
 ]
@@ -269,8 +270,8 @@ async def test_delayed_route_kept_past_scheduled_time(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """A route running late stays in the window until its delay has elapsed."""
-    # TRAINS[0] is scheduled for 10:10 but runs 15 minutes late, so it only
-    # leaves at 10:25 and is still boardable at 10:15.
+    # TRAINS[0] is scheduled for 10:10 but runs 8 minutes late, so it only
+    # leaves at 10:18 and is still boardable at 10:15.
     mock_israelrail.query.return_value = DELAYED_TRAINS
     freeze_before_first_train.move_to("2021-10-10T10:15:00+00:00")
 
@@ -281,7 +282,7 @@ async def test_delayed_route_kept_past_scheduled_time(
     assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 30)
     assert hass.states.get("sensor.mock_title_train_number").state == "1234"
     # The displayed departure stays the scheduled time; the delay is its own sensor.
-    assert hass.states.get("sensor.mock_title_departure_delay").state == "15"
+    assert hass.states.get("sensor.mock_title_departure_delay").state == "8"
 
 
 async def test_delayed_route_dropped_once_delay_elapsed(
@@ -291,14 +292,14 @@ async def test_delayed_route_dropped_once_delay_elapsed(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """A route running late leaves the window once its delayed departure passes."""
-    # TRAINS[0] leaves at 10:25 (10:10 + 15) and TRAINS[1] at 10:20, so by 10:26
-    # the window starts at TRAINS[2].
+    # TRAINS[0] leaves at 10:18 (10:10 + 8), so by 10:19 the window starts at
+    # TRAINS[1], which is still upcoming at 10:20.
     mock_israelrail.query.return_value = DELAYED_TRAINS
-    freeze_before_first_train.move_to("2021-10-10T10:26:00+00:00")
+    freeze_before_first_train.move_to("2021-10-10T10:19:00+00:00")
 
     await init_integration(hass, mock_config_entry)
 
-    assert hass.states.get("sensor.mock_title_departure").state == get_time(10, 30)
-    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 40)
-    assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 50)
-    assert hass.states.get("sensor.mock_title_train_number").state == "1236"
+    assert hass.states.get("sensor.mock_title_departure").state == get_time(10, 20)
+    assert hass.states.get("sensor.mock_title_departure_1").state == get_time(10, 30)
+    assert hass.states.get("sensor.mock_title_departure_2").state == get_time(10, 40)
+    assert hass.states.get("sensor.mock_title_train_number").state == "1235"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The coordinator picks the next three routes by comparing each route's scheduled
departure against now, ignoring the delay it already reads for the `departure_delay`
sensor. A delayed train is therefore dropped as soon as its scheduled time passes, even
though it hasn't left the station yet.

`is_upcoming()` now compares the scheduled departure plus the delay, so a route stays in
the window until it has actually left its origin. `sensor.*_departure` still reports the
scheduled time, with the delay on its own sensor as before, so no existing state changes
meaning.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
