### PR TITLE
Fix swallowed exceptions in smlight action handlers

### DIFF
--- a/homeassistant/components/smlight/light.py
+++ b/homeassistant/components/smlight/light.py
@@ -17,8 +17,10 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
 from .entity import SmEntity
 
@@ -128,10 +130,13 @@ class SmLightEntity(SmEntity, LightEntity):
             effect_name: str = kwargs[ATTR_EFFECT]
             try:
                 idx = self.entity_description.effect_list.index(effect_name)
-            # pylint: disable-next=home-assistant-action-swallowed-exception
-            except ValueError:
-                _LOGGER.warning("Unknown effect: %s", effect_name)
-                return
+            except ValueError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="unknown_effect",
+                    translation_placeholders={"effect": effect_name},
+                ) from err
+
             payload.ultLedMode = AmbiEffect(idx)
         elif not self.is_on:
             payload.ultLedMode = AmbiEffect.WSULT_SOLID

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -195,6 +195,9 @@
     },
     "send_ir_code_failed": {
       "message": "Failed to send IR code: {error}."
+    },
+    "unknown_effect": {
+      "message": "Unknown effect: {effect}."
     }
   },
   "issues": {

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -193,6 +193,9 @@
     "play_tone_failed": {
       "message": "Failed to play tone on {device_name}: {error}."
     },
+    "reboot_timeout": {
+      "message": "Timeout waiting for {device_name} to reboot after update."
+    },
     "send_ir_code_failed": {
       "message": "Failed to send IR code: {error}."
     },

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -194,7 +194,7 @@
       "message": "Failed to play tone on {device_name}: {error}."
     },
     "reboot_timeout": {
-      "message": "Timeout waiting for {device_name} to reboot after update."
+      "message": "Timeout waiting for {hostname} to reboot after update"
     },
     "send_ir_code_failed": {
       "message": "Failed to send IR code: {error}."

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -275,5 +275,6 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
                         },
                     ) from err
             finally:
+                self._update_done()
                 self.coordinator.in_progress = False
                 self._finished_event.clear()

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, LOGGER, ZWAVE_TYPES
+from .const import DOMAIN, ZWAVE_TYPES
 from .coordinator import SmConfigEntry, SmFirmwareUpdateCoordinator, SmFwData
 from .entity import SmEntity
 
@@ -265,12 +265,12 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
                     ):
                         await self.coordinator.async_refresh()
                         await asyncio.sleep(1)
-            # pylint: disable-next=home-assistant-action-swallowed-exception
-            except TimeoutError:
-                LOGGER.warning(
-                    "Timeout waiting for %s to reboot after update",
-                    self.coordinator.data.info.hostname,
-                )
+            except TimeoutError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="reboot_timeout",
+                    translation_placeholders={"device_name": str(self.name)},
+                ) from err
 
             self.coordinator.in_progress = False
             self._finished_event.clear()

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -15,7 +15,7 @@ from homeassistant.components.update import (
     UpdateEntityDescription,
     UpdateEntityFeature,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -251,26 +251,29 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
             self._attr_update_percentage = None
             self.register_callbacks()
 
-            await self.coordinator.client.fw_update(self._firmware, self.idx)
-
-            # block until update finished event received
-            await self._finished_event.wait()
-
-            # allow time for SLZB-06 to reboot before updating coordinator data
             try:
-                async with asyncio.timeout(180):
-                    while (
-                        self.coordinator.in_progress
-                        and self.installed_version != self._firmware.ver
-                    ):
-                        await self.coordinator.async_refresh()
-                        await asyncio.sleep(1)
-            except TimeoutError as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="reboot_timeout",
-                    translation_placeholders={"device_name": str(self.name)},
-                ) from err
+                await self.coordinator.client.fw_update(self._firmware, self.idx)
 
-            self.coordinator.in_progress = False
-            self._finished_event.clear()
+                # block until update finished event received
+                await self._finished_event.wait()
+
+                # allow time for SLZB-06 to reboot before updating coordinator data
+                try:
+                    async with asyncio.timeout(180):
+                        while (
+                            self.coordinator.in_progress
+                            and self.installed_version != self._firmware.ver
+                        ):
+                            await self.coordinator.async_refresh()
+                            await asyncio.sleep(1)
+                except TimeoutError as err:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="reboot_timeout",
+                        translation_placeholders={
+                            "hostname": self.coordinator.config_entry.data[CONF_HOST],
+                        },
+                    ) from err
+            finally:
+                self.coordinator.in_progress = False
+                self._finished_event.clear()

--- a/tests/components/smlight/test_light.py
+++ b/tests/components/smlight/test_light.py
@@ -239,18 +239,19 @@ async def test_light_invalid_effect(
     mock_config_entry: MockConfigEntry,
     mock_ultima_client: MagicMock,
 ) -> None:
-    """Test handling of invalid effect name is ignored."""
+    """Test handling of invalid effect name raises a translated error."""
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
 
     mock_ultima_client.actions.ambilight.reset_mock()
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "InvalidEffect"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError, match="Unknown effect: InvalidEffect"):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "InvalidEffect"},
+            blocking=True,
+        )
 
     mock_ultima_client.actions.ambilight.assert_not_called()
 

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -273,15 +273,13 @@ async def test_update_firmware_failed(
     assert state.attributes[ATTR_UPDATE_PERCENTAGE] is None
 
 
-@patch("homeassistant.components.smlight.const.LOGGER.warning")
 async def test_update_reboot_timeout(
-    mock_warning: MagicMock,
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_smlight_client: MagicMock,
 ) -> None:
-    """Test firmware updates."""
+    """Test reboot timeout raises a translated user-facing error."""
     await setup_integration(hass, mock_config_entry)
     entity_id = "update.mock_title_core_firmware"
     state = hass.states.get(entity_id)
@@ -318,7 +316,16 @@ async def test_update_reboot_timeout(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-        mock_warning.assert_called_once()
+        with pytest.raises(
+            HomeAssistantError,
+            match=r"Timeout waiting for .* to reboot after update\.",
+        ):
+            await hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -320,6 +320,10 @@ async def test_update_reboot_timeout(
         ):
             await install_task
 
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_IN_PROGRESS] is False
+    assert state.attributes[ATTR_UPDATE_PERCENTAGE] is None
+
 
 @pytest.mark.parametrize(
     "entity_id",

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -1,5 +1,6 @@
 """Tests for the SMLIGHT update platform."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -275,7 +276,6 @@ async def test_update_firmware_failed(
 
 async def test_update_reboot_timeout(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_smlight_client: MagicMock,
 ) -> None:
@@ -297,35 +297,28 @@ async def test_update_reboot_timeout(
             return_value=None,
         ),
     ):
-        await hass.services.async_call(
-            UPDATE_DOMAIN,
-            SERVICE_INSTALL,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=False,
+        install_task = hass.async_create_task(
+            hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
         )
+        await asyncio.sleep(0)
 
         assert len(mock_smlight_client.fw_update.mock_calls) == 1
 
         event_function = get_mock_event_function(
             mock_smlight_client, SmEvents.FW_UPD_done
         )
-
         event_function(MOCK_FIRMWARE_DONE)
-
-        freezer.tick(timedelta(seconds=5))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
 
         with pytest.raises(
             HomeAssistantError,
-            match=r"Timeout waiting for .* to reboot after update\.",
+            match=r"Timeout waiting for .* to reboot after update",
         ):
-            await hass.services.async_call(
-                UPDATE_DOMAIN,
-                SERVICE_INSTALL,
-                {ATTR_ENTITY_ID: entity_id},
-                blocking=True,
-            )
+            await install_task
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix exceptions to properly raise Home Assistant errors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/170640
- This PR is related to issue:  https://github.com/home-assistant/epics/issues/64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
