### PR TITLE
Make sensor value unknown on missing phyrate in devolo_home_network

### DIFF
--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -256,13 +256,18 @@ class DevoloPlcDataRateSensorEntity(
 
     @property
     @override
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """State of the sensor."""
-        return self.entity_description.value_func(
-            next(
-                data_rate
-                for data_rate in self.coordinator.data.data_rates
-                if data_rate.mac_address_from == self.device.mac
-                and data_rate.mac_address_to == self._peer
+        if (
+            data_rate := next(
+                (
+                    data_rate
+                    for data_rate in self.coordinator.data.data_rates
+                    if data_rate.mac_address_from == self.device.mac
+                    and data_rate.mac_address_to == self._peer
+                ),
+                None,
             )
-        )
+        ) is None:
+            return None
+        return self.entity_description.value_func(data_rate)

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -172,4 +172,35 @@ PLCNET_ATTACHED = LogicalNetwork(
     ],
 )
 
+PLCNET_MISSING_DATA_RATE = LogicalNetwork(
+    devices=[
+        {
+            "mac_address": "00:00:5E:00:53:00",
+            "attached_to_router": False,
+            "topology": LOCAL,
+            "user_device_name": "test1",
+        },
+        {
+            "mac_address": "00:00:5E:00:53:02",
+            "attached_to_router": True,
+            "topology": REMOTE,
+            "user_device_name": "test2",
+        },
+        {
+            "mac_address": "00:00:5E:00:53:03",
+            "attached_to_router": False,
+            "topology": REMOTE,
+            "user_device_name": "test3",
+        },
+    ],
+    data_rates=[
+        {
+            "mac_address_from": "00:00:5E:00:53:00",
+            "mac_address_to": "00:00:5E:00:53:03",
+            "rx_rate": 150.0,
+            "tx_rate": 150.0,
+        },
+    ],
+)
+
 UPTIME = 100

--- a/tests/components/devolo_home_network/snapshots/test_sensor.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_sensor.ambr
@@ -313,3 +313,113 @@
     'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
   })
 # ---
+# name: test_update_plc_phyrates_missing_data_rate
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'data_rate',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title PLC downlink PHY rate (test2)',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_update_plc_phyrates_missing_data_rate.1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PLC downlink PHY rate (test2)',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'PLC downlink PHY rate (test2)',
+    'platform': 'devolo_home_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'plc_rx_rate',
+    'unique_id': '1234567890_plc_rx_rate_00:00:5E:00:53:02',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_update_plc_phyrates_missing_data_rate.2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'data_rate',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title PLC downlink PHY rate (test2)',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_update_plc_phyrates_missing_data_rate.3
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PLC downlink PHY rate (test2)',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'PLC downlink PHY rate (test2)',
+    'platform': 'devolo_home_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'plc_rx_rate',
+    'unique_id': '1234567890_plc_rx_rate_00:00:5E:00:53:02',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---

--- a/tests/components/devolo_home_network/snapshots/test_sensor.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_sensor.ambr
@@ -372,11 +372,11 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'data_rate',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title PLC downlink PHY rate (test2)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title PLC uplink PHY rate (test2)',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'entity_id': 'sensor.mock_title_plc_uplink_phy_rate_test2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -397,7 +397,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.mock_title_plc_downlink_phy_rate_test2',
+    'entity_id': 'sensor.mock_title_plc_uplink_phy_rate_test2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -405,7 +405,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'PLC downlink PHY rate (test2)',
+    'object_id_base': 'PLC uplink PHY rate (test2)',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -413,13 +413,13 @@
     }),
     'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
     'original_icon': None,
-    'original_name': 'PLC downlink PHY rate (test2)',
+    'original_name': 'PLC uplink PHY rate (test2)',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'plc_rx_rate',
-    'unique_id': '1234567890_plc_rx_rate_00:00:5E:00:53:02',
+    'translation_key': 'plc_tx_rate',
+    'unique_id': '1234567890_plc_tx_rate_00:00:5E:00:53:02',
     'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
   })
 # ---

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -216,8 +216,8 @@ async def test_update_plc_phyrates_missing_data_rate(
 
     assert hass.states.get(entity_id_downlink) == snapshot
     assert entity_registry.async_get(entity_id_downlink) == snapshot
-    assert hass.states.get(entity_id_downlink) == snapshot
-    assert entity_registry.async_get(entity_id_downlink) == snapshot
+    assert hass.states.get(entity_id_uplink) == snapshot
+    assert entity_registry.async_get(entity_id_uplink) == snapshot
 
     # Emulate the PLC link to the peer getting lost
     mock_device.plcnet.async_get_network_overview = AsyncMock(

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -15,12 +15,12 @@ from homeassistant.components.devolo_home_network.const import (
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import configure_integration
-from .const import PLCNET
+from .const import PLCNET, PLCNET_MISSING_DATA_RATE
 from .mock import MockDevice
 
 from tests.common import async_fire_time_changed
@@ -191,6 +191,49 @@ async def test_update_plc_phyrates(
     state = hass.states.get(entity_id_uplink)
     assert state is not None
     assert state.state == str(PLCNET.data_rates[0].tx_rate)
+
+
+async def test_update_plc_phyrates_missing_data_rate(
+    hass: HomeAssistant,
+    mock_device: MockDevice,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test plc_downlink_phyrate and plc_uplink_phyrate sensors on a lost PLC link."""
+    entry = configure_integration(hass)
+    device_name = entry.title.replace(" ", "_").lower()
+    entity_id_downlink = (
+        f"{SENSOR_DOMAIN}.{device_name}_plc_downlink_phy_rate_"
+        f"{PLCNET.devices[1].user_device_name}"
+    )
+    entity_id_uplink = (
+        f"{SENSOR_DOMAIN}.{device_name}_plc_uplink_phy_rate_"
+        f"{PLCNET.devices[1].user_device_name}"
+    )
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id_downlink) == snapshot
+    assert entity_registry.async_get(entity_id_downlink) == snapshot
+    assert hass.states.get(entity_id_downlink) == snapshot
+    assert entity_registry.async_get(entity_id_downlink) == snapshot
+
+    # Emulate the PLC link to the peer getting lost
+    mock_device.plcnet.async_get_network_overview = AsyncMock(
+        return_value=PLCNET_MISSING_DATA_RATE
+    )
+    freezer.tick(LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id_downlink)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    state = hass.states.get(entity_id_uplink)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_update_last_update_auth_failed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It seems, that bad connections between devolo PLC devices can lead to confusing API responses. In that case the API knows more devices than it reports data rates for. So in this case we now show unknown and hope it will recover in the next update cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178140
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
