### PR TITLE
Split user flow init and submission in bsblan config flow tests

### DIFF
--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -69,12 +69,11 @@ def zeroconf_discovery_info_different_mac() -> ZeroconfServiceInfo:
 # Helper functions to reduce repetition
 
 
-async def _init_user_flow(hass: HomeAssistant, user_input: dict | None = None):
+async def _init_user_flow(hass: HomeAssistant):
     """Initialize a user config flow."""
     return await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data=user_input,
     )
 
 
@@ -255,8 +254,12 @@ async def test_connection_error(
     """Test we show user form on BSBLan connection error."""
     mock_bsblan.device.side_effect = BSBLANConnectionError
 
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
@@ -284,10 +287,13 @@ async def test_authentication_error(
         CONF_PASSWORD: "wrongpassword",
     }
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data=user_input,
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        user_input,
     )
 
     assert result.get("type") is FlowResultType.FORM
@@ -332,8 +338,12 @@ async def test_authentication_error_vs_connection_error(
     # Test connection error first
     mock_bsblan.device.side_effect = BSBLANConnectionError
 
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
@@ -345,8 +355,12 @@ async def test_authentication_error_vs_connection_error(
     # Reset and test authentication error
     mock_bsblan.device.side_effect = BSBLANAuthError
 
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
@@ -366,8 +380,12 @@ async def test_user_device_exists_abort(
     """Test we abort flow if BSBLAN device already configured."""
     mock_config_entry.add_to_hass(hass)
 
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
@@ -591,8 +609,12 @@ async def test_user_flow_can_update_existing_host_port(
     entry.add_to_hass(hass)
 
     # Try to configure the same device with different host/port via user flow
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "10.0.2.60",  # Different IP
             CONF_PORT: 80,  # Different port
@@ -675,8 +697,12 @@ async def test_connection_error_recovery(
     # First attempt fails with connection error
     mock_bsblan.device.side_effect = BSBLANConnectionError
 
-    result = await _init_user_flow(
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
         hass,
+        result["flow_id"],
         {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

No breaking changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Split BSBLAN user-flow test setup from form submission. Each affected test now starts the user flow without input, asserts the user form is shown, and submits the test data through `async_configure`, matching the real user interaction.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178837
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
