### PR TITLE
Migrate integrations passing merge parameters to async_update_device

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -127,16 +127,16 @@ async def async_migrate_unique_id(
     ):
         for connection in device_entry.connections:
             if connection[1] == old_unique_id:
-                new_connections = {(CONNECTION_NETWORK_MAC, new_mac)}
+                mac_connection = {(CONNECTION_NETWORK_MAC, new_mac)}
 
                 _LOGGER.debug(
                     "Migrating device %s connections to %s",
                     device_entry.name,
-                    new_connections,
+                    mac_connection,
                 )
                 dev_reg.async_update_device(
                     device_entry.id,
-                    merge_connections=new_connections,
+                    new_connections=device_entry.connections | mac_connection,
                 )
 
         if device_entry.name is None:

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -115,7 +115,7 @@ async def async_setup_entry(
         # the correct device.
         dev_reg.async_update_device(
             device_id,
-            merge_connections={(dr.CONNECTION_UPNP, udn)},
+            new_connections=device_entry.connections | {(dr.CONNECTION_UPNP, udn)},
         )
 
     # Create our own device-wrapping entity

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -98,7 +98,9 @@ async def test_get_actions(
     # Add alternate identifiers, to make sure we can handle future formats
     identifiers: list[str] = list(*device_entry.identifiers)
     device_registry.async_update_device(
-        device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
+        device_entry.id,
+        new_identifiers=device_entry.identifiers
+        | {(identifiers[0], "_".join(identifiers[1:]))},
     )
     device_entry = device_registry.async_get_device_by_identifier(
         device.device_identifier, mock_entry.entry_id

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -96,7 +96,9 @@ async def test_get_triggers(
     # Add alternate identifiers, to make sure we can handle future formats
     identifiers: list[str] = list(event.device_identifier)
     device_registry.async_update_device(
-        device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
+        device_entry.id,
+        new_identifiers=device_entry.identifiers
+        | {(identifiers[0], "_".join(identifiers[1:]))},
     )
     device_entry = device_registry.async_get_device_by_identifier(
         event.device_identifier, mock_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate integrations passing `merge_connections` or `merge_identifiers` to `async_update_device`

Adapts integrations (including tests) to https://github.com/home-assistant/core/pull/178888

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
