### PR TITLE
Add watering contours for gardena

### DIFF
--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -24,6 +24,7 @@ from .coordinator import (
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.IMAGE,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/gardena_bluetooth/coordinator.py
+++ b/homeassistant/components/gardena_bluetooth/coordinator.py
@@ -14,6 +14,7 @@ from gardena_bluetooth.exceptions import (
 )
 from gardena_bluetooth.parse import (
     Characteristic,
+    CharacteristicSegmented,
     CharacteristicTime,
     CharacteristicType,
 )
@@ -137,6 +138,11 @@ class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         data: dict[str, Any] = {}
         for unique_id in unique_ids:
             char = self.characteristics[unique_id]
+            # Segmented characteristics are slow multi frame transfers carrying
+            # data that only changes when it is taught to the device again.
+            if isinstance(char, CharacteristicSegmented) and unique_id in self.data:
+                data[unique_id] = self.data[unique_id]
+                continue
             try:
                 data[unique_id] = await self.client.read_char(char)
             except CharacteristicNoAccess as exception:

--- a/homeassistant/components/gardena_bluetooth/coordinator.py
+++ b/homeassistant/components/gardena_bluetooth/coordinator.py
@@ -30,6 +30,8 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=60)
+SEGMENTED_SCAN_INTERVAL = timedelta(minutes=30)
+SEGMENTED_SCAN_COUNT = int(SEGMENTED_SCAN_INTERVAL / SCAN_INTERVAL)
 LOGGER = logging.getLogger(__name__)
 
 type GardenaBluetoothConfigEntry = ConfigEntry[GardenaBluetoothCoordinator]
@@ -64,6 +66,7 @@ class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.data = {}
         self.client = client
         self.characteristics: dict[str, Characteristic] = {}
+        self._update_count = 0
         self.device_info = DeviceInfo(
             identifiers={(DOMAIN, address)},
             connections={(dr.CONNECTION_BLUETOOTH, address)},
@@ -135,14 +138,22 @@ class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not unique_ids:
             return {}
 
+        # Segmented characteristics carry data that only changes when it is
+        # taught to the device again, so they are read every nth poll only.
+        skip_segmented = bool(self._update_count % SEGMENTED_SCAN_COUNT)
+        self._update_count += 1
+
         data: dict[str, Any] = {}
         for unique_id in unique_ids:
             char = self.characteristics[unique_id]
-            # Segmented characteristics are slow multi frame transfers carrying
-            # data that only changes when it is taught to the device again.
-            if isinstance(char, CharacteristicSegmented) and unique_id in self.data:
+            if (
+                isinstance(char, CharacteristicSegmented)
+                and skip_segmented
+                and unique_id in self.data
+            ):
                 data[unique_id] = self.data[unique_id]
                 continue
+
             try:
                 data[unique_id] = await self.client.read_char(char)
             except CharacteristicNoAccess as exception:

--- a/homeassistant/components/gardena_bluetooth/icons.json
+++ b/homeassistant/components/gardena_bluetooth/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "image": {
+      "active_contour": {
+        "default": "mdi:sprinkler-variant"
+      },
+      "contour": {
+        "default": "mdi:vector-polygon"
+      }
+    },
     "text": {
       "contour_name": {
         "default": "mdi:vector-polygon"

--- a/homeassistant/components/gardena_bluetooth/image.py
+++ b/homeassistant/components/gardena_bluetooth/image.py
@@ -1,0 +1,168 @@
+"""Support for image entities."""
+
+from dataclasses import dataclass, field
+from typing import Any, override
+
+from gardena_bluetooth.const import (
+    AquaContour,
+    AquaContourContours,
+    AquaContourPosition,
+    AquaContourWateringMode,
+    Spray,
+)
+from gardena_bluetooth.parse import CharacteristicContourPoints, ContourPoints
+from gardena_bluetooth.utils import contour_to_svg
+
+from homeassistant.components.image import ImageEntity, ImageEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .coordinator import GardenaBluetoothConfigEntry, GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothDescriptorEntity, GardenaBluetoothEntity
+
+CONTOURS: dict[int, CharacteristicContourPoints] = {
+    AquaContourWateringMode.CONTOUR_1: AquaContourContours.contour_points_1,
+    AquaContourWateringMode.CONTOUR_2: AquaContourContours.contour_points_2,
+    AquaContourWateringMode.CONTOUR_3: AquaContourContours.contour_points_3,
+    AquaContourWateringMode.CONTOUR_4: AquaContourContours.contour_points_4,
+    AquaContourWateringMode.CONTOUR_5: AquaContourContours.contour_points_5,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class GardenaBluetoothImageEntityDescription(ImageEntityDescription):
+    """Description of entity."""
+
+    key: str = field(init=False)
+    translation_key: str = field(init=False, default="contour")
+    char: CharacteristicContourPoints
+    contour: int
+
+    def __post_init__(self):
+        """Initialize calculated fields."""
+        object.__setattr__(self, "key", self.char.unique_id)
+
+
+DESCRIPTIONS = tuple(
+    GardenaBluetoothImageEntityDescription(
+        char=char,
+        contour=contour,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+    for contour, char in CONTOURS.items()
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: GardenaBluetoothConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up image based on a config entry."""
+    coordinator = entry.runtime_data
+    entities: list[ImageEntity] = [
+        GardenaBluetoothContourImage(coordinator, description)
+        for description in DESCRIPTIONS
+        if description.char.unique_id in coordinator.characteristics
+    ]
+    if GardenaBluetoothActiveContourImage.characteristics.issubset(
+        coordinator.characteristics
+    ):
+        entities.append(GardenaBluetoothActiveContourImage(coordinator))
+    async_add_entities(entities)
+
+
+class GardenaBluetoothImage(GardenaBluetoothEntity, ImageEntity):
+    """Base for an image rendered from cached contour data."""
+
+    _attr_content_type = "image/svg+xml"
+    _image: bytes | None = None
+
+    def __init__(
+        self, coordinator: GardenaBluetoothCoordinator, context: Any = None
+    ) -> None:
+        """Initialize the image."""
+        super().__init__(coordinator, context)
+        # The coordinator entity does not chain its init, so image setup is missed.
+        ImageEntity.__init__(self, coordinator.hass)
+
+    def _render(self) -> bytes | None:
+        """Render the current image."""
+        raise NotImplementedError
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        if (image := self._render()) != self._image:
+            self._image = image
+            self._attr_image_last_updated = dt_util.utcnow()
+        super()._handle_coordinator_update()
+
+    @override
+    async def async_image(self) -> bytes | None:
+        """Return bytes of image."""
+        return self._image
+
+
+class GardenaBluetoothContourImage(
+    GardenaBluetoothDescriptorEntity, GardenaBluetoothImage
+):
+    """Representation of a taught contour as a map."""
+
+    entity_description: GardenaBluetoothImageEntityDescription
+
+    def __init__(
+        self,
+        coordinator: GardenaBluetoothCoordinator,
+        description: GardenaBluetoothImageEntityDescription,
+    ) -> None:
+        """Initialize the contour image."""
+        super().__init__(coordinator, description, {description.char.unique_id})
+        self._attr_translation_placeholders = {"number": str(description.contour)}
+
+    @override
+    def _render(self) -> bytes | None:
+        return contour_to_svg(self.coordinator.get_cached(self.entity_description.char))
+
+
+class GardenaBluetoothActiveContourImage(GardenaBluetoothImage):
+    """Representation of the contour in use, with the current spray drawn in."""
+
+    _attr_translation_key = "active_contour"
+
+    characteristics = {
+        AquaContour.active_contour.unique_id,
+        AquaContourPosition.active_position.unique_id,
+        Spray.current_sector.unique_id,
+        Spray.current_distance.unique_id,
+        *(char.unique_id for char in CONTOURS.values()),
+    }
+
+    def __init__(self, coordinator: GardenaBluetoothCoordinator) -> None:
+        """Initialize the active contour image."""
+        super().__init__(coordinator, self.characteristics)
+        self._attr_unique_id = f"{coordinator.address}-active_contour"
+
+    def _active_points(self) -> ContourPoints | None:
+        """Points of the contour assigned to the position the sprinkler is at."""
+        position = self.coordinator.get_cached(AquaContourPosition.active_position)
+        assigned = self.coordinator.get_cached(AquaContour.active_contour) or []
+        if position is None or position < 1 or position > len(assigned):
+            return None
+        if (char := CONTOURS.get(assigned[position - 1])) is None:
+            return None
+        return self.coordinator.get_cached(char)
+
+    def _spray(self) -> tuple[int, int] | None:
+        """Angle and distance the sprinkler is currently throwing at."""
+        angle = self.coordinator.get_cached(Spray.current_sector)
+        distance = self.coordinator.get_cached(Spray.current_distance)
+        if angle is None or not distance:
+            return None
+        return angle, distance
+
+    @override
+    def _render(self) -> bytes | None:
+        return contour_to_svg(self._active_points(), self._spray())

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -38,6 +38,14 @@
         "name": "Factory reset"
       }
     },
+    "image": {
+      "active_contour": {
+        "name": "Active contour"
+      },
+      "contour": {
+        "name": "Contour {number}"
+      }
+    },
     "number": {
       "manual_watering_time": {
         "name": "Manual watering time"

--- a/tests/components/gardena_bluetooth/snapshots/test_image.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_image.ambr
@@ -1,0 +1,319 @@
+# serializer version: 1
+# name: test_image_content[image.mock_title_active_contour]
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1260.0 -1260.0 2520.0 2520.0"><path d="M 0.0,0.0 0.0,-900.0 1200.0,-0.0 0.0,900.0 -600.0,0.0 Z" fill="#03a9f4" fill-opacity="0.3" stroke="#03a9f4" stroke-width="12.60" stroke-linejoin="round"/><path d="M 0.0,0.0 495.0,-495.0" stroke="#ff9800" stroke-width="18.90" stroke-linecap="round"/><circle r="25.20" fill="#ff9800"/></svg>'
+# ---
+# name: test_image_content[image.mock_title_contour_1]
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1260.0 -1260.0 2520.0 2520.0"><path d="M 0.0,0.0 0.0,-900.0 1200.0,-0.0 0.0,900.0 -600.0,0.0 Z" fill="#03a9f4" fill-opacity="0.3" stroke="#03a9f4" stroke-width="12.60" stroke-linejoin="round"/><circle r="25.20" fill="#ff9800"/></svg>'
+# ---
+# name: test_setup[image.mock_title_active_contour-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.mock_title_active_contour',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active contour',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Active contour',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-active_contour',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_active_contour-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_active_contour?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Active contour',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_active_contour',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-01-01T01:00:00+00:00',
+  })
+# ---
+# name: test_setup[image.mock_title_contour_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'image.mock_title_contour_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Contour 1',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-98bd0b12-0b0e-421a-84e5-ddbf75dc6de4:1:segment1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_contour_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_1?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_contour_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-01-01T01:00:00+00:00',
+  })
+# ---
+# name: test_setup[image.mock_title_contour_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'image.mock_title_contour_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 2',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Contour 2',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-98bd0b12-0b0e-421a-84e5-ddbf75dc6de4:1:segment2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_contour_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_2?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_contour_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-01-01T01:00:00+00:00',
+  })
+# ---
+# name: test_setup[image.mock_title_contour_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'image.mock_title_contour_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 3',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Contour 3',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-98bd0b12-0b0e-421a-84e5-ddbf75dc6de4:1:segment3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_contour_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_3?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 3',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_contour_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-01-01T01:00:00+00:00',
+  })
+# ---
+# name: test_setup[image.mock_title_contour_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'image.mock_title_contour_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 4',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Contour 4',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-98bd0b12-0b0e-421a-84e5-ddbf75dc6de4:1:segment4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_contour_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_4?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 4',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_contour_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_setup[image.mock_title_contour_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'image.mock_title_contour_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 5',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Contour 5',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour',
+    'unique_id': '00000000-0000-0000-0000-000000000003-98bd0b12-0b0e-421a-84e5-ddbf75dc6de4:1:segment5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[image.mock_title_contour_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_5?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 5',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.mock_title_contour_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/gardena_bluetooth/test_image.py
+++ b/tests/components/gardena_bluetooth/test_image.py
@@ -1,0 +1,255 @@
+"""Test Gardena Bluetooth image entities."""
+
+from collections.abc import Awaitable, Callable, Generator, Iterable
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+from aiohttp.test_utils import TestClient
+from gardena_bluetooth.const import (
+    AquaContour,
+    AquaContourContours,
+    AquaContourPosition,
+    Spray,
+)
+from gardena_bluetooth.exceptions import CharacteristicNoAccess
+from gardena_bluetooth.parse import CharacteristicContourPoints
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.gardena_bluetooth.image import CONTOURS
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import AQUA_CONTOUR_SERVICE_INFO, setup_entry
+
+from tests.common import snapshot_platform
+from tests.typing import ClientSessionGenerator
+
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
+ENTITY_ID = "image.mock_title_contour_1"
+
+
+def _contour_reads(client: Mock) -> int:
+    """Count how many segmented contour reads the client was asked for."""
+    return sum(
+        isinstance(args[0], CharacteristicContourPoints)
+        for args, _ in client.read_char.call_args_list
+    )
+
+
+async def _contour(client: TestClient, entity_id: str) -> str:
+    """Fetch the svg an image entity currently serves."""
+    resp = await client.get(f"/api/image_proxy/{entity_id}")
+    assert resp.status == HTTPStatus.OK
+    return (await resp.read()).decode()
+
+
+def _encode(points: Iterable[tuple[int, int]]) -> bytes:
+    """Encode angle and distance pairs the way the device transmits them."""
+    return b"".join(
+        bytes([angle >> 1, ((angle & 1) << 7) | distance // 10])
+        for angle, distance in points
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_getrandbits() -> Generator[None]:
+    """Mock image access token which normally is randomized."""
+    with patch(
+        "homeassistant.components.image.SystemRandom.getrandbits",
+        return_value=1,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_contours(
+    mock_read_char_raw: dict[str, bytes | Exception],
+) -> dict[str, bytes | Exception]:
+    """Mock contour data on the device."""
+    mock_read_char_raw.update(
+        {
+            # The device exposes the pair the segmented read is written to and
+            # received on; the five contours are virtual characteristics on it
+            AquaContourContours.contour_receive.unique_id: b"",
+            AquaContourContours.contour_transmit.unique_id: b"",
+            AquaContourContours.contour_points_1.unique_id: _encode(
+                [(0, 900), (90, 1200), (180, 900), (270, 600)]
+            ),
+            AquaContourContours.contour_points_2.unique_id: _encode(
+                [(0, 500), (90, 800), (180, 500), (270, 800)]
+            ),
+            AquaContourContours.contour_points_3.unique_id: _encode(
+                [(angle % 360, 900) for angle in range(300, 421, 10)]
+            ),
+            AquaContourContours.contour_points_4.unique_id: b"",
+            AquaContourContours.contour_points_5.unique_id: b"",
+            # Position 2 is assigned contour 1, with the sprinkler throwing
+            # 700 out at 45 degrees.
+            AquaContour.active_contour.unique_id: AquaContour.active_contour.encode(
+                [3, 1, 2, 4, 5]
+            ),
+            AquaContourPosition.active_position.unique_id: (
+                AquaContourPosition.active_position.encode(2)
+            ),
+            Spray.current_sector.unique_id: Spray.current_sector.encode(45),
+            Spray.current_distance.unique_id: Spray.current_distance.encode(700),
+        }
+    )
+    return mock_read_char_raw
+
+
+@pytest.mark.usefixtures("mock_contours")
+async def test_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test setup creates expected entities."""
+    entry = await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_contours")
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "image.mock_title_contour_1",
+        "image.mock_title_active_contour",
+    ],
+)
+async def test_image_content(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+) -> None:
+    """Test the rendered contour is served as an svg."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+
+    client = await hass_client()
+    resp = await client.get(f"/api/image_proxy/{entity_id}")
+    assert resp.status == HTTPStatus.OK
+    assert resp.content_type == "image/svg+xml"
+    assert (await resp.read()).decode() == snapshot
+
+
+@pytest.mark.usefixtures("mock_contours")
+async def test_image_without_contour(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a contour slot that has no points has no image to serve."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+
+    state = hass.states.get("image.mock_title_contour_4")
+    assert state
+    assert state.state == "unknown"
+
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.mock_title_contour_4")
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+async def test_active_contour_follows_position(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_contours: dict[str, bytes | Exception],
+    scan_step: Callable[[], Awaitable[None]],
+) -> None:
+    """Test the position selects which contour is drawn."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+    client = await hass_client()
+    active = "image.mock_title_active_contour"
+
+    # Position 2 is assigned contour 1, position 3 is assigned contour 2. Stop
+    # watering so the spray is not drawn over the contour being compared.
+    mock_contours[Spray.current_distance.unique_id] = Spray.current_distance.encode(0)
+    await scan_step()
+    assert await _contour(client, active) == await _contour(
+        client, "image.mock_title_contour_1"
+    )
+
+    mock_contours[AquaContourPosition.active_position.unique_id] = (
+        AquaContourPosition.active_position.encode(3)
+    )
+    await scan_step()
+
+    assert await _contour(client, active) == await _contour(
+        client, "image.mock_title_contour_2"
+    )
+
+
+@pytest.mark.usefixtures("mock_contours")
+async def test_active_contour_idle_drops_spray(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_read_char_raw: dict[str, bytes | Exception],
+    scan_step: Callable[[], Awaitable[None]],
+) -> None:
+    """Test the spray is only drawn while a contour is being watered."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+    client = await hass_client()
+
+    watering = await _contour(client, "image.mock_title_active_contour")
+    assert watering != await _contour(client, "image.mock_title_contour_1")
+
+    mock_read_char_raw[Spray.current_distance.unique_id] = (
+        Spray.current_distance.encode(0)
+    )
+    await scan_step()
+
+    # Idle keeps the contour on screen, just without the jet drawn across it.
+    idle = await _contour(client, "image.mock_title_active_contour")
+    assert idle == await _contour(client, "image.mock_title_contour_1")
+
+
+@pytest.mark.usefixtures("mock_contours")
+async def test_contour_read_once(
+    hass: HomeAssistant,
+    mock_client: Mock,
+    scan_step: Callable[[], Awaitable[None]],
+) -> None:
+    """Test the slow segmented reads are not repeated on every poll."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+    assert _contour_reads(mock_client) == len(CONTOURS)
+
+    await scan_step()
+
+    assert _contour_reads(mock_client) == len(CONTOURS)
+
+
+async def test_contour_read_failure(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_contours: dict[str, bytes | Exception],
+) -> None:
+    """Test an unreadable contour leaves the others rendered."""
+    mock_contours[AquaContourContours.contour_points_1.unique_id] = (
+        CharacteristicNoAccess("Mock failure")
+    )
+
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == "unknown"
+
+    client = await hass_client()
+    assert await _contour(client, "image.mock_title_contour_2")

--- a/tests/components/gardena_bluetooth/test_image.py
+++ b/tests/components/gardena_bluetooth/test_image.py
@@ -16,6 +16,7 @@ from gardena_bluetooth.parse import CharacteristicContourPoints
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.gardena_bluetooth.coordinator import SEGMENTED_SCAN_COUNT
 from homeassistant.components.gardena_bluetooth.image import CONTOURS
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -217,20 +218,25 @@ async def test_active_contour_idle_drops_spray(
 
 
 @pytest.mark.usefixtures("mock_contours")
-async def test_contour_read_once(
+async def test_contour_refresh(
     hass: HomeAssistant,
     mock_client: Mock,
     scan_step: Callable[[], Awaitable[None]],
 ) -> None:
-    """Test the slow segmented reads are not repeated on every poll."""
+    """Test the slow segmented reads run on their own slower cadence."""
     await setup_entry(
         hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
     )
     assert _contour_reads(mock_client) == len(CONTOURS)
 
+    # In between they are carried over from the previous poll.
+    for _ in range(SEGMENTED_SCAN_COUNT - 1):
+        await scan_step()
+    assert _contour_reads(mock_client) == len(CONTOURS)
+
     await scan_step()
 
-    assert _contour_reads(mock_client) == len(CONTOURS)
+    assert _contour_reads(mock_client) == 2 * len(CONTOURS)
 
 
 async def test_contour_read_failure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add visualisations of watering contours as image entities as well as the current watering directions. The image will look similar to (although the animation is part of a later library bump): 

<img width="150" height="150" alt="test_contour_to_svg_snapshot_spraying_within_contour" src="https://github.com/user-attachments/assets/a112323e-3913-4f92-8a3c-f163211a307c" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47362
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
