### PR TITLE
Bump pnpm in E2E tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,12 @@
     "pip_requirements",
     "pre-commit",
     "dockerfile",
+    "npm",
     "custom.regex",
     "homeassistant-manifest"
   ],
+
+  "ignorePaths": ["**/node_modules/**"],
 
   "pre-commit": {
     "enabled": true
@@ -24,6 +27,10 @@
 
   "dockerfile": {
     "managerFilePatterns": ["/^Dockerfile$/"]
+  },
+
+  "npm": {
+    "managerFilePatterns": ["/^tests/e2e/package\\.json$/"]
   },
 
   "homeassistant-manifest": {
@@ -177,6 +184,14 @@
         "yamllint",
         "zizmor"
       ],
+      "enabled": true,
+      "labels": ["dependency"]
+    },
+    {
+      "description": "pnpm version pinned in the E2E tests packageManager field (allowlisted)",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["packageManager"],
+      "matchPackageNames": ["pnpm"],
       "enabled": true,
       "labels": ["dependency"]
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,10 +29,6 @@
     "managerFilePatterns": ["/^Dockerfile$/"]
   },
 
-  "npm": {
-    "managerFilePatterns": ["/^tests/e2e/package\\.json$/"]
-  },
-
   "homeassistant-manifest": {
     "managerFilePatterns": [
       "/^homeassistant/components/[^/]+/manifest\\.json$/"
@@ -190,6 +186,7 @@
     {
       "description": "pnpm version pinned in the E2E tests packageManager field (allowlisted)",
       "matchManagers": ["npm"],
+      "matchFileNames": ["tests/e2e/package.json"],
       "matchDepTypes": ["packageManager"],
       "matchPackageNames": ["pnpm"],
       "enabled": true,

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "End-to-end browser tests for Home Assistant Core",
   "private": true,
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "test": "playwright test"
   },


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The E2E test workflow is currently failing on every run, before a single test executes:

```
[ERR_PNPM_BROKEN_PNPM_RELEASE] pnpm v11.13.0 is a broken release and cannot be installed
Its "@pnpm/exe" build shipped without a binary and does not run.
##[error]Something went wrong, self-installer exits with code 1
```

`pnpm/action-setup` takes its version from the `packageManager` field in `tests/e2e/package.json`, which was pinned to `pnpm@11.13.0`. pnpm has since marked that release as broken, so its self-installer now refuses to install it and every E2E job dies at the "Set up pnpm" step.

This bumps the pin to `pnpm@11.21.0` (current `latest` on npm). `pnpm install --frozen-lockfile` was verified locally against 11.21.0: the lockfile is already up to date, so `tests/e2e/pnpm-lock.yaml` needs no changes.

The second part of this PR makes sure we do not end up on a stale pin again. Neither Renovate (`npm` was not in `enabledManagers`) nor Dependabot (GitHub Actions only) was watching this version, so it could only ever be bumped by hand. Renovate now maintains it:

- `npm` added to `enabledManagers`, scoped with `managerFilePatterns` to `tests/e2e/package.json` only.
- A packageRule allowlisting `pnpm`, narrowed to `matchDepTypes: ["packageManager"]` so it can only ever touch this one pin (the config denies everything by default).
- `ignorePaths` narrowed to `**/node_modules/**`. This one is easy to miss: `config:recommended` pulls in `:ignoreModulesAndTests`, whose ignore list contains `**/tests/**`, which made `tests/e2e/package.json` invisible to Renovate. Without this change the `npm` manager extracts zero files. Every enabled manager is already explicitly scoped through `managerFilePatterns`, so nothing else widens as a result.

`@playwright/test` deliberately stays unmanaged, since Playwright bumps also need the browser download and the lockfile to move with them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Failing run this fixes: https://github.com/home-assistant/core/actions/runs/31662509044/job/94331534669

Verification performed locally, all against Renovate 44.27.0 (note that `npx renovate-config-validator` resolves to the `maint/42.x` tag by default, which falsely rejects our pre-existing `homeassistant-manifest` manager):

- `renovate-config-validator` — validated successfully.
- `renovate --platform=local --dry-run=extract` — `npm: {fileCount: 1, depCount: 2}`, with every other manager's counts byte-identical to before the change (dockerfile 3/9, homeassistant-manifest 1098/1219, pep621 2/56, pip_requirements 6/1384, pre-commit 1/7, regex 4/4). The relaxed `ignorePaths` pulls in exactly the one intended file.
- `renovate --platform=local --dry-run=lookup` — Renovate queries the registry for `pnpm` and logs `Dependency: @playwright/test, is disabled`, confirming the allowlist gate behaves as intended. No pnpm PR would open right now, since 11.21.0 is already `latest`.
- `pnpm@11.21.0 install --frozen-lockfile` in `tests/e2e` — succeeds against the unchanged lockfile.

The global `minimumReleaseAge: "7 days"` applies to pnpm as well, which gives some cushion against picking up another release that gets flagged broken shortly after publish.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr