### PR TITLE
KNX: Initialize first expose value without sending

### DIFF
--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -286,13 +286,13 @@ class KnxExposeEntity:
         """Handle entity change for all options."""
         new_state = event.data["new_state"]
 
-        if (
-            event.data["old_state"] is None
-            and self.hass.state in (CoreState.not_running, CoreState.starting)
+        if event.data["old_state"] is None and self.hass.state in (
+            CoreState.not_running,
+            CoreState.starting,
         ):
             self._set_expose_state(new_state)
             return
-        
+
         async with TaskGroup() as tg:
             for option, xknx_expose in self._exposures:
                 expose_value = self._get_expose_value(new_state, option)

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -209,7 +209,7 @@ class KnxExposeEntity:
     def _set_expose_state(self, state: State | None) -> None:
         """Set the local state of all exposures without sending to KNX."""
         for option, xknx_expose in self._exposures:
-            state_value = self._get_expose_value(state, option)            
+            state_value = self._get_expose_value(state, option)
             try:
                 xknx_expose.sensor_value.value = state_value
             except ConversionError:

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import (
+    CoreState
     Event,
     EventStateChangedData,
     HomeAssistant,
@@ -201,10 +202,14 @@ class KnxExposeEntity:
 
     @callback
     def _init_expose_state(self) -> None:
-        """Initialize state of all exposures."""
-        init_state = self.hass.states.get(self.entity_id)
+        """Initialize state of all exposures from the current HA state."""
+        self._set_expose_state(self.hass.states.get(self.entity_id))
+
+    @callback
+    def _set_expose_state(self, state: State | None) -> None:
+        """Set the local state of all exposures without sending to KNX."""
         for option, xknx_expose in self._exposures:
-            state_value = self._get_expose_value(init_state, option)
+            state_value = self._get_expose_value(state, option)            
             try:
                 xknx_expose.sensor_value.value = state_value
             except ConversionError:
@@ -280,6 +285,14 @@ class KnxExposeEntity:
     async def _async_entity_changed(self, event: Event[EventStateChangedData]) -> None:
         """Handle entity change for all options."""
         new_state = event.data["new_state"]
+
+        if (
+            event.data["old_state"] is None
+            and self.hass.state is CoreState.starting
+        ):
+            self._set_expose_state(new_state)
+            return
+        
         async with TaskGroup() as tg:
             for option, xknx_expose in self._exposures:
                 expose_value = self._get_expose_value(new_state, option)

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import (
-    CoreState
+    CoreState,
     Event,
     EventStateChangedData,
     HomeAssistant,

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -290,7 +290,7 @@ class KnxExposeEntity:
                 expose_value = self._get_expose_value(new_state, option)
                 if expose_value is None:
                     continue
-                    
+
                 if xknx_expose.sensor_value.value is None:
                     try:
                         xknx_expose.initialize_value(expose_value)
@@ -302,9 +302,7 @@ class KnxExposeEntity:
                         )
                     continue
 
-                tg.create_task(
-                    self._async_set_knx_value(xknx_expose, expose_value)
-                )
+                tg.create_task(self._async_set_knx_value(xknx_expose, expose_value))
 
     async def _async_set_knx_value(
         self, xknx_expose: ExposeSensor, value: StateType

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -202,11 +202,7 @@ class KnxExposeEntity:
     @callback
     def _init_expose_state(self) -> None:
         """Initialize state of all exposures from the current HA state."""
-        self._set_expose_state(self.hass.states.get(self.entity_id))
-
-    @callback
-    def _set_expose_state(self, state: State | None) -> None:
-        """Set the local state of all exposures without sending to KNX."""
+        state = self.hass.states.get(self.entity_id)
         for option, xknx_expose in self._exposures:
             state_value = self._get_expose_value(state, option)
             if state_value is None:

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -26,7 +26,6 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import (
-    CoreState,
     Event,
     EventStateChangedData,
     HomeAssistant,
@@ -211,7 +210,7 @@ class KnxExposeEntity:
         for option, xknx_expose in self._exposures:
             state_value = self._get_expose_value(state, option)
             try:
-                xknx_expose.sensor_value.value = state_value
+                xknx_expose.initialize_value(state_value)
             except ConversionError:
                 _LOGGER.exception(
                     "Error setting value %s for expose sensor %s",
@@ -286,19 +285,26 @@ class KnxExposeEntity:
         """Handle entity change for all options."""
         new_state = event.data["new_state"]
 
-        if event.data["old_state"] is None and self.hass.state in (
-            CoreState.not_running,
-            CoreState.starting,
-        ):
-            self._set_expose_state(new_state)
-            return
-
         async with TaskGroup() as tg:
             for option, xknx_expose in self._exposures:
                 expose_value = self._get_expose_value(new_state, option)
                 if expose_value is None:
                     continue
-                tg.create_task(self._async_set_knx_value(xknx_expose, expose_value))
+                    
+                if xknx_expose.sensor_value.value is None:
+                    try:
+                        xknx_expose.initialize_value(expose_value)
+                    except ConversionError:
+                        _LOGGER.exception(
+                            "Error setting value %s for expose sensor %s",
+                            expose_value,
+                            xknx_expose.name,
+                        )
+                    continue
+
+                tg.create_task(
+                    self._async_set_knx_value(xknx_expose, expose_value)
+                )
 
     async def _async_set_knx_value(
         self, xknx_expose: ExposeSensor, value: StateType

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -204,15 +204,15 @@ class KnxExposeEntity:
         """Initialize state of all exposures from the current HA state."""
         state = self.hass.states.get(self.entity_id)
         for option, xknx_expose in self._exposures:
-            state_value = self._get_expose_value(state, option)
-            if state_value is None:
+            expose_value = self._get_expose_value(state, option)
+            if expose_value is None:
                 continue
             try:
-                xknx_expose.initialize_value(state_value)
+                xknx_expose.initialize_value(expose_value)
             except ConversionError:
                 _LOGGER.exception(
                     "Error setting value %s for expose sensor %s",
-                    state_value,
+                    expose_value,
                     xknx_expose.name,
                 )
 

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -209,6 +209,8 @@ class KnxExposeEntity:
         """Set the local state of all exposures without sending to KNX."""
         for option, xknx_expose in self._exposures:
             state_value = self._get_expose_value(state, option)
+            if state_value is None:
+                continue
             try:
                 xknx_expose.initialize_value(state_value)
             except ConversionError:

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -288,7 +288,7 @@ class KnxExposeEntity:
 
         if (
             event.data["old_state"] is None
-            and self.hass.state is CoreState.starting
+            and self.hass.state in (CoreState.not_running, CoreState.starting)
         ):
             self._set_expose_state(new_state)
             return

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_VALUE_TEMPLATE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 
 from .conftest import KNXTestKit
 
@@ -50,6 +50,39 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # Change attribute and state
     hass.states.async_set(entity_id, "off", {"brightness": 0})
+    await hass.async_block_till_done()
+    await knx.assert_write("1/1/8", False)
+
+
+async def test_binary_expose_does_not_send_initial_state_during_startup(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test an initial state during startup is not exposed to KNX."""
+    entity_id = "binary_sensor.fake"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "binary",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+            }
+        },
+    )
+
+    hass.set_state(CoreState.starting)
+
+    # Restored/initial state during startup initializes the expose value only.
+    hass.states.async_set(entity_id, "on", {})
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
+
+    # The initialized value is available for GroupValueRead responses.
+    await knx.receive_read("1/1/8")
+    await knx.assert_response("1/1/8", True)
+
+    # Once startup is complete, actual state changes are exposed normally.
+    hass.set_state(CoreState.running)
+    hass.states.async_set(entity_id, "off", {})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)
 

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -79,7 +79,7 @@ async def test_binary_expose_does_not_send_initial_state(
     await knx.receive_read("1/1/8")
     await knx.assert_response("1/1/8", True)
 
-    # A subsequent state change is exposed even while HA is still starting.
+    # A subsequent state change is exposed normally.
     hass.states.async_set(entity_id, "off", {})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -38,17 +38,17 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
         },
     )
 
-    # Change state to on
+    # First known state initializes the expose without sending.
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
-    await knx.assert_write("1/1/8", True)
+    await knx.assert_no_telegram()
 
-    # Change attribute; keep state
+    # Change attribute; keep state.
     hass.states.async_set(entity_id, "on", {"brightness": 180})
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
 
-    # Change attribute and state
+    # Change state.
     hass.states.async_set(entity_id, "off", {"brightness": 0})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_VALUE_TEMPLATE,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
 

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -54,10 +54,6 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_write("1/1/8", False)
 
 
-@pytest.mark.parametrize(
-    "core_state",
-    [CoreState.not_running, CoreState.starting],
-)
 async def test_binary_expose_does_not_send_initial_state_during_startup(
     hass: HomeAssistant,
     knx: KNXTestKit,
@@ -73,7 +69,6 @@ async def test_binary_expose_does_not_send_initial_state_during_startup(
             }
         },
     )
-    hass.set_state(CoreState.starting)
 
     # The first known value initializes the exposure without sending.
     hass.states.async_set(entity_id, "on", {})
@@ -323,7 +318,6 @@ async def test_expose_periodic_send(
             }
         },
     )
-    hass.set_state(CoreState.starting)
 
     # Initial value is adopted without sending.
     hass.states.async_set(entity_id, "15", {})

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -264,6 +264,7 @@ async def test_expose_cooldown(
     entity_id = "fake.entity"
 
     hass.states.async_set(entity_id, "0", {})
+    await hass.async_block_till_done()
 
     await knx.setup_integration(
         {
@@ -338,7 +339,8 @@ async def test_expose_value_template(
     percent_address = "2/2/2"
 
     hass.states.async_set(entity_id, "off", {attribute: 255})
-
+    await hass.async_block_till_done()
+    
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: [
@@ -442,6 +444,7 @@ async def test_ui_expose_create_and_update(
     ws_client = await hass_ws_client(hass)
 
     hass.states.async_set(ENTITY_ID, "off", {"brightness": 30})
+    await hass.async_block_till_done()
 
     await ws_client.send_json_auto_id(
         {
@@ -492,6 +495,12 @@ async def test_ui_expose_create_and_update(
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 50})
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_2, (128,))
+    await knx.assert_no_telegram()
+    
+    hass.states.async_set(ENTITY_ID, "off", {"brightness": 50})
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, False)
+    await knx.assert_no_telegram()
 
 
 async def test_ui_expose_with_options(

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -53,9 +53,14 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)
 
-
+@pytest.mark.parametrize(
+    "core_state",
+    [CoreState.not_running, CoreState.starting],
+)
 async def test_binary_expose_does_not_send_initial_state_during_startup(
-    hass: HomeAssistant, knx: KNXTestKit
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    core_state: CoreState,
 ) -> None:
     """Test an initial state during startup is not exposed to KNX."""
     entity_id = "binary_sensor.fake"
@@ -69,7 +74,7 @@ async def test_binary_expose_does_not_send_initial_state_during_startup(
         },
     )
 
-    hass.set_state(CoreState.starting)
+    hass.set_state(core_state)
 
     # Restored/initial state during startup initializes the expose value only.
     hass.states.async_set(entity_id, "on", {})

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -58,12 +58,13 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     "core_state",
     [CoreState.not_running, CoreState.starting],
 )
+
+
 async def test_binary_expose_does_not_send_initial_state_during_startup(
     hass: HomeAssistant,
     knx: KNXTestKit,
-    core_state: CoreState,
 ) -> None:
-    """Test an initial state during startup is not exposed to KNX."""
+    """Test only the initial state during startup is not exposed to KNX."""
     entity_id = "binary_sensor.fake"
     await knx.setup_integration(
         {
@@ -74,10 +75,9 @@ async def test_binary_expose_does_not_send_initial_state_during_startup(
             }
         },
     )
+    hass.set_state(CoreState.starting)
 
-    hass.set_state(core_state)
-
-    # Restored/initial state during startup initializes the expose value only.
+    # The first known value initializes the exposure without sending.
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
@@ -86,8 +86,7 @@ async def test_binary_expose_does_not_send_initial_state_during_startup(
     await knx.receive_read("1/1/8")
     await knx.assert_response("1/1/8", True)
 
-    # Once startup is complete, actual state changes are exposed normally.
-    hass.set_state(CoreState.running)
+    # A subsequent state change is exposed even while HA is still starting.
     hass.states.async_set(entity_id, "off", {})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -53,6 +53,7 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)
 
+
 @pytest.mark.parametrize(
     "core_state",
     [CoreState.not_running, CoreState.starting],

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -58,8 +58,6 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     "core_state",
     [CoreState.not_running, CoreState.starting],
 )
-
-
 async def test_binary_expose_does_not_send_initial_state_during_startup(
     hass: HomeAssistant,
     knx: KNXTestKit,
@@ -349,7 +347,7 @@ async def test_expose_value_template(
     percent_address = "2/2/2"
 
     hass.states.async_set(entity_id, "off", {attribute: 255})
-    
+
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: [

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -495,12 +495,10 @@ async def test_ui_expose_create_and_update(
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 50})
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_2, (128,))
-    await knx.assert_no_telegram()
 
     hass.states.async_set(ENTITY_ID, "off", {"brightness": 50})
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_1, False)
-    await knx.assert_no_telegram()
 
 
 async def test_ui_expose_with_options(

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -116,10 +116,10 @@ async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.async_block_till_done()
     await knx.assert_telegram_count(0)
 
-    # Change attribute; keep state
+    # First known attribute value initializes the expose without sending.
     hass.states.async_set(entity_id, "on", {attribute: 1})
     await hass.async_block_till_done()
-    await knx.assert_write("1/1/8", (1,))
+    await knx.assert_no_telegram()
 
     # Change attribute below resolution of DPT; expect no telegram
     hass.states.async_set(entity_id, "on", {attribute: 1.2})
@@ -186,7 +186,10 @@ async def test_expose_attribute_with_default(
     # Change state to "on"; no attribute -> default
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
-    await knx.assert_write("1/1/8", (0,))
+    # Change state to "on"; no attribute -> default
+    hass.states.async_set(entity_id, "on", {})
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
 
     # Change attribute; keep state
     hass.states.async_set(entity_id, "on", {attribute: 1})
@@ -269,6 +272,9 @@ async def test_expose_cooldown(
     """Test an expose with cooldown."""
     cooldown_time = 2
     entity_id = "fake.entity"
+
+    hass.states.async_set(entity_id, "0", {})
+
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: {
@@ -279,10 +285,12 @@ async def test_expose_cooldown(
             }
         },
     )
+
     # Change state to 1
     hass.states.async_set(entity_id, "1", {})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", (1,))
+
     # Change state to 2 - skip because of cooldown
     hass.states.async_set(entity_id, "2", {})
     await hass.async_block_till_done()
@@ -292,6 +300,7 @@ async def test_expose_cooldown(
     hass.states.async_set(entity_id, "3", {})
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
+
     # Wait for cooldown to pass
     freezer.tick(timedelta(seconds=cooldown_time))
     async_fire_time_changed(hass)
@@ -300,9 +309,11 @@ async def test_expose_cooldown(
 
 
 async def test_expose_periodic_send(
-    hass: HomeAssistant, knx: KNXTestKit, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test an expose with periodic send."""
+    """Test an initialized expose with periodic send."""
     entity_id = "fake.entity"
     await knx.setup_integration(
         {
@@ -314,11 +325,14 @@ async def test_expose_periodic_send(
             }
         },
     )
-    # Initialize state
+    hass.set_state(CoreState.starting)
+
+    # Initial value is adopted without sending.
     hass.states.async_set(entity_id, "15", {})
     await hass.async_block_till_done()
-    await knx.assert_write("1/1/8", (15,))
-    # Wait for time to pass
+    await knx.assert_no_telegram()
+
+    # The initialized value is still picked up by periodic_send.
     freezer.tick(timedelta(seconds=60))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -333,6 +347,9 @@ async def test_expose_value_template(
     attribute = "brightness"
     binary_address = "1/1/1"
     percent_address = "2/2/2"
+
+    hass.states.async_set(entity_id, "off", {attribute: 255})
+    
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: [
@@ -435,6 +452,8 @@ async def test_ui_expose_create_and_update(
     await knx.setup_integration()
     ws_client = await hass_ws_client(hass)
 
+    hass.states.async_set(ENTITY_ID, "off", {"brightness": 30})
+
     await ws_client.send_json_auto_id(
         {
             "type": "knx/update_expose",
@@ -483,7 +502,6 @@ async def test_ui_expose_create_and_update(
 
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 50})
     await hass.async_block_till_done()
-    await knx.assert_write(GROUP_ADDRESS_1, True)
     await knx.assert_write(GROUP_ADDRESS_2, (128,))
 
 

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -179,9 +179,6 @@ async def test_expose_attribute_with_default(
     # Change state to "on"; no attribute -> default
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
-    # Change state to "on"; no attribute -> default
-    hass.states.async_set(entity_id, "on", {})
-    await hass.async_block_till_done()
     await knx.assert_no_telegram()
 
     # Change attribute; keep state

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -54,11 +54,11 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_write("1/1/8", False)
 
 
-async def test_binary_expose_does_not_send_initial_state_during_startup(
+async def test_binary_expose_does_not_send_initial_state(
     hass: HomeAssistant,
     knx: KNXTestKit,
 ) -> None:
-    """Test only the initial state during startup is not exposed to KNX."""
+    """Test only the initial state is not exposed to KNX."""
     entity_id = "binary_sensor.fake"
     await knx.setup_integration(
         {
@@ -340,7 +340,7 @@ async def test_expose_value_template(
 
     hass.states.async_set(entity_id, "off", {attribute: 255})
     await hass.async_block_till_done()
-    
+
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: [
@@ -496,7 +496,7 @@ async def test_ui_expose_create_and_update(
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_2, (128,))
     await knx.assert_no_telegram()
-    
+
     hass.states.async_set(ENTITY_ID, "off", {"brightness": 50})
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_1, False)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -541,11 +541,11 @@ async def test_ui_expose_with_options(
     assert res["success"], res
     assert res["result"]["success"] is True, res["result"]
 
-    # Change attribute to None - 1 because of value template
+    # Change attribute to 1 - because of value template
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 10})
     await hass.async_block_till_done()
     await knx.assert_write(GROUP_ADDRESS_1, (1,))
-    # Change attribute to 2 - skip because of cooldown
+    # Change attribute to 50 - skip because of cooldown
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 100})
     await hass.async_block_till_done()
     await knx.assert_no_telegram()

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -515,6 +515,9 @@ async def test_ui_expose_with_options(
     await knx.setup_integration()
     ws_client = await hass_ws_client(hass)
 
+    hass.states.async_set(ENTITY_ID, "on", {"brightness": 100})
+    await hass.async_block_till_done()    
+
     await ws_client.send_json_auto_id(
         {
             "type": "knx/update_expose",

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -516,7 +516,7 @@ async def test_ui_expose_with_options(
     ws_client = await hass_ws_client(hass)
 
     hass.states.async_set(ENTITY_ID, "on", {"brightness": 100})
-    await hass.async_block_till_done()    
+    await hass.async_block_till_done()
 
     await ws_client.send_json_auto_id(
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
KNX exposes no longer send the first valid value of an exposed Home Assistant entity to the KNX bus when that value becomes available after the expose has been registered.

Previously, an entity that already existed when the expose was registered was initialized silently, while an entity that became available later immediately caused a GroupValueWrite.

With this change, both cases behave consistently: the first valid value is adopted locally without sending a telegram. The value is still available for GroupValueRead responses and for periodic_send, if configured. Subsequent actual value changes continue to be sent normally.

Setups that relied on the first value of a newly available entity being written immediately to KNX will therefore no longer receive that initial telegram.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make KNX expose initialization consistent regardless of when the exposed Home Assistant entity becomes available.

An ExposeSensor now treats the first valid value it learns as its initial value:

If the expose does not have a value yet, the value is initialized locally using ExposeSensor.initialize_value() without sending a telegram.
Once the expose has been initialized, subsequent value changes are handled normally and are written to KNX when appropriate.

This replaces the previous startup-specific handling. The behavior no longer depends on Home Assistant's CoreState or on whether a state_changed event has an old_state.

Using ExposeSensor.initialize_value() also initializes the internal payload used by XKNX, ensuring that GroupValueRead responses, periodic_send, and skip_unchanged work correctly after initialization.

This fixes the inconsistent previous behavior:

Before

Entity exists when the KNX expose is registered → initial value is adopted without sending.
Entity becomes available after the KNX expose is registered → first value causes a GroupValueWrite.

After

First valid value learned by the KNX expose → adopted locally without sending.
Subsequent actual value changes → exposed to KNX normally.

This also prevents restored entity states from generating unintended KNX telegrams after a Home Assistant restart.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/XKNX/knx-frontend/issues/436
- XKNX support for ExposeSensor.initialize_value() was added in XKNX/xknx#1906.
- The required XKNX 3.20.0 dependency update was merged separately in home-assistant/core#179260.
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
