### PR TITLE
Translate Imou button, switch, and camera API errors

### DIFF
--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import PTZ_MOVE_DURATION_MS, imou_device_identifier
+from .const import DOMAIN, PTZ_MOVE_DURATION_MS, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 
@@ -110,4 +110,7 @@ class ImouButton(ImouEntity, ButtonEntity):
                 duration,
             )
         except ImouException as e:
-            raise HomeAssistantError(str(e)) from e
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="press_button_failed",
+            ) from e

--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -113,4 +113,5 @@ class ImouButton(ImouEntity, ButtonEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="press_button_failed",
+                translation_placeholders={"error": e.message},
             ) from e

--- a/homeassistant/components/imou/camera.py
+++ b/homeassistant/components/imou/camera.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import PARAM_HEADER_DETECT, imou_device_identifier
+from .const import DOMAIN, PARAM_HEADER_DETECT, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 
@@ -98,7 +98,10 @@ class ImouCamera(ImouEntity, Camera):
                 PYIMOUAPI_LIVE_PROTOCOL,
             )
         except ImouException as err:
-            raise HomeAssistantError(str(err)) from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="get_stream_failed",
+            ) from err
 
     @override
     async def async_camera_image(
@@ -111,7 +114,10 @@ class ImouCamera(ImouEntity, Camera):
                 PYIMOUAPI_SNAPSHOT_WAIT_SECONDS,
             )
         except ImouException as err:
-            raise HomeAssistantError(str(err)) from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="get_image_failed",
+            ) from err
 
     @property
     @override

--- a/homeassistant/components/imou/camera.py
+++ b/homeassistant/components/imou/camera.py
@@ -101,6 +101,7 @@ class ImouCamera(ImouEntity, Camera):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="get_stream_failed",
+                translation_placeholders={"error": err.message},
             ) from err
 
     @override
@@ -117,6 +118,7 @@ class ImouCamera(ImouEntity, Camera):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="get_image_failed",
+                translation_placeholders={"error": err.message},
             ) from err
 
     @property

--- a/homeassistant/components/imou/select.py
+++ b/homeassistant/components/imou/select.py
@@ -99,5 +99,6 @@ class ImouSelect(ImouEntity, SelectEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="select_option_failed",
+                translation_placeholders={"error": e.message},
             ) from e
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -124,7 +124,19 @@
     }
   },
   "exceptions": {
+    "get_image_failed": {
+      "message": "Error communicating with the Imou API"
+    },
+    "get_stream_failed": {
+      "message": "Error communicating with the Imou API"
+    },
+    "press_button_failed": {
+      "message": "Error communicating with the Imou API"
+    },
     "select_option_failed": {
+      "message": "Error communicating with the Imou API"
+    },
+    "switch_operation_failed": {
       "message": "Error communicating with the Imou API"
     }
   },

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -125,19 +125,19 @@
   },
   "exceptions": {
     "get_image_failed": {
-      "message": "Error communicating with the Imou API"
+      "message": "Could not get a snapshot from Imou: {error}"
     },
     "get_stream_failed": {
-      "message": "Error communicating with the Imou API"
+      "message": "Could not get the live stream URL from Imou: {error}"
     },
     "press_button_failed": {
-      "message": "Error communicating with the Imou API"
+      "message": "Imou rejected the button press: {error}"
     },
     "select_option_failed": {
-      "message": "Error communicating with the Imou API"
+      "message": "Imou rejected the new option: {error}"
     },
     "switch_operation_failed": {
-      "message": "Error communicating with the Imou API"
+      "message": "Imou rejected the switch change: {error}"
     }
   },
   "selector": {

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
+    DOMAIN,
     PARAM_AB_ALARM_SOUND,
     PARAM_AUDIO_ENCODE_CONTROL,
     PARAM_CLOSE_CAMERA,
@@ -131,5 +132,8 @@ class ImouSwitch(ImouEntity, SwitchEntity):
                 enable,
             )
         except ImouException as e:
-            raise HomeAssistantError(str(e)) from e
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_operation_failed",
+            ) from e
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -135,5 +135,6 @@ class ImouSwitch(ImouEntity, SwitchEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="switch_operation_failed",
+                translation_placeholders={"error": e.message},
             ) from e
         await self.coordinator.async_request_refresh()

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -130,7 +130,7 @@ async def test_press_button_service_propagates_api_error(
     entity_id = hass.states.async_all("button")[0].entity_id
 
     with pytest.raises(
-        HomeAssistantError, match="Error communicating with the Imou API"
+        HomeAssistantError, match="Imou rejected the button press: cloud failure"
     ):
         await hass.services.async_call(
             BUTTON_DOMAIN,

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -129,7 +129,9 @@ async def test_press_button_service_propagates_api_error(
 
     entity_id = hass.states.async_all("button")[0].entity_id
 
-    with pytest.raises(HomeAssistantError, match="cloud failure"):
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with the Imou API"
+    ):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -296,7 +296,8 @@ async def test_camera_stream_source_propagates_api_error(
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(
-        HomeAssistantError, match="Error communicating with the Imou API"
+        HomeAssistantError,
+        match="Could not get the live stream URL from Imou: stream failure",
     ):
         await async_get_stream_source(hass, entity_id)
 
@@ -327,7 +328,8 @@ async def test_camera_image_propagates_api_error(
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(
-        HomeAssistantError, match="Error communicating with the Imou API"
+        HomeAssistantError,
+        match="Could not get a snapshot from Imou: image failure",
     ):
         await async_get_image(hass, entity_id)
 

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -295,8 +295,41 @@ async def test_camera_stream_source_propagates_api_error(
     )
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
-    with pytest.raises(HomeAssistantError, match="stream failure"):
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with the Imou API"
+    ):
         await async_get_stream_source(hass, entity_id)
+
+
+@pytest.mark.parametrize(
+    "imou_mock_devices",
+    [
+        [
+            create_online_device(
+                "d1",
+                "Device 1",
+                channel_id="1",
+                button_keys=(),
+            )
+        ]
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_camera_image_propagates_api_error(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Imou API errors from snapshot fetch surface to the caller."""
+    init_integration.async_get_device_image.side_effect = ImouException("image failure")
+
+    entity_id = _camera_entity_id(entity_registry, mock_config_entry)
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with the Imou API"
+    ):
+        await async_get_image(hass, entity_id)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_select.py
+++ b/tests/components/imou/test_select.py
@@ -145,7 +145,7 @@ async def test_select_option_propagates_api_error(
     )
 
     with pytest.raises(
-        HomeAssistantError, match="Error communicating with the Imou API"
+        HomeAssistantError, match="Imou rejected the new option: cloud failure"
     ):
         await hass.services.async_call(
             SELECT_DOMAIN,

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -169,7 +169,9 @@ async def test_turn_on_service_propagates_api_error(
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 
-    with pytest.raises(HomeAssistantError, match="cloud failure"):
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with the Imou API"
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -170,7 +170,7 @@ async def test_turn_on_service_propagates_api_error(
     entity_id = hass.states.async_all("switch")[0].entity_id
 
     with pytest.raises(
-        HomeAssistantError, match="Error communicating with the Imou API"
+        HomeAssistantError, match="Imou rejected the switch change: cloud failure"
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #177456: align button, switch, camera, and select with translated `HomeAssistantError`, including the vendor reason via `translation_placeholders`.

When `ImouException` is raised from press / switch / select / stream / snapshot calls, raise:

```python
HomeAssistantError(
    translation_domain=DOMAIN,
    translation_key="…",
    translation_placeholders={"error": e.message},
)
```

instead of `HomeAssistantError(str(e))` (or a fixed message with no detail). Users see a stable translated prefix plus the API reason, matching the community `imou_life` pattern and Core integrations that use `{error}` placeholders.

Exception keys / English copy:

- `press_button_failed` — Imou rejected the button press: {error}
- `switch_operation_failed` — Imou rejected the switch change: {error}
- `select_option_failed` — Imou rejected the new option: {error} (updates the key added in #177456)
- `get_stream_failed` — Could not get the live stream URL from Imou: {error}
- `get_image_failed` — Could not get a snapshot from Imou: {error}

Out of scope (still follow-ups from #177456): import shared `PARAM_*` from pyimouapi; change `init_integration` to return `MockConfigEntry`; `alarm_control_panel` for mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #177456
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr