### PR TITLE
Return MockConfigEntry from Imou init_integration fixture

### DIFF
--- a/tests/components/imou/conftest.py
+++ b/tests/components/imou/conftest.py
@@ -99,10 +99,10 @@ async def init_integration(
     mock_imou_openapi_client: AsyncMock,
     mock_imou_ha_device_manager: MagicMock,
     platforms: list[Platform],
-) -> MagicMock:
-    """Set up Imou with mocked library clients; returns the HA device manager mock."""
+) -> MockConfigEntry:
+    """Set up Imou with mocked library clients; returns the config entry."""
     mock_config_entry.add_to_hass(hass)
     with patch("homeassistant.components.imou.PLATFORMS", platforms):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-    return mock_imou_ha_device_manager
+    return mock_config_entry

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -66,7 +66,7 @@ async def test_press_button_via_service(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Pressing a button calls the vendor library through the coordinator."""
     entries = er.async_entries_for_config_entry(
@@ -82,8 +82,8 @@ async def test_press_button_via_service(
         blocking=True,
     )
 
-    init_integration.async_press_button.assert_awaited_once()
-    call = init_integration.async_press_button.await_args
+    mock_imou_ha_device_manager.async_press_button.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_press_button.await_args
     assert call is not None
     assert call.args[1] == PARAM_MUTE
     assert call.args[2] == 0
@@ -93,7 +93,7 @@ async def test_press_button_via_service(
 async def test_press_ptz_button_passes_move_duration(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """PTZ buttons pass the configured move duration to the vendor library."""
@@ -109,8 +109,8 @@ async def test_press_ptz_button_passes_move_duration(
         blocking=True,
     )
 
-    init_integration.async_press_button.assert_awaited_once()
-    call = init_integration.async_press_button.await_args
+    mock_imou_ha_device_manager.async_press_button.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_press_button.await_args
     assert call is not None
     assert call.args[1] == PARAM_PTZ_UP
     assert call.args[2] == PTZ_MOVE_DURATION_MS
@@ -119,10 +119,10 @@ async def test_press_ptz_button_passes_move_duration(
 @pytest.mark.usefixtures("init_integration")
 async def test_press_button_service_propagates_api_error(
     hass: HomeAssistant,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Imou API errors from async_press_button surface to the service call."""
-    init_integration.async_press_button.side_effect = ImouException("cloud failure")
+    mock_imou_ha_device_manager.async_press_button.side_effect = ImouException("cloud failure")
 
     entity_id = hass.states.async_all("button")[0].entity_id
 
@@ -157,7 +157,6 @@ async def test_press_unavailable_offline_device_via_service(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
-    init_integration: MagicMock,
 ) -> None:
     """Pressing an offline device does not call the vendor library."""
     mute_entry = next(
@@ -187,7 +186,7 @@ async def test_press_unavailable_offline_device_via_service(
         blocking=True,
     )
 
-    init_integration.async_press_button.assert_not_called()
+    mock_imou_ha_device_manager.async_press_button.assert_not_called()
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -122,7 +122,9 @@ async def test_press_button_service_propagates_api_error(
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Imou API errors from async_press_button surface to the service call."""
-    mock_imou_ha_device_manager.async_press_button.side_effect = ImouException("cloud failure")
+    mock_imou_ha_device_manager.async_press_button.side_effect = ImouException(
+        "cloud failure"
+    )
 
     entity_id = hass.states.async_all("button")[0].entity_id
 

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -324,7 +324,9 @@ async def test_camera_image_propagates_api_error(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Imou API errors from snapshot fetch surface to the caller."""
-    mock_imou_ha_device_manager.async_get_device_image.side_effect = ImouException("image failure")
+    mock_imou_ha_device_manager.async_get_device_image.side_effect = ImouException(
+        "image failure"
+    )
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -126,13 +126,13 @@ async def test_no_camera_without_channel(
 async def test_camera_stream_source(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
     camera_key: str,
     expected_resolution: str,
 ) -> None:
     """Fetching stream source calls the vendor library with the entity resolution."""
-    init_integration.async_get_device_stream.return_value = TEST_STREAM_URL
+    mock_imou_ha_device_manager.async_get_device_stream.return_value = TEST_STREAM_URL
 
     entity_id = _camera_entity_id(
         entity_registry, mock_config_entry, camera_key=camera_key
@@ -140,8 +140,8 @@ async def test_camera_stream_source(
     stream_source = await async_get_stream_source(hass, entity_id)
 
     assert stream_source == TEST_STREAM_URL
-    init_integration.async_get_device_stream.assert_awaited_once()
-    call = init_integration.async_get_device_stream.await_args
+    mock_imou_ha_device_manager.async_get_device_stream.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_get_device_stream.await_args
     assert call is not None
     assert call.args[1] == expected_resolution
     assert call.args[2] == PYIMOUAPI_LIVE_PROTOCOL
@@ -165,18 +165,18 @@ async def test_camera_stream_source(
 async def test_camera_image(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Still image fetch calls the vendor library with the configured wait time."""
-    init_integration.async_get_device_image.return_value = TEST_IMAGE_BYTES
+    mock_imou_ha_device_manager.async_get_device_image.return_value = TEST_IMAGE_BYTES
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     image = await async_get_image(hass, entity_id)
 
     assert image.content == TEST_IMAGE_BYTES
-    init_integration.async_get_device_image.assert_awaited_once()
-    call = init_integration.async_get_device_image.await_args
+    mock_imou_ha_device_manager.async_get_device_image.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_get_device_image.await_args
     assert call is not None
     assert call.args[1] == PYIMOUAPI_SNAPSHOT_WAIT_SECONDS
 
@@ -286,11 +286,11 @@ async def test_camera_state(
 async def test_camera_stream_source_propagates_api_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Imou API errors from stream fetch surface to the caller."""
-    init_integration.async_get_device_stream.side_effect = ImouException(
+    mock_imou_ha_device_manager.async_get_device_stream.side_effect = ImouException(
         "stream failure"
     )
 
@@ -320,11 +320,11 @@ async def test_camera_stream_source_propagates_api_error(
 async def test_camera_image_propagates_api_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Imou API errors from snapshot fetch surface to the caller."""
-    init_integration.async_get_device_image.side_effect = ImouException("image failure")
+    mock_imou_ha_device_manager.async_get_device_image.side_effect = ImouException("image failure")
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(

--- a/tests/components/imou/test_init.py
+++ b/tests/components/imou/test_init.py
@@ -28,11 +28,10 @@ EXPECTED_TRANSLATION_KEYS = {
 }
 
 
-@pytest.mark.usefixtures("mock_imou_openapi_client", "mock_imou_ha_device_manager")
+@pytest.mark.usefixtures("init_integration")
 async def test_setup_and_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    init_integration: MagicMock,
 ) -> None:
     """Test loading and unloading the config entry."""
     assert mock_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -94,10 +94,10 @@ async def test_turn_on_via_service(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Turning on a switch calls the vendor library through the coordinator."""
-    init_integration.async_switch_operation.side_effect = _apply_switch_operation
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = _apply_switch_operation
     motion_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(
@@ -113,8 +113,8 @@ async def test_turn_on_via_service(
         blocking=True,
     )
 
-    init_integration.async_switch_operation.assert_awaited_once()
-    call = init_integration.async_switch_operation.await_args
+    mock_imou_ha_device_manager.async_switch_operation.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_switch_operation.await_args
     assert call is not None
     assert call.args[1] == PARAM_MOTION_DETECT
     assert call.args[2] is True
@@ -127,10 +127,10 @@ async def test_turn_off_via_service(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Turning off a switch calls the vendor library through the coordinator."""
-    init_integration.async_switch_operation.side_effect = _apply_switch_operation
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = _apply_switch_operation
     header_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(
@@ -146,8 +146,8 @@ async def test_turn_off_via_service(
         blocking=True,
     )
 
-    init_integration.async_switch_operation.assert_awaited_once()
-    call = init_integration.async_switch_operation.await_args
+    mock_imou_ha_device_manager.async_switch_operation.assert_awaited_once()
+    call = mock_imou_ha_device_manager.async_switch_operation.await_args
     assert call is not None
     assert call.args[1] == PARAM_HEADER_DETECT
     assert call.args[2] is False
@@ -158,10 +158,10 @@ async def test_turn_off_via_service(
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on_service_propagates_api_error(
     hass: HomeAssistant,
-    init_integration: MagicMock,
+    mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Imou API errors from async_switch_operation surface to the service call."""
-    init_integration.async_switch_operation.side_effect = ImouException("cloud failure")
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = ImouException("cloud failure")
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 
@@ -197,7 +197,6 @@ async def test_turn_off_unavailable_offline_device_via_service(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
-    init_integration: MagicMock,
 ) -> None:
     """Turning off an offline device does not call the vendor library."""
     motion_entry = next(
@@ -227,7 +226,7 @@ async def test_turn_off_unavailable_offline_device_via_service(
         blocking=True,
     )
 
-    init_integration.async_switch_operation.assert_not_called()
+    mock_imou_ha_device_manager.async_switch_operation.assert_not_called()
 
 
 @pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -97,7 +97,9 @@ async def test_turn_on_via_service(
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Turning on a switch calls the vendor library through the coordinator."""
-    mock_imou_ha_device_manager.async_switch_operation.side_effect = _apply_switch_operation
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = (
+        _apply_switch_operation
+    )
     motion_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(
@@ -130,7 +132,9 @@ async def test_turn_off_via_service(
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Turning off a switch calls the vendor library through the coordinator."""
-    mock_imou_ha_device_manager.async_switch_operation.side_effect = _apply_switch_operation
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = (
+        _apply_switch_operation
+    )
     header_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(
@@ -161,7 +165,9 @@ async def test_turn_on_service_propagates_api_error(
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
     """Imou API errors from async_switch_operation surface to the service call."""
-    mock_imou_ha_device_manager.async_switch_operation.side_effect = ImouException("cloud failure")
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = ImouException(
+        "cloud failure"
+    )
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #177456 / #178796 / #178798: change the Imou test helper `init_integration` so it returns `MockConfigEntry` after setup, instead of the `ImouHaDeviceManager` mock.

Tests that need to set `side_effect` or assert library calls now inject `mock_imou_ha_device_manager` explicitly (same pattern already used by select tests). Tests that only need setup keep `@pytest.mark.usefixtures("init_integration")`.

No production code changes.

Out of scope: `alarm_control_panel` for mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #177456
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr