### PR TITLE
Add brightness step buttons for Overkiz RTS dimmable lights

### DIFF
--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -19,6 +19,9 @@ from . import OverkizDataConfigEntry
 from .const import IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 
+# Default brightness step size used for RTS dimming commands
+_BRIGHTNESS_STEP_SIZE = 5
+
 
 @dataclass(frozen=True)
 class OverkizButtonDescription(ButtonEntityDescription):
@@ -89,13 +92,13 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
         name="Brightness up",
         icon="mdi:brightness-7",
         # step (0-127), execution duration (0-15, optional)
-        press_args=[5],
+        press_args=[_BRIGHTNESS_STEP_SIZE],
     ),
     OverkizButtonDescription(
         key=OverkizCommand.STEP_NEGATIVE,
         name="Brightness down",
         icon="mdi:brightness-3",
-        press_args=[5],
+        press_args=[_BRIGHTNESS_STEP_SIZE],
     ),
     # SmokeSensor
     OverkizButtonDescription(

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -19,9 +19,6 @@ from . import OverkizDataConfigEntry
 from .const import IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 
-# Default brightness step size used for RTS dimming commands
-_BRIGHTNESS_STEP_SIZE = 5
-
 
 @dataclass(frozen=True)
 class OverkizButtonDescription(ButtonEntityDescription):
@@ -92,13 +89,14 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
         name="Brightness up",
         icon="mdi:brightness-7",
         # step (0-127), execution duration (0-15, optional)
-        press_args=[_BRIGHTNESS_STEP_SIZE],
+        press_args=[5],
     ),
     OverkizButtonDescription(
         key=OverkizCommand.STEP_NEGATIVE,
         name="Brightness down",
         icon="mdi:brightness-3",
-        press_args=[_BRIGHTNESS_STEP_SIZE],
+        # step (0-127), execution duration (0-15, optional)
+        press_args=[5],
     ),
     # SmokeSensor
     OverkizButtonDescription(

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -24,7 +24,7 @@ from .entity import OverkizDescriptiveEntity
 class OverkizButtonDescription(ButtonEntityDescription):
     """Class to describe an Overkiz button."""
 
-    press_args: OverkizStateType | None = None
+    press_args: list[OverkizStateType] | None = None
 
 
 BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
@@ -74,7 +74,7 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
     # DynamicScreen (ogp:blind) uses goToAlias (id 1: favorite1) instead of 'my'
     OverkizButtonDescription(
         key=OverkizCommand.GO_TO_ALIAS,
-        press_args="1",
+        press_args=["1"],
         name="My position",
         icon="mdi:star",
     ),
@@ -83,10 +83,25 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
         name="Toggle",
         icon="mdi:sync",
     ),
+    # DimmerOnOffLight (rts:DimmableLightRTSComponent)
+    # RTS is one-way, thus this light can only be dimmed relatively. Parameters
+    # are the step (0..127) and cancel timeout in seconds, as sent by the Somfy app.
+    OverkizButtonDescription(
+        key=OverkizCommand.STEP_POSITIVE,
+        name="Brightness up",
+        icon="mdi:brightness-7",
+        press_args=[5, 0],
+    ),
+    OverkizButtonDescription(
+        key=OverkizCommand.STEP_NEGATIVE,
+        name="Brightness down",
+        icon="mdi:brightness-3",
+        press_args=[5, 0],
+    ),
     # SmokeSensor
     OverkizButtonDescription(
         key=OverkizCommand.CHECK_EVENT_TRIGGER,
-        press_args=OverkizCommandParam.SHORT,
+        press_args=[OverkizCommandParam.SHORT],
         name="Test",
         icon="mdi:smoke-detector",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -138,9 +153,9 @@ class OverkizButton(OverkizDescriptiveEntity, ButtonEntity):
     @override
     async def async_press(self) -> None:
         """Handle the button press."""
-        if self.entity_description.press_args:
+        if (press_args := self.entity_description.press_args) is not None:
             await self.executor.async_execute_command(
-                self.entity_description.key, self.entity_description.press_args
+                self.entity_description.key, *press_args
             )
             return
 

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -84,12 +84,11 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
         icon="mdi:sync",
     ),
     # DimmerOnOffLight (rts:DimmableLightRTSComponent)
-    # RTS is one-way, thus this light can only be dimmed relatively. Parameters
-    # are the step (0..127) and cancel timeout in seconds, as sent by the Somfy app.
     OverkizButtonDescription(
         key=OverkizCommand.STEP_POSITIVE,
         name="Brightness up",
         icon="mdi:brightness-7",
+        # step (0-127), execution duration (0-15, optional)
         press_args=[5, 0],
     ),
     OverkizButtonDescription(

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -89,13 +89,13 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
         name="Brightness up",
         icon="mdi:brightness-7",
         # step (0-127), execution duration (0-15, optional)
-        press_args=[5, 0],
+        press_args=[5],
     ),
     OverkizButtonDescription(
         key=OverkizCommand.STEP_NEGATIVE,
         name="Brightness down",
         icon="mdi:brightness-3",
-        press_args=[5, 0],
+        press_args=[5],
     ),
     # SmokeSensor
     OverkizButtonDescription(

--- a/tests/components/overkiz/fixtures/setup/cloud_somfy_connexoon_rts_asia.json
+++ b/tests/components/overkiz/fixtures/setup/cloud_somfy_connexoon_rts_asia.json
@@ -611,6 +611,97 @@
       "type": 1,
       "oid": "97f85fd1-53f7-4cdf-8c73-9b2c172dbd62",
       "uiClass": "Generic"
+    },
+    {
+      "creationTime": 1613676730000,
+      "lastUpdateTime": 1613676730000,
+      "label": "LED Strip",
+      "deviceURL": "rts://1234-1234-6362/16752757",
+      "shortcut": false,
+      "controllableName": "rts:DimmableLightRTSComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "down",
+            "nparams": 1
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "my",
+            "nparams": 1
+          },
+          {
+            "commandName": "off",
+            "nparams": 0
+          },
+          {
+            "commandName": "on",
+            "nparams": 0
+          },
+          {
+            "commandName": "onWithTimer",
+            "nparams": 1
+          },
+          {
+            "commandName": "rest",
+            "nparams": 1
+          },
+          {
+            "commandName": "stop",
+            "nparams": 1
+          },
+          {
+            "commandName": "test",
+            "nparams": 0
+          },
+          {
+            "commandName": "up",
+            "nparams": 1
+          },
+          {
+            "commandName": "openConfiguration",
+            "nparams": 1
+          },
+          {
+            "commandName": "stepNegative",
+            "nparams": 2
+          },
+          {
+            "commandName": "stepPositive",
+            "nparams": 2
+          }
+        ],
+        "states": [],
+        "dataProperties": [
+          {
+            "value": "0",
+            "qualifiedName": "core:identifyInterval"
+          }
+        ],
+        "widgetName": "DimmerOnOffLight",
+        "uiProfiles": ["SwitchableLight", "Switchable", "UpDown"],
+        "uiClass": "Light",
+        "qualifiedName": "rts:DimmableLightRTSComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [],
+      "attributes": [
+        {
+          "name": "rts:diy",
+          "type": 6,
+          "value": false
+        }
+      ],
+      "available": true,
+      "enabled": true,
+      "placeOID": "6133b4a0-f514-4553-b635-d1b7beb7e7b2",
+      "widget": "DimmerOnOffLight",
+      "type": 1,
+      "oid": "1ebe282d-951d-4fb6-97a6-1ebfd2ff7f8f",
+      "uiClass": "Light"
     }
   ],
   "zones": [],

--- a/tests/components/overkiz/snapshots/test_button.ambr
+++ b/tests/components/overkiz/snapshots/test_button.ambr
@@ -1793,6 +1793,786 @@
     'state': 'unknown',
   })
 # ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_jaloezie_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_jaloezie_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16730044-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_jaloezie_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Jaloezie My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_jaloezie_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_jaloezie_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_jaloezie_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16730044-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_jaloezie_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Jaloezie Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_jaloezie_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_sheer_screen_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_kitchen_sheer_screen_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16753206-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_sheer_screen_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Sheer Screen My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_kitchen_sheer_screen_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_sheer_screen_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_kitchen_sheer_screen_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16753206-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_sheer_screen_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Sheer Screen Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_kitchen_sheer_screen_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_shutter_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_kitchen_shutter_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16749917-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_shutter_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Shutter My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_kitchen_shutter_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_shutter_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_kitchen_shutter_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16749917-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_kitchen_shutter_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Shutter Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_kitchen_shutter_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_brightness_down-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_led_strip_brightness_down',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Brightness down',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:brightness-3',
+    'original_name': 'Brightness down',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16752757-stepNegative',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_brightness_down-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LED Strip Brightness down',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:brightness-3',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_led_strip_brightness_down',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_brightness_up-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_led_strip_brightness_up',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Brightness up',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:brightness-7',
+    'original_name': 'Brightness up',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16752757-stepPositive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_brightness_up-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LED Strip Brightness up',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:brightness-7',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_led_strip_brightness_up',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_led_strip_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16752757-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LED Strip My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_led_strip_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_led_strip_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16752757-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_led_strip_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LED Strip Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_led_strip_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_living_room_screen_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_living_room_screen_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16718220-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_living_room_screen_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Room Screen Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_living_room_screen_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_office_venetian_blind_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_office_venetian_blind_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16747291-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_office_venetian_blind_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Office Venetian Blind My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_office_venetian_blind_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_office_venetian_blind_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_office_venetian_blind_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16747291-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_office_venetian_blind_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Office Venetian Blind Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_office_venetian_blind_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_patio_shutter_my_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.palm_court_patio_shutter_my_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'My position',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:star',
+    'original_name': 'My position',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16730022-my',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_patio_shutter_my_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Patio Shutter My position',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:star',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_patio_shutter_my_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_patio_shutter_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.palm_court_patio_shutter_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16730022-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][button.palm_court_patio_shutter_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Patio Shutter Start identify',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.palm_court_patio_shutter_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.dining_room_studio_shutter_identify-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/overkiz/snapshots/test_light.ambr
+++ b/tests/components/overkiz/snapshots/test_light.ambr
@@ -176,6 +176,66 @@
     'state': 'off',
   })
 # ---
+# name: test_light_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][light.palm_court_led_strip-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.palm_court_led_strip',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16752757',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][light.palm_court_led_strip-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LED Strip',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.palm_court_led_strip',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_light_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][light.dining_room_wall_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/overkiz/test_button.py
+++ b/tests/components/overkiz/test_button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -38,11 +39,22 @@ CHECK_EVENT_TRIGGER = FixtureDevice(
     "io://1234-5678-1698/8907539",
     "button.maple_residence_living_room_smoke_detector_test",
 )
+STEP_POSITIVE = FixtureDevice(
+    "setup/cloud_somfy_connexoon_rts_asia.json",
+    "rts://1234-1234-6362/16752757",
+    "button.palm_court_led_strip_brightness_up",
+)
+STEP_NEGATIVE = FixtureDevice(
+    "setup/cloud_somfy_connexoon_rts_asia.json",
+    "rts://1234-1234-6362/16752757",
+    "button.palm_court_led_strip_brightness_down",
+)
 
 SNAPSHOT_FIXTURES = [
     MY_POSITION,
     GO_TO_ALIAS,
     CHECK_EVENT_TRIGGER,
+    STEP_POSITIVE,
 ]
 
 
@@ -94,26 +106,37 @@ async def test_button_press(
     )
 
 
+@pytest.mark.parametrize(
+    ("device", "command_name", "parameters"),
+    [
+        pytest.param(GO_TO_ALIAS, "goToAlias", ["1"], id="go_to_alias"),
+        pytest.param(STEP_POSITIVE, "stepPositive", [5, 0], id="step_positive"),
+        pytest.param(STEP_NEGATIVE, "stepNegative", [5, 0], id="step_negative"),
+    ],
+)
 async def test_button_press_with_args(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
+    device: FixtureDevice,
+    command_name: str,
+    parameters: list[Any],
 ) -> None:
     """Test pressing a button with arguments sends the correct command."""
-    await setup_overkiz_integration(fixture=GO_TO_ALIAS.fixture)
+    await setup_overkiz_integration(fixture=device.fixture)
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: GO_TO_ALIAS.entity_id},
+        {ATTR_ENTITY_ID: device.entity_id},
         blocking=True,
     )
 
     assert_command_call(
         mock_client,
-        device_url=GO_TO_ALIAS.device_url,
-        command_name="goToAlias",
-        parameters=["1"],
+        device_url=device.device_url,
+        command_name=command_name,
+        parameters=parameters,
     )
 
 

--- a/tests/components/overkiz/test_button.py
+++ b/tests/components/overkiz/test_button.py
@@ -110,8 +110,8 @@ async def test_button_press(
     ("device", "command_name", "parameters"),
     [
         pytest.param(GO_TO_ALIAS, "goToAlias", ["1"], id="go_to_alias"),
-        pytest.param(STEP_POSITIVE, "stepPositive", [5, 0], id="step_positive"),
-        pytest.param(STEP_NEGATIVE, "stepNegative", [5, 0], id="step_negative"),
+        pytest.param(STEP_POSITIVE, "stepPositive", [5], id="step_positive"),
+        pytest.param(STEP_NEGATIVE, "stepNegative", [5], id="step_negative"),
     ],
 )
 async def test_button_press_with_args(

--- a/tests/components/overkiz/test_light.py
+++ b/tests/components/overkiz/test_light.py
@@ -52,11 +52,19 @@ RGB_LIGHT = FixtureDevice(
     "io://1234-5678-3293/14608095",
     "light.light_terras_rgb",
 )
+# RTS is one-way, thus this dimmable light can only be dimmed via the
+# stepPositive/stepNegative buttons and is exposed as an on/off light.
+RTS_DIMMABLE_LIGHT = FixtureDevice(
+    "setup/cloud_somfy_connexoon_rts_asia.json",
+    "rts://1234-1234-6362/16752757",
+    "light.palm_court_led_strip",
+)
 
 SNAPSHOT_FIXTURES = [
     ONOFF_LIGHT,
     DIMMABLE_LIGHT,
     RGB_LIGHT,
+    RTS_DIMMABLE_LIGHT,
 ]
 
 


### PR DESCRIPTION
## Proposed change

RTS dimmable lights (`rts:DimmableLightRTSComponent`, widget `DimmerOnOffLight`) are exposed as on/off-only, since `ColorMode.BRIGHTNESS` requires `setIntensity`; a command these devices don't have. They only support the relative `stepPositive` / `stepNegative`.

A brightness slider isn't possible here: RTS is one-way, so these devices report no states at all, and Home Assistant resolves `brightness_step_pct` into an absolute brightness before the entity sees it. This PR exposes the two commands as buttons instead, matching how the TaHoma app drives these devices:

- **Brightness up** (`stepPositive`)
- **Brightness down** (`stepNegative`)

`OverkizButtonDescription.press_args` was widened to a list, since these commands take a
step parameter.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176649
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
