### PR TITLE
Don't drop color adjustments when happening concurrently with brigthness

### DIFF
--- a/homeassistant/components/switchbot_cloud/light.py
+++ b/homeassistant/components/switchbot_cloud/light.py
@@ -97,17 +97,23 @@ class SwitchBotCloudLight(SwitchBotCloudEntity, LightEntity):
         rgb_color: tuple[int, int, int] | None = kwargs.get("rgb_color")
         color_temp_kelvin: int | None = kwargs.get("color_temp_kelvin")
 
-        if brightness is not None:
-            self._attr_color_mode = self._get_default_color_mode()
-            await self._send_brightness_command(brightness)
-        elif rgb_color is not None:
+        if rgb_color is not None:
             self._attr_color_mode = ColorMode.RGB
-            await self._send_rgb_color_command(rgb_color)
         elif color_temp_kelvin is not None:
             self._attr_color_mode = ColorMode.COLOR_TEMP
-            await self._send_color_temperature_command(color_temp_kelvin)
         else:
             self._attr_color_mode = self._get_default_color_mode()
+
+        # Brightness adjustment can be sent by HASS in a single command with color adjustment,
+        # so we need to send brightness command separately if it is present.
+        if brightness is not None:
+            await self._send_brightness_command(brightness)
+
+        if rgb_color is not None:
+            await self._send_rgb_color_command(rgb_color)
+        elif color_temp_kelvin is not None:
+            await self._send_color_temperature_command(color_temp_kelvin)
+        elif brightness is None:
             await self.send_api_command(CommonCommands.ON)
         await asyncio.sleep(AFTER_COMMAND_REFRESH)
         await self.coordinator.async_request_refresh()

--- a/tests/components/switchbot_cloud/test_light.py
+++ b/tests/components/switchbot_cloud/test_light.py
@@ -1,9 +1,15 @@
 """Test for the Switchbot Light Entity."""
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
-from switchbot_api import CeilingLightCommands, CommonCommands, Device, SwitchBotAPI
+from switchbot_api import (
+    CeilingLightCommands,
+    CommonCommands,
+    Device,
+    RGBWWLightCommands,
+    SwitchBotAPI,
+)
 
 from homeassistant.components.light import (
     ATTR_COLOR_MODE,
@@ -548,3 +554,158 @@ async def test_candle_warmer_lamp(
         mock_send_command.assert_called()
     state = hass.states.get(entity_id)
     assert state.state is STATE_ON
+
+
+async def test_rgbww_light_brightness_and_color_temp(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test RGBWW light turn on with both brightness and color temperature."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="light-id-1",
+            deviceName="light-1",
+            deviceType="Strip Light 3",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "brightness": 1, "color": "0:0:0", "colorTemperature": 4567},
+        {"power": "on", "brightness": 38, "color": "0:0:0", "colorTemperature": 3000},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "light.light_1"
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                "brightness": 99,
+                "color_temp_kelvin": 3000,
+            },
+            blocking=True,
+        )
+        assert mock_send_command.call_count == 2
+        mock_send_command.assert_has_calls(
+            [
+                call("light-id-1", RGBWWLightCommands.SET_BRIGHTNESS, "command", "38"),
+                call(
+                    "light-id-1",
+                    RGBWWLightCommands.SET_COLOR_TEMPERATURE,
+                    "command",
+                    "3000",
+                ),
+            ]
+        )
+    state = hass.states.get(entity_id)
+    assert state.state is STATE_ON
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
+
+
+async def test_rgbww_light_brightness_and_rgb_color(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test RGBWW light turn on with both brightness and RGB color."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="light-id-1",
+            deviceName="light-1",
+            deviceType="Strip Light 3",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "brightness": 1, "color": "0:0:0", "colorTemperature": 4567},
+        {
+            "power": "on",
+            "brightness": 38,
+            "color": "255:246:158",
+            "colorTemperature": 4567,
+        },
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "light.light_1"
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                "brightness": 99,
+                "rgb_color": (255, 246, 158),
+            },
+            blocking=True,
+        )
+        assert mock_send_command.call_count == 2
+        mock_send_command.assert_has_calls(
+            [
+                call("light-id-1", RGBWWLightCommands.SET_BRIGHTNESS, "command", "38"),
+                call(
+                    "light-id-1",
+                    RGBWWLightCommands.SET_COLOR,
+                    "command",
+                    "255:246:158",
+                ),
+            ]
+        )
+    state = hass.states.get(entity_id)
+    assert state.state is STATE_ON
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.RGB
+
+
+@pytest.mark.parametrize("device_type", ["Ceiling Light", "Ceiling Light Pro"])
+async def test_ceiling_light_brightness_and_color_temp(
+    hass: HomeAssistant, mock_list_devices, mock_get_status, device_type
+) -> None:
+    """Test ceiling light turn on with both brightness and color temperature."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="light-id-1",
+            deviceName="light-1",
+            deviceType=device_type,
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "brightness": 1, "colorTemperature": 4567},
+        {"power": "on", "brightness": 38, "colorTemperature": 3000},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "light.light_1"
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                "brightness": 99,
+                "color_temp_kelvin": 3000,
+            },
+            blocking=True,
+        )
+        assert mock_send_command.call_count == 2
+        mock_send_command.assert_has_calls(
+            [
+                call(
+                    "light-id-1", CeilingLightCommands.SET_BRIGHTNESS, "command", "38"
+                ),
+                call(
+                    "light-id-1",
+                    CeilingLightCommands.SET_COLOR_TEMPERATURE,
+                    "command",
+                    "3000",
+                ),
+            ]
+        )
+    state = hass.states.get(entity_id)
+    assert state.state is STATE_ON
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes an issue where a simultaneous update of both brightness and [color OR color_temperature] would drop the color update.

This is (I think?) impossible to actually do interactively, but it can happen if you have scenes/automations that adjust both.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
