### PR TITLE
Add pull_latch action with PIN support to homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/button.py
+++ b/homeassistant/components/homematicip_cloud/button.py
@@ -4,35 +4,16 @@ from typing import override
 
 from homematicip.base.functionalChannels import AccessAuthorizationChannel
 from homematicip.device import WallMountedGarageDoorController
-import voluptuous as vol
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import HomematicipGenericEntity
 from .hap import HomematicIPConfigEntry, HomematicipHAP
+from .helpers import get_door_opener_authorization_channel
 
 DOOR_OPENER_MODELS = {"HmIP-FLC", "HmIP-FDC"}
-
-ATTR_PIN = "pin"
-SERVICE_PULL_LATCH = "pull_latch"
-
-
-def _door_opener_authorization_channel(
-    device: object,
-) -> AccessAuthorizationChannel | None:
-    """Return the AccessAuthorizationChannel routed to the door opener."""
-    for channel in getattr(device, "functionalChannels", []):
-        if (
-            isinstance(channel, AccessAuthorizationChannel)
-            and getattr(channel, "channelRole", None) == "DOOR_OPENER_ACTUATOR"
-        ):
-            return channel
-    return None
 
 
 async def async_setup_entry(
@@ -52,30 +33,12 @@ async def async_setup_entry(
         HomematicipDoorOpenerButton(hap, device, auth_channel)
         for device in hap.home.devices
         if getattr(device, "modelType", None) in DOOR_OPENER_MODELS
-        and (auth_channel := _door_opener_authorization_channel(device)) is not None
+        and (auth_channel := get_door_opener_authorization_channel(device)) is not None
     )
     async_add_entities(entities)
 
-    entity_platform.async_get_current_platform().async_register_entity_service(
-        SERVICE_PULL_LATCH,
-        {vol.Optional(ATTR_PIN): cv.string},
-        "async_pull_latch",
-    )
 
-
-class HomematicipButtonEntity(HomematicipGenericEntity, ButtonEntity):
-    """Base class for HomematicIP buttons."""
-
-    async def async_pull_latch(self, pin: str | None = None) -> None:
-        """Pull the latch of a door opener."""
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="pull_latch_not_supported",
-            translation_placeholders={"entity_id": self.entity_id},
-        )
-
-
-class HomematicipGarageDoorControllerButton(HomematicipButtonEntity):
+class HomematicipGarageDoorControllerButton(HomematicipGenericEntity, ButtonEntity):
     """Representation of the HomematicIP Wall mounted Garage Door Controller."""
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
@@ -89,7 +52,7 @@ class HomematicipGarageDoorControllerButton(HomematicipButtonEntity):
         await self._device.send_start_impulse_async()
 
 
-class HomematicipDoorOpenerButton(HomematicipButtonEntity):
+class HomematicipDoorOpenerButton(HomematicipGenericEntity, ButtonEntity):
     """Representation of a HomematicIP door opener (HmIP-FLC, HmIP-FDC)."""
 
     def __init__(
@@ -113,8 +76,3 @@ class HomematicipDoorOpenerButton(HomematicipButtonEntity):
         channel rejects them with CLIENT_ACCESS_DENIED.
         """
         await self._auth_channel.async_pull_latch()
-
-    @override
-    async def async_pull_latch(self, pin: str | None = None) -> None:
-        """Pull the latch, optionally with the authorization PIN."""
-        await self._auth_channel.async_pull_latch(pin)

--- a/homeassistant/components/homematicip_cloud/button.py
+++ b/homeassistant/components/homematicip_cloud/button.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import HomematicipGenericEntity
 from .hap import HomematicIPConfigEntry, HomematicipHAP
-from .helpers import get_door_opener_authorization_channel
+from .helpers import get_door_opener_authorization_channel, handle_errors
 
 DOOR_OPENER_MODELS = {"HmIP-FLC", "HmIP-FDC"}
 
@@ -68,6 +68,7 @@ class HomematicipDoorOpenerButton(HomematicipGenericEntity, ButtonEntity):
         self._attr_icon = "mdi:door-open"
         self._auth_channel = auth_channel
 
+    @handle_errors
     @override
     async def async_press(self) -> None:
         """Pull the latch via the access-authorization channel.
@@ -75,4 +76,4 @@ class HomematicipDoorOpenerButton(HomematicipGenericEntity, ButtonEntity):
         This is the only path non-admin clients may use; the door-switch
         channel rejects them with CLIENT_ACCESS_DENIED.
         """
-        await self._auth_channel.async_pull_latch()
+        return await self._auth_channel.async_pull_latch()

--- a/homeassistant/components/homematicip_cloud/button.py
+++ b/homeassistant/components/homematicip_cloud/button.py
@@ -4,15 +4,22 @@ from typing import override
 
 from homematicip.base.functionalChannels import AccessAuthorizationChannel
 from homematicip.device import WallMountedGarageDoorController
+import voluptuous as vol
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .entity import HomematicipGenericEntity
 from .hap import HomematicIPConfigEntry, HomematicipHAP
 
 DOOR_OPENER_MODELS = {"HmIP-FLC", "HmIP-FDC"}
+
+ATTR_PIN = "pin"
+SERVICE_PULL_LATCH = "pull_latch"
 
 
 def _door_opener_authorization_channel(
@@ -49,8 +56,26 @@ async def async_setup_entry(
     )
     async_add_entities(entities)
 
+    entity_platform.async_get_current_platform().async_register_entity_service(
+        SERVICE_PULL_LATCH,
+        {vol.Optional(ATTR_PIN): cv.string},
+        "async_pull_latch",
+    )
 
-class HomematicipGarageDoorControllerButton(HomematicipGenericEntity, ButtonEntity):
+
+class HomematicipButtonEntity(HomematicipGenericEntity, ButtonEntity):
+    """Base class for HomematicIP buttons."""
+
+    async def async_pull_latch(self, pin: str | None = None) -> None:
+        """Pull the latch of a door opener."""
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="pull_latch_not_supported",
+            translation_placeholders={"entity_id": self.entity_id},
+        )
+
+
+class HomematicipGarageDoorControllerButton(HomematicipButtonEntity):
     """Representation of the HomematicIP Wall mounted Garage Door Controller."""
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
@@ -64,7 +89,7 @@ class HomematicipGarageDoorControllerButton(HomematicipGenericEntity, ButtonEnti
         await self._device.send_start_impulse_async()
 
 
-class HomematicipDoorOpenerButton(HomematicipGenericEntity, ButtonEntity):
+class HomematicipDoorOpenerButton(HomematicipButtonEntity):
     """Representation of a HomematicIP door opener (HmIP-FLC, HmIP-FDC)."""
 
     def __init__(
@@ -88,3 +113,8 @@ class HomematicipDoorOpenerButton(HomematicipGenericEntity, ButtonEntity):
         channel rejects them with CLIENT_ACCESS_DENIED.
         """
         await self._auth_channel.async_pull_latch()
+
+    @override
+    async def async_pull_latch(self, pin: str | None = None) -> None:
+        """Pull the latch, optionally with the authorization PIN."""
+        await self._auth_channel.async_pull_latch(pin)

--- a/homeassistant/components/homematicip_cloud/helpers.py
+++ b/homeassistant/components/homematicip_cloud/helpers.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Concatenate, TypeGuard
 
 from homematicip.base.enums import FunctionalChannelType
+from homematicip.base.functionalChannels import AccessAuthorizationChannel
 from homematicip.device import Device
 
 from homeassistant.exceptions import HomeAssistantError
@@ -50,6 +51,19 @@ def handle_errors[_HomematicipGenericEntityT: HomematicipGenericEntity, **_P](
             )
 
     return inner
+
+
+def get_door_opener_authorization_channel(
+    device: Device,
+) -> AccessAuthorizationChannel | None:
+    """Return the AccessAuthorizationChannel routed to the door opener."""
+    for channel in getattr(device, "functionalChannels", []):
+        if (
+            isinstance(channel, AccessAuthorizationChannel)
+            and getattr(channel, "channelRole", None) == "DOOR_OPENER_ACTUATOR"
+        ):
+            return channel
+    return None
 
 
 def get_channels_from_device(device: Device, channel_type: FunctionalChannelType):

--- a/homeassistant/components/homematicip_cloud/icons.json
+++ b/homeassistant/components/homematicip_cloud/icons.json
@@ -29,6 +29,9 @@
     "dump_hap_config": {
       "service": "mdi:database-export"
     },
+    "pull_latch": {
+      "service": "mdi:door-open"
+    },
     "reset_energy_counter": {
       "service": "mdi:reload"
     },

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 from homematicip.async_home import AsyncHome
 from homematicip.base.helpers import handle_config
-from homematicip.device import SwitchMeasuring
+from homematicip.device import Device, SwitchMeasuring
 from homematicip.group import HeatingGroup
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.config_validation import comp_entity_ids
 from homeassistant.helpers.service import (
     async_register_admin_service,
@@ -21,6 +21,7 @@ from homeassistant.helpers.service import (
 
 from .const import DOMAIN
 from .hap import HomematicIPConfigEntry
+from .helpers import get_door_opener_authorization_channel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ ATTR_CONFIG_OUTPUT_PATH = "config_output_path"
 ATTR_DURATION = "duration"
 ATTR_ENDTIME = "endtime"
 ATTR_COOLING = "cooling"
+ATTR_PIN = "pin"
 
 DEFAULT_CONFIG_FILE_PREFIX = "hmip-config"
 
@@ -41,6 +43,7 @@ SERVICE_ACTIVATE_VACATION = "activate_vacation"
 SERVICE_DEACTIVATE_ECO_MODE = "deactivate_eco_mode"
 SERVICE_DEACTIVATE_VACATION = "deactivate_vacation"
 SERVICE_DUMP_HAP_CONFIG = "dump_hap_config"
+SERVICE_PULL_LATCH = "pull_latch"
 SERVICE_RESET_ENERGY_COUNTER = "reset_energy_counter"
 SERVICE_SET_ACTIVE_CLIMATE_PROFILE = "set_active_climate_profile"
 SERVICE_SET_HOME_COOLING_MODE = "set_home_cooling_mode"
@@ -52,6 +55,7 @@ HMIPC_SERVICES = [
     SERVICE_DEACTIVATE_ECO_MODE,
     SERVICE_DEACTIVATE_VACATION,
     SERVICE_DUMP_HAP_CONFIG,
+    SERVICE_PULL_LATCH,
     SERVICE_RESET_ENERGY_COUNTER,
     SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
     SERVICE_SET_HOME_COOLING_MODE,
@@ -117,6 +121,13 @@ SCHEMA_SET_HOME_COOLING_MODE = vol.Schema(
     }
 )
 
+SCHEMA_PULL_LATCH = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_PIN): cv.string,
+    }
+)
+
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
@@ -139,6 +150,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
             await _async_deactivate_vacation(service)
         elif service_name == SERVICE_DUMP_HAP_CONFIG:
             await _async_dump_hap_config(service)
+        elif service_name == SERVICE_PULL_LATCH:
+            await _async_pull_latch(service)
         elif service_name == SERVICE_RESET_ENERGY_COUNTER:
             await _async_reset_energy_counter(service)
         elif service_name == SERVICE_SET_ACTIVE_CLIMATE_PROFILE:
@@ -186,6 +199,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         service=SERVICE_SET_ACTIVE_CLIMATE_PROFILE,
         service_func=async_call_hmipc_service,
         schema=SCHEMA_SET_ACTIVE_CLIMATE_PROFILE,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_PULL_LATCH,
+        service_func=async_call_hmipc_service,
+        schema=SCHEMA_PULL_LATCH,
     )
 
     async_register_admin_service(
@@ -347,6 +367,45 @@ async def _async_set_home_cooling_mode(service: ServiceCall):
         entry: HomematicIPConfigEntry
         for entry in service.hass.config_entries.async_loaded_entries(DOMAIN):
             await entry.runtime_data.home.set_cooling_async(cooling)
+
+
+async def _async_pull_latch(service: ServiceCall) -> None:
+    """Service to pull the latch of a door opener."""
+    pin = service.data.get(ATTR_PIN)
+    device_registry = dr.async_get(service.hass)
+
+    for device_id in service.data[ATTR_DEVICE_ID]:
+        device = _get_device(service.hass, device_registry, device_id)
+        channel = get_door_opener_authorization_channel(device)
+        if channel is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="pull_latch_not_supported",
+                translation_placeholders={"device_name": device.label},
+            )
+        await channel.async_pull_latch(pin)
+
+
+def _get_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, device_id: str
+) -> Device:
+    """Return the HmIP device for a device registry entry."""
+    if device_entry := device_registry.async_get(device_id):
+        hmip_id = next(
+            (ident[1] for ident in device_entry.identifiers if ident[0] == DOMAIN),
+            None,
+        )
+        entry: HomematicIPConfigEntry
+        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+            for device in entry.runtime_data.home.devices:
+                if str(device.id) == hmip_id:
+                    return device
+
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="device_not_found",
+        translation_placeholders={"device_id": device_id},
+    )
 
 
 def _get_home(hass: HomeAssistant, hapid: str) -> AsyncHome | None:

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.config_validation import comp_entity_ids
 from homeassistant.helpers.service import (
@@ -21,7 +21,7 @@ from homeassistant.helpers.service import (
 
 from .const import DOMAIN
 from .hap import HomematicIPConfigEntry
-from .helpers import get_door_opener_authorization_channel
+from .helpers import get_door_opener_authorization_channel, is_error_response
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -383,7 +383,16 @@ async def _async_pull_latch(service: ServiceCall) -> None:
                 translation_key="pull_latch_not_supported",
                 translation_placeholders={"device_name": device.label},
             )
-        await channel.async_pull_latch(pin)
+        result = await channel.async_pull_latch(pin)
+        if is_error_response(result):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="pull_latch_failed",
+                translation_placeholders={
+                    "device_name": device.label,
+                    "error_code": str(result.get("errorCode")),
+                },
+            )
 
 
 def _get_device(

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -111,11 +111,12 @@ set_home_cooling_mode:
         text:
 
 pull_latch:
-  target:
-    entity:
-      integration: homematicip_cloud
-      domain: button
   fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: homematicip_cloud
     pin:
       example: "1234"
       selector:

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -120,3 +120,4 @@ pull_latch:
       example: "1234"
       selector:
         text:
+          type: password

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -117,6 +117,7 @@ pull_latch:
       selector:
         device:
           integration: homematicip_cloud
+          multiple: true
     pin:
       example: "1234"
       selector:

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -109,3 +109,14 @@ set_home_cooling_mode:
       example: 3014xxxxxxxxxxxxxxxxxxxx
       selector:
         text:
+
+pull_latch:
+  target:
+    entity:
+      integration: homematicip_cloud
+      domain: button
+  fields:
+    pin:
+      example: "1234"
+      selector:
+        text:

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -139,6 +139,9 @@
     },
     "alarm_activation_failed": {
       "message": "The alarm system did not accept the requested state"
+    },
+    "pull_latch_not_supported": {
+      "message": "{entity_id} is not a door opener and cannot pull a latch"
     }
   },
   "services": {
@@ -225,6 +228,16 @@
         }
       },
       "name": "Dump HAP config"
+    },
+    "pull_latch": {
+      "description": "Pulls the latch of a door opener, optionally using the PIN of its access authorization.",
+      "fields": {
+        "pin": {
+          "description": "The PIN of the access authorization. Only needed if a PIN is configured for it.",
+          "name": "PIN"
+        }
+      },
+      "name": "Pull latch"
     },
     "reset_energy_counter": {
       "description": "Resets the energy counter of a measuring entity.",

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -143,6 +143,9 @@
     "device_not_found": {
       "message": "No matching Homematic IP device found for device ID {device_id}"
     },
+    "pull_latch_failed": {
+      "message": "{device_name} did not pull the latch, the access point returned {error_code}"
+    },
     "pull_latch_not_supported": {
       "message": "{device_name} is not a door opener and cannot pull a latch"
     }
@@ -236,8 +239,8 @@
       "description": "Pulls the latch of a door opener, optionally using the PIN of its access authorization.",
       "fields": {
         "device_id": {
-          "description": "The door opener device whose latch is pulled.",
-          "name": "Device"
+          "description": "The door opener devices whose latch is pulled.",
+          "name": "Devices"
         },
         "pin": {
           "description": "The PIN of the access authorization. Only needed if a PIN is configured for it.",

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -140,8 +140,11 @@
     "alarm_activation_failed": {
       "message": "The alarm system did not accept the requested state"
     },
+    "device_not_found": {
+      "message": "No matching Homematic IP device found for device ID {device_id}"
+    },
     "pull_latch_not_supported": {
-      "message": "{entity_id} is not a door opener and cannot pull a latch"
+      "message": "{device_name} is not a door opener and cannot pull a latch"
     }
   },
   "services": {
@@ -232,6 +235,10 @@
     "pull_latch": {
       "description": "Pulls the latch of a door opener, optionally using the PIN of its access authorization.",
       "fields": {
+        "device_id": {
+          "description": "The door opener device whose latch is pulled.",
+          "name": "Device"
+        },
         "pin": {
           "description": "The PIN of the access authorization. Only needed if a PIN is configured for it.",
           "name": "PIN"

--- a/tests/components/homematicip_cloud/test_button.py
+++ b/tests/components/homematicip_cloud/test_button.py
@@ -4,10 +4,17 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.homematicip_cloud.button import (
+    ATTR_PIN,
+    SERVICE_PULL_LATCH,
+)
+from homeassistant.components.homematicip_cloud.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
 from .helper import HomeFactory, get_and_check_entity_basics
@@ -175,3 +182,86 @@ async def test_hmip_full_flush_door_controller_button(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == now.isoformat()
+
+
+async def test_hmip_full_flush_lock_controller_pull_latch_with_pin(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+) -> None:
+    """The pull_latch action forwards the PIN the button press cannot carry."""
+    entity_id = "button.universal_motorschloss_controller_door_opener"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Universal Motorschloss Controller"],
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
+    auth_channel = next(
+        ch
+        for ch in hmip_device.functionalChannels
+        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+
+    with patch.object(
+        auth_channel, "async_pull_latch", new_callable=AsyncMock
+    ) as mock_pull_latch:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PIN: "1234"},
+            blocking=True,
+        )
+
+    mock_pull_latch.assert_awaited_once_with("1234")
+
+
+async def test_hmip_full_flush_lock_controller_pull_latch_without_pin(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+) -> None:
+    """Without a PIN the action behaves like a plain button press."""
+    entity_id = "button.universal_motorschloss_controller_door_opener"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Universal Motorschloss Controller"],
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
+    auth_channel = next(
+        ch
+        for ch in hmip_device.functionalChannels
+        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+
+    with patch.object(
+        auth_channel, "async_pull_latch", new_callable=AsyncMock
+    ) as mock_pull_latch:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    mock_pull_latch.assert_awaited_once_with(None)
+
+
+async def test_hmip_pull_latch_on_non_opener_button(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+) -> None:
+    """Targeting a button that is not a door opener reports a clear error."""
+    entity_name = "Garagentor"
+    await default_mock_hap_factory.async_get_mock_hap(test_devices=[entity_name])
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_ENTITY_ID: "button.garagentor"},
+            blocking=True,
+        )

--- a/tests/components/homematicip_cloud/test_button.py
+++ b/tests/components/homematicip_cloud/test_button.py
@@ -184,12 +184,18 @@ async def test_hmip_full_flush_door_controller_button(
     assert state.state == now.isoformat()
 
 
-async def test_hmip_full_flush_lock_controller_pull_latch_with_pin(
+@pytest.mark.parametrize(
+    ("service_data", "expected_pin"),
+    [({ATTR_PIN: "1234"}, "1234"), ({}, None)],
+)
+async def test_hmip_full_flush_lock_controller_pull_latch(
     hass: HomeAssistant,
     default_mock_hap_factory: HomeFactory,
     full_flush_lock_controller_device_data: dict[str, Any],
+    service_data: dict[str, str],
+    expected_pin: str | None,
 ) -> None:
-    """The pull_latch action forwards the PIN the button press cannot carry."""
+    """The pull_latch action forwards the PIN a button press cannot carry."""
     entity_id = "button.universal_motorschloss_controller_door_opener"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Universal Motorschloss Controller"],
@@ -210,44 +216,11 @@ async def test_hmip_full_flush_lock_controller_pull_latch_with_pin(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_PULL_LATCH,
-            {ATTR_ENTITY_ID: entity_id, ATTR_PIN: "1234"},
+            {ATTR_ENTITY_ID: entity_id} | service_data,
             blocking=True,
         )
 
-    mock_pull_latch.assert_awaited_once_with("1234")
-
-
-async def test_hmip_full_flush_lock_controller_pull_latch_without_pin(
-    hass: HomeAssistant,
-    default_mock_hap_factory: HomeFactory,
-    full_flush_lock_controller_device_data: dict[str, Any],
-) -> None:
-    """Without a PIN the action behaves like a plain button press."""
-    entity_id = "button.universal_motorschloss_controller_door_opener"
-    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=["Universal Motorschloss Controller"],
-        extra_devices=[full_flush_lock_controller_device_data],
-    )
-
-    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
-    auth_channel = next(
-        ch
-        for ch in hmip_device.functionalChannels
-        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
-        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
-    )
-
-    with patch.object(
-        auth_channel, "async_pull_latch", new_callable=AsyncMock
-    ) as mock_pull_latch:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_PULL_LATCH,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=True,
-        )
-
-    mock_pull_latch.assert_awaited_once_with(None)
+    mock_pull_latch.assert_awaited_once_with(expected_pin)
 
 
 async def test_hmip_pull_latch_on_non_opener_button(

--- a/tests/components/homematicip_cloud/test_button.py
+++ b/tests/components/homematicip_cloud/test_button.py
@@ -4,17 +4,10 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.components.homematicip_cloud.button import (
-    ATTR_PIN,
-    SERVICE_PULL_LATCH,
-)
-from homeassistant.components.homematicip_cloud.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
 from .helper import HomeFactory, get_and_check_entity_basics
@@ -182,59 +175,3 @@ async def test_hmip_full_flush_door_controller_button(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == now.isoformat()
-
-
-@pytest.mark.parametrize(
-    ("service_data", "expected_pin"),
-    [({ATTR_PIN: "1234"}, "1234"), ({}, None)],
-)
-async def test_hmip_full_flush_lock_controller_pull_latch(
-    hass: HomeAssistant,
-    default_mock_hap_factory: HomeFactory,
-    full_flush_lock_controller_device_data: dict[str, Any],
-    service_data: dict[str, str],
-    expected_pin: str | None,
-) -> None:
-    """The pull_latch action forwards the PIN a button press cannot carry."""
-    entity_id = "button.universal_motorschloss_controller_door_opener"
-    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=["Universal Motorschloss Controller"],
-        extra_devices=[full_flush_lock_controller_device_data],
-    )
-
-    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
-    auth_channel = next(
-        ch
-        for ch in hmip_device.functionalChannels
-        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
-        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
-    )
-
-    with patch.object(
-        auth_channel, "async_pull_latch", new_callable=AsyncMock
-    ) as mock_pull_latch:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_PULL_LATCH,
-            {ATTR_ENTITY_ID: entity_id} | service_data,
-            blocking=True,
-        )
-
-    mock_pull_latch.assert_awaited_once_with(expected_pin)
-
-
-async def test_hmip_pull_latch_on_non_opener_button(
-    hass: HomeAssistant,
-    default_mock_hap_factory: HomeFactory,
-) -> None:
-    """Targeting a button that is not a door opener reports a clear error."""
-    entity_name = "Garagentor"
-    await default_mock_hap_factory.async_get_mock_hap(test_devices=[entity_name])
-
-    with pytest.raises(ServiceValidationError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_PULL_LATCH,
-            {ATTR_ENTITY_ID: "button.garagentor"},
-            blocking=True,
-        )

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -198,7 +198,7 @@ async def test_setup_services(hass: HomeAssistant) -> None:
 
     # Check services are created
     hmipc_services = hass.services.async_services()[DOMAIN]
-    assert len(hmipc_services) == 9
+    assert len(hmipc_services) == 10
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1

--- a/tests/components/homematicip_cloud/test_services.py
+++ b/tests/components/homematicip_cloud/test_services.py
@@ -1,0 +1,97 @@
+"""Tests for HomematicIP Cloud services."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.homematicip_cloud import DOMAIN
+from homeassistant.components.homematicip_cloud.services import (
+    ATTR_PIN,
+    SERVICE_PULL_LATCH,
+)
+from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+
+from .helper import HomeFactory
+
+
+@pytest.mark.parametrize(
+    ("service_data", "expected_pin"),
+    [({ATTR_PIN: "1234"}, "1234"), ({}, None)],
+)
+async def test_pull_latch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+    service_data: dict[str, str],
+    expected_pin: str | None,
+) -> None:
+    """The pull_latch service forwards the PIN a button press cannot carry."""
+    entity_id = "button.universal_motorschloss_controller_door_opener"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Universal Motorschloss Controller"],
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+
+    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
+    auth_channel = next(
+        ch
+        for ch in hmip_device.functionalChannels
+        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+
+    with patch.object(
+        auth_channel, "async_pull_latch", new_callable=AsyncMock
+    ) as mock_pull_latch:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_DEVICE_ID: entity_entry.device_id} | service_data,
+            blocking=True,
+        )
+
+    mock_pull_latch.assert_awaited_once_with(expected_pin)
+
+
+async def test_pull_latch_on_non_opener_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    default_mock_hap_factory: HomeFactory,
+) -> None:
+    """Targeting a device that is not a door opener reports a clear error."""
+    await default_mock_hap_factory.async_get_mock_hap(test_devices=["Garagentor"])
+
+    entity_entry = entity_registry.async_get("button.garagentor")
+    assert entity_entry
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_DEVICE_ID: entity_entry.device_id},
+            blocking=True,
+        )
+
+
+async def test_pull_latch_unknown_device(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+) -> None:
+    """Targeting an unknown device reports a clear error."""
+    await default_mock_hap_factory.async_get_mock_hap(test_devices=["Garagentor"])
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_DEVICE_ID: "does-not-exist"},
+            blocking=True,
+        )

--- a/tests/components/homematicip_cloud/test_services.py
+++ b/tests/components/homematicip_cloud/test_services.py
@@ -12,7 +12,7 @@ from homeassistant.components.homematicip_cloud.services import (
 )
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .helper import HomeFactory
@@ -59,6 +59,47 @@ async def test_pull_latch(
         )
 
     mock_pull_latch.assert_awaited_once_with(expected_pin)
+
+
+async def test_pull_latch_rejected_by_access_point(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+) -> None:
+    """A rejected latch pull, a wrong PIN for instance, is not reported as success."""
+    entity_id = "button.universal_motorschloss_controller_door_opener"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Universal Motorschloss Controller"],
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+
+    hmip_device = mock_hap.hmip_device_by_entity_id[entity_id]
+    auth_channel = next(
+        ch
+        for ch in hmip_device.functionalChannels
+        if ch.functionalChannelType.name == "ACCESS_AUTHORIZATION_CHANNEL"
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+
+    with (
+        patch.object(
+            auth_channel,
+            "async_pull_latch",
+            new_callable=AsyncMock,
+            return_value={"errorCode": "INVALID_AUTHORIZATION_PIN"},
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PULL_LATCH,
+            {ATTR_DEVICE_ID: entity_entry.device_id, ATTR_PIN: "0000"},
+            blocking=True,
+        )
 
 
 async def test_pull_latch_on_non_opener_device(


### PR DESCRIPTION
## Proposed change

The door opener button covers access authorizations without a PIN. Where one is configured, it has to reach the cloud in the `pullLatch` body, and a button press carries no fields.

Adds a `pull_latch` entity action with an optional `pin`. The PIN is passed per call, not stored. Buttons that are not door openers raise a validation error when targeted.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: hahn-th/homematicip-rest-api#606
- Link to documentation pull request: home-assistant/home-assistant.io#47397
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

