### PR TITLE
Import shared Imou PARAM constants from pyimouapi

### DIFF
--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -2,6 +2,7 @@
 
 from typing import override
 
+from pyimouapi.const import PARAM_RESTART_DEVICE
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
@@ -19,8 +20,7 @@ from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 
 PARALLEL_UPDATES = 1
-# Button types
-PARAM_RESTART_DEVICE = "restart_device"
+# Button types not yet exported by pyimouapi (keep module-local).
 PARAM_MUTE = "mute"
 PARAM_PTZ_UP = "ptz_up"
 PARAM_PTZ_DOWN = "ptz_down"

--- a/homeassistant/components/imou/const.py
+++ b/homeassistant/components/imou/const.py
@@ -26,9 +26,7 @@ CONF_API_URL = "api_url"
 CONF_APP_ID = "app_id"
 CONF_APP_SECRET = "app_secret"
 
-PARAM_STATUS = "status"
-PARAM_STATE = "state"
-PARAM_MOTION_DETECT = "motion_detect"
+# Switch keys not yet exported by pyimouapi (keep integration-local).
 PARAM_HEADER_DETECT = "header_detect"
 PARAM_WHITE_LIGHT = "white_light"
 PARAM_CLOSE_CAMERA = "close_camera"
@@ -36,8 +34,6 @@ PARAM_AB_ALARM_SOUND = "ab_alarm_sound"
 PARAM_AUDIO_ENCODE_CONTROL = "audio_encode_control"
 PARAM_LIGHT = "light"
 PARAM_PLUG_SWITCH = "switch"
-PARAM_NIGHT_VISION_MODE = "night_vision_mode"
-PARAM_DEVICE_VOLUME = "device_volume"
 
 # How long each PTZ button press moves the camera, in milliseconds (Imou cloud API).
 PTZ_MOVE_DURATION_MS = 500

--- a/homeassistant/components/imou/entity.py
+++ b/homeassistant/components/imou/entity.py
@@ -2,13 +2,14 @@
 
 from typing import override
 
+from pyimouapi.const import PARAM_STATE, PARAM_STATUS
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, PARAM_STATE, PARAM_STATUS, imou_device_identifier
+from .const import DOMAIN, imou_device_identifier
 from .coordinator import ImouDataUpdateCoordinator
 
 

--- a/homeassistant/components/imou/select.py
+++ b/homeassistant/components/imou/select.py
@@ -2,7 +2,12 @@
 
 from typing import override
 
-from pyimouapi.const import PARAM_CURRENT_OPTION, PARAM_OPTIONS
+from pyimouapi.const import (
+    PARAM_CURRENT_OPTION,
+    PARAM_DEVICE_VOLUME,
+    PARAM_NIGHT_VISION_MODE,
+    PARAM_OPTIONS,
+)
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
@@ -12,12 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    DOMAIN,
-    PARAM_DEVICE_VOLUME,
-    PARAM_NIGHT_VISION_MODE,
-    imou_device_identifier,
-)
+from .const import DOMAIN, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 

--- a/homeassistant/components/imou/sensor.py
+++ b/homeassistant/components/imou/sensor.py
@@ -3,7 +3,12 @@
 from dataclasses import dataclass
 from typing import override
 
-from pyimouapi.const import PARAM_STATE_VARIANT, STATE_VARIANT_NUMERIC
+from pyimouapi.const import (
+    PARAM_STATE,
+    PARAM_STATE_VARIANT,
+    PARAM_STATUS,
+    STATE_VARIANT_NUMERIC,
+)
 from pyimouapi.ha_device import ImouHaDevice
 
 from homeassistant.components.sensor import (
@@ -26,7 +31,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import PARAM_STATE, PARAM_STATUS, imou_device_identifier
+from .const import imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -2,6 +2,7 @@
 
 from typing import Any, override
 
+from pyimouapi.const import PARAM_MOTION_DETECT, PARAM_STATE
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
@@ -21,9 +22,7 @@ from .const import (
     PARAM_CLOSE_CAMERA,
     PARAM_HEADER_DETECT,
     PARAM_LIGHT,
-    PARAM_MOTION_DETECT,
     PARAM_PLUG_SWITCH,
-    PARAM_STATE,
     PARAM_WHITE_LIGHT,
     imou_device_identifier,
 )

--- a/tests/components/imou/const.py
+++ b/tests/components/imou/const.py
@@ -3,7 +3,11 @@
 from pyimouapi.const import (
     PARAM_BATTERY,
     PARAM_CURRENT_OPTION,
+    PARAM_DEVICE_VOLUME,
+    PARAM_MOTION_DETECT,
+    PARAM_NIGHT_VISION_MODE,
     PARAM_OPTIONS,
+    PARAM_RESTART_DEVICE,
     PARAM_STATE,
     PARAM_STATE_VARIANT,
     PARAM_STATUS,
@@ -13,20 +17,13 @@ from pyimouapi.const import (
 )
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 
-from homeassistant.components.imou.button import (
-    PARAM_MUTE,
-    PARAM_PTZ_UP,
-    PARAM_RESTART_DEVICE,
-)
+from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import (
     CONF_API_URL,
     CONF_APP_ID,
     CONF_APP_SECRET,
-    PARAM_DEVICE_VOLUME,
     PARAM_HEADER_DETECT,
     PARAM_LIGHT,
-    PARAM_MOTION_DETECT,
-    PARAM_NIGHT_VISION_MODE,
     PARAM_PLUG_SWITCH,
 )
 

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+from pyimouapi.const import PARAM_STATE, PARAM_STATUS
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
@@ -10,11 +11,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
-from homeassistant.components.imou.const import (
-    PARAM_STATE,
-    PARAM_STATUS,
-    PTZ_MOVE_DURATION_MS,
-)
+from homeassistant.components.imou.const import PTZ_MOVE_DURATION_MS
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant

--- a/tests/components/imou/test_init.py
+++ b/tests/components/imou/test_init.py
@@ -3,12 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+from pyimouapi.const import PARAM_STATE, PARAM_STATUS
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
-from homeassistant.components.imou.const import DOMAIN, PARAM_STATE, PARAM_STATUS
+from homeassistant.components.imou.const import DOMAIN
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE

--- a/tests/components/imou/test_select.py
+++ b/tests/components/imou/test_select.py
@@ -3,18 +3,19 @@
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
-from pyimouapi.const import PARAM_CURRENT_OPTION, PARAM_OPTIONS
+from pyimouapi.const import (
+    PARAM_CURRENT_OPTION,
+    PARAM_DEVICE_VOLUME,
+    PARAM_NIGHT_VISION_MODE,
+    PARAM_OPTIONS,
+    PARAM_STATE,
+    PARAM_STATUS,
+)
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.imou.const import (
-    PARAM_DEVICE_VOLUME,
-    PARAM_NIGHT_VISION_MODE,
-    PARAM_STATE,
-    PARAM_STATUS,
-)
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.const import (

--- a/tests/components/imou/test_sensor.py
+++ b/tests/components/imou/test_sensor.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock
 from freezegun.api import FrozenDateTimeFactory
 from pyimouapi.const import (
     PARAM_BATTERY,
+    PARAM_STATE,
     PARAM_STATE_VARIANT,
+    PARAM_STATUS,
     PARAM_STORAGE_USED,
     STATE_VARIANT_ENUM,
 )
@@ -13,7 +15,6 @@ from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.imou.const import PARAM_STATE, PARAM_STATUS
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -3,17 +3,13 @@
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+from pyimouapi.const import PARAM_MOTION_DETECT, PARAM_STATE, PARAM_STATUS
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.imou.const import (
-    PARAM_HEADER_DETECT,
-    PARAM_MOTION_DETECT,
-    PARAM_STATE,
-    PARAM_STATUS,
-)
+from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #177456 / #178796: import shared device field constants from `pyimouapi.const` instead of redefining them in the Imou integration.

**Imported from pyimouapi** (where used): `PARAM_STATE`, `PARAM_STATUS`, `PARAM_MOTION_DETECT`, `PARAM_NIGHT_VISION_MODE`, `PARAM_DEVICE_VOLUME`, `PARAM_RESTART_DEVICE` (plus existing uses of `PARAM_HD`, `PARAM_CURRENT_OPTION`, `PARAM_OPTIONS`, `PARAM_STATE_VARIANT`, etc.).

**Kept integration-local** (not exported by pyimouapi 1.3.4): switch keys such as `header_detect`, `white_light`, `close_camera`, `ab_alarm_sound`, `audio_encode_control`, `light`, plug `switch`; button keys `mute` / `ptz_*`.

`homeassistant.components.imou.const` is not used as a re-export hub for library constants.

Out of scope: change `init_integration` to return `MockConfigEntry`; `alarm_control_panel` for mode; library bump / exporting additional keys.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #177456
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr