### PR TITLE
Refresh Wyoming service info periodically

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -3,12 +3,13 @@
 import logging
 
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import ATTR_SPEAKER, DOMAIN
+from .coordinator import WyomingInfoCoordinator
 from .data import WyomingService
 from .devices import SatelliteDevice
 from .models import DomainDataItem, WyomingConfigEntry
@@ -46,7 +47,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: WyomingConfigEntry) -> b
     if service is None:
         raise ConfigEntryNotReady("Unable to connect")
 
-    item = DomainDataItem(service=service)
+    coordinator = WyomingInfoCoordinator(
+        hass, entry, entry.data["host"], entry.data["port"]
+    )
+
+    @callback
+    def _async_update_service_info() -> None:
+        service.info = coordinator.data
+
+    # The coordinator only schedules refreshes while it has listeners, so this
+    # also keeps it polling for platforms that read info without listening.
+    entry.async_on_unload(coordinator.async_add_listener(_async_update_service_info))
+    coordinator.async_set_updated_data(service.info)
+
+    item = DomainDataItem(service=service, coordinator=coordinator)
     entry.runtime_data = item
 
     await hass.config_entries.async_forward_entry_setups(entry, service.platforms)

--- a/homeassistant/components/wyoming/coordinator.py
+++ b/homeassistant/components/wyoming/coordinator.py
@@ -1,0 +1,50 @@
+"""Coordinator for refreshing Wyoming service info."""
+
+from datetime import timedelta
+import logging
+from typing import override
+
+from wyoming.info import Info
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .data import load_wyoming_info
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+
+class WyomingInfoCoordinator(DataUpdateCoordinator[Info]):
+    """Periodically refresh info from a Wyoming service.
+
+    Services can gain or lose voices, wake word models, etc. while Home
+    Assistant is running, so the info collected during setup goes stale.
+    """
+
+    def __init__(
+        self, hass: HomeAssistant, config_entry: ConfigEntry, host: str, port: int
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{host}:{port}",
+            update_interval=UPDATE_INTERVAL,
+            always_update=False,
+        )
+        self.host = host
+        self.port = port
+
+    @override
+    async def _async_update_data(self) -> Info:
+        """Fetch info from the Wyoming service."""
+        # A single attempt is enough because the next interval retries anyway.
+        info = await load_wyoming_info(self.host, self.port, retries=0)
+        if info is None:
+            raise UpdateFailed(f"Unable to get info from {self.host}:{self.port}")
+
+        return info

--- a/homeassistant/components/wyoming/models.py
+++ b/homeassistant/components/wyoming/models.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from homeassistant.config_entries import ConfigEntry
 
+from .coordinator import WyomingInfoCoordinator
 from .data import WyomingService
 from .devices import SatelliteDevice
 
@@ -13,6 +14,7 @@ class DomainDataItem:
     """Domain data item."""
 
     service: WyomingService
+    coordinator: WyomingInfoCoordinator
     device: SatelliteDevice | None = None
 
 

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -10,6 +10,7 @@ import wave
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
 from wyoming.error import Error
+from wyoming.info import TtsProgram
 from wyoming.tts import (
     Synthesize,
     SynthesizeChunk,
@@ -25,6 +26,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_SPEAKER
+from .coordinator import WyomingInfoCoordinator
 from .data import WyomingService
 from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
@@ -41,7 +43,7 @@ async def async_setup_entry(
     item = config_entry.runtime_data
     async_add_entities(
         [
-            WyomingTtsProvider(config_entry, item.service),
+            WyomingTtsProvider(config_entry, item.coordinator, item.service),
         ]
     )
 
@@ -55,22 +57,59 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
     def __init__(
         self,
         config_entry: WyomingConfigEntry,
+        coordinator: WyomingInfoCoordinator,
         service: WyomingService,
     ) -> None:
         """Set up provider."""
         self.config_entry = config_entry
+        self.coordinator = coordinator
         self.service = service
-        self._tts_service = next(tts for tts in service.info.tts if tts.installed)
 
+        # The platform is only set up when an installed TTS service exists.
+        self._tts_service = next(tts for tts in service.info.tts if tts.installed)
+        self._voices: dict[str, list[tts.Voice]] = {}
+        self._supported_languages: list[str] = []
+        self._rebuild_voices(self._tts_service)
+
+        if self._supported_languages:
+            self._attr_default_language = self._supported_languages[0]
+
+        self._attr_name = self._tts_service.name
+        self._attr_unique_id = f"{config_entry.entry_id}-tts"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to info updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_info_update)
+        )
+
+    @callback
+    def _handle_info_update(self) -> None:
+        """Rebuild the voice list when the service reports new info."""
+        tts_service = next(
+            (tts for tts in self.coordinator.data.tts if tts.installed), None
+        )
+        if tts_service is None:
+            # Keep the last known voices if the service reports none.
+            return
+
+        self._tts_service = tts_service
+        self._rebuild_voices(tts_service)
+
+    @callback
+    def _rebuild_voices(self, tts_service: TtsProgram) -> None:
+        """Collect the installed voices, grouped by language."""
         voice_languages: set[str] = set()
-        self._voices: dict[str, list[tts.Voice]] = defaultdict(list)
-        for voice in self._tts_service.voices:
+        voices: dict[str, list[tts.Voice]] = defaultdict(list)
+        for voice in tts_service.voices:
             if not voice.installed:
                 continue
 
             voice_languages.update(voice.languages)
             for language in voice.languages:
-                self._voices[language].append(
+                voices[language].append(
                     tts.Voice(
                         voice_id=voice.name,
                         name=voice.description or voice.name,
@@ -78,17 +117,17 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
                 )
 
         # Sort voices by name
-        for language in self._voices:
-            self._voices[language] = sorted(
-                self._voices[language], key=lambda v: v.name
-            )
+        for language_voices in voices.values():
+            language_voices.sort(key=lambda v: v.name)
 
-        self._attr_supported_languages = list(voice_languages)
-        if self._attr_supported_languages:
-            self._attr_default_language = self._attr_supported_languages[0]
+        self._voices = voices
+        self._supported_languages = list(voice_languages)
 
-        self._attr_name = self._tts_service.name
-        self._attr_unique_id = f"{config_entry.entry_id}-tts"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
+    @property
+    @override
+    def supported_languages(self) -> list[str]:
+        """Return a list of supported languages."""
+        return self._supported_languages
 
     @callback
     @override

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -68,11 +68,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
         # The platform is only set up when an installed TTS service exists.
         self._tts_service = next(tts for tts in service.info.tts if tts.installed)
         self._voices: dict[str, list[tts.Voice]] = {}
-        self._supported_languages: list[str] = []
         self._rebuild_voices(self._tts_service)
-
-        if self._supported_languages:
-            self._attr_default_language = self._supported_languages[0]
 
         self._attr_name = self._tts_service.name
         self._attr_unique_id = f"{config_entry.entry_id}-tts"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
@@ -121,13 +117,13 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
             language_voices.sort(key=lambda v: v.name)
 
         self._voices = voices
-        self._supported_languages = list(voice_languages)
+        self._attr_supported_languages = sorted(voice_languages)
 
-    @property
-    @override
-    def supported_languages(self) -> list[str]:
-        """Return a list of supported languages."""
-        return self._supported_languages
+        # Only move the default when the current one is gone so that installing
+        # an unrelated voice cannot change it.
+        current_default = getattr(self, "_attr_default_language", None)
+        if voice_languages and current_default not in voice_languages:
+            self._attr_default_language = self._attr_supported_languages[0]
 
     @callback
     @override

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -71,11 +71,14 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
     @callback
     def _handle_info_update(self) -> None:
         """Rebuild the wake word list when the service reports new info."""
-        if not self.coordinator.data.wake:
+        wake_service = next(
+            (wake for wake in self.coordinator.data.wake if wake.installed), None
+        )
+        if wake_service is None:
             # Keep the last known wake words if the service reports none.
             return
 
-        self._rebuild_wake_words(self.coordinator.data.wake[0])
+        self._rebuild_wake_words(wake_service)
 
     @callback
     def _rebuild_wake_words(self, wake_service: WakeProgram) -> None:

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -52,8 +52,8 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
         self.coordinator = coordinator
         self.service = service
 
-        # The platform is only set up when a wake service exists.
-        wake_service = service.info.wake[0]
+        # The platform is only set up when an installed wake service exists.
+        wake_service = next(wake for wake in service.info.wake if wake.installed)
         self._supported_wake_words: list[wake_word.WakeWord] = []
         self._rebuild_wake_words(wake_service)
 

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -8,13 +8,15 @@ from typing import override
 from wyoming.audio import AudioChunk, AudioStart
 from wyoming.client import AsyncTcpClient
 from wyoming.error import Error
+from wyoming.info import WakeProgram
 from wyoming.wake import Detect, Detection
 
 from homeassistant.components import wake_word
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .data import WyomingService, load_wyoming_info
+from .coordinator import WyomingInfoCoordinator
+from .data import WyomingService
 from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
@@ -30,7 +32,7 @@ async def async_setup_entry(
     item = config_entry.runtime_data
     async_add_entities(
         [
-            WyomingWakeWordProvider(hass, config_entry, item.service),
+            WyomingWakeWordProvider(hass, config_entry, item.coordinator, item.service),
         ]
     )
 
@@ -42,40 +44,52 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
         self,
         hass: HomeAssistant,
         config_entry: WyomingConfigEntry,
+        coordinator: WyomingInfoCoordinator,
         service: WyomingService,
     ) -> None:
         """Set up provider."""
         self.hass = hass
+        self.coordinator = coordinator
         self.service = service
-        wake_service = service.info.wake[0]
 
+        # The platform is only set up when a wake service exists.
+        wake_service = service.info.wake[0]
+        self._supported_wake_words: list[wake_word.WakeWord] = []
+        self._rebuild_wake_words(wake_service)
+
+        self._attr_name = wake_service.name
+        self._attr_unique_id = f"{config_entry.entry_id}-wake_word"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to info updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_info_update)
+        )
+
+    @callback
+    def _handle_info_update(self) -> None:
+        """Rebuild the wake word list when the service reports new info."""
+        if not self.coordinator.data.wake:
+            # Keep the last known wake words if the service reports none.
+            return
+
+        self._rebuild_wake_words(self.coordinator.data.wake[0])
+
+    @callback
+    def _rebuild_wake_words(self, wake_service: WakeProgram) -> None:
+        """Collect the wake words offered by the service."""
         self._supported_wake_words = [
             wake_word.WakeWord(
                 id=ww.name, name=ww.description or ww.name, phrase=ww.phrase
             )
             for ww in wake_service.models
         ]
-        self._attr_name = wake_service.name
-        self._attr_unique_id = f"{config_entry.entry_id}-wake_word"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
 
     @override
     async def get_supported_wake_words(self) -> list[wake_word.WakeWord]:
         """Return a list of supported wake words."""
-        info = await load_wyoming_info(
-            self.service.host, self.service.port, retries=0, timeout=1
-        )
-
-        if info is not None:
-            wake_service = info.wake[0]
-            self._supported_wake_words = [
-                wake_word.WakeWord(
-                    id=ww.name,
-                    name=ww.description or ww.name,
-                    phrase=ww.phrase,
-                )
-                for ww in wake_service.models
-            ]
-
         return self._supported_wake_words
 
     @override

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -100,6 +100,28 @@ TTS_INFO_NEW_VOICE = Info(
         )
     ]
 )
+TTS_INFO_LANGUAGE_REPLACED = Info(
+    tts=[
+        TtsProgram(
+            name="Test TTS",
+            description="Test TTS",
+            installed=True,
+            attribution=TEST_ATTR,
+            voices=[
+                TtsVoice(
+                    name="New Voice",
+                    description="New Voice",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["de-DE"],
+                    speakers=None,
+                    version=None,
+                )
+            ],
+            version=None,
+        )
+    ]
+)
 TTS_STREAMING_INFO = Info(
     tts=[
         TtsProgram(

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -69,6 +69,37 @@ TTS_INFO = Info(
         )
     ]
 )
+TTS_INFO_NEW_VOICE = Info(
+    tts=[
+        TtsProgram(
+            name="Test TTS",
+            description="Test TTS",
+            installed=True,
+            attribution=TEST_ATTR,
+            voices=[
+                TtsVoice(
+                    name="Test Voice",
+                    description="Test Voice",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US"],
+                    speakers=[TtsVoiceSpeaker(name="Test Speaker")],
+                    version=None,
+                ),
+                TtsVoice(
+                    name="New Voice",
+                    description="New Voice",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["de-DE"],
+                    speakers=None,
+                    version=None,
+                ),
+            ],
+            version=None,
+        )
+    ]
+)
 TTS_STREAMING_INFO = Info(
     tts=[
         TtsProgram(

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 
-from . import TTS_INFO_NEW_VOICE, MockAsyncTcpClient
+from . import TTS_INFO_LANGUAGE_REPLACED, TTS_INFO_NEW_VOICE, MockAsyncTcpClient
 
 from tests.common import async_fire_time_changed
 
@@ -65,8 +65,31 @@ async def test_voices_refreshed(
     assert voices is not None
     assert [voice.voice_id for voice in voices] == ["New Voice"]
 
+    # Adding a language must not move the default away from a supported one.
+    assert entity.default_language == "en-US"
+
     # Refreshed info is shared with the rest of the integration.
     assert init_wyoming_tts.runtime_data.service.info == TTS_INFO_NEW_VOICE
+
+
+@pytest.mark.usefixtures("init_wyoming_tts")
+async def test_default_language_follows_removed_language(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the default language moves when the current one is removed."""
+    entity = hass.data[DATA_INSTANCES]["tts"].get_entity("tts.test_tts")
+    assert entity is not None
+    assert entity.default_language == "en-US"
+
+    with patch(
+        "homeassistant.components.wyoming.coordinator.load_wyoming_info",
+        return_value=TTS_INFO_LANGUAGE_REPLACED,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+        await hass.async_block_till_done()
+
+    assert entity.supported_languages == ["de-DE"]
+    assert entity.default_language == "de-DE"
 
 
 @pytest.mark.usefixtures("init_wyoming_tts")

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -12,11 +12,16 @@ from wyoming.error import Error
 from wyoming.tts import SynthesizeStopped
 
 from homeassistant.components import tts, wyoming
+from homeassistant.components.wyoming.coordinator import UPDATE_INTERVAL
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.util import dt as dt_util
 
-from . import MockAsyncTcpClient
+from . import TTS_INFO_NEW_VOICE, MockAsyncTcpClient
+
+from tests.common import async_fire_time_changed
 
 
 async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:
@@ -38,6 +43,49 @@ async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:
     assert voices[0].name == "Test Voice"
     assert voices[0].voice_id == "Test Voice"
     assert not entity.async_get_supported_voices("de-DE")
+
+
+async def test_voices_refreshed(
+    hass: HomeAssistant, init_wyoming_tts: ConfigEntry
+) -> None:
+    """Test that a voice added on the service becomes available."""
+    entity = hass.data[DATA_INSTANCES]["tts"].get_entity("tts.test_tts")
+    assert entity is not None
+    assert entity.async_get_supported_voices("de-DE") is None
+
+    with patch(
+        "homeassistant.components.wyoming.coordinator.load_wyoming_info",
+        return_value=TTS_INFO_NEW_VOICE,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+        await hass.async_block_till_done()
+
+    assert set(entity.supported_languages) == {"en-US", "de-DE"}
+    voices = entity.async_get_supported_voices("de-DE")
+    assert voices is not None
+    assert [voice.voice_id for voice in voices] == ["New Voice"]
+
+    # Refreshed info is shared with the rest of the integration.
+    assert init_wyoming_tts.runtime_data.service.info == TTS_INFO_NEW_VOICE
+
+
+@pytest.mark.usefixtures("init_wyoming_tts")
+async def test_voices_kept_when_refresh_fails(hass: HomeAssistant) -> None:
+    """Test that the last known voices are kept when a refresh fails."""
+    entity = hass.data[DATA_INSTANCES]["tts"].get_entity("tts.test_tts")
+    assert entity is not None
+
+    with patch(
+        "homeassistant.components.wyoming.coordinator.load_wyoming_info",
+        return_value=None,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+        await hass.async_block_till_done()
+
+    assert entity.supported_languages == ["en-US"]
+    voices = entity.async_get_supported_voices("en-US")
+    assert voices is not None
+    assert [voice.voice_id for voice in voices] == ["Test Voice"]
 
 
 async def test_get_tts_audio(

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -267,3 +267,64 @@ async def test_dynamic_wake_word_info(
         wake_word.WakeWord("ww1", "Wake Word 1", "Wake Word Phrase 1"),
         wake_word.WakeWord("ww2", "Wake Word 2", "Wake Word Phrase 2"),
     ]
+
+
+@pytest.mark.usefixtures("init_wyoming_wake_word")
+async def test_uninstalled_wake_service_skipped(hass: HomeAssistant) -> None:
+    """Test that wake words are taken from an installed program."""
+    entity = wake_word.async_get_wake_word_detection_entity(
+        hass, "wake_word.test_wake_word"
+    )
+    assert entity is not None
+
+    new_info = Info(
+        wake=[
+            WakeProgram(
+                name="not-installed",
+                description="Not Installed",
+                installed=False,
+                attribution=TEST_ATTR,
+                models=[
+                    WakeModel(
+                        name="unavailable",
+                        description="Unavailable",
+                        phrase="Unavailable Phrase",
+                        installed=False,
+                        attribution=TEST_ATTR,
+                        languages=[],
+                        version=None,
+                    )
+                ],
+                version=None,
+            ),
+            WakeProgram(
+                name="installed",
+                description="Installed",
+                installed=True,
+                attribution=TEST_ATTR,
+                models=[
+                    WakeModel(
+                        name="available",
+                        description="Available",
+                        phrase="Available Phrase",
+                        installed=True,
+                        attribution=TEST_ATTR,
+                        languages=[],
+                        version=None,
+                    )
+                ],
+                version=None,
+            ),
+        ]
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.coordinator.load_wyoming_info",
+        return_value=new_info,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+        await hass.async_block_till_done()
+
+    assert (await entity.get_supported_wake_words()) == [
+        wake_word.WakeWord("available", "Available", "Available Phrase")
+    ]

--- a/tests/components/wyoming/test_wake_word.py
+++ b/tests/components/wyoming/test_wake_word.py
@@ -11,9 +11,13 @@ from wyoming.info import Info, WakeModel, WakeProgram
 from wyoming.wake import Detection
 
 from homeassistant.components import wake_word
+from homeassistant.components.wyoming.coordinator import UPDATE_INTERVAL
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import TEST_ATTR, MockAsyncTcpClient
+
+from tests.common import async_fire_time_changed
 
 
 async def test_support(hass: HomeAssistant, init_wyoming_wake_word) -> None:
@@ -251,12 +255,15 @@ async def test_dynamic_wake_word_info(
         ]
     )
 
-    # Different Wyoming info will be fetched
+    # Different Wyoming info will be fetched on the next refresh
     with patch(
-        "homeassistant.components.wyoming.wake_word.load_wyoming_info",
+        "homeassistant.components.wyoming.coordinator.load_wyoming_info",
         return_value=new_info,
     ):
-        assert (await entity.get_supported_wake_words()) == [
-            wake_word.WakeWord("ww1", "Wake Word 1", "Wake Word Phrase 1"),
-            wake_word.WakeWord("ww2", "Wake Word 2", "Wake Word Phrase 2"),
-        ]
+        async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+        await hass.async_block_till_done()
+
+    assert (await entity.get_supported_wake_words()) == [
+        wake_word.WakeWord("ww1", "Wake Word 1", "Wake Word Phrase 1"),
+        wake_word.WakeWord("ww2", "Wake Word 2", "Wake Word Phrase 2"),
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wyoming services can gain or lose voices and wake word models while Home Assistant is running, but `info` was only fetched during setup. The config entry had to be reloaded before those changes showed up, which is awkward when someone installs a new voice in a Piper add-on and then goes to pick it in the UI.

This adds a `DataUpdateCoordinator` per config entry that re-fetches `info` every 30 seconds.

- The coordinator is seeded with the `Info` that `WyomingService.create` already fetched during setup, so there is no extra `Describe` at startup and the retry behavior on initial connect is unchanged.
- The TTS and wake word entities subscribe and rebuild their voice / wake word lists when the info changes. `always_update=False` means they only rebuild when the `Info` actually differs.
- If a refresh fails, the last known lists are kept, so a restarting service cannot empty a voice picker. The coordinator logs the failure once rather than on every interval.
- `supported_languages` and `default_language` are updated through their `_attr_` fields. `TextToSpeechEntity` declares both via the `CachedProperties` metaclass, so writing the `_attr_` invalidates the cached property.
- The default language only moves when the current one is no longer offered, so installing an unrelated voice cannot silently change it. Supported languages are sorted so that the default does not depend on set iteration order.

This also replaces the fetch inside `get_supported_wake_words`, which opened a connection every time the wake word list was requested. Wake words are now up to 30 seconds stale rather than always fresh, in exchange for not connecting on every UI request.

STT and conversation are deliberately not covered here. Their models do not tend to change as frequently as TTS voices and wake words, so the extra plumbing did not seem worth it yet. They can subscribe to the same coordinator in the future if that changes.

One known limitation: a service that gains an entirely new capability (a TTS service where there was none, say) still needs a config entry reload, because the platform is not set up at all in that case. Refreshing `info` cannot help there. That is left for a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
