### PR TITLE
Add backwards compatibility for custom integrations accessing child devices

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -654,11 +654,60 @@ class DeviceEntry(BaseDeviceEntry):
         return self._suggested_area
 
 
+_CHILD_DEVICE_COMPAT_ATTRS = frozenset(
+    {
+        "configuration_url",
+        "connections",
+        "entry_type",
+        "hw_version",
+        "manufacturer",
+        "model",
+        "model_id",
+        "serial_number",
+        # "suggested_area",  # Excluded, to be removed in 2026.9
+        "sw_version",
+        "via_device_id",
+    }
+)
+
+
 @attr.s(frozen=True, slots=True)
 class ChildDeviceEntry(BaseDeviceEntry):
     """Child Device Registry Entry."""
 
     parent_device_id: str = attr.ib(kw_only=True)
+
+    if not TYPE_CHECKING:
+        # Hidden from the type checker, otherwise mypy disables [attr-defined]
+        # errors when it sees the __getattr__ below.
+        def __getattr__(self, name: str) -> Any:
+            """Return the DeviceEntry default for a DeviceEntry-only attribute.
+
+            Backwards-compatibility shim for custom integrations that access an
+            attribute which only exists on DeviceEntry (e.g. connections,
+            manufacturer): they get the DeviceEntry default and a deprecation warning.
+            """
+            if name not in _CHILD_DEVICE_COMPAT_ATTRS:
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            try:
+                integration_frame = get_integration_frame()
+            except MissingIntegrationFrame:
+                integration_frame = None
+            if integration_frame is None or not integration_frame.custom_integration:
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            report_usage(
+                f"accesses ChildDeviceEntry.{name}, which does not exist on child "
+                "devices",
+                breaks_in_ha_version="2027.9.0",
+                core_behavior=ReportBehavior.IGNORE,
+                core_integration_behavior=ReportBehavior.IGNORE,
+                custom_integration_behavior=ReportBehavior.LOG,
+            )
+            return set() if name == "connections" else None
 
     @property
     @override

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -9708,6 +9708,103 @@ async def test_child_device_create(
     }
 
 
+@pytest.mark.parametrize(
+    ("attr_name", "expected_default"),
+    [
+        ("configuration_url", None),
+        ("connections", set()),
+        ("entry_type", None),
+        ("hw_version", None),
+        ("manufacturer", None),
+        ("model", None),
+        ("model_id", None),
+        ("serial_number", None),
+        ("sw_version", None),
+        ("via_device_id", None),
+    ],
+)
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expectation", "expected_log"),
+    [
+        pytest.param(
+            "homeassistant/test_core", pytest.raises(AttributeError), 0, id="core"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration",
+            pytest.raises(AttributeError),
+            0,
+            id="core integration",
+        ),
+        pytest.param(
+            "custom_components/test_integration",
+            nullcontext(),
+            1,
+            id="custom integration",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_child_device_deprecated_device_entry_attrs(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    attr_name: str,
+    expected_default: Any,
+    expectation: AbstractContextManager,
+    expected_log: int,
+) -> None:
+    """Test accessing a DeviceEntry-only attribute on a child device.
+
+    Custom integrations get the DeviceEntry default value and a deprecation warning;
+    core and core integrations raise AttributeError so the attribute reads as missing.
+    """
+    _, child_device = _create_parent_and_child(
+        device_registry, mock_config_entry.entry_id
+    )
+
+    what = (
+        f"accesses ChildDeviceEntry.{attr_name}, which does not exist on child devices"
+    )
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
+        assert getattr(child_device, attr_name) == expected_default
+    assert caplog.text.count(what) == expected_log
+
+
+@pytest.mark.parametrize("attr_name", sorted(dr._CHILD_DEVICE_COMPAT_ATTRS))
+@pytest.mark.usefixtures("hass")
+async def test_child_device_deprecated_attrs_missing_for_core(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    attr_name: str,
+) -> None:
+    """Test DeviceEntry-only attributes read as missing without an integration frame.
+
+    This is the template/pure-core path: hasattr must be False so device_attr and
+    is_device_attr fall back to None instead of raising.
+    """
+    _, child_device = _create_parent_and_child(
+        device_registry, mock_config_entry.entry_id
+    )
+
+    assert hasattr(child_device, attr_name) is False
+    with pytest.raises(AttributeError, match=f"has no attribute '{attr_name}'"):
+        getattr(child_device, attr_name)
+
+
+@pytest.mark.usefixtures("hass")
+async def test_child_device_unknown_attribute_raises(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test accessing a genuinely unknown attribute on a child device raises."""
+    _, child_device = _create_parent_and_child(
+        device_registry, mock_config_entry.entry_id
+    )
+
+    with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+        getattr(child_device, "does_not_exist")  # noqa: B009
+
+
 @pytest.mark.usefixtures("hass")
 async def test_async_get_exclude_child_devices(
     device_registry: dr.DeviceRegistry,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add backwards compatibility for custom integrations unintentionally accessing child devices via `DeviceRegistry.async_get`

Note: The alternative, to not return child devices from `DeviceRegistry.async_get` unless specified would break many more custom integrations (hundreds) which don't have a problem acting on a child device.

AI generated review of custom integrations which raise without the shim added by this PR:
```
here's the dissection of why custom integrations crash under include_child_devices=True. The headline is decisive: of all 85 crash sites, exactly 0 pass their own device id. Every one resolves an externally-sourced id, so 84/85 sites across all 58 domains will actually crash (1 lone site was UNKNOWN provenance and judged non-crashing). There are no "own-device false positives" diluting the exposure — which makes sense: an integration already holds its own device objects; it only calls async_get to resolve ids it got from elsewhere.

Q1 — where the crashing id comes from

┌───────────────────────────────────────────────────────────────────┬───────┬─────────┬────────────────────────────────┐
│                            Provenance                             │ sites │ domains │        can be a child?         │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ ENTITY_DERIVED (entity_entry.device_id)                           │ 37    │ 31      │ ✅ entities attach to children │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ CONFIG_SELECTOR (device picked in a config/options/subentry flow) │ 19    │ 11      │ ✅ user picks any device       │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ USER_SERVICE_TARGET (call.data["device_id"])                      │ 16    │ 12      │ ✅ user targets any device     │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ EVENT_OR_TRIGGER (device-trigger/webhook payload)                 │ 8     │ 7       │ ✅                             │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ FOREIGN_LINKED (a linked/other-integration device id)             │ 4     │ 4       │ ✅                             │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ UNKNOWN                                                           │ 1     │ 1       │ —                              │
├───────────────────────────────────────────────────────────────────┼───────┼─────────┼────────────────────────────────┤
│ OWN_DEVICE (integration's own registered device)                  │ 0     │ 0       │ ❌ never a child               │
└───────────────────────────────────────────────────────────────────┴───────┴─────────┴────────────────────────────────┘

The dominant pattern (37 sites) is "resolve this entity's device" — e.g. powercalc, battery_notes, mqtt_vacuum_camera, spook, qubino_wire_pilot taking a source entity's device_id. Next is "the device the user selected in my config" (19) and "the device targeted in my service call" (16, e.g. bambu_lab filament services, esphome_update_manager force-install, gasbuddy clear_cache).

Q2 — what attribute they read on the child (→ AttributeError)

┌───────────────────────┬───────┬───────────────────┐
│         Field         │ hits  │       group       │
├───────────────────────┼───────┼───────────────────┤
│ connections           │ 35    │ topology/identity │
├───────────────────────┼───────┼───────────────────┤
│ model                 │ 34    │ hardware metadata │
├───────────────────────┼───────┼───────────────────┤
│ manufacturer          │ 30    │ hardware metadata │
├───────────────────────┼───────┼───────────────────┤
│ sw_version            │ 12    │ hardware metadata │
├───────────────────────┼───────┼───────────────────┤
│ via_device_id         │ 10    │ topology          │
├───────────────────────┼───────┼───────────────────┤
│ hw_version            │ 10    │ hardware metadata │
├───────────────────────┼───────┼───────────────────┤
│ configuration_url     │ 6     │ misc              │
├───────────────────────┼───────┼───────────────────┤
│ serial_number         │ 5     │ hardware metadata │
├───────────────────────┼───────┼───────────────────┤
│ model_id / entry_type │ 3 / 3 │ misc              │
├───────────────────────┼───────┼───────────────────┤
│ suggested_area        │ 2     │ misc              │
└───────────────────────┴───────┴───────────────────┘

So it's overwhelmingly hardware metadata (model/manufacturer/sw_version/hw_version/serial_number/model_id ≈ 94 accesses) and topology (connections/via_device_id ≈ 45) — exactly the DeviceEntry-only fields a ChildDeviceEntry doesn't carry. Integrations resolve a foreign/user/entity id and immediately read the physical-device attributes off it.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
