### PR TITLE
Improve Monzo webhook retry logging

### DIFF
--- a/homeassistant/components/monzo/webhook.py
+++ b/homeassistant/components/monzo/webhook.py
@@ -70,6 +70,7 @@ class MonzoWebhookManager:
         self._active = True
         self._register_lock = asyncio.Lock()
         self._retry_cancel: CALLBACK_TYPE | None = None
+        self._retrying = False
         self._webhook_url: str | None = None
 
     async def async_setup(self) -> None:
@@ -120,7 +121,7 @@ class MonzoWebhookManager:
                             self.hass, self.entry.data[CONF_WEBHOOK_ID]
                         )
                     except cloud.CloudNotAvailable:
-                        self._schedule_retry()
+                        self._schedule_retry("Unable to create Monzo cloud webhook")
                         return
                     self.hass.config_entries.async_update_entry(
                         self.entry,
@@ -152,11 +153,11 @@ class MonzoWebhookManager:
                 return
             except (ClientError, InvalidMonzoAPIResponseError, TimeoutError) as err:
                 await self._async_rollback_remote_webhooks(registered_webhook_ids)
-                _LOGGER.warning("Unable to register Monzo webhooks: %s", err)
-                self._schedule_retry()
+                self._schedule_retry("Unable to register Monzo webhooks", err)
                 return
 
             self._cancel_retry()
+            self._log_retry_success()
             self._webhook_url = webhook_url
             if self.entry.data.get(CONF_WEBHOOK_URL) != webhook_url:
                 self.hass.config_entries.async_update_entry(
@@ -228,10 +229,11 @@ class MonzoWebhookManager:
             self.entry.async_start_reauth(self.hass)
             return
         except (ClientError, InvalidMonzoAPIResponseError, TimeoutError) as err:
-            _LOGGER.warning("Unable to remove obsolete Monzo webhooks: %s", err)
-            self._schedule_retry()
+            self._schedule_retry("Unable to remove obsolete Monzo webhooks", err)
             return
 
+        self._cancel_retry()
+        self._log_retry_success()
         self._webhook_url = None
         data = dict(self.entry.data)
         data.pop(CONF_WEBHOOK_URL, None)
@@ -329,13 +331,30 @@ class MonzoWebhookManager:
             name,
         )
 
-    def _schedule_retry(self) -> None:
+    def _schedule_retry(self, message: str, err: Exception | None = None) -> None:
         """Schedule another remote webhook registration attempt."""
         if self._retry_cancel is not None:
             return
+        if not self._retrying:
+            if err is None:
+                _LOGGER.info("%s; retrying in %s seconds", message, WEBHOOK_RETRY_DELAY)
+            else:
+                _LOGGER.info(
+                    "%s: %s; retrying in %s seconds",
+                    message,
+                    err,
+                    WEBHOOK_RETRY_DELAY,
+                )
+            self._retrying = True
         self._retry_cancel = async_call_later(
             self.hass, WEBHOOK_RETRY_DELAY, self._async_retry
         )
+
+    def _log_retry_success(self) -> None:
+        """Log when remote webhook management recovers."""
+        if self._retrying:
+            _LOGGER.info("Successfully updated Monzo webhooks after retrying")
+            self._retrying = False
 
     async def _async_retry(self, now: datetime) -> None:
         """Retry remote webhook registration."""

--- a/homeassistant/components/monzo/webhook.py
+++ b/homeassistant/components/monzo/webhook.py
@@ -217,6 +217,8 @@ class MonzoWebhookManager:
     async def _async_remove_previous_remote_webhooks(self) -> None:
         """Remove remote webhooks when no callback URL is available."""
         if (previous_url := self.entry.data.get(CONF_WEBHOOK_URL)) is None:
+            self._cancel_retry()
+            self._retrying = False
             return
 
         try:

--- a/tests/components/monzo/test_webhook.py
+++ b/tests/components/monzo/test_webhook.py
@@ -864,6 +864,45 @@ async def test_cloudhook_creation_failure_is_retried(
     assert "Successfully updated Monzo webhooks after retrying" in caplog.text
 
 
+async def test_retry_is_cancelled_when_callback_url_becomes_unavailable(
+    hass: HomeAssistant,
+    monzo: AsyncMock,
+    polling_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a retry is cancelled when there is no callback or previous URL."""
+    caplog.set_level(logging.INFO)
+    with (
+        patch.object(cloud, "async_active_subscription", return_value=True),
+        patch.object(cloud, "async_is_connected", return_value=True),
+        patch.object(
+            cloud,
+            "async_get_or_create_cloudhook",
+            side_effect=cloud.CloudNotAvailable,
+        ),
+    ):
+        await setup_integration(hass, polling_config_entry)
+
+    with (
+        patch.object(cloud, "async_active_subscription", return_value=False),
+        patch(
+            "homeassistant.components.monzo.webhook.webhook.async_generate_url",
+            side_effect=NoURLAvailableError,
+        ) as generate_url,
+    ):
+        await hass.config.async_update(external_url=None)
+        await hass.async_block_till_done()
+
+        freezer.tick(timedelta(seconds=WEBHOOK_RETRY_DELAY))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    generate_url.assert_called_once()
+    monzo.user_account.list_account_webhooks.assert_not_awaited()
+    assert "Successfully updated Monzo webhooks after retrying" not in caplog.text
+
+
 async def test_registration_auth_failure_starts_reauthentication(
     hass: HomeAssistant,
     monzo: AsyncMock,

--- a/tests/components/monzo/test_webhook.py
+++ b/tests/components/monzo/test_webhook.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+import logging
 from unittest.mock import AsyncMock, Mock, call, patch
 
 from aiohttp import ClientError
@@ -779,8 +780,10 @@ async def test_external_url_cleanup_failure_is_retried_once(
     monzo: AsyncMock,
     polling_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test repeated URL updates share one remote cleanup retry."""
+    caplog.set_level(logging.INFO)
     await setup_integration(hass, polling_config_entry)
     monzo.user_account.list_account_webhooks.side_effect = [
         InvalidMonzoAPIResponseError(),
@@ -808,6 +811,8 @@ async def test_external_url_cleanup_failure_is_retried_once(
         call("old-current"),
         call("old-flex"),
     ]
+    assert caplog.text.count("Unable to remove obsolete Monzo webhooks") == 1
+    assert caplog.text.count("Successfully updated Monzo webhooks after retrying") == 1
 
 
 async def test_no_external_url_skips_remote_registration(
@@ -831,8 +836,10 @@ async def test_cloudhook_creation_failure_is_retried(
     monzo: AsyncMock,
     polling_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test unavailable cloud connection schedules webhook registration retry."""
+    caplog.set_level(logging.INFO)
     with (
         patch.object(cloud, "async_active_subscription", return_value=True),
         patch.object(cloud, "async_is_connected", return_value=True),
@@ -853,6 +860,8 @@ async def test_cloudhook_creation_failure_is_retried(
         call("acc_curr", CLOUDHOOK_URL),
         call("acc_flex", CLOUDHOOK_URL),
     ]
+    assert "Unable to create Monzo cloud webhook; retrying in 60 seconds" in caplog.text
+    assert "Successfully updated Monzo webhooks after retrying" in caplog.text
 
 
 async def test_registration_auth_failure_starts_reauthentication(
@@ -902,9 +911,12 @@ async def test_registration_failure_is_retried(
     monzo: AsyncMock,
     polling_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a transient invalid response schedules another registration attempt."""
+    caplog.set_level(logging.INFO)
     monzo.user_account.list_account_webhooks.side_effect = [
+        InvalidMonzoAPIResponseError(),
         InvalidMonzoAPIResponseError(),
         [],
         [],
@@ -917,4 +929,10 @@ async def test_registration_failure_is_retried(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    freezer.tick(timedelta(seconds=WEBHOOK_RETRY_DELAY))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
     assert monzo.user_account.register_webhook.await_count == 2
+    assert caplog.text.count("Unable to register Monzo webhooks") == 1
+    assert caplog.text.count("Successfully updated Monzo webhooks after retrying") == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve Monzo webhook retry logging so a persistent failure logs once at info level and a successful retry logs once when webhook management recovers. This covers cloudhook creation, remote webhook registration, and obsolete webhook cleanup without filling the log on every 60-second retry.

A successful webhook update also cancels any pending retry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
