### PR TITLE
Bump teslemetry-stream to 0.11.0

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -635,11 +635,6 @@ async def async_setup_stream(
 ) -> None:
     """Set up the stream for a vehicle."""
     await vehicle.stream_vehicle.get_config()
-    entry.async_create_background_task(
-        hass,
-        vehicle.stream_vehicle.prefer_typed(True),
-        f"Prefer typed for {vehicle.vin}",
-    )
 
     entry.async_on_unload(
         vehicle.stream_vehicle.listen_Version(

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla_fleet_api", "teslemetry_stream"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==1.8.2", "teslemetry-stream==0.10.0"]
+  "requirements": ["tesla-fleet-api==1.8.2", "teslemetry-stream==0.11.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3184,7 +3184,7 @@ tesla-powerwall==0.5.3
 tesla-wall-connector==1.2.0
 
 # homeassistant.components.teslemetry
-teslemetry-stream==0.10.0
+teslemetry-stream==0.11.0
 
 # homeassistant.components.tessie
 tessie-api==0.1.3

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -170,7 +170,7 @@ def mock_add_listener():
         def unsubscribe() -> None:
             return
 
-        def side_effect(callback, filters):
+        def side_effect(callback, filters, internal=False):
             mock_add_listener.listeners.append((callback, filters))
             return unsubscribe
 

--- a/tests/components/teslemetry/fixtures/config.json
+++ b/tests/components/teslemetry/fixtures/config.json
@@ -2,7 +2,6 @@
   "exp": 1749261108,
   "hostname": "na.teslemetry.com",
   "port": 4431,
-  "prefer_typed": true,
   "pending": false,
   "fields": {
     "ChargeAmps": { "interval_seconds": 60 }

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -590,7 +590,6 @@
           'config': dict({
             'fields': dict({
             }),
-            'prefer_typed': None,
           }),
         }),
       }),


### PR DESCRIPTION
## Breaking change


## Proposed change

Bump `teslemetry-stream` from 0.10.0 to 0.11.0.

The new release removes the `prefer_typed()` method, so the now-removed call in
`async_setup_stream` is dropped. String coercion for older vehicles is retained
in the library, so value handling is unchanged. The test mock and diagnostics
snapshot are updated for the library's dropped `prefer_typed` config field and
the new `internal` listener argument.

Library diff: https://github.com/Teslemetry/python-teslemetry-stream/compare/v0.10.0...v0.11.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/core/integration-quality-scale/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
