### PR TITLE
Deprecate the mop drying binary sensor in favor of the switch

### DIFF
--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -14,12 +14,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory
+from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from .const import DOMAIN
 from .coordinator import (
     RoborockConfigEntry,
     RoborockCoordinatorType,
@@ -29,6 +31,7 @@ from .coordinator import (
 )
 from .entity import RoborockCoordinatedEntityA01, RoborockCoordinatedEntityV1
 from .models import DeviceState
+from .util import deprecate_entity
 
 PARALLEL_UPDATES = 0
 
@@ -56,17 +59,6 @@ class RoborockBinarySensorDescriptionA01(BinarySensorEntityDescription):
 
 
 BINARY_SENSOR_DESCRIPTIONS = [
-    RoborockBinarySensorDescription(
-        key="dry_status",
-        translation_key="mop_drying_status",
-        device_class=BinarySensorDeviceClass.RUNNING,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.status.dry_status,
-        is_dock_entity=True,
-        support_fn=lambda api: api.device_features.is_field_supported(
-            StatusV2, StatusField.DRY_STATUS
-        ),
-    ),
     RoborockBinarySensorDescription(
         key="water_box_carriage_status",
         translation_key="mop_attached",
@@ -147,6 +139,16 @@ BINARY_SENSOR_DESCRIPTIONS = [
 ]
 
 
+MOP_DRYING_BINARY_SENSOR_DESCRIPTION = RoborockBinarySensorDescription(
+    key="dry_status",
+    translation_key="mop_drying_status",
+    device_class=BinarySensorDeviceClass.RUNNING,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    value_fn=lambda data: data.status.dry_status,
+    is_dock_entity=True,
+)
+
+
 ZEO_BINARY_SENSOR_DESCRIPTIONS: list[RoborockBinarySensorDescriptionA01] = [
     RoborockBinarySensorDescriptionA01(
         key="detergent_empty",
@@ -174,6 +176,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Roborock vacuum binary sensors."""
     coordinators = config_entry.runtime_data
+    entity_registry = er.async_get(hass)
 
     @callback
     def async_add_coordinator_entities(
@@ -187,6 +190,31 @@ async def async_setup_entry(
                 for description in BINARY_SENSOR_DESCRIPTIONS
                 if description.support_fn(coordinator.properties_api)
             )
+            mop_drying_unique_id = (
+                f"{MOP_DRYING_BINARY_SENSOR_DESCRIPTION.key}_{coordinator.duid_slug}"
+            )
+            mop_drying_issue_id = f"deprecated_mop_drying_{coordinator.duid_slug}"
+            if not coordinator.properties_api.device_features.dock_features.is_dryable:
+                # The sensor was created for every device reporting the drying
+                # status data point, so a dock that cannot dry always read off.
+                if entity_id := entity_registry.async_get_entity_id(
+                    Platform.BINARY_SENSOR, DOMAIN, mop_drying_unique_id
+                ):
+                    entity_registry.async_remove(entity_id)
+                ir.async_delete_issue(hass, DOMAIN, mop_drying_issue_id)
+            elif deprecate_entity(
+                hass,
+                entity_registry,
+                platform_domain=Platform.BINARY_SENSOR,
+                entity_unique_id=mop_drying_unique_id,
+                issue_id=mop_drying_issue_id,
+                translation_key="deprecated_mop_drying",
+            ):
+                entities.append(
+                    RoborockBinarySensorEntity(
+                        coordinator, MOP_DRYING_BINARY_SENSOR_DESCRIPTION
+                    )
+                )
         elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
             entities.extend(
                 RoborockBinarySensorEntityA01(coordinator, description)

--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -14,12 +14,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory
+from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from .const import DOMAIN
 from .coordinator import (
     RoborockConfigEntry,
     RoborockCoordinatorType,
@@ -29,6 +31,7 @@ from .coordinator import (
 )
 from .entity import RoborockCoordinatedEntityA01, RoborockCoordinatedEntityV1
 from .models import DeviceState
+from .util import deprecate_entity
 
 PARALLEL_UPDATES = 0
 
@@ -56,17 +59,6 @@ class RoborockBinarySensorDescriptionA01(BinarySensorEntityDescription):
 
 
 BINARY_SENSOR_DESCRIPTIONS = [
-    RoborockBinarySensorDescription(
-        key="dry_status",
-        translation_key="mop_drying_status",
-        device_class=BinarySensorDeviceClass.RUNNING,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.status.dry_status,
-        is_dock_entity=True,
-        support_fn=lambda api: api.device_features.is_field_supported(
-            StatusV2, StatusField.DRY_STATUS
-        ),
-    ),
     RoborockBinarySensorDescription(
         key="dust_collection_status",
         translation_key="dust_collection_status",
@@ -156,6 +148,16 @@ BINARY_SENSOR_DESCRIPTIONS = [
 ]
 
 
+MOP_DRYING_BINARY_SENSOR_DESCRIPTION = RoborockBinarySensorDescription(
+    key="dry_status",
+    translation_key="mop_drying_status",
+    device_class=BinarySensorDeviceClass.RUNNING,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    value_fn=lambda data: data.status.dry_status,
+    is_dock_entity=True,
+)
+
+
 ZEO_BINARY_SENSOR_DESCRIPTIONS: list[RoborockBinarySensorDescriptionA01] = [
     RoborockBinarySensorDescriptionA01(
         key="detergent_empty",
@@ -183,6 +185,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Roborock vacuum binary sensors."""
     coordinators = config_entry.runtime_data
+    entity_registry = er.async_get(hass)
 
     @callback
     def async_add_coordinator_entities(
@@ -196,6 +199,29 @@ async def async_setup_entry(
                 for description in BINARY_SENSOR_DESCRIPTIONS
                 if description.support_fn(coordinator.properties_api)
             )
+            mop_drying_unique_id = (
+                f"{MOP_DRYING_BINARY_SENSOR_DESCRIPTION.key}_{coordinator.duid_slug}"
+            )
+            if not coordinator.properties_api.device_features.dock_features.is_dryable:
+                # The sensor was created for every device reporting the drying
+                # status data point, so a dock that cannot dry always read off.
+                if entity_id := entity_registry.async_get_entity_id(
+                    Platform.BINARY_SENSOR, DOMAIN, mop_drying_unique_id
+                ):
+                    entity_registry.async_remove(entity_id)
+            elif deprecate_entity(
+                hass,
+                entity_registry,
+                platform_domain=Platform.BINARY_SENSOR,
+                entity_unique_id=mop_drying_unique_id,
+                issue_id=f"deprecated_mop_drying_{coordinator.duid_slug}",
+                translation_key="deprecated_mop_drying",
+            ):
+                entities.append(
+                    RoborockBinarySensorEntity(
+                        coordinator, MOP_DRYING_BINARY_SENSOR_DESCRIPTION
+                    )
+                )
         elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
             entities.extend(
                 RoborockBinarySensorEntityA01(coordinator, description)

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -738,6 +738,14 @@
     "cloud_api_used": {
       "description": "The Roborock integration is unable to connect directly to {device_name} and falling back to the cloud API. This is not recommended as it can lead to rate limiting. Please make your vacuum accessible on the local network by your Home Assistant instance.",
       "title": "Cloud API used"
+    },
+    "deprecated_mop_drying": {
+      "description": "The `{entity_id}` ({entity_name}) binary sensor is deprecated and has been replaced by the **Mop drying** switch, which reports the same state and can also start and stop drying.\n\nUpdate any dashboards, templates, automations or scripts to use the new switch entity, then disable `{entity_id}` to have it removed.",
+      "title": "The Roborock mop drying binary sensor is deprecated"
+    },
+    "deprecated_mop_drying_scripts": {
+      "description": "The `{entity_id}` ({entity_name}) binary sensor is deprecated and has been replaced by the **Mop drying** switch, which reports the same state and can also start and stop drying.\n\nIt is still used in the following automations or scripts:\n{items}\n\nUpdate them to use the new switch entity, then disable `{entity_id}` to have it removed.",
+      "title": "[%key:component::roborock::issues::deprecated_mop_drying::title%]"
     }
   },
   "options": {

--- a/homeassistant/components/roborock/util.py
+++ b/homeassistant/components/roborock/util.py
@@ -1,0 +1,101 @@
+"""Utility helpers for the Roborock integration."""
+
+from homeassistant.components.automation import automations_with_entity
+from homeassistant.components.script import scripts_with_entity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
+
+from .const import DOMAIN
+
+# Version in which deprecated entities will be removed.
+DEPRECATED_REMOVAL_VERSION = "2027.3.0"
+
+
+def deprecate_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    *,
+    platform_domain: str,
+    entity_unique_id: str,
+    issue_id: str,
+    translation_key: str,
+) -> bool:
+    """Handle deprecation of an entity that has been replaced.
+
+    Return True if the deprecated entity should still be set up, which is the
+    case while it exists in the entity registry. A repair issue informs the user
+    about the replacement and the removal date; when the entity is still used by
+    automations or scripts they are listed in the issue. The entity is removed
+    once the user disables it and nothing references it anymore. New
+    installations never create the entity.
+    """
+    entity_id = entity_registry.async_get_entity_id(
+        platform_domain, DOMAIN, entity_unique_id
+    )
+    if entity_id is None:
+        async_delete_issue(hass, DOMAIN, issue_id)
+        return False
+
+    entity_entry = entity_registry.async_get(entity_id)
+    if entity_entry is None:
+        async_delete_issue(hass, DOMAIN, issue_id)
+        return False
+
+    items = _automations_and_scripts_using_entity(hass, entity_registry, entity_id)
+
+    if entity_entry.disabled and not items:
+        entity_registry.async_remove(entity_id)
+        async_delete_issue(hass, DOMAIN, issue_id)
+        return False
+
+    placeholders = {
+        "entity_id": entity_id,
+        "entity_name": entity_entry.name or entity_entry.original_name or entity_id,
+    }
+    if items:
+        translation_key = f"{translation_key}_scripts"
+        placeholders["items"] = "\n".join(items)
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        breaks_in_ha_version=DEPRECATED_REMOVAL_VERSION,
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key=translation_key,
+        translation_placeholders=placeholders,
+    )
+    return True
+
+
+def _automations_and_scripts_using_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    entity_id: str,
+) -> list[str]:
+    """Return markdown list items for automations and scripts using an entity."""
+    automations = automations_with_entity(hass, entity_id)
+    scripts = scripts_with_entity(hass, entity_id)
+    if not automations and not scripts:
+        return []
+
+    items: list[str] = []
+    for integration, used_entities in (
+        ("automation", automations),
+        ("script", scripts),
+    ):
+        for used_entity_id in used_entities:
+            if entry := entity_registry.async_get(used_entity_id):
+                items.append(
+                    f"- [{entry.original_name}](/config/{integration}/edit/{entry.unique_id})"
+                )
+            else:
+                items.append(f"- `{used_entity_id}`")
+
+    return items

--- a/tests/components/roborock/snapshots/test_binary_sensor.ambr
+++ b/tests/components/roborock/snapshots/test_binary_sensor.ambr
@@ -254,57 +254,6 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mop drying',
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
-    'original_icon': None,
-    'original_name': 'Mop drying',
-    'platform': 'roborock',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'mop_drying_status',
-    'unique_id': 'dry_status_device_2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock S7 2 Dock Mop drying',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_2_mop_attached-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -711,57 +660,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mop drying',
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
-    'original_icon': None,
-    'original_name': 'Mop drying',
-    'platform': 'roborock',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'mop_drying_status',
-    'unique_id': 'dry_status_abc123',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock S7 MaxV Dock Mop drying',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_maxv_mop_attached-entry]

--- a/tests/components/roborock/snapshots/test_binary_sensor.ambr
+++ b/tests/components/roborock/snapshots/test_binary_sensor.ambr
@@ -305,57 +305,6 @@
     'state': 'off',
   })
 # ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mop drying',
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
-    'original_icon': None,
-    'original_name': 'Mop drying',
-    'platform': 'roborock',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'mop_drying_status',
-    'unique_id': 'dry_status_device_2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock S7 2 Dock Mop drying',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_2_mop_attached-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -809,57 +758,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.roborock_s7_maxv_dock_emptying_dust_bin',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mop drying',
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
-    'original_icon': None,
-    'original_name': 'Mop drying',
-    'platform': 'roborock',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'mop_drying_status',
-    'unique_id': 'dry_status_abc123',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock S7 MaxV Dock Mop drying',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -4,12 +4,17 @@ import copy
 from typing import Any
 
 import pytest
+from roborock.data import RoborockDockTypeCode
+from roborock.device_features import RoborockDockFeatures
 from roborock.exceptions import RoborockException
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
 
 from .conftest import FakeDevice
 
@@ -122,3 +127,182 @@ async def test_zeo_request_protocols_filtered_by_schema(
     # Verify that the second Zeo device has detergent entities but NOT softener entities
     assert hass.states.get("binary_sensor.zeo_two_detergent") is not None
     assert hass.states.get("binary_sensor.zeo_two_softener") is None
+
+
+@pytest.fixture
+def dock_type(request: pytest.FixtureRequest, fake_vacuum: FakeDevice) -> None:
+    """Report the parametrized dock type for the fake vacuum."""
+    fake_vacuum.v1_properties.device_features.dock_features = (
+        RoborockDockFeatures.from_dock_type(request.param)
+    )
+
+
+MOP_DRYING_UNIQUE_ID = "dry_status_abc123"
+MOP_DRYING_ISSUE_ID = "deprecated_mop_drying_abc123"
+MOP_DRYING_ENTITY_ID = "binary_sensor.roborock_s7_maxv_dock_mop_drying"
+
+
+def register_mop_drying_sensor(
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    disabled_by: er.RegistryEntryDisabler | None = None,
+) -> None:
+    """Register the mop drying binary sensor as an existing installation would have."""
+    entity_registry.async_get_or_create(
+        Platform.BINARY_SENSOR,
+        DOMAIN,
+        MOP_DRYING_UNIQUE_ID,
+        config_entry=config_entry,
+        suggested_object_id="roborock_s7_maxv_dock_mop_drying",
+        disabled_by=disabled_by,
+    )
+
+
+async def test_mop_drying_sensor_not_created_for_new_installs(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    setup_entry: MockConfigEntry,
+) -> None:
+    """Test the deprecated mop drying sensor is not created on a fresh install."""
+    assert hass.states.get(MOP_DRYING_ENTITY_ID) is None
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_deprecated(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test an existing mop drying sensor is kept and raises a repair issue."""
+    register_mop_drying_sensor(entity_registry, mock_roborock_entry)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MOP_DRYING_ENTITY_ID).state == "off"
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) in issue_registry.issues
+
+
+@pytest.mark.parametrize(
+    "dock_type", [RoborockDockTypeCode.o1_dock], indirect=True, ids=["collect-only"]
+)
+@pytest.mark.usefixtures("dock_type")
+async def test_mop_drying_sensor_removed_for_dock_without_drying(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test the sensor is removed without a repair issue when the dock cannot dry."""
+    register_mop_drying_sensor(entity_registry, mock_roborock_entry)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MOP_DRYING_ENTITY_ID) is None
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_repair_cleared_when_dock_replaced(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test the repair issue is cleared when the dock no longer supports drying."""
+    register_mop_drying_sensor(entity_registry, mock_roborock_entry)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) in issue_registry.issues
+
+    fake_vacuum.v1_properties.device_features.dock_features = (
+        RoborockDockFeatures.from_dock_type(RoborockDockTypeCode.o1_dock)
+    )
+    await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_removed_when_disabled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test a disabled mop drying sensor is removed and the repair issue cleared."""
+    register_mop_drying_sensor(
+        entity_registry, mock_roborock_entry, er.RegistryEntryDisabler.USER
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_kept_when_used_by_automation(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test a mop drying sensor used by an automation is kept and the usage listed."""
+    register_mop_drying_sensor(
+        entity_registry, mock_roborock_entry, er.RegistryEntryDisabler.USER
+    )
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: {
+                "alias": "test_automation",
+                "triggers": {
+                    "trigger": "state",
+                    "entity_id": MOP_DRYING_ENTITY_ID,
+                },
+                "actions": {"action": "notify.notify", "data": {}},
+            }
+        },
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is not None
+    )
+    issue = issue_registry.async_get_issue(DOMAIN, MOP_DRYING_ISSUE_ID)
+    assert issue.translation_key == "deprecated_mop_drying_scripts"

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -10,9 +10,12 @@ from roborock.device_features import RoborockDockFeatures
 from roborock.exceptions import RoborockException
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from .conftest import FakeDevice
@@ -173,3 +176,144 @@ async def test_emptying_dust_bin_requires_collectable_dock(
     """Test the emptying sensor only exists for a dock that can empty."""
     entity_id = "binary_sensor.roborock_s7_maxv_dock_emptying_dust_bin"
     assert (hass.states.get(entity_id) is not None) == expected
+
+
+MOP_DRYING_UNIQUE_ID = "dry_status_abc123"
+MOP_DRYING_ISSUE_ID = "deprecated_mop_drying_abc123"
+MOP_DRYING_ENTITY_ID = "binary_sensor.roborock_s7_maxv_dock_mop_drying"
+
+
+def register_mop_drying_sensor(
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    disabled_by: er.RegistryEntryDisabler | None = None,
+) -> None:
+    """Register the mop drying binary sensor as an existing installation would have."""
+    entity_registry.async_get_or_create(
+        Platform.BINARY_SENSOR,
+        DOMAIN,
+        MOP_DRYING_UNIQUE_ID,
+        config_entry=config_entry,
+        suggested_object_id="roborock_s7_maxv_dock_mop_drying",
+        disabled_by=disabled_by,
+    )
+
+
+async def test_mop_drying_sensor_not_created_for_new_installs(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    setup_entry: MockConfigEntry,
+) -> None:
+    """Test the deprecated mop drying sensor is not created on a fresh install."""
+    assert hass.states.get(MOP_DRYING_ENTITY_ID) is None
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_deprecated(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test an existing mop drying sensor is kept and raises a repair issue."""
+    register_mop_drying_sensor(entity_registry, mock_roborock_entry)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MOP_DRYING_ENTITY_ID).state == "off"
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) in issue_registry.issues
+
+
+@pytest.mark.parametrize(
+    "dock_type", [RoborockDockTypeCode.o1_dock], indirect=True, ids=["collect-only"]
+)
+@pytest.mark.usefixtures("dock_type")
+async def test_mop_drying_sensor_removed_for_dock_without_drying(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test the sensor is removed without a repair issue when the dock cannot dry."""
+    register_mop_drying_sensor(entity_registry, mock_roborock_entry)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MOP_DRYING_ENTITY_ID) is None
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_removed_when_disabled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test a disabled mop drying sensor is removed and the repair issue cleared."""
+    register_mop_drying_sensor(
+        entity_registry, mock_roborock_entry, er.RegistryEntryDisabler.USER
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is None
+    )
+    assert (DOMAIN, MOP_DRYING_ISSUE_ID) not in issue_registry.issues
+
+
+async def test_mop_drying_sensor_kept_when_used_by_automation(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test a mop drying sensor used by an automation is kept and the usage listed."""
+    register_mop_drying_sensor(
+        entity_registry, mock_roborock_entry, er.RegistryEntryDisabler.USER
+    )
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: {
+                "alias": "test_automation",
+                "triggers": {
+                    "trigger": "state",
+                    "entity_id": MOP_DRYING_ENTITY_ID,
+                },
+                "actions": {"action": "notify.notify", "data": {}},
+            }
+        },
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, MOP_DRYING_UNIQUE_ID
+        )
+        is not None
+    )
+    issue = issue_registry.async_get_issue(DOMAIN, MOP_DRYING_ISSUE_ID)
+    assert issue.translation_key == "deprecated_mop_drying_scripts"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The mop drying binary sensor is deprecated and replaced by `switch.<vacuum>_dock_mop_drying`, which reports the same state and can also start and stop drying. The sensor keeps working and a repair issue names the replacement. Update dashboards, templates, automations and scripts to use the switch, then disable the sensor to have it removed. It is removed for everyone in 2027.3.

On docks without mop drying, the sensor always reported *Not running* and is removed automatically. No action is needed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecates the mop drying binary sensor, replaced by the switch added in #177404, using the same `deprecate_entity` helper as whirlpool, elkm1, v2c, jvc_projector and smartthings. Docks that cannot dry get the sensor removed directly, as the old support check was based on a status data point rather than a dock capability and gave them a sensor stuck at *Not running*.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177404
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47369
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
