### PR TITLE
Track meteo_france alert departments with a HassKey

### DIFF
--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -1,5 +1,4 @@
 """Support for Meteo-France weather data."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
 
@@ -10,7 +9,7 @@ from requests import RequestException
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, PLATFORMS
+from .const import DEPARTMENTS_WITH_ALERT, PLATFORMS
 from .coordinator import (
     MeteoFranceAlertUpdateCoordinator,
     MeteoFranceConfigEntry,
@@ -24,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: MeteoFranceConfigEntry) -> bool:
     """Set up a Meteo-France account from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+    departments_with_alert = hass.data.setdefault(DEPARTMENTS_WITH_ALERT, set())
 
     client = MeteoFranceClient()
 
@@ -55,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MeteoFranceConfigEntry) 
         department,
     )
     if department is not None and is_valid_warning_department(department):
-        if not hass.data[DOMAIN].get(department):
+        if department not in departments_with_alert:
             coordinator_alert = MeteoFranceAlertUpdateCoordinator(
                 hass,
                 entry,
@@ -66,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MeteoFranceConfigEntry) 
             await coordinator_alert.async_refresh()
 
             if coordinator_alert.last_update_success:
-                hass.data[DOMAIN][department] = True
+                departments_with_alert.add(department)
         else:
             _LOGGER.warning(
                 (
@@ -108,7 +107,7 @@ async def async_unload_entry(
     """Unload a config entry."""
     if entry.runtime_data.alert_coordinator:
         department = entry.runtime_data.forecast_coordinator.data.position.get("dept")
-        hass.data[DOMAIN][department] = False
+        hass.data[DEPARTMENTS_WITH_ALERT].discard(department)
         _LOGGER.debug(
             (
                 "Weather alert for depatment %s unloaded and released. It can be added"
@@ -119,8 +118,8 @@ async def async_unload_entry(
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
+        if not hass.data[DEPARTMENTS_WITH_ALERT]:
+            hass.data.pop(DEPARTMENTS_WITH_ALERT)
 
     return unload_ok
 

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -9,7 +9,7 @@ from requests import RequestException
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DEPARTMENTS_WITH_ALERT, PLATFORMS
+from .const import METEO_FRANCE_DATA, PLATFORMS
 from .coordinator import (
     MeteoFranceAlertUpdateCoordinator,
     MeteoFranceConfigEntry,
@@ -23,7 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: MeteoFranceConfigEntry) -> bool:
     """Set up a Meteo-France account from a config entry."""
-    departments_with_alert = hass.data.setdefault(DEPARTMENTS_WITH_ALERT, set())
+    if (departments_with_alert := hass.data.get(METEO_FRANCE_DATA)) is None:
+        departments_with_alert = hass.data[METEO_FRANCE_DATA] = set()
 
     client = MeteoFranceClient()
 
@@ -107,7 +108,7 @@ async def async_unload_entry(
     """Unload a config entry."""
     if entry.runtime_data.alert_coordinator:
         department = entry.runtime_data.forecast_coordinator.data.position.get("dept")
-        hass.data[DEPARTMENTS_WITH_ALERT].discard(department)
+        hass.data[METEO_FRANCE_DATA].discard(department)
         _LOGGER.debug(
             (
                 "Weather alert for depatment %s unloaded and released. It can be added"
@@ -118,8 +119,8 @@ async def async_unload_entry(
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        if not hass.data[DEPARTMENTS_WITH_ALERT]:
-            hass.data.pop(DEPARTMENTS_WITH_ALERT)
+        if not hass.data[METEO_FRANCE_DATA]:
+            hass.data.pop(METEO_FRANCE_DATA)
 
     return unload_ok
 

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -18,9 +18,15 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_WINDY_VARIANT,
 )
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
 
 DOMAIN = "meteo_france"
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
+
+# Departments that already have a city providing weather alerts. Only one city
+# per department may do so, so this is shared between config entries rather than
+# owned by any one of them.
+DEPARTMENTS_WITH_ALERT: HassKey[set[str]] = HassKey(f"{DOMAIN}_departments_with_alert")
 ATTRIBUTION = "Data provided by Météo-France"
 MODEL = "Météo-France mobile API"
 MANUFACTURER = "Météo-France"

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -26,7 +26,7 @@ PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 # Departments that already have a city providing weather alerts. Only one city
 # per department may do so, so this is shared between config entries rather than
 # owned by any one of them.
-DEPARTMENTS_WITH_ALERT: HassKey[set[str]] = HassKey(f"{DOMAIN}_departments_with_alert")
+METEO_FRANCE_DATA: HassKey[set[str]] = HassKey(DOMAIN)
 ATTRIBUTION = "Data provided by Météo-France"
 MODEL = "Météo-France mobile API"
 MANUFACTURER = "Météo-France"

--- a/tests/components/meteo_france/test_init.py
+++ b/tests/components/meteo_france/test_init.py
@@ -1,0 +1,83 @@
+"""Test Météo France init."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.meteo_france.const import (
+    CONF_CITY,
+    DEPARTMENTS_WITH_ALERT,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.meteo_france.PLATFORMS", []):
+        yield
+
+
+def _second_city(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a second entry for a different city in the same department."""
+    entry_data = {
+        CONF_CITY: "Le Grand-Bornand",
+        CONF_LATITUDE: 45.94179,
+        CONF_LONGITUDE: 6.42794,
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        unique_id=f"{entry_data[CONF_LATITUDE], entry_data[CONF_LONGITUDE]}",
+        title=entry_data[CONF_CITY],
+        data=entry_data,
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+async def test_only_one_city_per_department_provides_alerts(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test the second city in a department does not also provide alerts."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.runtime_data.alert_coordinator is not None
+
+    second_entry = _second_city(hass)
+    await hass.config_entries.async_setup(second_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert second_entry.state is ConfigEntryState.LOADED
+    assert second_entry.runtime_data.alert_coordinator is None
+
+
+async def test_unload_releases_the_department(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading releases the department so another city can claim it."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.data[DEPARTMENTS_WITH_ALERT]
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The last entry is gone, so the shared registry is cleaned up entirely.
+    assert DEPARTMENTS_WITH_ALERT not in hass.data
+
+    second_entry = _second_city(hass)
+    await hass.config_entries.async_setup(second_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert second_entry.runtime_data.alert_coordinator is not None

--- a/tests/components/meteo_france/test_init.py
+++ b/tests/components/meteo_france/test_init.py
@@ -7,8 +7,8 @@ import pytest
 
 from homeassistant.components.meteo_france.const import (
     CONF_CITY,
-    DEPARTMENTS_WITH_ALERT,
     DOMAIN,
+    METEO_FRANCE_DATA,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
@@ -68,13 +68,13 @@ async def test_unload_releases_the_department(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.data[DEPARTMENTS_WITH_ALERT]
+    assert hass.data[METEO_FRANCE_DATA]
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
     # The last entry is gone, so the shared registry is cleaned up entirely.
-    assert DEPARTMENTS_WITH_ALERT not in hass.data
+    assert METEO_FRANCE_DATA not in hass.data
 
     second_entry = _second_city(hass)
     await hass.config_entries.async_setup(second_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Only one city per department may provide Météo-France weather alerts, so the set of claimed departments is shared between config entries rather than owned by any one of them. That is why it lives in `hass.data` and why the module carries a `# pylint: disable=home-assistant-use-runtime-data` suppression — `entry.runtime_data` would be rebuilt per entry and reset on reload, which is the opposite of what this registry needs.

This gives it a typed `HassKey` instead, which is the supported way to hold genuinely global state, and drops the suppression rather than carrying it.

It also stores the registry as a set of claimed departments instead of a `dict[str, bool]`. Unload marked a department `False` rather than removing it, so the mapping was never empty and the cleanup at the end of `async_unload_entry`

```python
if not hass.data[DOMAIN]:
    hass.data.pop(DOMAIN)
```

could not run once any city had ever registered — `hass.data[DOMAIN]` was `{"74": False}`, which is truthy. Discarding the department makes that branch reachable and leaves nothing behind after the last entry unloads. The claim check changes from `if not hass.data[DOMAIN].get(department)` to `if department not in departments_with_alert`, which is equivalent for both the never-claimed and the released case.

Added `tests/components/meteo_france/test_init.py` covering the one-city-per-department rule and the release on unload. The release test fails against the current code and passes with this change.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
