### PR TITLE
Bump pystiebeleltron to 0.6.3

### DIFF
--- a/homeassistant/components/stiebel_eltron/manifest.json
+++ b/homeassistant/components/stiebel_eltron/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_polling",
   "loggers": ["pymodbus", "pystiebeleltron"],
   "quality_scale": "silver",
-  "requirements": ["pystiebeleltron==0.6.2"]
+  "requirements": ["pystiebeleltron==0.6.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2620,7 +2620,7 @@ pyspeex-noise==1.0.2
 pysqueezebox==0.14.0
 
 # homeassistant.components.stiebel_eltron
-pystiebeleltron==0.6.2
+pystiebeleltron==0.6.3
 
 # homeassistant.components.suez_water
 pysuezV2==2.0.7

--- a/tests/components/stiebel_eltron/conftest.py
+++ b/tests/components/stiebel_eltron/conftest.py
@@ -36,7 +36,7 @@ async def mock_connect_tcp(
     mock_modbus_connection: MockModbusConnection,
 ) -> AsyncGenerator[AsyncMock]:
     """Patch connect_tcp to return the in-memory mock connection."""
-    await mock_modbus_connection.connect()
+    assert mock_modbus_connection.connected
     connect = AsyncMock(return_value=mock_modbus_connection)
     with (
         patch("homeassistant.components.stiebel_eltron.connect_tcp", new=connect),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `pystiebeleltron` from 0.6.2 to 0.6.3 for the `stiebel_eltron` integration. 0.6.3 constrains `modbus-connection` to `>=3.7,<4`, so an incompatible 4.x release can no longer be selected. This aligns Core with the released 0.6.3 pin of the HACS integration and follows up on #178362.

The test fixture no longer calls `await mock_modbus_connection.connect()`. That method does not exist on the mock of the compatible 3.x dependency, which starts connected, so the fixture asserts `mock_modbus_connection.connected` instead.

`requirements_all.txt` was regenerated with `python3 -m script.gen_requirements_all`.

Validation after rebasing on current `dev`: 39 Stiebel integration tests and 3 snapshots pass, Ruff check and Ruff format pass. An earlier integration-specific hassfest run passed with only the expected stricter pymodbus range warning. A full local bootstrap is not available in this environment because of an unrelated dtlssocket/autoconf failure, so this was not verified against a complete Core run.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/pail23/stiebel_eltron_isg_component/issues/648
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

## Dependency diff

- Release notes: https://github.com/ThyMYthOS/python-stiebel-eltron/releases/tag/v0.6.3
- Diff v0.6.2...v0.6.3: https://github.com/ThyMYthOS/python-stiebel-eltron/compare/v0.6.2...v0.6.3
- PyPI: https://pypi.org/project/pystiebeleltron/0.6.3/

<!--
  Thank you for contributing <3

  Below are some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
