### PR TITLE
Trigger SleepIQ reauth flow on authentication failure during updates

### DIFF
--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
+from http import HTTPStatus
 import logging
 from typing import override
 
@@ -11,6 +12,7 @@ from asyncsleepiq import AsyncSleepIQ, SleepIQAPIException, SleepIQTimeoutExcept
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,6 +56,10 @@ class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[None]):
         except SleepIQTimeoutException as err:
             raise UpdateFailed(f"Timed out fetching SleepIQ data: {err}") from err
         except SleepIQAPIException as err:
+            if err.code == HTTPStatus.UNAUTHORIZED:
+                raise ConfigEntryAuthFailed(
+                    f"Authentication to SleepIQ failed: {err}"
+                ) from err
             raise UpdateFailed(f"Failed to fetch SleepIQ data: {err}") from err
 
 
@@ -87,6 +93,10 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
         except SleepIQTimeoutException as err:
             raise UpdateFailed(f"Timed out fetching SleepIQ pause data: {err}") from err
         except SleepIQAPIException as err:
+            if err.code == HTTPStatus.UNAUTHORIZED:
+                raise ConfigEntryAuthFailed(
+                    f"Authentication to SleepIQ failed: {err}"
+                ) from err
             raise UpdateFailed(f"Failed to fetch SleepIQ pause data: {err}") from err
 
 
@@ -125,6 +135,10 @@ class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
         except SleepIQTimeoutException as err:
             raise UpdateFailed(f"Timed out fetching SleepIQ sleep data: {err}") from err
         except SleepIQAPIException as err:
+            if err.code == HTTPStatus.UNAUTHORIZED:
+                raise ConfigEntryAuthFailed(
+                    f"Authentication to SleepIQ failed: {err}"
+                ) from err
             raise UpdateFailed(f"Failed to fetch SleepIQ sleep data: {err}") from err
 
 

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -57,9 +57,7 @@ class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed(f"Timed out fetching SleepIQ data: {err}") from err
         except SleepIQAPIException as err:
             if err.code == HTTPStatus.UNAUTHORIZED:
-                raise ConfigEntryAuthFailed(
-                    f"Authentication to SleepIQ failed: {err}"
-                ) from err
+                raise ConfigEntryAuthFailed from err
             raise UpdateFailed(f"Failed to fetch SleepIQ data: {err}") from err
 
 
@@ -94,9 +92,7 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed(f"Timed out fetching SleepIQ pause data: {err}") from err
         except SleepIQAPIException as err:
             if err.code == HTTPStatus.UNAUTHORIZED:
-                raise ConfigEntryAuthFailed(
-                    f"Authentication to SleepIQ failed: {err}"
-                ) from err
+                raise ConfigEntryAuthFailed from err
             raise UpdateFailed(f"Failed to fetch SleepIQ pause data: {err}") from err
 
 
@@ -136,9 +132,7 @@ class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed(f"Timed out fetching SleepIQ sleep data: {err}") from err
         except SleepIQAPIException as err:
             if err.code == HTTPStatus.UNAUTHORIZED:
-                raise ConfigEntryAuthFailed(
-                    f"Authentication to SleepIQ failed: {err}"
-                ) from err
+                raise ConfigEntryAuthFailed from err
             raise UpdateFailed(f"Failed to fetch SleepIQ sleep data: {err}") from err
 
 

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -10,6 +10,7 @@ from asyncsleepiq import (
     SleepIQLoginException,
     SleepIQTimeoutException,
 )
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.sleepiq.const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
@@ -124,6 +125,7 @@ async def test_api_timeout(hass: HomeAssistant, mock_asyncsleepiq) -> None:
 )
 async def test_update_auth_error_starts_reauth_flow(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_asyncsleepiq: MagicMock,
     mock_bed: MagicMock,
     get_fetch_mock: Callable[[MagicMock, MagicMock], MagicMock],
@@ -136,7 +138,8 @@ async def test_update_auth_error_starts_reauth_flow(
     get_fetch_mock(mock_asyncsleepiq, mock_bed).side_effect = SleepIQAPIException(
         HTTPStatus.UNAUTHORIZED, "unauthorized"
     )
-    async_fire_time_changed(hass, utcnow() + interval)
+    freezer.tick(interval)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
@@ -146,7 +149,9 @@ async def test_update_auth_error_starts_reauth_flow(
 
 
 async def test_update_api_error_does_not_start_reauth_flow(
-    hass: HomeAssistant, mock_asyncsleepiq: MagicMock
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_asyncsleepiq: MagicMock,
 ) -> None:
     """Test a non-authentication API error during an update does not start reauth."""
     await setup_platform(hass, "sensor")
@@ -154,7 +159,8 @@ async def test_update_api_error_does_not_start_reauth_flow(
     mock_asyncsleepiq.fetch_bed_statuses.side_effect = SleepIQAPIException(
         HTTPStatus.INTERNAL_SERVER_ERROR, "server error"
     )
-    async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert mock_asyncsleepiq.fetch_bed_statuses.call_count == 2

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -1,14 +1,24 @@
 """Tests for the SleepIQ integration."""
 
+from collections.abc import Callable
+from datetime import timedelta
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
 from asyncsleepiq import (
     SleepIQAPIException,
     SleepIQLoginException,
     SleepIQTimeoutException,
 )
+import pytest
 
 from homeassistant.components.sleepiq.const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
-from homeassistant.components.sleepiq.coordinator import UPDATE_INTERVAL
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.sleepiq.coordinator import (
+    LONGER_UPDATE_INTERVAL,
+    SLEEP_DATA_UPDATE_INTERVAL,
+    UPDATE_INTERVAL,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_USERNAME, PRESSURE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -87,6 +97,68 @@ async def test_api_timeout(hass: HomeAssistant, mock_asyncsleepiq) -> None:
     mock_asyncsleepiq.init_beds.side_effect = SleepIQTimeoutException
     entry = await setup_platform(hass, None)
     assert not await hass.config_entries.async_setup(entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("get_fetch_mock", "platform", "interval"),
+    [
+        pytest.param(
+            lambda client, bed: client.fetch_bed_statuses,
+            "sensor",
+            UPDATE_INTERVAL,
+            id="bed_status",
+        ),
+        pytest.param(
+            lambda client, bed: bed.fetch_pause_mode,
+            "switch",
+            LONGER_UPDATE_INTERVAL,
+            id="pause_mode",
+        ),
+        pytest.param(
+            lambda client, bed: bed.sleepers[0].fetch_sleep_data,
+            "sensor",
+            SLEEP_DATA_UPDATE_INTERVAL,
+            id="sleep_data",
+        ),
+    ],
+)
+async def test_update_auth_error_starts_reauth_flow(
+    hass: HomeAssistant,
+    mock_asyncsleepiq: MagicMock,
+    mock_bed: MagicMock,
+    get_fetch_mock: Callable[[MagicMock, MagicMock], MagicMock],
+    platform: str,
+    interval: timedelta,
+) -> None:
+    """Test an authentication failure during an update starts the reauth flow."""
+    entry = await setup_platform(hass, platform)
+
+    get_fetch_mock(mock_asyncsleepiq, mock_bed).side_effect = SleepIQAPIException(
+        HTTPStatus.UNAUTHORIZED, "unauthorized"
+    )
+    async_fire_time_changed(hass, utcnow() + interval)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["context"]["entry_id"] == entry.entry_id
+
+
+async def test_update_api_error_does_not_start_reauth_flow(
+    hass: HomeAssistant, mock_asyncsleepiq: MagicMock
+) -> None:
+    """Test a non-authentication API error during an update does not start reauth."""
+    await setup_platform(hass, "sensor")
+
+    mock_asyncsleepiq.fetch_bed_statuses.side_effect = SleepIQAPIException(
+        HTTPStatus.INTERNAL_SERVER_ERROR, "server error"
+    )
+    async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    assert mock_asyncsleepiq.fetch_bed_statuses.call_count == 2
+    assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
 
 
 async def test_unique_id_migration(hass: HomeAssistant, mock_asyncsleepiq) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raise `ConfigEntryAuthFailed` when a SleepIQ coordinator update fails with an HTTP 401, so Home Assistant triggers the integration's existing reauth flow.

Today a 401 during any of the three coordinator updates is wrapped in `UpdateFailed`, so the integration silently retries forever and the reauth flow (which `config_flow.py` already implements) is never started. The user sees repeating log errors and permanently stale entities, with no repair issue and no reauth prompt. The `asyncsleepiq` library already retries a 401 once with a fresh login before raising, so an error that survives that retry is a genuine authentication failure rather than a transient session expiry.

Observed in production: a stale SleepIQ session produced repeating `API call error response 401` errors on the pause and sleep-data coordinators for days, with no reauth prompt ever appearing.

Tests cover all three coordinators (bed status, pause mode, sleep data) confirming a 401 starts a reauth flow for the right entry, and that a non-auth API error (500) still maps to `UpdateFailed` without starting reauth.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
