### PR TITLE
Add Monzo spent today sensor

### DIFF
--- a/homeassistant/components/monzo/sensor.py
+++ b/homeassistant/components/monzo/sensor.py
@@ -39,6 +39,13 @@ ACCOUNT_SENSORS = (
         device_class=SensorDeviceClass.MONETARY,
         suggested_display_precision=2,
     ),
+    MonzoSensorEntityDescription(
+        key="spend_today",
+        translation_key="spend_today",
+        value_fn=lambda data: abs(data["balance"]["spend_today"]) / 100,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+    ),
 )
 
 POT_SENSORS = (

--- a/homeassistant/components/monzo/strings.json
+++ b/homeassistant/components/monzo/strings.json
@@ -57,6 +57,9 @@
       "pot_balance": {
         "name": "[%key:component::monzo::entity::sensor::balance::name%]"
       },
+      "spend_today": {
+        "name": "Spent today"
+      },
       "total_balance": {
         "name": "Total balance"
       }

--- a/tests/components/monzo/conftest.py
+++ b/tests/components/monzo/conftest.py
@@ -27,13 +27,23 @@ TEST_ACCOUNTS = [
         "id": "acc_curr",
         "name": "Current Account",
         "type": "uk_retail",
-        "balance": {"balance": 123, "total_balance": 321, "currency": "GBP"},
+        "balance": {
+            "balance": 123,
+            "total_balance": 321,
+            "spend_today": -45,
+            "currency": "GBP",
+        },
     },
     {
         "id": "acc_flex",
         "name": "Flex",
         "type": "uk_monzo_flex",
-        "balance": {"balance": 123, "total_balance": 321, "currency": "EUR"},
+        "balance": {
+            "balance": 123,
+            "total_balance": 321,
+            "spend_today": -67,
+            "currency": "EUR",
+        },
     },
 ]
 TEST_POTS = [

--- a/tests/components/monzo/snapshots/test_sensor.ambr
+++ b/tests/components/monzo/snapshots/test_sensor.ambr
@@ -55,6 +55,62 @@
     'state': '1.23',
   })
 # ---
+# name: test_all_entities[sensor.current_account_spent_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.current_account_spent_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Spent today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
+    'original_icon': None,
+    'original_name': 'Spent today',
+    'platform': 'monzo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'spend_today',
+    'unique_id': 'acc_curr_spend_today',
+    'unit_of_measurement': 'GBP',
+  })
+# ---
+# name: test_all_entities[sensor.current_account_spent_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monzo',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Current Account Spent today',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'GBP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.current_account_spent_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.45',
+  })
+# ---
 # name: test_all_entities[sensor.current_account_total_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -165,6 +221,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.23',
+  })
+# ---
+# name: test_all_entities[sensor.flex_spent_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flex_spent_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Spent today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
+    'original_icon': None,
+    'original_name': 'Spent today',
+    'platform': 'monzo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'spend_today',
+    'unique_id': 'acc_flex_spend_today',
+    'unit_of_measurement': 'EUR',
+  })
+# ---
+# name: test_all_entities[sensor.flex_spent_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monzo',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Flex Spent today',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flex_spent_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.67',
   })
 # ---
 # name: test_all_entities[sensor.flex_total_balance-entry]

--- a/tests/components/monzo/test_sensor.py
+++ b/tests/components/monzo/test_sensor.py
@@ -29,6 +29,7 @@ from tests.typing import ClientSessionGenerator
 EXPECTED_VALUE_GETTERS = {
     "balance": lambda x: x["balance"]["balance"] / 100,
     "total_balance": lambda x: x["balance"]["total_balance"] / 100,
+    "spend_today": lambda x: abs(x["balance"]["spend_today"]) / 100,
     "pot_balance": lambda x: x["balance"] / 100,
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an account-level **Spent today** monetary sensor to the Monzo integration. The Monzo API reports spending as a negative minor-unit value, so the sensor exposes its magnitude as a positive currency value to make its meaning clear to users.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47385
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
