### PR TITLE
Add battery sensors to SensorPush

### DIFF
--- a/homeassistant/components/sensorpush/__init__.py
+++ b/homeassistant/components/sensorpush/__init__.py
@@ -2,33 +2,79 @@
 
 import logging
 
-from sensorpush_ble import SensorPushBluetoothDeviceData
+from sensorpush_ble import SensorPushBluetoothDeviceData, SensorUpdate
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
-from homeassistant.components.bluetooth.passive_update_processor import (
-    PassiveBluetoothProcessorCoordinator,
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
+)
+from homeassistant.components.bluetooth.active_update_processor import (
+    ActiveBluetoothProcessorCoordinator,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
-type SensorPushConfigEntry = ConfigEntry[PassiveBluetoothProcessorCoordinator]
+type SensorPushConfigEntry = ConfigEntry[
+    ActiveBluetoothProcessorCoordinator[SensorUpdate]
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SensorPushConfigEntry) -> bool:
     """Set up SensorPush BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-    coordinator = PassiveBluetoothProcessorCoordinator(
+    data = SensorPushBluetoothDeviceData()
+
+    def _needs_poll(
+        service_info: BluetoothServiceInfoBleak, last_poll: float | None
+    ) -> bool:
+        # Only poll if hass is running, we need to poll,
+        # and we actually have a way to connect to the device
+        return (
+            hass.state is CoreState.running
+            and data.poll_needed(service_info, last_poll)
+            and bool(
+                async_ble_device_from_address(
+                    hass, service_info.device.address, connectable=True
+                )
+            )
+        )
+
+    async def _async_poll(service_info: BluetoothServiceInfoBleak) -> SensorUpdate:
+        # Make sure the device we have is one that we can connect with
+        # in case its coming from a passive scanner
+        if service_info.connectable:
+            connectable_device = service_info.device
+        elif device := async_ble_device_from_address(
+            hass, service_info.device.address, True
+        ):
+            connectable_device = device
+        else:
+            # We have no bluetooth controller that is in range of
+            # the device to poll it
+            raise RuntimeError(
+                f"No connectable device found for {service_info.device.address}"
+            )
+        return await data.async_poll(connectable_device)
+
+    coordinator = ActiveBluetoothProcessorCoordinator(
         hass,
         _LOGGER,
         address=address,
         mode=BluetoothScanningMode.PASSIVE,
-        update_method=SensorPushBluetoothDeviceData().update,
+        update_method=data.update,
+        needs_poll_method=_needs_poll,
+        poll_method=_async_poll,
+        # We will take advertisements from non-connectable devices
+        # since we will trade the BLEDevice for a connectable one
+        # if we need to poll it
+        connectable=False,
     )
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/sensorpush/manifest.json
+++ b/homeassistant/components/sensorpush/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sensorpush",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["sensorpush-ble==1.9.0"]
+  "requirements": ["sensorpush-ble==1.10.0"]
 }

--- a/homeassistant/components/sensorpush/sensor.py
+++ b/homeassistant/components/sensorpush/sensor.py
@@ -19,6 +19,8 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfElectricPotential,
     UnitOfPressure,
     UnitOfTemperature,
 )
@@ -29,6 +31,20 @@ from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 from . import SensorPushConfigEntry
 
 SENSOR_DESCRIPTIONS = {
+    (DeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
+        key=f"{DeviceClass.BATTERY}_{Units.PERCENTAGE}",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    (DeviceClass.VOLTAGE, Units.ELECTRIC_POTENTIAL_VOLT): SensorEntityDescription(
+        key=f"{DeviceClass.VOLTAGE}_{Units.ELECTRIC_POTENTIAL_VOLT}",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
         key=f"{DeviceClass.TEMPERATURE}_{Units.TEMP_CELSIUS}",
         device_class=SensorDeviceClass.TEMPERATURE,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3007,7 +3007,7 @@ sensorpro-ble==0.7.1
 sensorpush-api==2.1.3
 
 # homeassistant.components.sensorpush
-sensorpush-ble==1.9.0
+sensorpush-ble==1.10.0
 
 # homeassistant.components.sensorpush_cloud
 sensorpush-ha==1.3.2

--- a/tests/components/sensorpush/conftest.py
+++ b/tests/components/sensorpush/conftest.py
@@ -1,8 +1,27 @@
 """SensorPush session fixtures."""
 
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from sensorpush_ble import SensorUpdate
 
 
 @pytest.fixture(autouse=True)
 def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
+
+
+@pytest.fixture(autouse=True)
+def mock_async_poll() -> Generator[AsyncMock]:
+    """Stop every advertisement from trying to connect to a real device.
+
+    Any second generation SensorPush is due a battery poll the first time it is
+    seen, so without this each injected advertisement would open a Bluetooth
+    connection. Tests that care about polling set a return value on this mock.
+    """
+    with patch(
+        "homeassistant.components.sensorpush.SensorPushBluetoothDeviceData.async_poll",
+        AsyncMock(return_value=SensorUpdate(title=None, devices={})),
+    ) as mock_poll:
+        yield mock_poll

--- a/tests/components/sensorpush/test_sensor.py
+++ b/tests/components/sensorpush/test_sensor.py
@@ -2,6 +2,17 @@
 
 from datetime import timedelta
 import time
+from unittest.mock import AsyncMock, patch
+
+from sensorpush_ble import (
+    DeviceClass,
+    DeviceKey,
+    SensorDescription,
+    SensorDeviceInfo,
+    SensorUpdate,
+    SensorValue,
+    Units,
+)
 
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -79,6 +90,106 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     temp_sensor = hass.states.get("sensor.htp_xw_f4d_temperature")
     assert temp_sensor.state == "20.11"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def _battery_sensor_update() -> SensorUpdate:
+    """Return the update a successful battery poll produces."""
+    return SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="HTP.xw F4D",
+                model="HTP.xw",
+                manufacturer="SensorPush",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=DeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="voltage", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="voltage", device_id=None),
+                device_class=DeviceClass.VOLTAGE,
+                native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=75,
+            ),
+            DeviceKey(key="voltage", device_id=None): SensorValue(
+                device_key=DeviceKey(key="voltage", device_id=None),
+                name="Voltage",
+                native_value=2.85,
+            ),
+        },
+    )
+
+
+async def test_battery_poll(hass: HomeAssistant, mock_async_poll: AsyncMock) -> None:
+    """Test that polling the device creates the battery sensors."""
+    mock_async_poll.return_value = _battery_sensor_update()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    inject_bluetooth_service_info(hass, HTPWX_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    mock_async_poll.assert_awaited_once()
+
+    battery_sensor = hass.states.get("sensor.htp_xw_f4d_battery")
+    assert battery_sensor.state == "75"
+    assert battery_sensor.attributes[ATTR_FRIENDLY_NAME] == "HTP.xw F4D Battery"
+    assert battery_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == "%"
+    assert battery_sensor.attributes[ATTR_STATE_CLASS] == "measurement"
+
+    voltage_sensor = hass.states.get("sensor.htp_xw_f4d_voltage")
+    assert voltage_sensor.state == "2.85"
+    assert voltage_sensor.attributes[ATTR_FRIENDLY_NAME] == "HTP.xw F4D Voltage"
+    assert voltage_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == "V"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_no_poll_without_a_connectable_device(
+    hass: HomeAssistant, mock_async_poll: AsyncMock
+) -> None:
+    """Test we do not poll when nothing in range can connect to the device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.sensorpush.async_ble_device_from_address",
+        return_value=None,
+    ):
+        inject_bluetooth_service_info(hass, HTPWX_SERVICE_INFO)
+        await hass.async_block_till_done()
+
+    mock_async_poll.assert_not_awaited()
+    # The advertisement is still parsed, we just never connect.
+    assert hass.states.get("sensor.htp_xw_f4d_temperature").state == "20.11"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds a battery percentage and a battery voltage sensor to the SensorPush Bluetooth integration.

SensorPush does not put the battery in its advertisement, so this cannot be done passively — it is only readable by connecting and reading a GATT characteristic on the second generation service. The integration therefore moves from `PassiveBluetoothProcessorCoordinator` to `ActiveBluetoothProcessorCoordinator`, following `xiaomi_ble`, and polls at most once a day (connecting spends some of the battery being measured).

The Bluetooth matchers deliberately stay `"connectable": false`: advertisements are still accepted from passive-only scanners, and the `BLEDevice` is traded for a connectable one only when a poll is actually due. `_needs_poll` returns `False` when nothing in range can connect, so users covered only by a passive proxy keep working exactly as before, just without the battery entities.

The decoding, the once-a-day interval and the exclusion of the first generation HT1 (which does not expose the service) live in the library: Bluetooth-Devices/sensorpush-ble#93. Both new sensors are `EntityCategory.DIAGNOSTIC`, matching `xiaomi_ble`.

Requested in #123134.

**Blocked on** Bluetooth-Devices/sensorpush-ble#93 — this is a draft until `sensorpush-ble` 1.10.0 is released, at which point I will confirm the pin in `manifest.json` and mark it ready. The documentation PR is home-assistant/home-assistant.io#47368.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NB: Remove the ones that do not apply
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #123134
- Link to documentation pull request: home-assistant/home-assistant.io#47368

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is included in the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a lot of PRs.
  Thanks for your contribution!
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/development_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Testing

New tests in `tests/components/sensorpush/test_sensor.py` cover a successful poll creating both sensors with the right device classes, and that no connection is attempted when no connectable device is in range. An autouse fixture stops the existing tests from opening real connections, since every gen 2 device is due a poll the first time it is seen.

```
$ pytest tests/components/sensorpush
3 passed
```

Also verified end to end on a live Home Assistant 2026.8.1 instance against two real sensors, exercising both connection paths:

| Device | Model | Path | Voltage | Battery |
|---|---|---|---|---|
| `90:7B:C6:AE:B3:42` | HT.w | ESPHome Bluetooth proxy | 2.882 V | 80 % |
| `90:7B:C6:AF:4A:CB` | HTP.xw | local `hci0` adapter | 2.828 V | 71 % |

No further connections were attempted after the initial poll of each device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vrLbWPbFFogGyNRmudS2s

