### PR TITLE
Bump lyngdorf to 1.4.9

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.8"],
+  "requirements": ["lyngdorf==1.4.9"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.8
+lyngdorf==1.4.9
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps the `lyngdorf` dependency from `1.4.8` to `1.4.9`.

Fixes reconnect logic (`lyngdorf/api.py`) opening duplicate/orphaned connections on a device-initiated disconnect:

- `_handle_disconnected` spawned a reconnect task unconditionally and could fire twice per drop, starting several concurrent reconnect loops.
- `_async_reconnect` checked `not self.healthy` before taking the connect lock, so a second loop could establish a duplicate connection after the first had already reconnected.
- `_async_establish_connection` overwrote `self._protocol` without closing the previous transport, orphaning it.
- `_schedule_monitor` never cancelled the prior monitor, so monitors accumulated and could each independently trigger their own reconnect.

On models with a small connection table (e.g. TDAI-3400, control port 84) these orphaned sockets accumulate — ESTABLISHED on the device but unreferenced by the client — until the device starts rejecting every new connection, requiring a reboot to clear. Reproduced and verified against a real TDAI-3400 (fishloa/lyngdorf#30, contributed by svwhisper).

Compare: https://github.com/fishloa/lyngdorf/compare/v1.4.8...v1.4.9

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: fishloa/lyngdorf#30
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

PyPI: https://pypi.org/project/lyngdorf/1.4.9/

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

