### PR TITLE
Reject iZone airflow values that are not multiples of 5

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -53,7 +53,7 @@ IZONE_SERVICE_AIRFLOW_MAX = "airflow_max"
 
 IZONE_SERVICE_AIRFLOW_SCHEMA: VolDictType = {
     vol.Required(ATTR_AIRFLOW): vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), msg="invalid airflow"
+        vol.Coerce(int), vol.In(range(0, 101, 5)), msg="invalid airflow"
     ),
 }
 

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -53,7 +53,10 @@ IZONE_SERVICE_AIRFLOW_MAX = "airflow_max"
 
 IZONE_SERVICE_AIRFLOW_SCHEMA: VolDictType = {
     vol.Required(ATTR_AIRFLOW): vol.All(
-        vol.Coerce(int), vol.In(range(0, 101, 5)), msg="invalid airflow"
+        vol.Coerce(float),
+        vol.In(range(0, 101, 5)),
+        vol.Coerce(int),
+        msg="invalid airflow",
     ),
 }
 

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 from pizone import Controller, ControllerCommandError, Zone
 import pytest
 from syrupy.assertion import SnapshotAssertion
+import voluptuous as vol
 
 from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE,
@@ -20,6 +21,11 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     ClimateEntityFeature,
     HVACMode,
+)
+from homeassistant.components.izone.climate import (
+    ATTR_AIRFLOW,
+    IZONE_SERVICE_AIRFLOW_MAX,
+    IZONE_SERVICE_AIRFLOW_MIN,
 )
 from homeassistant.components.izone.const import DOMAIN
 from homeassistant.components.izone.coordinator import UPDATE_INTERVAL
@@ -623,3 +629,26 @@ async def test_command_connection_error_recovers_on_coordinator_refresh(
 
     assert hass.states.get(CONTROLLER_ENTITY).state == HVACMode.COOL
     assert hass.states.get(ZONE_ENTITY).state == HVACMode.HEAT_COOL
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "service",
+    [IZONE_SERVICE_AIRFLOW_MIN, IZONE_SERVICE_AIRFLOW_MAX],
+)
+async def test_airflow_rejects_non_multiples_of_five(
+    hass: HomeAssistant,
+    mock_zones: list[Mock],
+    service: str,
+) -> None:
+    """Airflow services reject values that are not multiples of 5."""
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ZONE_ENTITY, ATTR_AIRFLOW: 41},
+            blocking=True,
+        )
+
+    mock_zones[0].set_airflow_min.assert_not_called()
+    mock_zones[0].set_airflow_max.assert_not_called()

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -633,20 +633,26 @@ async def test_command_connection_error_recovers_on_coordinator_refresh(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    "service",
-    [IZONE_SERVICE_AIRFLOW_MIN, IZONE_SERVICE_AIRFLOW_MAX],
+    ("service", "airflow"),
+    [
+        pytest.param(IZONE_SERVICE_AIRFLOW_MIN, 41, id="min-int"),
+        pytest.param(IZONE_SERVICE_AIRFLOW_MAX, 41, id="max-int"),
+        pytest.param(IZONE_SERVICE_AIRFLOW_MIN, 40.9, id="min-float"),
+        pytest.param(IZONE_SERVICE_AIRFLOW_MAX, 40.9, id="max-float"),
+    ],
 )
 async def test_airflow_rejects_non_multiples_of_five(
     hass: HomeAssistant,
     mock_zones: list[Mock],
     service: str,
+    airflow: float,
 ) -> None:
     """Airflow services reject values that are not multiples of 5."""
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
             DOMAIN,
             service,
-            {ATTR_ENTITY_ID: ZONE_ENTITY, ATTR_AIRFLOW: 41},
+            {ATTR_ENTITY_ID: ZONE_ENTITY, ATTR_AIRFLOW: airflow},
             blocking=True,
         )
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tighten the iZone `airflow_min` / `airflow_max` entity service schema so
values must be multiples of 5 (0–100). The UI selector already uses
`step: 5`, but the Voluptuous schema only enforced a 0–100 range, so
non-multiples could reach python-izone and raise a raw `AttributeError`.

This closes the remaining gap called out for `action-exceptions` on
#177131 (scorecard claim will be updated there separately).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177131
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr