### PR TITLE
Fix IAMMETER DataUpdateCoordinator config entry

### DIFF
--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -134,6 +134,7 @@ async def async_setup_platform(
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
+        config_entry=None,
         name=config_name,
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,

--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -132,10 +132,10 @@ async def async_setup_platform(
             raise UpdateFailed from err
 
     coordinator = DataUpdateCoordinator(
-    hass,
-    _LOGGER,
-    config_entry=None,
-    name=config_name,
+        hass,
+        _LOGGER,
+        config_entry=None,
+        name=config_name,
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(

--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -132,9 +132,10 @@ async def async_setup_platform(
             raise UpdateFailed from err
 
     coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=config_name,
+    hass,
+    _LOGGER,
+    config_entry=None,
+    name=config_name,
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(


### PR DESCRIPTION
## Proposed change

Explicitly pass `config_entry=None` when creating the IAMMETER `DataUpdateCoordinator`.

IAMMETER is configured as a YAML sensor platform and therefore does not have a config entry to pass. Home Assistant 2026.8 reports that relying on the implicit ContextVar is deprecated and may cause the integration to stop working. Passing `None` explicitly follows the pattern used by other YAML-based integrations.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #167483
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr