### PR TITLE
Change energenie key to one without dashes

### DIFF
--- a/homeassistant/components/energenie_power_sockets/__init__.py
+++ b/homeassistant/components/energenie_power_sockets/__init__.py
@@ -15,6 +15,16 @@ PLATFORMS = [Platform.SWITCH]
 type EnergenieConfigEntry = ConfigEntry[PowerStripUSB]
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: EnergenieConfigEntry) -> bool:
+    """Migrate old config entry."""
+    if entry.version == 1:
+        new_data = {**entry.data}
+        new_data[CONF_DEVICE_API_ID] = new_data.pop("api-device-id")
+        hass.config_entries.async_update_entry(entry, data=new_data, version=2)
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: EnergenieConfigEntry) -> bool:
     """Set up Energenie Power Sockets."""
     try:

--- a/homeassistant/components/energenie_power_sockets/config_flow.py
+++ b/homeassistant/components/energenie_power_sockets/config_flow.py
@@ -14,6 +14,8 @@ from .const import CONF_DEVICE_API_ID, DOMAIN, LOGGER
 class EGPSConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the config flow for EGPS devices."""
 
+    VERSION = 2
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/energenie_power_sockets/const.py
+++ b/homeassistant/components/energenie_power_sockets/const.py
@@ -4,5 +4,5 @@ import logging
 
 LOGGER = logging.getLogger(__package__)
 
-CONF_DEVICE_API_ID = "api-device-id"
+CONF_DEVICE_API_ID = "device"
 DOMAIN = "energenie_power_sockets"

--- a/tests/components/energenie_power_sockets/conftest.py
+++ b/tests/components/energenie_power_sockets/conftest.py
@@ -32,6 +32,7 @@ def valid_config_entry() -> MockConfigEntry:
     """Return a valid egps config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
+        version=2,
         data=DEMO_CONFIG_DATA,
         unique_id=DEMO_CONFIG_DATA[CONF_DEVICE_API_ID],
     )

--- a/tests/components/energenie_power_sockets/test_init.py
+++ b/tests/components/energenie_power_sockets/test_init.py
@@ -4,8 +4,14 @@ from unittest.mock import MagicMock
 
 from pyegps.exceptions import UsbError
 
+from homeassistant.components.energenie_power_sockets.const import (
+    CONF_DEVICE_API_ID,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from .conftest import DEMO_CONFIG_DATA
 
 from tests.common import MockConfigEntry
 
@@ -59,3 +65,25 @@ async def test_usb_error(
     await hass.async_block_till_done()
 
     assert valid_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    mock_get_device: MagicMock,
+) -> None:
+    """Test migrating a version 1 config entry to version 2."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={"api-device-id": DEMO_CONFIG_DATA[CONF_DEVICE_API_ID]},
+        unique_id=DEMO_CONFIG_DATA[CONF_DEVICE_API_ID],
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 2
+    assert "api-device-id" not in entry.data
+    assert entry.data[CONF_DEVICE_API_ID] == DEMO_CONFIG_DATA[CONF_DEVICE_API_ID]
+    assert entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change energenie key to one without dashes. As #171725 pointed out that the flow is missing a translation key. After looking into it, the current key uses dashes, which is something we don't want in our strings, so instead I chose to migrate the key to one that we do like.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171725
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
