### PR TITLE
Fix ESPHome deleting entity registry entries when firmware re-derives keys

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -42,6 +42,46 @@ _EntityT = TypeVar("_EntityT", bound="EsphomeEntity[Any,Any]")
 _StateT = TypeVar("_StateT", bound=EntityState)
 
 
+def _build_identity_indexes(
+    current_infos: dict[DeviceEntityKey, EntityInfo],
+    mac: str,
+    new_unique_ids: set[str],
+) -> tuple[dict[str, DeviceEntityKey], dict[str, DeviceEntityKey]]:
+    """Index the old infos by unique_id and by name.
+
+    The unique_id (mac/device_id/type/name) is the long term identity
+    and matches entities across key changes; the name is the device
+    independent identity and matches entities that moved between
+    devices. Duplicates cannot be matched by identity and are left to
+    the key based matching; entities whose unique_id is still present
+    are not move candidates.
+    """
+    old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
+    duplicate_unique_ids: set[str] = set()
+    movable_by_name: dict[str, DeviceEntityKey] = {}
+    duplicate_names: set[str] = set()
+    for dict_key, existing_info in current_infos.items():
+        old_unique_id = build_device_unique_id(mac, existing_info)
+        if old_unique_id in duplicate_unique_ids:
+            continue
+        if old_unique_id in old_info_by_unique_id:
+            duplicate_unique_ids.add(old_unique_id)
+            del old_info_by_unique_id[old_unique_id]
+            continue
+        old_info_by_unique_id[old_unique_id] = dict_key
+        if old_unique_id in new_unique_ids:
+            continue
+        name = existing_info.name
+        if name in duplicate_names:
+            continue
+        if name in movable_by_name:
+            duplicate_names.add(name)
+            del movable_by_name[name]
+            continue
+        movable_by_name[name] = dict_key
+    return old_info_by_unique_id, movable_by_name
+
+
 @callback
 def async_static_info_updated(
     hass: HomeAssistant,
@@ -64,14 +104,13 @@ def async_static_info_updated(
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
-    # The API key is only stable for a session; the unique_id
-    # (mac/device_id/type/name) is the long term identity, so index the
-    # old infos by unique_id to match entities across key changes.
+    # The API key is only stable for a session, so entities are matched
+    # by identity first: unique_id, then name for cross device moves
     mac = device_info.mac_address
-    old_info_by_unique_id: dict[str, DeviceEntityKey] = {
-        build_device_unique_id(mac, old_info): dict_key
-        for dict_key, old_info in current_infos.items()
-    }
+    new_unique_ids = {build_device_unique_id(mac, info) for info in infos}
+    old_info_by_unique_id, movable_by_name = _build_identity_indexes(
+        current_infos, mac, new_unique_ids
+    )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
     # Track info by (info.device_id, info.key) to properly handle entities
@@ -83,32 +122,43 @@ def async_static_info_updated(
 
         # Identity match by unique_id: same device_id, type and name.
         # Survives the key being re-derived by a firmware update.
-        if (
-            old_dict_key := old_info_by_unique_id.pop(unique_id, None)
-        ) is not None and (
-            old_info := current_infos.pop(old_dict_key, None)
-        ) is not None:
-            if old_info.key != info.key:
-                # Same entity with a new key: the live entity re-points
-                # its key based subscriptions after the loop. The
-                # registry entry is untouched.
-                rekeys.append((old_info, info))
-            # Equal unique_ids imply equal device_ids, so no migration needed
-            continue
+        if (old_dict_key := old_info_by_unique_id.pop(unique_id, None)) is not None:
+            if (matched_info := current_infos.pop(old_dict_key, None)) is not None:
+                if matched_info.key != info.key:
+                    # Same entity with a new key: the live entity re-points
+                    # its key based subscriptions after the loop. The
+                    # registry entry is untouched.
+                    rekeys.append((matched_info, info))
+                # Equal unique_ids imply equal device_ids, no migration needed
+                continue
 
         # Same key and device_id: a rename on firmware where the key is
         # not derived from the name; the entity is updated in place
         if current_infos.pop(info_key, None) is not None:
             continue
 
-        # Search for the same key on a different device_id
-        # This handles the case where entity moved between devices
-        for existing_device_id, existing_key in list(current_infos):
-            if existing_key == info.key:
-                old_info = current_infos.pop((existing_device_id, existing_key))
-                break
-        else:
-            # Create new entity if it doesn't exist
+        # Match by name when unambiguous: the entity moved between
+        # devices. Survives the key changing at the same time.
+        old_info: EntityInfo | None = None
+        if (move_dict_key := movable_by_name.pop(info.name, None)) is not None:
+            old_info = current_infos.pop(move_dict_key, None)
+
+        # Search for the same name and key on a different device_id to
+        # resolve moves of entities with ambiguous names, skipping
+        # entities whose identity is still present in the new infos so
+        # a reused key cannot steal an unrelated entity
+        if old_info is None:
+            for existing_dict_key, existing_info in list(current_infos.items()):
+                if (
+                    existing_dict_key[1] == info.key
+                    and existing_info.name == info.name
+                    and build_device_unique_id(mac, existing_info) not in new_unique_ids
+                ):
+                    old_info = current_infos.pop(existing_dict_key)
+                    break
+
+        # Create new entity if it doesn't exist
+        if old_info is None:
             add_entities.append(entity_type(entry_data, info, state_type))
             continue
 
@@ -176,8 +226,11 @@ def async_static_info_updated(
         )
 
         # Signal the existing entity to remove itself
-        # The entity is registered with the old device_id, so we signal with that
-        entry_data.async_signal_entity_removal(info_type, old_info.device_id, info.key)
+        # The entity is registered with the old device_id and old key,
+        # so we signal with those
+        entry_data.async_signal_entity_removal(
+            info_type, old_info.device_id, old_info.key
+        )
 
         # Create new entity with the new device_id
         add_entities.append(entity_type(entry_data, info, state_type))

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -87,7 +87,9 @@ def async_static_info_updated(
     device_info = entry_data.device_info
     if TYPE_CHECKING:
         assert device_info is not None
-    new_infos: dict[DeviceEntityKey, EntityInfo] = {}
+    new_infos: dict[DeviceEntityKey, EntityInfo] = {
+        (info.device_id, info.key): info for info in infos
+    }
     add_entities: list[_EntityT] = []
 
     ent_reg = er.async_get(hass)
@@ -97,8 +99,6 @@ def async_static_info_updated(
     mac = device_info.mac_address
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
-    for info in infos:
-        new_infos[(info.device_id, info.key)] = info
     old_info_by_unique_id, movable_by_name = _build_identity_indexes(
         current_infos, mac, new_unique_ids
     )
@@ -122,18 +122,11 @@ def async_static_info_updated(
         # Name match: the entity moved between devices. Prefer a
         # candidate whose (device_id, key) slot has no incoming info,
         # since that slot's info is an in place rename of the candidate
-        old_info: EntityInfo | None = None
-        if candidates := movable_by_name.get(info.name):
-            for idx, move_dict_key in enumerate(candidates):
-                if move_dict_key not in new_infos:
-                    old_info = current_infos.pop(candidates.pop(idx))
-                    break
-            else:
-                old_info = current_infos.pop(candidates.pop(0))
-
-        if old_info is None:
+        if not (candidates := movable_by_name.get(info.name)):
             deferred.append((info, unique_id))
             continue
+        idx = next((i for i, key in enumerate(candidates) if key not in new_infos), 0)
+        old_info = current_infos.pop(candidates.pop(idx))
 
         # Entity has switched devices, need to migrate unique_id
         # and handle state subscriptions
@@ -226,19 +219,25 @@ def async_static_info_updated(
 
     if rekeys:
         entry_data.async_update_entity_keys(info_type, rekeys)
-        # Prune states cached under retired keys
-        states = entry_data.state[state_type]
-        live_keys = {key for _, key in new_infos}
-        for rekeyed_info, _ in rekeys:
-            if (old_key := rekeyed_info.key) not in live_keys:
-                states.pop(old_key, None)
-                entry_data.stale_state.discard(
-                    (state_type, rekeyed_info.device_id, old_key)
-                )
 
     # Anything still in current_infos is now gone
     if current_infos:
         entry_data.async_remove_entities(hass, current_infos.values(), mac)
+
+    # The state cache holds only live keys so a future entity that
+    # reuses a retired key cannot adopt a stale state
+    if rekeys or current_infos:
+        live_keys = {key for _, key in new_infos}
+        states = entry_data.state[state_type]
+        for cached_key in list(states):
+            if cached_key not in live_keys:
+                del states[cached_key]
+        entry_data.stale_state -= {
+            stale_key
+            for stale_key in entry_data.stale_state
+            if stale_key[0] is state_type
+            and (stale_key[1], stale_key[2]) not in new_infos
+        }
 
     # Then update the actual info
     entry_data.info[info_type] = new_infos

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -463,18 +463,11 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
             static_info = cast(_InfoT, static_info)
             assert device_info
         unique_id = build_device_unique_id(device_info.mac_address, static_info)
-        if (
-            new_key := static_info.key
-        ) != self._key and unique_id != self._attr_unique_id:
-            # A key change is only valid for this entity's unique_id; keys
-            # are not collision safe, so never adopt an info that belongs
-            # to a different entity.
-            return
         self._static_info = static_info
-        if new_key != self._key:
+        if static_info.key != self._key:
             # The key is only stable for a session; a firmware update may
             # re-derive it. Move the key based subscriptions to the new key.
-            self._key = new_key
+            self._key = static_info.key
             if self._key_unsubs:
                 self._unsubscribe_key_updates()
                 self._subscribe_key_updates()

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -32,7 +32,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 
 # Import config flow so that it's added to the registry
-from .entry_data import DeviceEntityKey, ESPHomeConfigEntry, RuntimeEntryData
+from .entry_data import (
+    DeviceEntityKey,
+    ESPHomeConfigEntry,
+    RuntimeEntryData,
+    async_migrate_unique_id,
+)
 from .enum_mapper import EsphomeEnumMapper
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,19 +57,12 @@ def _build_identity_indexes(
     set[DeviceEntityKey],
     set[DeviceEntityKey],
 ]:
-    """Index the old infos by unique_id and by name.
+    """Index old infos by unique_id and by name for identity matching.
 
-    The unique_id (mac/device_id/type/name) is the long term identity
-    and matches entities across key changes; the name is the device
-    independent identity and matches entities that moved between
-    devices. Duplicates cannot be matched by identity and are left to
-    the key based matching; entities whose unique_id is still present
-    are not move candidates and are returned as still_present so the
-    key based matching can skip them as well. Non duplicate entries
-    whose unique_id is claimed by an incoming info are returned as
-    reserved: they are guaranteed a unique_id match, and the key based
-    matches must not consume them, or a reused key could swap two
-    entities' identities.
+    Duplicates are unmatchable by identity and left to key matching.
+    still_present: unique_id also occurs in the new infos (not movable).
+    reserved: guaranteed a unique_id match; key matches must skip these
+    or a reused key could swap two entities' identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     duplicate_unique_ids: set[str] = set()
@@ -84,8 +82,7 @@ def _build_identity_indexes(
             duplicate_unique_ids.add(old_unique_id)
             reserved.discard(old_info_by_unique_id[old_unique_id])
             del old_info_by_unique_id[old_unique_id]
-            # Duplicate unique_ids share a name, so the earlier
-            # occurrence must not stay name matchable either
+            # Duplicate unique_ids share a name
             duplicate_names.add(name)
             movable_by_name.pop(name, None)
             continue
@@ -125,11 +122,11 @@ def async_static_info_updated(
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
-    # The API key is only stable for a session, so entities are matched
-    # by identity first: unique_id, then name for cross device moves
+    # The key is only session stable, so match by identity first
     mac = device_info.mac_address
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
+    new_names = {info.name for info in infos}
     old_info_by_unique_id, movable_by_name, still_present, reserved = (
         _build_identity_indexes(current_infos, mac, new_unique_ids)
     )
@@ -141,51 +138,46 @@ def async_static_info_updated(
         info_key = (info.device_id, info.key)
         new_infos[info_key] = info
 
-        # Identity match by unique_id: same device_id, type and name.
-        # Survives the key being re-derived by a firmware update.
+        # Identity match by unique_id; survives key re-derivation
         if (old_dict_key := old_info_by_unique_id.pop(unique_id, None)) is not None:
             if (matched_info := current_infos.pop(old_dict_key, None)) is not None:
                 if matched_info.key != info.key:
-                    # Same entity with a new key: the live entity re-points
-                    # its key based subscriptions after the loop. The
-                    # registry entry is untouched.
+                    # Same entity, new key: re-point subscriptions after
+                    # the loop; the registry entry is untouched
                     rekeys.append((matched_info, info))
-                # Equal unique_ids imply equal device_ids, no migration needed
+                # Equal unique_ids imply equal device_ids
                 continue
 
-        # Match by name when unambiguous: the entity moved between
-        # devices. Survives the key changing at the same time. This
-        # runs before the key match so a move into a slot vacated by
-        # a removed entity is not mistaken for a rename of that entity.
+        # Unambiguous name match: the entity moved between devices.
+        # Runs before the key match so a move into a vacated key slot
+        # is not mistaken for a rename.
         old_info: EntityInfo | None = None
         if (move_dict_key := movable_by_name.pop(info.name, None)) is not None:
             old_info = current_infos.pop(move_dict_key, None)
 
-        # Same key and device_id: a rename on firmware where the key is
-        # not derived from the name; the entity is updated in place and
-        # its registry entry follows the new name based unique_id
+        # Same key and device_id: a rename with a stable key; the
+        # registry entry follows the new unique_id. Skip candidates a
+        # later info will claim by unique_id or by name move.
         if (
             old_info is None
             and info_key not in reserved
-            and (renamed_info := current_infos.pop(info_key, None)) is not None
+            and (renamed_info := current_infos.get(info_key)) is not None
+            and not (
+                renamed_info.name in new_names
+                and movable_by_name.get(renamed_info.name) == info_key
+            )
         ):
-            old_unique_id = build_device_unique_id(mac, renamed_info)
-            if (
-                old_unique_id != unique_id
-                and (
-                    entity_id := ent_reg.async_get_entity_id(
-                        platform.domain, DOMAIN, old_unique_id
-                    )
-                )
-                and not ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id)
-            ):
-                ent_reg.async_update_entity(entity_id, new_unique_id=unique_id)
+            del current_infos[info_key]
+            async_migrate_unique_id(
+                ent_reg,
+                platform.domain,
+                build_device_unique_id(mac, renamed_info),
+                unique_id,
+            )
             continue
 
-        # Search for the same name and key on a different device_id to
-        # resolve moves of entities with ambiguous names, skipping
-        # entities whose identity is still present in the new infos so
-        # a reused key cannot steal an unrelated entity
+        # Same name and key on another device: a move with an
+        # ambiguous name; skip entities a unique_id match will claim
         if old_info is None:
             for existing_dict_key, existing_info in current_infos.items():
                 if (
@@ -282,9 +274,10 @@ def async_static_info_updated(
         removed_infos: list[EntityInfo] = []
         for dict_key, leftover_info in current_infos.items():
             if dict_key in still_present:
-                # The registry entry is claimed by a surviving entity
-                # (duplicate unique_ids), so remove only the stale
-                # entity object and leave the registry entry alone
+                # A surviving entity claims the registry entry
+                # (duplicate unique_ids); remove only the entity object.
+                # Removal is eager and frees the platform slot before
+                # the pending adds run.
                 entry_data.async_signal_entity_removal(
                     info_type, dict_key[0], dict_key[1]
                 )

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -165,15 +165,28 @@ def async_static_info_updated(
 
         updates: dict[str, Any] = {}
 
-        # Update unique_id if it changed and the new one is not claimed
+        # Update unique_id if it changed. A claimant of the new
+        # unique_id is a stale orphan and is removed so the moved
+        # entity keeps its identity and helpers; a disabled claimant
+        # is kept so the disable preference survives.
         if old_unique_id != unique_id:
-            if ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id):
-                _LOGGER.debug(
-                    "Cannot migrate unique_id %s -> %s: already claimed",
-                    old_unique_id,
-                    unique_id,
-                )
-            else:
+            migrate = True
+            if claimant_id := ent_reg.async_get_entity_id(
+                platform.domain, DOMAIN, unique_id
+            ):
+                claimant = ent_reg.async_get(claimant_id)
+                if claimant is not None and claimant.disabled_by is not None:
+                    _LOGGER.debug(
+                        "Cannot migrate unique_id %s -> %s: claimed by "
+                        "disabled entry %s",
+                        old_unique_id,
+                        unique_id,
+                        claimant_id,
+                    )
+                    migrate = False
+                else:
+                    ent_reg.async_remove(claimant_id)
+            if migrate:
                 updates["new_unique_id"] = unique_id
 
         # Update device assignment in registry

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -136,11 +136,12 @@ def async_static_info_updated(
         idx = next((i for i, key in enumerate(candidates) if key not in new_infos), 0)
         old_info = current_infos.pop(candidates.pop(idx))
 
-        # A foreign cached state at the mover's destination key must
-        # not be adopted when the mover is re-added
-        if (
-            cached_state := states.get(info.key)
-        ) is not None and cached_state.device_id != old_info.device_id:
+        # A cached state at the mover's destination key is only the
+        # mover's own if it was written from the mover's old slot;
+        # anything else is foreign and must not be adopted on re-add
+        if (cached_state := states.get(info.key)) is not None and (
+            cached_state.device_id != old_info.device_id or info.key != old_info.key
+        ):
             del states[info.key]
 
         # Entity has switched devices, need to migrate unique_id

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -47,7 +47,10 @@ def _build_identity_indexes(
     mac: str,
     new_unique_ids: set[str],
 ) -> tuple[
-    dict[str, DeviceEntityKey], dict[str, DeviceEntityKey], set[DeviceEntityKey]
+    dict[str, DeviceEntityKey],
+    dict[str, DeviceEntityKey],
+    set[DeviceEntityKey],
+    set[DeviceEntityKey],
 ]:
     """Index the old infos by unique_id and by name.
 
@@ -56,23 +59,30 @@ def _build_identity_indexes(
     independent identity and matches entities that moved between
     devices. Duplicates cannot be matched by identity and are left to
     the key based matching; entities whose unique_id is still present
-    are not move candidates and are returned separately so the key
-    based matching can skip them as well.
+    are not move candidates and are returned as still_present so the
+    key based matching can skip them as well. Non duplicate entries
+    whose unique_id is claimed by an incoming info are returned as
+    reserved: they are guaranteed a unique_id match, and the key based
+    matches must not consume them, or a reused key could swap two
+    entities' identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     duplicate_unique_ids: set[str] = set()
     movable_by_name: dict[str, DeviceEntityKey] = {}
     duplicate_names: set[str] = set()
     still_present: set[DeviceEntityKey] = set()
+    reserved: set[DeviceEntityKey] = set()
     for dict_key, existing_info in current_infos.items():
         old_unique_id = build_device_unique_id(mac, existing_info)
         name = existing_info.name
-        if old_unique_id in new_unique_ids:
+        present = old_unique_id in new_unique_ids
+        if present:
             still_present.add(dict_key)
         if old_unique_id in duplicate_unique_ids:
             continue
         if old_unique_id in old_info_by_unique_id:
             duplicate_unique_ids.add(old_unique_id)
+            reserved.discard(old_info_by_unique_id[old_unique_id])
             del old_info_by_unique_id[old_unique_id]
             # Duplicate unique_ids share a name, so the earlier
             # occurrence must not stay name matchable either
@@ -80,7 +90,8 @@ def _build_identity_indexes(
             movable_by_name.pop(name, None)
             continue
         old_info_by_unique_id[old_unique_id] = dict_key
-        if old_unique_id in new_unique_ids:
+        if present:
+            reserved.add(dict_key)
             continue
         if name in duplicate_names:
             continue
@@ -89,7 +100,7 @@ def _build_identity_indexes(
             del movable_by_name[name]
             continue
         movable_by_name[name] = dict_key
-    return old_info_by_unique_id, movable_by_name, still_present
+    return old_info_by_unique_id, movable_by_name, still_present, reserved
 
 
 @callback
@@ -119,17 +130,9 @@ def async_static_info_updated(
     mac = device_info.mac_address
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
-    old_info_by_unique_id, movable_by_name, still_present = _build_identity_indexes(
-        current_infos, mac, new_unique_ids
+    old_info_by_unique_id, movable_by_name, still_present, reserved = (
+        _build_identity_indexes(current_infos, mac, new_unique_ids)
     )
-    # Old infos whose identity is claimed by an incoming info are
-    # reserved for that unique_id match; the key based matches must not
-    # consume them, or a reused key could swap two entities' identities
-    reserved = {
-        dict_key
-        for unique_id, dict_key in old_info_by_unique_id.items()
-        if unique_id in new_unique_ids
-    }
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
     # Track info by (info.device_id, info.key) to properly handle entities
@@ -150,16 +153,34 @@ def async_static_info_updated(
                 # Equal unique_ids imply equal device_ids, no migration needed
                 continue
 
-        # Same key and device_id: a rename on firmware where the key is
-        # not derived from the name; the entity is updated in place
-        if info_key not in reserved and current_infos.pop(info_key, None) is not None:
-            continue
-
         # Match by name when unambiguous: the entity moved between
-        # devices. Survives the key changing at the same time.
+        # devices. Survives the key changing at the same time. This
+        # runs before the key match so a move into a slot vacated by
+        # a removed entity is not mistaken for a rename of that entity.
         old_info: EntityInfo | None = None
         if (move_dict_key := movable_by_name.pop(info.name, None)) is not None:
             old_info = current_infos.pop(move_dict_key, None)
+
+        # Same key and device_id: a rename on firmware where the key is
+        # not derived from the name; the entity is updated in place and
+        # its registry entry follows the new name based unique_id
+        if (
+            old_info is None
+            and info_key not in reserved
+            and (renamed_info := current_infos.pop(info_key, None)) is not None
+        ):
+            old_unique_id = build_device_unique_id(mac, renamed_info)
+            if (
+                old_unique_id != unique_id
+                and (
+                    entity_id := ent_reg.async_get_entity_id(
+                        platform.domain, DOMAIN, old_unique_id
+                    )
+                )
+                and not ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id)
+            ):
+                ent_reg.async_update_entity(entity_id, new_unique_id=unique_id)
+            continue
 
         # Search for the same name and key on a different device_id to
         # resolve moves of entities with ambiguous names, skipping
@@ -258,7 +279,19 @@ def async_static_info_updated(
 
     # Anything still in current_infos is now gone
     if current_infos:
-        entry_data.async_remove_entities(hass, current_infos.values(), mac)
+        removed_infos: list[EntityInfo] = []
+        for dict_key, leftover_info in current_infos.items():
+            if dict_key in still_present:
+                # The registry entry is claimed by a surviving entity
+                # (duplicate unique_ids), so remove only the stale
+                # entity object and leave the registry entry alone
+                entry_data.async_signal_entity_removal(
+                    info_type, dict_key[0], dict_key[1]
+                )
+            else:
+                removed_infos.append(leftover_info)
+        if removed_infos:
+            entry_data.async_remove_entities(hass, removed_infos, mac)
 
     # Then update the actual info
     entry_data.info[info_type] = new_infos

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -51,32 +51,24 @@ def _build_identity_indexes(
     current_infos: dict[DeviceEntityKey, EntityInfo],
     mac: str,
     new_unique_ids: set[str],
-) -> tuple[
-    dict[str, DeviceEntityKey],
-    dict[str, list[DeviceEntityKey]],
-    set[DeviceEntityKey],
-]:
+) -> tuple[dict[str, DeviceEntityKey], dict[str, list[DeviceEntityKey]]]:
     """Index old infos by unique_id and by name for identity matching.
 
     ESPHome validates that names are unique per device_id, so
     unique_ids are unique. The key derives from the name (hash of the
     name, or of the object_id which derives from the name), so a key
-    can never disambiguate entities the name cannot; the same name on
-    multiple devices shares one key and moves are matched in listing
-    order. reserved: guaranteed a unique_id match; key matches must
-    skip these or a reused key could swap two entities' identities.
+    can never disambiguate entities the name cannot. Entities whose
+    unique_id is still present are matched by unique_id and are not
+    move candidates.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     movable_by_name: dict[str, list[DeviceEntityKey]] = {}
-    reserved: set[DeviceEntityKey] = set()
     for dict_key, existing_info in current_infos.items():
         old_unique_id = build_device_unique_id(mac, existing_info)
         old_info_by_unique_id[old_unique_id] = dict_key
-        if old_unique_id in new_unique_ids:
-            reserved.add(dict_key)
-            continue
-        movable_by_name.setdefault(existing_info.name, []).append(dict_key)
-    return old_info_by_unique_id, movable_by_name, reserved
+        if old_unique_id not in new_unique_ids:
+            movable_by_name.setdefault(existing_info.name, []).append(dict_key)
+    return old_info_by_unique_id, movable_by_name
 
 
 @callback
@@ -105,25 +97,18 @@ def async_static_info_updated(
     mac = device_info.mac_address
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
-    old_info_by_unique_id, movable_by_name, reserved = _build_identity_indexes(
+    for info in infos:
+        new_infos[(info.device_id, info.key)] = info
+    old_info_by_unique_id, movable_by_name = _build_identity_indexes(
         current_infos, mac, new_unique_ids
     )
-    # Names of incoming infos without a unique_id match; these claim
-    # same named old entities as moves, so the in place key match must
-    # not consume those candidates
-    claimed_names = {
-        info.name
-        for info, unique_id in zip(infos, unique_ids, strict=True)
-        if unique_id not in old_info_by_unique_id
-    }
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
+    deferred: list[tuple[EntityInfo, str]] = []
 
-    # Track info by (info.device_id, info.key) to properly handle entities
-    # moving between devices and support sub-devices with overlapping keys
+    # First pass: unique_id matches and moves between devices. All
+    # moves resolve before any rename so a rename candidate cannot be
+    # mistaken for a mover.
     for info, unique_id in zip(infos, unique_ids, strict=True):
-        info_key = (info.device_id, info.key)
-        new_infos[info_key] = info
-
         # Identity match by unique_id; survives key re-derivation
         if (old_dict_key := old_info_by_unique_id.pop(unique_id, None)) is not None:
             matched_info = current_infos.pop(old_dict_key)
@@ -134,34 +119,20 @@ def async_static_info_updated(
             # Equal unique_ids imply equal device_ids
             continue
 
-        # Name match: the entity moved between devices. Runs before the
-        # key match so a move into a vacated key slot is not mistaken
-        # for a rename.
+        # Name match: the entity moved between devices. Prefer a
+        # candidate whose (device_id, key) slot has no incoming info,
+        # since that slot's info is an in place rename of the candidate
         old_info: EntityInfo | None = None
-        if move_dict_keys := movable_by_name.get(info.name):
-            old_info = current_infos.pop(move_dict_keys.pop(0))
+        if candidates := movable_by_name.get(info.name):
+            for idx, move_dict_key in enumerate(candidates):
+                if move_dict_key not in new_infos:
+                    old_info = current_infos.pop(candidates.pop(idx))
+                    break
+            else:
+                old_info = current_infos.pop(candidates.pop(0))
 
-        # Same key and device_id: a rename with a stable key; the
-        # registry entry follows the new unique_id. Skip candidates a
-        # later info will claim by name move.
-        if (
-            old_info is None
-            and info_key not in reserved
-            and (renamed_info := current_infos.get(info_key)) is not None
-            and renamed_info.name not in claimed_names
-        ):
-            del current_infos[info_key]
-            async_migrate_unique_id(
-                ent_reg,
-                platform.domain,
-                build_device_unique_id(mac, renamed_info),
-                unique_id,
-            )
-            continue
-
-        # Create new entity if it doesn't exist
         if old_info is None:
-            add_entities.append(entity_type(entry_data, info, state_type))
+            deferred.append((info, unique_id))
             continue
 
         # Entity has switched devices, need to migrate unique_id
@@ -236,6 +207,22 @@ def async_static_info_updated(
 
         # Create new entity with the new device_id
         add_entities.append(entity_type(entry_data, info, state_type))
+
+    # Second pass: anything left at an incoming (device_id, key) slot
+    # is a rename with a stable key; the registry entry follows the
+    # new unique_id. Everything else is a new entity.
+    for info, unique_id in deferred:
+        if (
+            renamed_info := current_infos.pop((info.device_id, info.key), None)
+        ) is None:
+            add_entities.append(entity_type(entry_data, info, state_type))
+            continue
+        async_migrate_unique_id(
+            ent_reg,
+            platform.domain,
+            build_device_unique_id(mac, renamed_info),
+            unique_id,
+        )
 
     if rekeys:
         entry_data.async_update_entity_keys(info_type, rekeys)

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -104,6 +104,7 @@ def async_static_info_updated(
     )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
     deferred: list[tuple[EntityInfo, str]] = []
+    new_entity_slots: set[DeviceEntityKey] = set()
 
     # First pass: unique_id matches and moves between devices. All
     # moves resolve before any rename so a rename candidate cannot be
@@ -208,6 +209,7 @@ def async_static_info_updated(
         if (
             renamed_info := current_infos.pop((info.device_id, info.key), None)
         ) is None:
+            new_entity_slots.add((info.device_id, info.key))
             add_entities.append(entity_type(entry_data, info, state_type))
             continue
         async_migrate_unique_id(
@@ -224,13 +226,14 @@ def async_static_info_updated(
     if current_infos:
         entry_data.async_remove_entities(hass, current_infos.values(), mac)
 
-    # The state cache holds only live keys so a future entity that
-    # reuses a retired key cannot adopt a stale state
-    if rekeys or current_infos:
-        live_keys = {key for _, key in new_infos}
+    # A cached state is only valid while its (device_id, key) slot is
+    # occupied by the same entity; anything else is stale and must not
+    # be adopted by another entity through a reused key
+    if rekeys or current_infos or new_entity_slots:
         states = entry_data.state[state_type]
-        for cached_key in list(states):
-            if cached_key not in live_keys:
+        for cached_key, cached_state in list(states.items()):
+            slot = (cached_state.device_id, cached_key)
+            if slot not in new_infos or slot in new_entity_slots:
                 del states[cached_key]
         entry_data.stale_state -= {
             stale_key

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -108,8 +108,9 @@ def async_static_info_updated(
     )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
     deferred: list[tuple[EntityInfo, str]] = []
-    # Slots of brand new entities; movers re-added in the first pass
-    # keep their own cached state and are deliberately not tracked
+    # Slots of brand new entities; movers are deliberately not
+    # tracked, though a mover's cached state under its old slot is
+    # still dropped whenever the sweep below runs
     new_entity_slots: set[DeviceEntityKey] = set()
     states = entry_data.state[state_type]
 

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -111,6 +111,7 @@ def async_static_info_updated(
     # Slots of brand new entities; movers re-added in the first pass
     # keep their own cached state and are deliberately not tracked
     new_entity_slots: set[DeviceEntityKey] = set()
+    states = entry_data.state[state_type]
 
     # First pass: unique_id matches and moves between devices. All
     # moves resolve before any rename so a rename candidate cannot be
@@ -135,6 +136,13 @@ def async_static_info_updated(
         idx = next((i for i, key in enumerate(candidates) if key not in new_infos), 0)
         old_info = current_infos.pop(candidates.pop(idx))
 
+        # A foreign cached state at the mover's destination key must
+        # not be adopted when the mover is re-added
+        if (
+            cached_state := states.get(info.key)
+        ) is not None and cached_state.device_id != old_info.device_id:
+            del states[info.key]
+
         # Entity has switched devices, need to migrate unique_id
         # and handle state subscriptions
         old_unique_id = build_device_unique_id(mac, old_info)
@@ -156,9 +164,16 @@ def async_static_info_updated(
 
         updates: dict[str, Any] = {}
 
-        # Update unique_id if it changed
+        # Update unique_id if it changed and the new one is not claimed
         if old_unique_id != unique_id:
-            updates["new_unique_id"] = unique_id
+            if ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id):
+                _LOGGER.debug(
+                    "Cannot migrate unique_id %s -> %s: already claimed",
+                    old_unique_id,
+                    unique_id,
+                )
+            else:
+                updates["new_unique_id"] = unique_id
 
         # Update device assignment in registry
         if info.device_id:
@@ -236,7 +251,6 @@ def async_static_info_updated(
     # occupied by the same entity; anything else is stale and must not
     # be adopted by another entity through a reused key
     if rekeys or current_infos or new_entity_slots:
-        states = entry_data.state[state_type]
         for cached_key, cached_state in list(states.items()):
             slot = (cached_state.device_id, cached_key)
             if slot not in new_infos or slot in new_entity_slots:

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -53,7 +53,7 @@ def _build_identity_indexes(
     new_unique_ids: set[str],
 ) -> tuple[
     dict[str, DeviceEntityKey],
-    dict[str, DeviceEntityKey],
+    dict[str, list[DeviceEntityKey]],
     set[DeviceEntityKey],
 ]:
     """Index old infos by unique_id and by name for identity matching.
@@ -61,15 +61,13 @@ def _build_identity_indexes(
     ESPHome validates that names are unique per device_id, so
     unique_ids are unique. The key derives from the name (hash of the
     name, or of the object_id which derives from the name), so a key
-    can never disambiguate entities the name cannot. The same name may
-    exist on multiple devices; such names are ambiguous move
-    candidates. reserved: guaranteed a unique_id match; key matches
-    must skip these or a reused key could swap two entities'
-    identities.
+    can never disambiguate entities the name cannot; the same name on
+    multiple devices shares one key and moves are matched in listing
+    order. reserved: guaranteed a unique_id match; key matches must
+    skip these or a reused key could swap two entities' identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
-    movable_by_name: dict[str, DeviceEntityKey] = {}
-    duplicate_names: set[str] = set()
+    movable_by_name: dict[str, list[DeviceEntityKey]] = {}
     reserved: set[DeviceEntityKey] = set()
     for dict_key, existing_info in current_infos.items():
         old_unique_id = build_device_unique_id(mac, existing_info)
@@ -77,14 +75,7 @@ def _build_identity_indexes(
         if old_unique_id in new_unique_ids:
             reserved.add(dict_key)
             continue
-        name = existing_info.name
-        if name in duplicate_names:
-            continue
-        if name in movable_by_name:
-            duplicate_names.add(name)
-            del movable_by_name[name]
-            continue
-        movable_by_name[name] = dict_key
+        movable_by_name.setdefault(existing_info.name, []).append(dict_key)
     return old_info_by_unique_id, movable_by_name, reserved
 
 
@@ -114,10 +105,17 @@ def async_static_info_updated(
     mac = device_info.mac_address
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
-    new_names = {info.name for info in infos}
     old_info_by_unique_id, movable_by_name, reserved = _build_identity_indexes(
         current_infos, mac, new_unique_ids
     )
+    # Names of incoming infos without a unique_id match; these claim
+    # same named old entities as moves, so the in place key match must
+    # not consume those candidates
+    claimed_names = {
+        info.name
+        for info, unique_id in zip(infos, unique_ids, strict=True)
+        if unique_id not in old_info_by_unique_id
+    }
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
     # Track info by (info.device_id, info.key) to properly handle entities
@@ -128,32 +126,29 @@ def async_static_info_updated(
 
         # Identity match by unique_id; survives key re-derivation
         if (old_dict_key := old_info_by_unique_id.pop(unique_id, None)) is not None:
-            if (matched_info := current_infos.pop(old_dict_key, None)) is not None:
-                if matched_info.key != info.key:
-                    # Same entity, new key: re-point subscriptions after
-                    # the loop; the registry entry is untouched
-                    rekeys.append((matched_info, info))
-                # Equal unique_ids imply equal device_ids
-                continue
+            matched_info = current_infos.pop(old_dict_key)
+            if matched_info.key != info.key:
+                # Same entity, new key: re-point subscriptions after
+                # the loop; the registry entry is untouched
+                rekeys.append((matched_info, info))
+            # Equal unique_ids imply equal device_ids
+            continue
 
-        # Unambiguous name match: the entity moved between devices.
-        # Runs before the key match so a move into a vacated key slot
-        # is not mistaken for a rename.
+        # Name match: the entity moved between devices. Runs before the
+        # key match so a move into a vacated key slot is not mistaken
+        # for a rename.
         old_info: EntityInfo | None = None
-        if (move_dict_key := movable_by_name.pop(info.name, None)) is not None:
-            old_info = current_infos.pop(move_dict_key, None)
+        if move_dict_keys := movable_by_name.get(info.name):
+            old_info = current_infos.pop(move_dict_keys.pop(0))
 
         # Same key and device_id: a rename with a stable key; the
         # registry entry follows the new unique_id. Skip candidates a
-        # later info will claim by unique_id or by name move.
+        # later info will claim by name move.
         if (
             old_info is None
             and info_key not in reserved
             and (renamed_info := current_infos.get(info_key)) is not None
-            and not (
-                renamed_info.name in new_names
-                and movable_by_name.get(renamed_info.name) == info_key
-            )
+            and renamed_info.name not in claimed_names
         ):
             del current_infos[info_key]
             async_migrate_unique_id(
@@ -163,18 +158,6 @@ def async_static_info_updated(
                 unique_id,
             )
             continue
-
-        # Same name on another device: an ambiguous move. Same named
-        # entities share one key, so the key cannot disambiguate; take
-        # the first candidate a unique_id match will not claim.
-        if old_info is None:
-            for existing_dict_key, existing_info in current_infos.items():
-                if (
-                    existing_info.name == info.name
-                    and existing_dict_key not in reserved
-                ):
-                    old_info = current_infos.pop(existing_dict_key)
-                    break
 
         # Create new entity if it doesn't exist
         if old_info is None:

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -46,7 +46,9 @@ def _build_identity_indexes(
     current_infos: dict[DeviceEntityKey, EntityInfo],
     mac: str,
     new_unique_ids: set[str],
-) -> tuple[dict[str, DeviceEntityKey], dict[str, DeviceEntityKey]]:
+) -> tuple[
+    dict[str, DeviceEntityKey], dict[str, DeviceEntityKey], set[DeviceEntityKey]
+]:
     """Index the old infos by unique_id and by name.
 
     The unique_id (mac/device_id/type/name) is the long term identity
@@ -54,24 +56,32 @@ def _build_identity_indexes(
     independent identity and matches entities that moved between
     devices. Duplicates cannot be matched by identity and are left to
     the key based matching; entities whose unique_id is still present
-    are not move candidates.
+    are not move candidates and are returned separately so the key
+    based matching can skip them as well.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     duplicate_unique_ids: set[str] = set()
     movable_by_name: dict[str, DeviceEntityKey] = {}
     duplicate_names: set[str] = set()
+    still_present: set[DeviceEntityKey] = set()
     for dict_key, existing_info in current_infos.items():
         old_unique_id = build_device_unique_id(mac, existing_info)
+        name = existing_info.name
+        if old_unique_id in new_unique_ids:
+            still_present.add(dict_key)
         if old_unique_id in duplicate_unique_ids:
             continue
         if old_unique_id in old_info_by_unique_id:
             duplicate_unique_ids.add(old_unique_id)
             del old_info_by_unique_id[old_unique_id]
+            # Duplicate unique_ids share a name, so the earlier
+            # occurrence must not stay name matchable either
+            duplicate_names.add(name)
+            movable_by_name.pop(name, None)
             continue
         old_info_by_unique_id[old_unique_id] = dict_key
         if old_unique_id in new_unique_ids:
             continue
-        name = existing_info.name
         if name in duplicate_names:
             continue
         if name in movable_by_name:
@@ -79,7 +89,7 @@ def _build_identity_indexes(
             del movable_by_name[name]
             continue
         movable_by_name[name] = dict_key
-    return old_info_by_unique_id, movable_by_name
+    return old_info_by_unique_id, movable_by_name, still_present
 
 
 @callback
@@ -107,18 +117,18 @@ def async_static_info_updated(
     # The API key is only stable for a session, so entities are matched
     # by identity first: unique_id, then name for cross device moves
     mac = device_info.mac_address
-    new_unique_ids = {build_device_unique_id(mac, info) for info in infos}
-    old_info_by_unique_id, movable_by_name = _build_identity_indexes(
+    unique_ids = [build_device_unique_id(mac, info) for info in infos]
+    new_unique_ids = set(unique_ids)
+    old_info_by_unique_id, movable_by_name, still_present = _build_identity_indexes(
         current_infos, mac, new_unique_ids
     )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
     # Track info by (info.device_id, info.key) to properly handle entities
     # moving between devices and support sub-devices with overlapping keys
-    for info in infos:
+    for info, unique_id in zip(infos, unique_ids, strict=True):
         info_key = (info.device_id, info.key)
         new_infos[info_key] = info
-        unique_id = build_device_unique_id(mac, info)
 
         # Identity match by unique_id: same device_id, type and name.
         # Survives the key being re-derived by a firmware update.
@@ -148,11 +158,11 @@ def async_static_info_updated(
         # entities whose identity is still present in the new infos so
         # a reused key cannot steal an unrelated entity
         if old_info is None:
-            for existing_dict_key, existing_info in list(current_infos.items()):
+            for existing_dict_key, existing_info in current_infos.items():
                 if (
                     existing_dict_key[1] == info.key
                     and existing_info.name == info.name
-                    and build_device_unique_id(mac, existing_info) not in new_unique_ids
+                    and existing_dict_key not in still_present
                 ):
                     old_info = current_infos.pop(existing_dict_key)
                     break

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -58,11 +58,14 @@ def _build_identity_indexes(
 ]:
     """Index old infos by unique_id and by name for identity matching.
 
-    Names are unique per device_id, so unique_ids are unique; the same
-    name may exist on multiple devices, and such names are ambiguous
-    move candidates left to key matching. reserved: guaranteed a
-    unique_id match; key matches must skip these or a reused key could
-    swap two entities' identities.
+    ESPHome validates that names are unique per device_id, so
+    unique_ids are unique. The key derives from the name (hash of the
+    name, or of the object_id which derives from the name), so a key
+    can never disambiguate entities the name cannot. The same name may
+    exist on multiple devices; such names are ambiguous move
+    candidates. reserved: guaranteed a unique_id match; key matches
+    must skip these or a reused key could swap two entities'
+    identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     movable_by_name: dict[str, DeviceEntityKey] = {}
@@ -161,13 +164,13 @@ def async_static_info_updated(
             )
             continue
 
-        # Same name and key on another device: a move with an
-        # ambiguous name; skip entities a unique_id match will claim
+        # Same name on another device: an ambiguous move. Same named
+        # entities share one key, so the key cannot disambiguate; take
+        # the first candidate a unique_id match will not claim.
         if old_info is None:
             for existing_dict_key, existing_info in current_infos.items():
                 if (
-                    existing_dict_key[1] == info.key
-                    and existing_info.name == info.name
+                    existing_info.name == info.name
                     and existing_dict_key not in reserved
                 ):
                     old_info = current_infos.pop(existing_dict_key)

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -165,28 +165,15 @@ def async_static_info_updated(
 
         updates: dict[str, Any] = {}
 
-        # Update unique_id if it changed. A claimant of the new
-        # unique_id is a stale orphan and is removed so the moved
-        # entity keeps its identity and helpers; a disabled claimant
-        # is kept so the disable preference survives.
+        # Update unique_id if it changed and the new one is not claimed
         if old_unique_id != unique_id:
-            migrate = True
-            if claimant_id := ent_reg.async_get_entity_id(
-                platform.domain, DOMAIN, unique_id
-            ):
-                claimant = ent_reg.async_get(claimant_id)
-                if claimant is not None and claimant.disabled_by is not None:
-                    _LOGGER.debug(
-                        "Cannot migrate unique_id %s -> %s: claimed by "
-                        "disabled entry %s",
-                        old_unique_id,
-                        unique_id,
-                        claimant_id,
-                    )
-                    migrate = False
-                else:
-                    ent_reg.async_remove(claimant_id)
-            if migrate:
+            if ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id):
+                _LOGGER.debug(
+                    "Cannot migrate unique_id %s -> %s: already claimed",
+                    old_unique_id,
+                    unique_id,
+                )
+            else:
                 updates["new_unique_id"] = unique_id
 
         # Update device assignment in registry

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -104,6 +104,8 @@ def async_static_info_updated(
     )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
     deferred: list[tuple[EntityInfo, str]] = []
+    # Slots of brand new entities; movers re-added in the first pass
+    # keep their own cached state and are deliberately not tracked
     new_entity_slots: set[DeviceEntityKey] = set()
 
     # First pass: unique_id matches and moves between devices. All

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -17,7 +17,7 @@ from aioesphomeapi import (
 import voluptuous as vol
 
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
@@ -64,37 +64,57 @@ def async_static_info_updated(
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
+    # The API key is only stable for a session; the unique_id
+    # (mac/device_id/type/name) is the long term identity, so index the
+    # old infos by unique_id to match entities across key changes.
+    mac = device_info.mac_address
+    old_info_by_unique_id: dict[str, DeviceEntityKey] = {
+        build_device_unique_id(mac, old_info): dict_key
+        for dict_key, old_info in current_infos.items()
+    }
+    rekeys: list[tuple[EntityInfo, EntityInfo]] = []
+
     # Track info by (info.device_id, info.key) to properly handle entities
     # moving between devices and support sub-devices with overlapping keys
     for info in infos:
         info_key = (info.device_id, info.key)
         new_infos[info_key] = info
+        unique_id = build_device_unique_id(mac, info)
 
-        # Try to find existing entity - first with current device_id
-        old_info = current_infos.pop(info_key, None)
-
-        # If not found, search for entity with same key but different device_id
-        # This handles the case where entity moved between devices
-        if not old_info:
-            for existing_device_id, existing_key in list(current_infos):
-                if existing_key == info.key:
-                    # Found entity with same key but different device_id
-                    old_info = current_infos.pop((existing_device_id, existing_key))
-                    break
-
-        # Create new entity if it doesn't exist
-        if not old_info:
-            entity = entity_type(entry_data, info, state_type)
-            add_entities.append(entity)
+        # Identity match by unique_id: same device_id, type and name.
+        # Survives the key being re-derived by a firmware update.
+        if (
+            old_dict_key := old_info_by_unique_id.pop(unique_id, None)
+        ) is not None and (
+            old_info := current_infos.pop(old_dict_key, None)
+        ) is not None:
+            if old_info.key != info.key:
+                # Same entity with a new key: the live entity re-points
+                # its key based subscriptions after the loop. The
+                # registry entry is untouched.
+                rekeys.append((old_info, info))
+            # Equal unique_ids imply equal device_ids, so no migration needed
             continue
 
-        # Entity exists - check if device_id has changed
-        if old_info.device_id == info.device_id:
+        # Same key and device_id: a rename on firmware where the key is
+        # not derived from the name; the entity is updated in place
+        if current_infos.pop(info_key, None) is not None:
+            continue
+
+        # Search for the same key on a different device_id
+        # This handles the case where entity moved between devices
+        for existing_device_id, existing_key in list(current_infos):
+            if existing_key == info.key:
+                old_info = current_infos.pop((existing_device_id, existing_key))
+                break
+        else:
+            # Create new entity if it doesn't exist
+            add_entities.append(entity_type(entry_data, info, state_type))
             continue
 
         # Entity has switched devices, need to migrate unique_id
         # and handle state subscriptions
-        old_unique_id = build_device_unique_id(device_info.mac_address, old_info)
+        old_unique_id = build_device_unique_id(mac, old_info)
         entity_id = ent_reg.async_get_entity_id(platform.domain, DOMAIN, old_unique_id)
 
         # If entity not found in registry, re-add it
@@ -112,23 +132,22 @@ def async_static_info_updated(
             continue
 
         updates: dict[str, Any] = {}
-        new_unique_id = build_device_unique_id(device_info.mac_address, info)
 
         # Update unique_id if it changed
-        if old_unique_id != new_unique_id:
-            updates["new_unique_id"] = new_unique_id
+        if old_unique_id != unique_id:
+            updates["new_unique_id"] = unique_id
 
         # Update device assignment in registry
         if info.device_id:
             # Entity now belongs to a sub device
             new_device = dev_reg.async_get_device_by_identifier(
-                (DOMAIN, f"{device_info.mac_address}_{info.device_id}"),
+                (DOMAIN, f"{mac}_{info.device_id}"),
                 entry_data.entry_id,
             )
         else:
             # Entity now belongs to the main device
             new_device = dev_reg.async_get_device_by_connection(
-                (dr.CONNECTION_NETWORK_MAC, device_info.mac_address),
+                (dr.CONNECTION_NETWORK_MAC, mac),
                 entry_data.entry_id,
             )
 
@@ -163,11 +182,12 @@ def async_static_info_updated(
         # Create new entity with the new device_id
         add_entities.append(entity_type(entry_data, info, state_type))
 
+    if rekeys:
+        entry_data.async_update_entity_keys(info_type, rekeys)
+
     # Anything still in current_infos is now gone
     if current_infos:
-        entry_data.async_remove_entities(
-            hass, current_infos.values(), device_info.mac_address
-        )
+        entry_data.async_remove_entities(hass, current_infos.values(), mac)
 
     # Then update the actual info
     entry_data.info[info_type] = new_infos
@@ -357,6 +377,7 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
         self._on_entry_data_changed()
         self._key = entity_info.key
         self._state_type = state_type
+        self._key_unsubs: list[CALLBACK_TYPE] = []
         self._on_static_info_update(entity_info)
 
         # Determine the device connection based on whether this
@@ -383,30 +404,41 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
                 self._on_device_update,
             )
         )
-        self.async_on_remove(
+        self._subscribe_key_updates()
+        self.async_on_remove(self._unsubscribe_key_updates)
+        self._update_state_from_entry_data()
+
+    @callback
+    def _subscribe_key_updates(self) -> None:
+        """Subscribe to updates that are keyed by the session stable key."""
+        entry_data = self._entry_data
+        static_info = self._static_info
+        self._key_unsubs = [
             entry_data.async_subscribe_state_update(
-                self._static_info.device_id,
+                static_info.device_id,
                 self._state_type,
                 self._key,
                 self._on_state_update,
-            )
-        )
-        self.async_on_remove(
+            ),
             entry_data.async_register_key_static_info_updated_callback(
-                self._static_info, self._on_static_info_update
-            )
-        )
-        # Register to be notified when this entity should remove itself
-        # This happens when the entity moves to a different device
-        self.async_on_remove(
+                static_info, self._on_static_info_update
+            ),
+            # Register to be notified when this entity should remove itself
+            # This happens when the entity moves to a different device
             entry_data.async_register_entity_removal_callback(
-                type(self._static_info),
-                self._static_info.device_id,
+                type(static_info),
+                static_info.device_id,
                 self._key,
                 self._on_removal_signal,
-            )
-        )
-        self._update_state_from_entry_data()
+            ),
+        ]
+
+    @callback
+    def _unsubscribe_key_updates(self) -> None:
+        """Unsubscribe from updates that are keyed by the session stable key."""
+        for unsub in self._key_unsubs:
+            unsub()
+        self._key_unsubs = []
 
     @callback
     def _on_removal_signal(self) -> None:
@@ -430,10 +462,23 @@ class EsphomeEntity(EsphomeBaseEntity, Generic[_InfoT, _StateT]):  # noqa: UP046
         if TYPE_CHECKING:
             static_info = cast(_InfoT, static_info)
             assert device_info
+        unique_id = build_device_unique_id(device_info.mac_address, static_info)
+        if (
+            new_key := static_info.key
+        ) != self._key and unique_id != self._attr_unique_id:
+            # A key change is only valid for this entity's unique_id; keys
+            # are not collision safe, so never adopt an info that belongs
+            # to a different entity.
+            return
         self._static_info = static_info
-        self._attr_unique_id = build_device_unique_id(
-            device_info.mac_address, static_info
-        )
+        if new_key != self._key:
+            # The key is only stable for a session; a firmware update may
+            # re-derive it. Move the key based subscriptions to the new key.
+            self._key = new_key
+            if self._key_unsubs:
+                self._unsubscribe_key_updates()
+                self._subscribe_key_updates()
+        self._attr_unique_id = unique_id
         self._attr_entity_registry_enabled_default = not static_info.disabled_by_default
         # https://github.com/home-assistant/core/issues/132532
         # If the name is "", we need to set it to None since otherwise

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -67,7 +67,11 @@ def _build_identity_indexes(
         old_unique_id = build_device_unique_id(mac, existing_info)
         old_info_by_unique_id[old_unique_id] = dict_key
         if old_unique_id not in new_unique_ids:
-            movable_by_name.setdefault(existing_info.name, []).append(dict_key)
+            # Unnamed entities use the device derived object_id as
+            # their identity so they cannot pair across devices
+            movable_by_name.setdefault(
+                existing_info.name or existing_info.object_id, []
+            ).append(dict_key)
     return old_info_by_unique_id, movable_by_name
 
 
@@ -125,7 +129,7 @@ def async_static_info_updated(
         # Name match: the entity moved between devices. Prefer a
         # candidate whose (device_id, key) slot has no incoming info,
         # since that slot's info is an in place rename of the candidate
-        if not (candidates := movable_by_name.get(info.name)):
+        if not (candidates := movable_by_name.get(info.name or info.object_id)):
             deferred.append((info, unique_id))
             continue
         idx = next((i for i, key in enumerate(candidates) if key not in new_infos), 0)

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -239,6 +239,15 @@ def async_static_info_updated(
 
     if rekeys:
         entry_data.async_update_entity_keys(info_type, rekeys)
+        # Prune states cached under retired keys
+        states = entry_data.state[state_type]
+        live_keys = {key for _, key in new_infos}
+        for rekeyed_info, _ in rekeys:
+            if (old_key := rekeyed_info.key) not in live_keys:
+                states.pop(old_key, None)
+                entry_data.stale_state.discard(
+                    (state_type, rekeyed_info.device_id, old_key)
+                )
 
     # Anything still in current_infos is now gone
     if current_infos:

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -55,41 +55,25 @@ def _build_identity_indexes(
     dict[str, DeviceEntityKey],
     dict[str, DeviceEntityKey],
     set[DeviceEntityKey],
-    set[DeviceEntityKey],
 ]:
     """Index old infos by unique_id and by name for identity matching.
 
-    Duplicates are unmatchable by identity and left to key matching.
-    still_present: unique_id also occurs in the new infos (not movable).
-    reserved: guaranteed a unique_id match; key matches must skip these
-    or a reused key could swap two entities' identities.
+    Names duplicated across devices are ambiguous and left to key
+    matching; a device never has duplicate names, so unique_ids are
+    unique. reserved: guaranteed a unique_id match; key matches must
+    skip these or a reused key could swap two entities' identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
-    duplicate_unique_ids: set[str] = set()
     movable_by_name: dict[str, DeviceEntityKey] = {}
     duplicate_names: set[str] = set()
-    still_present: set[DeviceEntityKey] = set()
     reserved: set[DeviceEntityKey] = set()
     for dict_key, existing_info in current_infos.items():
         old_unique_id = build_device_unique_id(mac, existing_info)
-        name = existing_info.name
-        present = old_unique_id in new_unique_ids
-        if present:
-            still_present.add(dict_key)
-        if old_unique_id in duplicate_unique_ids:
-            continue
-        if old_unique_id in old_info_by_unique_id:
-            duplicate_unique_ids.add(old_unique_id)
-            reserved.discard(old_info_by_unique_id[old_unique_id])
-            del old_info_by_unique_id[old_unique_id]
-            # Duplicate unique_ids share a name
-            duplicate_names.add(name)
-            movable_by_name.pop(name, None)
-            continue
         old_info_by_unique_id[old_unique_id] = dict_key
-        if present:
+        if old_unique_id in new_unique_ids:
             reserved.add(dict_key)
             continue
+        name = existing_info.name
         if name in duplicate_names:
             continue
         if name in movable_by_name:
@@ -97,7 +81,7 @@ def _build_identity_indexes(
             del movable_by_name[name]
             continue
         movable_by_name[name] = dict_key
-    return old_info_by_unique_id, movable_by_name, still_present, reserved
+    return old_info_by_unique_id, movable_by_name, reserved
 
 
 @callback
@@ -127,8 +111,8 @@ def async_static_info_updated(
     unique_ids = [build_device_unique_id(mac, info) for info in infos]
     new_unique_ids = set(unique_ids)
     new_names = {info.name for info in infos}
-    old_info_by_unique_id, movable_by_name, still_present, reserved = (
-        _build_identity_indexes(current_infos, mac, new_unique_ids)
+    old_info_by_unique_id, movable_by_name, reserved = _build_identity_indexes(
+        current_infos, mac, new_unique_ids
     )
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
@@ -183,7 +167,7 @@ def async_static_info_updated(
                 if (
                     existing_dict_key[1] == info.key
                     and existing_info.name == info.name
-                    and existing_dict_key not in still_present
+                    and existing_dict_key not in reserved
                 ):
                     old_info = current_infos.pop(existing_dict_key)
                     break
@@ -271,20 +255,7 @@ def async_static_info_updated(
 
     # Anything still in current_infos is now gone
     if current_infos:
-        removed_infos: list[EntityInfo] = []
-        for dict_key, leftover_info in current_infos.items():
-            if dict_key in still_present:
-                # A surviving entity claims the registry entry
-                # (duplicate unique_ids); remove only the entity object.
-                # Removal is eager and frees the platform slot before
-                # the pending adds run.
-                entry_data.async_signal_entity_removal(
-                    info_type, dict_key[0], dict_key[1]
-                )
-            else:
-                removed_infos.append(leftover_info)
-        if removed_infos:
-            entry_data.async_remove_entities(hass, removed_infos, mac)
+        entry_data.async_remove_entities(hass, current_infos.values(), mac)
 
     # Then update the actual info
     entry_data.info[info_type] = new_infos

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -58,10 +58,11 @@ def _build_identity_indexes(
 ]:
     """Index old infos by unique_id and by name for identity matching.
 
-    Names duplicated across devices are ambiguous and left to key
-    matching; a device never has duplicate names, so unique_ids are
-    unique. reserved: guaranteed a unique_id match; key matches must
-    skip these or a reused key could swap two entities' identities.
+    Names are unique per device_id, so unique_ids are unique; the same
+    name may exist on multiple devices, and such names are ambiguous
+    move candidates left to key matching. reserved: guaranteed a
+    unique_id match; key matches must skip these or a reused key could
+    swap two entities' identities.
     """
     old_info_by_unique_id: dict[str, DeviceEntityKey] = {}
     movable_by_name: dict[str, DeviceEntityKey] = {}

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -122,6 +122,14 @@ def async_static_info_updated(
     old_info_by_unique_id, movable_by_name, still_present = _build_identity_indexes(
         current_infos, mac, new_unique_ids
     )
+    # Old infos whose identity is claimed by an incoming info are
+    # reserved for that unique_id match; the key based matches must not
+    # consume them, or a reused key could swap two entities' identities
+    reserved = {
+        dict_key
+        for unique_id, dict_key in old_info_by_unique_id.items()
+        if unique_id in new_unique_ids
+    }
     rekeys: list[tuple[EntityInfo, EntityInfo]] = []
 
     # Track info by (info.device_id, info.key) to properly handle entities
@@ -144,7 +152,7 @@ def async_static_info_updated(
 
         # Same key and device_id: a rename on firmware where the key is
         # not derived from the name; the entity is updated in place
-        if current_infos.pop(info_key, None) is not None:
+        if info_key not in reserved and current_infos.pop(info_key, None) is not None:
             continue
 
         # Match by name when unambiguous: the entity moved between

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -134,7 +134,14 @@ def async_static_info_updated(
         if not (candidates := movable_by_name.get(info.name or info.object_id)):
             deferred.append((info, unique_id))
             continue
-        idx = next((i for i, key in enumerate(candidates) if key not in new_infos), 0)
+        idx = next((i for i, key in enumerate(candidates) if key not in new_infos), -1)
+        if idx == -1:
+            idx = 0
+            _LOGGER.debug(
+                "Ambiguous move for %s: every candidate slot is occupied, "
+                "taking the first candidate",
+                info.name or info.object_id,
+            )
         old_info = current_infos.pop(candidates.pop(idx))
 
         # A cached state at the mover's destination key is only the
@@ -164,39 +171,41 @@ def async_static_info_updated(
             add_entities.append(entity)
             continue
 
-        updates: dict[str, Any] = {}
-
-        # Update unique_id if it changed and the new one is not claimed
-        if old_unique_id != unique_id:
-            if ent_reg.async_get_entity_id(platform.domain, DOMAIN, unique_id):
-                _LOGGER.debug(
-                    "Cannot migrate unique_id %s -> %s: already claimed",
-                    old_unique_id,
-                    unique_id,
-                )
-            else:
-                updates["new_unique_id"] = unique_id
-
-        # Update device assignment in registry
-        if info.device_id:
-            # Entity now belongs to a sub device
-            new_device = dev_reg.async_get_device_by_identifier(
-                (DOMAIN, f"{mac}_{info.device_id}"),
-                entry_data.entry_id,
+        # Leave the entry untouched when the new unique_id is claimed;
+        # it cannot follow the move, so a partial update helps nothing
+        if old_unique_id != unique_id and ent_reg.async_get_entity_id(
+            platform.domain, DOMAIN, unique_id
+        ):
+            _LOGGER.warning(
+                "Cannot migrate unique_id %s -> %s: already claimed",
+                old_unique_id,
+                unique_id,
             )
         else:
-            # Entity now belongs to the main device
-            new_device = dev_reg.async_get_device_by_connection(
-                (dr.CONNECTION_NETWORK_MAC, mac),
-                entry_data.entry_id,
-            )
+            updates: dict[str, Any] = {}
+            if old_unique_id != unique_id:
+                updates["new_unique_id"] = unique_id
 
-        if new_device:
-            updates["device_id"] = new_device.id
+            # Update device assignment in registry
+            if info.device_id:
+                # Entity now belongs to a sub device
+                new_device = dev_reg.async_get_device_by_identifier(
+                    (DOMAIN, f"{mac}_{info.device_id}"),
+                    entry_data.entry_id,
+                )
+            else:
+                # Entity now belongs to the main device
+                new_device = dev_reg.async_get_device_by_connection(
+                    (dr.CONNECTION_NETWORK_MAC, mac),
+                    entry_data.entry_id,
+                )
 
-        # Apply all registry updates at once
-        if updates:
-            ent_reg.async_update_entity(entity_id, **updates)
+            if new_device:
+                updates["device_id"] = new_device.id
+
+            # Apply all registry updates at once
+            if updates:
+                ent_reg.async_update_entity(entity_id, **updates)
 
         # IMPORTANT: The entity's device assignment in Home
         # Assistant is only read when the entity is first added.

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -102,6 +102,26 @@ INFO_TYPE_TO_PLATFORM: dict[type[EntityInfo], Platform] = {
 }
 
 
+@callback
+def async_migrate_unique_id(
+    ent_reg: er.EntityRegistry,
+    platform_domain: str,
+    old_unique_id: str,
+    new_unique_id: str,
+) -> None:
+    """Migrate a registry entry to a new unique_id unless it is claimed."""
+    if (
+        old_unique_id != new_unique_id
+        and (
+            entity_id := ent_reg.async_get_entity_id(
+                platform_domain, DOMAIN, old_unique_id
+            )
+        )
+        and not ent_reg.async_get_entity_id(platform_domain, DOMAIN, new_unique_id)
+    ):
+        ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+
+
 class StoreData(TypedDict, total=False):
     """ESPHome storage data."""
 
@@ -260,17 +280,10 @@ class RuntimeEntryData:
         info_type: type[EntityInfo],
         rekeys: Iterable[tuple[EntityInfo, EntityInfo]],
     ) -> None:
-        """Notify entities registered under their old key that the key changed.
-
-        The API key is only stable for a session; a firmware update may
-        re-derive it. Dispatching the new info through the old key's
-        callbacks lets each entity re-point its key based subscriptions.
-        """
+        """Notify entities registered under their old key that the key changed."""
         callbacks = self.entity_info_key_updated_callbacks
-        # Snapshot every old key's callbacks before dispatching anything:
-        # entities re-subscribe under their new key during dispatch, and a
-        # new key may be another entity's old key, so a live lookup could
-        # deliver an info to the wrong entity when keys are swapped.
+        # Snapshot all old keys' callbacks first: entities re-subscribe
+        # during dispatch and a new key may be another entity's old key
         snapshots = [
             (
                 tuple(callbacks.get((info_type, old_info.device_id, old_info.key), ())),
@@ -322,7 +335,6 @@ class RuntimeEntryData:
             list
         )
         ent_reg = er.async_get(hass)
-        registry_get_entity = ent_reg.async_get_entity_id
         for info in infos:
             info_type = type(info)
             if platform := info_types_to_platform.get(info_type):
@@ -334,18 +346,12 @@ class RuntimeEntryData:
                 # legacy ids collided (the bug this fixes) only one registry
                 # entry exists for it, so the first iterated info claims it and
                 # the rest get fresh version 3 ids.
-                old_unique_id = build_device_unique_id(mac, info, version=1)
-                new_unique_id = build_device_unique_id(mac, info, version=3)
-                if (
-                    old_unique_id != new_unique_id
-                    and (
-                        old_entry := registry_get_entity(
-                            platform, DOMAIN, old_unique_id
-                        )
-                    )
-                    and not registry_get_entity(platform, DOMAIN, new_unique_id)
-                ):
-                    ent_reg.async_update_entity(old_entry, new_unique_id=new_unique_id)
+                async_migrate_unique_id(
+                    ent_reg,
+                    platform,
+                    build_device_unique_id(mac, info, version=1),
+                    build_device_unique_id(mac, info, version=3),
+                )
             else:
                 _LOGGER.warning(
                     "Entity type %s is not supported in this version of Home Assistant",
@@ -393,8 +399,7 @@ class RuntimeEntryData:
 
         @callback
         def _unsubscribe() -> None:
-            # A re-keyed entity may have taken over this slot while the
-            # old subscriber was being removed, so only remove our own.
+            # A re-keyed entity may have taken over this slot
             if self.state_subscriptions.get(subscription_key) is entity_callback:
                 del self.state_subscriptions[subscription_key]
 

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -287,11 +287,20 @@ class RuntimeEntryData:
         snapshots = [
             (
                 tuple(callbacks.get((info_type, old_info.device_id, old_info.key), ())),
+                old_info,
                 new_info,
             )
             for old_info, new_info in rekeys
         ]
-        for entity_callbacks, new_info in snapshots:
+        for entity_callbacks, old_info, new_info in snapshots:
+            if not entity_callbacks:
+                _LOGGER.debug(
+                    "%s: no subscriber for key change %s -> %s",
+                    new_info.name,
+                    old_info.key,
+                    new_info.key,
+                )
+                continue
             for callback_ in entity_callbacks:
                 callback_(new_info)
 

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -56,6 +56,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import discovery_flow, entity_registry as er
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.service_info.esphome import ESPHomeServiceInfo
 from homeassistant.helpers.storage import Store
 
@@ -187,9 +188,9 @@ class RuntimeEntryData:
     original_options: dict[str, Any] = field(default_factory=dict)
     # Keyed by the entity object so cleanup can never touch another
     # entity's entry and never-added entities self clean via GC
-    media_player_formats: WeakKeyDictionary[Any, list[MediaPlayerSupportedFormat]] = (
-        field(default_factory=WeakKeyDictionary)
-    )
+    media_player_formats: WeakKeyDictionary[
+        Entity, list[MediaPlayerSupportedFormat]
+    ] = field(default_factory=WeakKeyDictionary)
     assist_satellite_config_update_callbacks: list[
         Callable[[AssistSatelliteConfiguration], None]
     ] = field(default_factory=list)

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from functools import partial
 import logging
-from operator import delitem
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
 
 from aioesphomeapi import (
@@ -255,6 +254,34 @@ class RuntimeEntryData:
             ):
                 callback_(static_info)
 
+    @callback
+    def async_update_entity_keys(
+        self,
+        info_type: type[EntityInfo],
+        rekeys: Iterable[tuple[EntityInfo, EntityInfo]],
+    ) -> None:
+        """Notify entities registered under their old key that the key changed.
+
+        The API key is only stable for a session; a firmware update may
+        re-derive it. Dispatching the new info through the old key's
+        callbacks lets each entity re-point its key based subscriptions.
+        """
+        callbacks = self.entity_info_key_updated_callbacks
+        # Snapshot every old key's callbacks before dispatching anything:
+        # entities re-subscribe under their new key during dispatch, and a
+        # new key may be another entity's old key, so a live lookup could
+        # deliver an info to the wrong entity when keys are swapped.
+        snapshots = [
+            (
+                tuple(callbacks.get((info_type, old_info.device_id, old_info.key), ())),
+                new_info,
+            )
+            for old_info, new_info in rekeys
+        ]
+        for entity_callbacks, new_info in snapshots:
+            for callback_ in entity_callbacks:
+                callback_(new_info)
+
     async def _ensure_platforms_loaded(
         self,
         hass: HomeAssistant,
@@ -363,7 +390,15 @@ class RuntimeEntryData:
         """Subscribe to state updates."""
         subscription_key = (state_type, device_id, state_key)
         self.state_subscriptions[subscription_key] = entity_callback
-        return partial(delitem, self.state_subscriptions, subscription_key)
+
+        @callback
+        def _unsubscribe() -> None:
+            # A re-keyed entity may have taken over this slot while the
+            # old subscriber was being removed, so only remove our own.
+            if self.state_subscriptions.get(subscription_key) is entity_callback:
+                del self.state_subscriptions[subscription_key]
+
+        return _unsubscribe
 
     @callback
     def async_update_state(self, state: EntityState) -> None:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -110,16 +110,18 @@ def async_migrate_unique_id(
     new_unique_id: str,
 ) -> None:
     """Migrate a registry entry to a new unique_id unless it is claimed."""
-    if (
-        old_unique_id != new_unique_id
-        and (
-            entity_id := ent_reg.async_get_entity_id(
-                platform_domain, DOMAIN, old_unique_id
-            )
-        )
-        and not ent_reg.async_get_entity_id(platform_domain, DOMAIN, new_unique_id)
+    if old_unique_id == new_unique_id or not (
+        entity_id := ent_reg.async_get_entity_id(platform_domain, DOMAIN, old_unique_id)
     ):
-        ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+        return
+    if ent_reg.async_get_entity_id(platform_domain, DOMAIN, new_unique_id):
+        _LOGGER.debug(
+            "Cannot migrate unique_id %s -> %s: already claimed",
+            old_unique_id,
+            new_unique_id,
+        )
+        return
+    ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
 
 
 class StoreData(TypedDict, total=False):

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -298,7 +298,7 @@ class RuntimeEntryData:
             if not entity_callbacks:
                 _LOGGER.debug(
                     "%s: no subscriber for key change %s -> %s",
-                    new_info.name,
+                    new_info.name or new_info.object_id,
                     old_info.key,
                     new_info.key,
                 )

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
+from weakref import WeakKeyDictionary
 
 from aioesphomeapi import (
     COMPONENT_TYPE_TO_INFO,
@@ -184,8 +185,10 @@ class RuntimeEntryData:
         EntityInfoKey, list[Callable[[EntityInfo], None]]
     ] = field(default_factory=dict)
     original_options: dict[str, Any] = field(default_factory=dict)
-    media_player_formats: dict[str, list[MediaPlayerSupportedFormat]] = field(
-        default_factory=lambda: defaultdict(list)
+    # Keyed by the entity object so cleanup can never touch another
+    # entity's entry and never-added entities self clean via GC
+    media_player_formats: WeakKeyDictionary[Any, list[MediaPlayerSupportedFormat]] = (
+        field(default_factory=WeakKeyDictionary)
     )
     assist_satellite_config_update_callbacks: list[
         Callable[[AssistSatelliteConfiguration], None]

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -2,7 +2,7 @@
 
 from functools import partial
 import logging
-from typing import Any, cast, override
+from typing import Any, override
 from urllib.parse import urlparse
 
 from aioesphomeapi import (
@@ -90,6 +90,11 @@ class EsphomeMediaPlayer(
     """A media player implementation for esphome."""
 
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
+    # Stable dict key into entry_data.media_player_formats; the unique_id
+    # is not used since it follows static info updates, which could point
+    # the cleanup in async_will_remove_from_hass at another entity's
+    # entry when keys are reused across a reconnect.
+    _format_key: str | None = None
 
     @callback
     @override
@@ -103,9 +108,11 @@ class EsphomeMediaPlayer(
         for espflag in esp_flags:
             flags |= _FEATURES[espflag]
         self._attr_supported_features = flags
-        self._entry_data.media_player_formats[self.unique_id] = cast(
-            MediaPlayerInfo, static_info
-        ).supported_formats
+        if self._format_key is None:
+            self._format_key = self.unique_id
+        self._entry_data.media_player_formats[self._format_key] = (
+            self._static_info.supported_formats
+        )
 
     @property
     @esphome_state_property
@@ -144,7 +151,9 @@ class EsphomeMediaPlayer(
         announcement = kwargs.get(ATTR_MEDIA_ANNOUNCE)
         bypass_proxy = kwargs.get(ATTR_MEDIA_EXTRA, {}).get(ATTR_BYPASS_PROXY)
         supported_formats: list[MediaPlayerSupportedFormat] | None = (
-            self._entry_data.media_player_formats.get(self.unique_id)
+            self._entry_data.media_player_formats.get(self._format_key)
+            if self._format_key is not None
+            else None
         )
 
         if (
@@ -171,7 +180,8 @@ class EsphomeMediaPlayer(
     async def async_will_remove_from_hass(self) -> None:
         """Handle entity being removed."""
         await super().async_will_remove_from_hass()
-        self._entry_data.media_player_formats.pop(self.unique_id, None)
+        if self._format_key is not None:
+            self._entry_data.media_player_formats.pop(self._format_key, None)
 
     def _get_proxy_url(
         self,

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -143,9 +143,7 @@ class EsphomeMediaPlayer(
         media_id = async_process_play_media_url(self.hass, media_id)
         announcement = kwargs.get(ATTR_MEDIA_ANNOUNCE)
         bypass_proxy = kwargs.get(ATTR_MEDIA_EXTRA, {}).get(ATTR_BYPASS_PROXY)
-        supported_formats: list[MediaPlayerSupportedFormat] | None = (
-            self._entry_data.media_player_formats.get(self)
-        )
+        supported_formats = self._entry_data.media_player_formats.get(self)
 
         if (
             not bypass_proxy

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -90,9 +90,14 @@ class EsphomeMediaPlayer(
     """A media player implementation for esphome."""
 
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
-    # Stable media_player_formats key; unique_id follows static info
-    # updates and could point cleanup at another entity's entry
-    _format_key: str | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the media player."""
+        # Per instance media_player_formats key; a unique_id based key
+        # could alias another entity after a rename and point cleanup
+        # at that entity's entry
+        self._format_key = f"{id(self)}"
+        super().__init__(*args, **kwargs)
 
     @callback
     @override
@@ -106,8 +111,6 @@ class EsphomeMediaPlayer(
         for espflag in esp_flags:
             flags |= _FEATURES[espflag]
         self._attr_supported_features = flags
-        if self._format_key is None:
-            self._format_key = self.unique_id
         self._entry_data.media_player_formats[self._format_key] = (
             self._static_info.supported_formats
         )
@@ -148,11 +151,9 @@ class EsphomeMediaPlayer(
         media_id = async_process_play_media_url(self.hass, media_id)
         announcement = kwargs.get(ATTR_MEDIA_ANNOUNCE)
         bypass_proxy = kwargs.get(ATTR_MEDIA_EXTRA, {}).get(ATTR_BYPASS_PROXY)
-        supported_formats: list[MediaPlayerSupportedFormat] | None = None
-        if self._format_key is not None:
-            supported_formats = self._entry_data.media_player_formats.get(
-                self._format_key
-            )
+        supported_formats: list[MediaPlayerSupportedFormat] | None = (
+            self._entry_data.media_player_formats.get(self._format_key)
+        )
 
         if (
             not bypass_proxy
@@ -178,8 +179,7 @@ class EsphomeMediaPlayer(
     async def async_will_remove_from_hass(self) -> None:
         """Handle entity being removed."""
         await super().async_will_remove_from_hass()
-        if self._format_key is not None:
-            self._entry_data.media_player_formats.pop(self._format_key, None)
+        self._entry_data.media_player_formats.pop(self._format_key, None)
 
     def _get_proxy_url(
         self,

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -90,10 +90,8 @@ class EsphomeMediaPlayer(
     """A media player implementation for esphome."""
 
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
-    # Stable dict key into entry_data.media_player_formats; the unique_id
-    # is not used since it follows static info updates, which could point
-    # the cleanup in async_will_remove_from_hass at another entity's
-    # entry when keys are reused across a reconnect.
+    # Stable media_player_formats key; unique_id follows static info
+    # updates and could point cleanup at another entity's entry
     _format_key: str | None = None
 
     @callback
@@ -150,11 +148,11 @@ class EsphomeMediaPlayer(
         media_id = async_process_play_media_url(self.hass, media_id)
         announcement = kwargs.get(ATTR_MEDIA_ANNOUNCE)
         bypass_proxy = kwargs.get(ATTR_MEDIA_EXTRA, {}).get(ATTR_BYPASS_PROXY)
-        supported_formats: list[MediaPlayerSupportedFormat] | None = (
-            self._entry_data.media_player_formats.get(self._format_key)
-            if self._format_key is not None
-            else None
-        )
+        supported_formats: list[MediaPlayerSupportedFormat] | None = None
+        if self._format_key is not None:
+            supported_formats = self._entry_data.media_player_formats.get(
+                self._format_key
+            )
 
         if (
             not bypass_proxy

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -91,14 +91,6 @@ class EsphomeMediaPlayer(
 
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize the media player."""
-        # Per instance media_player_formats key; a unique_id based key
-        # could alias another entity after a rename and point cleanup
-        # at that entity's entry
-        self._format_key = f"{id(self)}"
-        super().__init__(*args, **kwargs)
-
     @callback
     @override
     def _on_static_info_update(self, static_info: EntityInfo) -> None:
@@ -111,7 +103,7 @@ class EsphomeMediaPlayer(
         for espflag in esp_flags:
             flags |= _FEATURES[espflag]
         self._attr_supported_features = flags
-        self._entry_data.media_player_formats[self._format_key] = (
+        self._entry_data.media_player_formats[self] = (
             self._static_info.supported_formats
         )
 
@@ -152,7 +144,7 @@ class EsphomeMediaPlayer(
         announcement = kwargs.get(ATTR_MEDIA_ANNOUNCE)
         bypass_proxy = kwargs.get(ATTR_MEDIA_EXTRA, {}).get(ATTR_BYPASS_PROXY)
         supported_formats: list[MediaPlayerSupportedFormat] | None = (
-            self._entry_data.media_player_formats.get(self._format_key)
+            self._entry_data.media_player_formats.get(self)
         )
 
         if (
@@ -179,7 +171,7 @@ class EsphomeMediaPlayer(
     async def async_will_remove_from_hass(self) -> None:
         """Handle entity being removed."""
         await super().async_will_remove_from_hass()
-        self._entry_data.media_player_formats.pop(self._format_key, None)
+        self._entry_data.media_player_formats.pop(self, None)
 
     def _get_proxy_url(
         self,

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -272,6 +272,7 @@ class MockESPHomeDevice:
         self.on_log_message: Callable[[SubscribeLogsResponse], None]
         self.device_info = device_info
         self.current_log_level = LogLevel.LOG_LEVEL_NONE
+        self.states: list[EntityState] = []
 
     def set_state_callback(self, state_callback: Callable[[EntityState], None]) -> None:
         """Set the state callback."""
@@ -450,11 +451,12 @@ async def _mock_generic_device_entry(
         }
 
     mock_device = MockESPHomeDevice(entry, mock_client, device_info)
+    mock_device.states = states
 
     def _subscribe_states(callback: Callable[[EntityState], None]) -> None:
         """Subscribe to state."""
         mock_device.set_state_callback(callback)
-        for state in states:
+        for state in mock_device.states:
             callback(state)
 
     def _subscribe_service_calls(
@@ -535,7 +537,7 @@ async def _mock_generic_device_entry(
             on_state_sub, on_state_request
         )
         # Set the initial states
-        for state in states:
+        for state in mock_device.states:
             on_state(state)
 
     mock_client.subscribe_home_assistant_states_and_services = (
@@ -760,6 +762,7 @@ async def reconnect_with_updated_entity_info(
     hass: HomeAssistant,
     device: MockESPHomeDevice,
     entity_info: list[EntityInfo],
+    states: list[EntityState] | None = None,
 ) -> None:
     """Reconnect the mock device with updated entity info."""
     mock_client = device.client
@@ -767,6 +770,8 @@ async def reconnect_with_updated_entity_info(
     mock_client.device_info_and_list_entities = AsyncMock(
         return_value=(device.device_info, entity_info, [])
     )
+    if states is not None:
+        device.states = states
     await device.mock_disconnect(expected_disconnect=False)
     await device.mock_connect()
     await hass.async_block_till_done()

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -759,10 +759,10 @@ async def mock_esphome_device(
 async def reconnect_with_updated_entity_info(
     hass: HomeAssistant,
     device: MockESPHomeDevice,
-    mock_client: APIClient,
     entity_info: list[EntityInfo],
 ) -> None:
     """Reconnect the mock device with updated entity info."""
+    mock_client = device.client
     mock_client.list_entities_services = AsyncMock(return_value=(entity_info, []))
     mock_client.device_info_and_list_entities = AsyncMock(
         return_value=(device.device_info, entity_info, [])

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -234,11 +234,16 @@ class MockESPHomeDevice:
     """Mock an esphome device."""
 
     def __init__(
-        self, entry: MockConfigEntry, client: APIClient, device_info: DeviceInfo
+        self,
+        entry: MockConfigEntry,
+        client: APIClient,
+        device_info: DeviceInfo,
+        states: list[EntityState],
     ) -> None:
         """Init the mock."""
         self.entry = entry
         self.client = client
+        self.states = states
         self.state_callback: Callable[[EntityState], None]
         self.service_call_callback: Callable[[HomeassistantServiceCall], None]
         self.on_disconnect: Callable[[bool], None]
@@ -272,7 +277,6 @@ class MockESPHomeDevice:
         self.on_log_message: Callable[[SubscribeLogsResponse], None]
         self.device_info = device_info
         self.current_log_level = LogLevel.LOG_LEVEL_NONE
-        self.states: list[EntityState] = []
 
     def set_state_callback(self, state_callback: Callable[[EntityState], None]) -> None:
         """Set the state callback."""
@@ -450,14 +454,7 @@ async def _mock_generic_device_entry(
             },
         }
 
-    mock_device = MockESPHomeDevice(entry, mock_client, device_info)
-    mock_device.states = states
-
-    def _subscribe_states(callback: Callable[[EntityState], None]) -> None:
-        """Subscribe to state."""
-        mock_device.set_state_callback(callback)
-        for state in mock_device.states:
-            callback(state)
+    mock_device = MockESPHomeDevice(entry, mock_client, device_info, states)
 
     def _subscribe_service_calls(
         callback: Callable[[HomeassistantServiceCall], None],

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -754,3 +754,19 @@ async def mock_esphome_device(
         )
 
     return _mock_device
+
+
+async def reconnect_with_updated_entity_info(
+    hass: HomeAssistant,
+    device: MockESPHomeDevice,
+    mock_client: APIClient,
+    entity_info: list[EntityInfo],
+) -> None:
+    """Reconnect the mock device with updated entity info."""
+    mock_client.list_entities_services = AsyncMock(return_value=(entity_info, []))
+    mock_client.device_info_and_list_entities = AsyncMock(
+        return_value=(device.device_info, entity_info, [])
+    )
+    await device.mock_disconnect(expected_disconnect=False)
+    await device.mock_connect()
+    await hass.async_block_till_done()

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2359,3 +2359,64 @@ async def test_entities_swap_keys(
     assert state_two.state == STATE_ON
     assert state_one.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor One"
     assert state_two.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor Two"
+
+
+async def test_entity_rekeyed_and_moved_between_devices(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test an entity changing key and device in the same update.
+
+    Neither the unique_id nor the key matches, so this is treated as a
+    remove and add; a device move changes the unique_id anyway.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert entity_registry.async_get("binary_sensor.test_sensor_one") is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+            device_id=11111111,
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    assert entity_registry.async_get("binary_sensor.test_sensor_one") is None
+    assert actions_one == ["remove"]
+    new_entry = entity_registry.async_get("binary_sensor.sub_one_sensor_one")
+    assert new_entry is not None
+
+    device.set_state(
+        BinarySensorState(key=101, state=False, missing_state=False, device_id=11111111)
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.sub_one_sensor_one").state == STATE_OFF

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -1829,7 +1829,15 @@ async def test_entities_rekeyed_after_firmware_update(
             name="Sensor Two",
         ),
     ]
-    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+    await reconnect_with_updated_entity_info(
+        hass,
+        device,
+        updated_entity_info,
+        states=[
+            BinarySensorState(key=101, state=True, missing_state=False),
+            BinarySensorState(key=102, state=True, missing_state=False),
+        ],
+    )
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
@@ -1841,6 +1849,11 @@ async def test_entities_rekeyed_after_firmware_update(
     assert new_entry_two.unique_id == entry_two.unique_id
     assert actions_one == []
     assert actions_two == []
+
+    # States cached under the retired keys must be pruned
+    entry_data = device.entry.runtime_data
+    assert 1 not in entry_data.state[BinarySensorState]
+    assert 2 not in entry_data.state[BinarySensorState]
 
     # State updates must follow the new key
     device.set_state(BinarySensorState(key=101, state=False, missing_state=False))
@@ -2774,3 +2787,93 @@ async def test_entity_moved_while_new_entity_takes_old_slot_listed_first(
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.test_foo").state == STATE_OFF
     assert hass.states.get("binary_sensor.test_bar").state == STATE_ON
+
+
+async def test_entity_renamed_with_stable_key_and_same_named_sibling(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a stable key rename while a sibling device shares the old name.
+
+    The sibling's Battery is claimed by its own unique_id match, so it
+    must not block the rename from being matched in place.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=22222222,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=22222222),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.sub_one_battery")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.sub_two_battery")
+
+    # Case only rename on sub_one keeps the object_id and key stable;
+    # sub_two still carries the old name
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="BATTERY",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=22222222,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    new_entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    new_entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert actions_two == []
+    assert "remove" not in actions_one
+    # The renamed entity's registry entry follows the new unique_id
+    assert new_entry_one.unique_id == build_device_unique_id(
+        device.device_info.mac_address, updated_entity_info[0]
+    )
+
+    device.set_state(
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=11111111)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.sub_one_battery")
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "sub_one BATTERY"

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2036,10 +2036,11 @@ async def test_entity_renamed_with_stable_key(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test a rename on firmware where the key is not name derived.
+    """Test a rename that keeps the object_id and key stable.
 
-    The key stays the same so the entity is updated in place and its
-    registry entry follows the new name based unique_id.
+    A case only rename keeps the object_id, and therefore the key,
+    stable; the entity is updated in place and its registry entry
+    follows the new name based unique_id.
     """
     entity_info = [
         BinarySensorInfo(
@@ -2065,7 +2066,7 @@ async def test_entity_renamed_with_stable_key(
         BinarySensorInfo(
             object_id="sensor_one",
             key=1,
-            name="Sensor One Renamed",
+            name="SENSOR ONE",
         ),
     ]
     await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
@@ -2084,7 +2085,7 @@ async def test_entity_renamed_with_stable_key(
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test_sensor_one")
     assert state.state == STATE_OFF
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor One Renamed"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test SENSOR ONE"
 
 
 async def test_entity_renamed_and_rekeyed(

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2715,6 +2715,7 @@ async def test_entity_moved_while_new_entity_takes_old_slot_listed_first(
     device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a move where a new entity takes the old slot and is listed first.
 
@@ -2764,8 +2765,11 @@ async def test_entity_moved_while_new_entity_takes_old_slot_listed_first(
             device_id=11111111,
         ),
     ]
-    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+    with caplog.at_level(logging.DEBUG, "homeassistant.components.esphome"):
+        await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
+    # Every candidate slot was occupied, so the ambiguous fallback ran
+    assert "Ambiguous move for Foo" in caplog.text
     new_entry_foo = entity_registry.async_get("binary_sensor.test_foo")
     assert new_entry_foo is not None
     assert new_entry_foo.id == entry_foo.id

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3032,7 +3032,6 @@ async def test_entity_renamed_while_same_named_sibling_moves(
 
 async def test_new_entities_reusing_retired_keys_do_not_adopt_stale_states(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
@@ -3345,3 +3344,55 @@ async def test_entity_move_with_claimed_unique_id(
     # The update completed: the sibling still processes states
     assert hass.states.get("binary_sensor.test_other").state == STATE_OFF
     assert entity_registry.async_get(orphan.entity_id) is not None
+
+
+async def test_mover_does_not_adopt_other_movers_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test two movers from one device cannot adopt each other's state.
+
+    A mover landing on another mover's old key must start unknown; the
+    cached state under that key was written from a different slot.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info, states = _two_binary_sensor_setup()
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_ON
+    assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_ON
+
+    # Both entities move to sub devices while a firmware rebuild
+    # re-derives keys; Sensor Two lands on Sensor One's old key and
+    # no states are streamed
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=5,
+            name="Sensor One",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=1,
+            name="Sensor Two",
+            device_id=22222222,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, updated_entity_info, states=[]
+    )
+
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_UNKNOWN
+    assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_UNKNOWN

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2801,3 +2801,85 @@ async def test_duplicate_name_entity_rekeyed_and_other_removed(
     device.set_state(BinarySensorState(key=5, state=False, missing_state=False))
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF
+
+
+async def test_entity_moved_while_new_entity_takes_old_slot_listed_first(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a move where a new entity takes the old slot and is listed first.
+
+    The new entity arrives first and matches the mover's old
+    (device_id, key) slot, but the mover's name is claimed by a later
+    info, so the in place key match must not consume it.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="foo",
+            key=1,
+            name="Foo",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_foo = entity_registry.async_get("binary_sensor.test_foo")
+    assert entry_foo is not None
+
+    actions_foo = track_entity_registry_actions(hass, "binary_sensor.test_foo")
+
+    # Foo moves to the sub device with a new key while new entity Bar
+    # takes over Foo's old (device_id, key) slot and is listed first
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="bar",
+            key=1,
+            name="Bar",
+        ),
+        BinarySensorInfo(
+            object_id="foo",
+            key=9,
+            name="Foo",
+            device_id=11111111,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    new_entry_foo = entity_registry.async_get("binary_sensor.test_foo")
+    assert new_entry_foo is not None
+    assert new_entry_foo.id == entry_foo.id
+    assert "remove" not in actions_foo
+
+    sub_one = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
+    )
+    assert sub_one is not None
+    assert new_entry_foo.device_id == sub_one.id
+
+    entry_bar = entity_registry.async_get("binary_sensor.test_bar")
+    assert entry_bar is not None
+    assert entry_bar.id != entry_foo.id
+
+    # Each entity must follow its own key
+    device.set_state(
+        BinarySensorState(key=9, state=False, missing_state=False, device_id=11111111)
+    )
+    device.set_state(BinarySensorState(key=1, state=True, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_bar").state == STATE_ON

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
@@ -1851,11 +1852,6 @@ async def test_entities_rekeyed_after_firmware_update(
     assert actions_one == []
     assert actions_two == []
 
-    # States cached under the retired keys must be pruned
-    entry_data = device.entry.runtime_data
-    assert 1 not in entry_data.state[BinarySensorState]
-    assert 2 not in entry_data.state[BinarySensorState]
-
     # State updates must follow the new key
     device.set_state(BinarySensorState(key=101, state=False, missing_state=False))
     await hass.async_block_till_done()
@@ -1983,7 +1979,12 @@ async def test_entity_rekeyed_and_another_removed(
             name="Sensor One",
         ),
     ]
-    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+    await reconnect_with_updated_entity_info(
+        hass,
+        device,
+        updated_entity_info,
+        states=[BinarySensorState(key=101, state=True, missing_state=False)],
+    )
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry_one is not None
@@ -3027,3 +3028,67 @@ async def test_entity_renamed_while_same_named_sibling_moves(
     assert state_main.state == STATE_OFF
     assert state_main.attributes[ATTR_FRIENDLY_NAME] == "Test BATTERY"
     assert state_sub.state == STATE_ON
+
+
+async def test_new_entities_reusing_retired_keys_do_not_adopt_stale_states(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test new entities reusing retired keys start unknown.
+
+    Keys retired by a re-key or a removal may be handed to unrelated
+    entities by a later firmware build; those entities must come up
+    unknown instead of adopting the retired key's last state.
+    """
+    entity_info, states = _two_binary_sensor_setup()
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_ON
+    assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_ON
+
+    # Sensor One is re-keyed to 101, Sensor Two is removed
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass,
+        device,
+        updated_entity_info,
+        states=[BinarySensorState(key=101, state=True, missing_state=False)],
+    )
+    assert hass.states.get("binary_sensor.test_sensor_two") is None
+
+    # A later build hands the retired keys 1 and 2 to new entities;
+    # no states are streamed for them
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_three",
+            key=1,
+            name="Sensor Three",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_four",
+            key=2,
+            name="Sensor Four",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, updated_entity_info, states=[]
+    )
+
+    assert hass.states.get("binary_sensor.test_sensor_three").state == STATE_UNKNOWN
+    assert hass.states.get("binary_sensor.test_sensor_four").state == STATE_UNKNOWN

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3273,9 +3273,9 @@ async def test_entity_move_with_claimed_unique_id(
 ) -> None:
     """Test a device move whose target unique_id is already claimed.
 
-    An orphaned registry entry holding the target unique_id must not
-    abort the update; the move keeps its old unique_id and the rest of
-    the entities are still processed.
+    A stale orphan claiming the target unique_id is removed so the
+    moved entity keeps its identity, and the rest of the entities are
+    still processed.
     """
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
@@ -3343,7 +3343,14 @@ async def test_entity_move_with_claimed_unique_id(
 
     # The update completed: the sibling still processes states
     assert hass.states.get("binary_sensor.test_other").state == STATE_OFF
-    assert entity_registry.async_get(orphan.entity_id) is not None
+    # The orphan was removed and the moved entity kept its identity
+    # with the new unique_id
+    assert entity_registry.async_get(orphan.entity_id) is None
+    moved_entry = entity_registry.async_get("binary_sensor.test_foo")
+    assert moved_entry is not None
+    assert moved_entry.unique_id == build_device_unique_id(
+        device.device_info.mac_address, moved_info
+    )
 
 
 async def test_mover_does_not_adopt_other_movers_state(
@@ -3396,3 +3403,65 @@ async def test_mover_does_not_adopt_other_movers_state(
 
     assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_UNKNOWN
     assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_UNKNOWN
+
+
+async def test_entity_move_with_disabled_claimant(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a device move whose target unique_id is claimed by a disabled entry.
+
+    The disabled entry is kept so the disable preference survives; the
+    moved entity binds to it and stays disabled.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="foo",
+            key=1,
+            name="Foo",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_ON
+
+    # A disabled registry entry claims Foo's post move unique_id
+    moved_info = BinarySensorInfo(
+        object_id="foo",
+        key=1,
+        name="Foo",
+        device_id=11111111,
+    )
+    claimant = entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        build_device_unique_id(device.device_info.mac_address, moved_info),
+        config_entry=device.entry,
+    )
+    entity_registry.async_update_entity(
+        claimant.entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
+
+    await reconnect_with_updated_entity_info(hass, device, [moved_info], states=[])
+
+    # The disabled claimant survives with its disable preference and
+    # the moved entity is not added
+    kept = entity_registry.async_get(claimant.entity_id)
+    assert kept is not None
+    assert kept.disabled_by is er.RegistryEntryDisabler.USER
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_UNAVAILABLE

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -13,6 +13,7 @@ from aioesphomeapi import (
     SensorInfo,
     SensorState,
     SubDeviceInfo,
+    build_device_unique_id,
     build_unique_id,
 )
 import pytest
@@ -1828,9 +1829,7 @@ async def test_entities_rekeyed_after_firmware_update(
             name="Sensor Two",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
@@ -1868,9 +1867,7 @@ async def test_entities_rekeyed_after_firmware_update(
             name="Sensor Two",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     device.set_state(BinarySensorState(key=101, state=True, missing_state=False))
     await hass.async_block_till_done()
@@ -1972,9 +1969,7 @@ async def test_entity_rekeyed_and_another_removed(
             name="Sensor One",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry_one is not None
@@ -2016,9 +2011,7 @@ async def test_entity_rekeyed_to_another_entities_old_key(
             name="Sensor One",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry_one is not None
@@ -2045,8 +2038,8 @@ async def test_entity_renamed_with_stable_key(
 ) -> None:
     """Test a rename on firmware where the key is not name derived.
 
-    The key stays the same so the entity is updated in place without
-    touching the registry.
+    The key stays the same so the entity is updated in place and its
+    registry entry follows the new name based unique_id.
     """
     entity_info = [
         BinarySensorInfo(
@@ -2075,14 +2068,17 @@ async def test_entity_renamed_with_stable_key(
             name="Sensor One Renamed",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry_one is not None
     assert new_entry_one.id == entry_one.id
     assert "remove" not in actions_one
+    # The registry unique_id must follow the rename so the entry is
+    # not orphaned on the next restart
+    assert new_entry_one.unique_id == build_device_unique_id(
+        device.device_info.mac_address, updated_entity_info[0]
+    )
 
     device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
     await hass.async_block_till_done()
@@ -2127,9 +2123,7 @@ async def test_entity_renamed_and_rekeyed(
             name="Sensor One Renamed",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     assert entity_registry.async_get("binary_sensor.test_sensor_one") is None
     assert actions_one == ["remove"]
@@ -2202,9 +2196,7 @@ async def test_entities_rekeyed_on_sub_devices_with_same_name(
             device_id=22222222,
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
     new_entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
@@ -2265,9 +2257,7 @@ async def test_entities_swap_keys(
             name="Sensor Two",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
     new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
@@ -2339,9 +2329,7 @@ async def test_entity_rekeyed_and_moved_between_devices(
             device_id=11111111,
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry is not None
@@ -2422,9 +2410,7 @@ async def test_entity_new_key_reuses_removed_entity_key_on_other_device(
             name="Sensor Three",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     assert entity_registry.async_get("binary_sensor.sub_one_sensor_two") is None
     assert actions_two == ["remove"]
@@ -2479,7 +2465,7 @@ async def test_entities_with_duplicate_names_not_removed_on_reconnect(
 
     actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
 
-    await reconnect_with_updated_entity_info(hass, device, mock_client, entity_info)
+    await reconnect_with_updated_entity_info(hass, device, entity_info)
 
     new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
     assert new_entry is not None
@@ -2570,9 +2556,7 @@ async def test_entities_with_same_name_moved_between_devices(
             device_id=44444444,
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
     new_entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
@@ -2649,9 +2633,7 @@ async def test_entity_rekeyed_while_old_key_reused_by_renamed_entity(
             name="Sensor Two",
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
     assert new_entry_two is not None
@@ -2675,3 +2657,147 @@ async def test_entity_rekeyed_while_old_key_reused_by_renamed_entity(
     assert state_two.state == STATE_OFF
     assert state_two.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor Two"
     assert state_renamed.state == STATE_ON
+
+
+async def test_entity_moved_into_removed_entities_key_slot(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a device move into a key slot vacated by a removed entity.
+
+    The moved entity keeps its key and lands on the removed entity's
+    old (device_id, key) slot; the name match must win so the move is
+    migrated instead of being mistaken for a rename of the removed
+    entity.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="batt",
+            key=5,
+            name="Batt",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="volt",
+            key=5,
+            name="Volt",
+            device_id=22222222,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=5, state=True, missing_state=False, device_id=11111111),
+        BinarySensorState(key=5, state=True, missing_state=False, device_id=22222222),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_batt = entity_registry.async_get("binary_sensor.sub_one_batt")
+    entry_volt = entity_registry.async_get("binary_sensor.sub_two_volt")
+    assert entry_batt is not None
+    assert entry_volt is not None
+
+    actions_batt = track_entity_registry_actions(hass, "binary_sensor.sub_one_batt")
+    actions_volt = track_entity_registry_actions(hass, "binary_sensor.sub_two_volt")
+
+    # Batt moves to sub_two keeping key 5, taking over Volt's old
+    # (device_id, key) slot; Volt is removed
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="batt",
+            key=5,
+            name="Batt",
+            device_id=22222222,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    new_entry_batt = entity_registry.async_get("binary_sensor.sub_one_batt")
+    assert new_entry_batt is not None
+    assert new_entry_batt.id == entry_batt.id
+    assert "remove" not in actions_batt
+
+    sub_two = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
+    )
+    assert sub_two is not None
+    assert new_entry_batt.device_id == sub_two.id
+
+    assert entity_registry.async_get("binary_sensor.sub_two_volt") is None
+    assert actions_volt == ["remove"]
+
+    device.set_state(
+        BinarySensorState(key=5, state=False, missing_state=False, device_id=22222222)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.sub_one_batt")
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "sub_two Batt"
+
+
+async def test_duplicate_name_entity_rekeyed_and_other_removed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test duplicate named entities where one is removed and one re-keyed.
+
+    Both old infos share a unique_id and one registry entry; the entry
+    is claimed by the surviving entity, so it must not be removed even
+    though both old infos are leftovers.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=1,
+            name="Duplicate",
+        ),
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=2,
+            name="Duplicate",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry = entity_registry.async_get("binary_sensor.test_duplicate")
+    assert entry is not None
+
+    actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=5,
+            name="Duplicate",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
+    assert new_entry is not None
+    assert new_entry.id == entry.id
+    assert "remove" not in actions
+
+    device.set_state(BinarySensorState(key=5, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -10,7 +10,6 @@ from aioesphomeapi import (
     BinarySensorInfo,
     BinarySensorState,
     DeviceInfo,
-    EntityInfo,
     SensorInfo,
     SensorState,
     SubDeviceInfo,
@@ -40,6 +39,7 @@ from .conftest import (
     MockESPHomeDevice,
     MockESPHomeDeviceType,
     MockGenericDeviceEntryType,
+    reconnect_with_updated_entity_info,
 )
 
 
@@ -57,20 +57,27 @@ def track_entity_registry_actions(hass: HomeAssistant, entity_id: str) -> list[s
     return events
 
 
-async def _reconnect_with_updated_entity_info(
-    hass: HomeAssistant,
-    device: MockESPHomeDevice,
-    mock_client: APIClient,
-    entity_info: list[EntityInfo],
-) -> None:
-    """Reconnect the mock device with updated entity info."""
-    mock_client.list_entities_services = AsyncMock(return_value=(entity_info, []))
-    mock_client.device_info_and_list_entities = AsyncMock(
-        return_value=(device.device_info, entity_info, [])
-    )
-    await device.mock_disconnect(expected_disconnect=False)
-    await device.mock_connect()
-    await hass.async_block_till_done()
+def _two_binary_sensor_setup() -> tuple[
+    list[BinarySensorInfo], list[BinarySensorState]
+]:
+    """Return two binary sensors and their states for re-key tests."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    return entity_info, states
 
 
 async def test_entities_removed(
@@ -1791,22 +1798,7 @@ async def test_entities_rekeyed_after_firmware_update(
     re-derive every key. The registry entries must be preserved so
     helpers pointing at the entities are not deleted.
     """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="sensor_one",
-            key=1,
-            name="Sensor One",
-        ),
-        BinarySensorInfo(
-            object_id="sensor_two",
-            key=2,
-            name="Sensor Two",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=True, missing_state=False),
-    ]
+    entity_info, states = _two_binary_sensor_setup()
     device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
@@ -1836,7 +1828,7 @@ async def test_entities_rekeyed_after_firmware_update(
             name="Sensor Two",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -1876,7 +1868,7 @@ async def test_entities_rekeyed_after_firmware_update(
             name="Sensor Two",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -1900,22 +1892,7 @@ async def test_entities_rekeyed_after_reload(
     Covers the path where entities are created from stored static infos
     with the old keys and the first connect delivers the new keys.
     """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="sensor_one",
-            key=1,
-            name="Sensor One",
-        ),
-        BinarySensorInfo(
-            object_id="sensor_two",
-            key=2,
-            name="Sensor Two",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=True, missing_state=False),
-    ]
+    entity_info, states = _two_binary_sensor_setup()
     device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
@@ -1975,22 +1952,7 @@ async def test_entity_rekeyed_and_another_removed(
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test a key change combined with a genuine entity removal."""
-    entity_info = [
-        BinarySensorInfo(
-            object_id="sensor_one",
-            key=1,
-            name="Sensor One",
-        ),
-        BinarySensorInfo(
-            object_id="sensor_two",
-            key=2,
-            name="Sensor Two",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=True, missing_state=False),
-    ]
+    entity_info, states = _two_binary_sensor_setup()
     device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
@@ -2010,7 +1972,7 @@ async def test_entity_rekeyed_and_another_removed(
             name="Sensor One",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2035,22 +1997,7 @@ async def test_entity_rekeyed_to_another_entities_old_key(
     which is removed at the same time. The unique_id match must win so
     the entities do not swap identities.
     """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="sensor_one",
-            key=1,
-            name="Sensor One",
-        ),
-        BinarySensorInfo(
-            object_id="sensor_two",
-            key=2,
-            name="Sensor Two",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=True, missing_state=False),
-    ]
+    entity_info, states = _two_binary_sensor_setup()
     device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
@@ -2069,7 +2016,7 @@ async def test_entity_rekeyed_to_another_entities_old_key(
             name="Sensor One",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2128,7 +2075,7 @@ async def test_entity_renamed_with_stable_key(
             name="Sensor One Renamed",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2180,7 +2127,7 @@ async def test_entity_renamed_and_rekeyed(
             name="Sensor One Renamed",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2255,7 +2202,7 @@ async def test_entities_rekeyed_on_sub_devices_with_same_name(
             device_id=22222222,
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2292,22 +2239,7 @@ async def test_entities_swap_keys(
     entity's old key to another entity. Each entity must follow its
     own unique_id and never adopt the other's identity.
     """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="sensor_one",
-            key=1,
-            name="Sensor One",
-        ),
-        BinarySensorInfo(
-            object_id="sensor_two",
-            key=2,
-            name="Sensor Two",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=True, missing_state=False),
-    ]
+    entity_info, states = _two_binary_sensor_setup()
     device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
@@ -2333,7 +2265,7 @@ async def test_entities_swap_keys(
             name="Sensor Two",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2407,7 +2339,7 @@ async def test_entity_rekeyed_and_moved_between_devices(
             device_id=11111111,
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2490,7 +2422,7 @@ async def test_entity_new_key_reuses_removed_entity_key_on_other_device(
             name="Sensor Three",
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 
@@ -2547,7 +2479,7 @@ async def test_entities_with_duplicate_names_not_removed_on_reconnect(
 
     actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
 
-    await _reconnect_with_updated_entity_info(hass, device, mock_client, entity_info)
+    await reconnect_with_updated_entity_info(hass, device, mock_client, entity_info)
 
     new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
     assert new_entry is not None
@@ -2638,7 +2570,7 @@ async def test_entities_with_same_name_moved_between_devices(
             device_id=44444444,
         ),
     ]
-    await _reconnect_with_updated_entity_info(
+    await reconnect_with_updated_entity_info(
         hass, device, mock_client, updated_entity_info
     )
 

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2528,6 +2528,11 @@ async def test_entities_with_duplicate_names_not_removed_on_reconnect(
             key=2,
             name="Duplicate",
         ),
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=3,
+            name="Duplicate",
+        ),
     ]
     states = [
         BinarySensorState(key=1, state=True, missing_state=False),
@@ -2552,3 +2557,121 @@ async def test_entities_with_duplicate_names_not_removed_on_reconnect(
     device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF
+
+
+async def test_entities_with_same_name_moved_between_devices(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test same named entities moving between devices at the same time.
+
+    The name is ambiguous so the moves are resolved by the key, which
+    migrates each entity to its own new device.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+        SubDeviceInfo(device_id=33333333, name="sub_three", area_id=0),
+        SubDeviceInfo(device_id=44444444, name="sub_four", area_id=0),
+        SubDeviceInfo(device_id=55555555, name="sub_five", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=2,
+            name="Battery",
+            device_id=22222222,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=5,
+            name="Battery",
+            device_id=55555555,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
+        BinarySensorState(key=2, state=True, missing_state=False, device_id=22222222),
+        BinarySensorState(key=5, state=True, missing_state=False, device_id=55555555),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert entry_one is not None
+    assert entry_two is not None
+    assert entity_registry.async_get("binary_sensor.sub_five_battery") is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.sub_one_battery")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.sub_two_battery")
+    actions_five = track_entity_registry_actions(hass, "binary_sensor.sub_five_battery")
+
+    # Two of the same named entities move to new sub devices with
+    # stable keys while the third is removed
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=33333333,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=2,
+            name="Battery",
+            device_id=44444444,
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    new_entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert "remove" not in actions_one
+    assert "remove" not in actions_two
+    assert entity_registry.async_get("binary_sensor.sub_five_battery") is None
+    assert actions_five == ["remove"]
+
+    mac = device.device_info.mac_address
+    sub_three = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mac}_33333333"), device.entry.entry_id
+    )
+    sub_four = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mac}_44444444"), device.entry.entry_id
+    )
+    assert sub_three is not None
+    assert sub_four is not None
+    assert new_entry_one.device_id == sub_three.id
+    assert new_entry_two.device_id == sub_four.id
+
+    # Each entity must follow its key on the new device
+    device.set_state(
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=33333333)
+    )
+    device.set_state(
+        BinarySensorState(key=2, state=True, missing_state=False, device_id=44444444)
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.sub_one_battery").state == STATE_OFF
+    assert hass.states.get("binary_sensor.sub_two_battery").state == STATE_ON

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3306,6 +3306,8 @@ async def test_entity_move_with_claimed_unique_id(
         states=states,
     )
     assert hass.states.get("binary_sensor.test_foo").state == STATE_ON
+    entry_foo = entity_registry.async_get("binary_sensor.test_foo")
+    assert entry_foo is not None
 
     # An orphaned registry entry already claims Foo's post move unique_id
     moved_info = BinarySensorInfo(
@@ -3343,7 +3345,15 @@ async def test_entity_move_with_claimed_unique_id(
 
     # The update completed: the sibling still processes states
     assert hass.states.get("binary_sensor.test_other").state == STATE_OFF
+    # The blocked migration leaves the original entry untouched; the
+    # moved entity binds to the orphan
+    original = entity_registry.async_get("binary_sensor.test_foo")
+    assert original is not None
+    assert original.unique_id == entry_foo.unique_id
+    assert original.device_id == entry_foo.device_id
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_UNAVAILABLE
     assert entity_registry.async_get(orphan.entity_id) is not None
+    assert hass.states.get(orphan.entity_id).state == STATE_ON
 
 
 async def test_mover_does_not_adopt_other_movers_state(

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2607,3 +2607,71 @@ async def test_entities_with_same_name_moved_between_devices(
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.sub_one_battery").state == STATE_OFF
     assert hass.states.get("binary_sensor.sub_two_battery").state == STATE_ON
+
+
+async def test_entity_rekeyed_while_old_key_reused_by_renamed_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a re-key where the freed key is reused by a renamed entity.
+
+    The renamed entity arrives first in the info list and matches
+    Sensor Two's old key, but Sensor Two's identity is claimed by a
+    later info, so the in place key match must not consume it.
+    """
+    entity_info, states = _two_binary_sensor_setup()
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    # Sensor Two is re-keyed 2 to 1 while a renamed entity takes over
+    # key 2; the renamed entity is listed first
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_renamed",
+            key=2,
+            name="Sensor Renamed",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=1,
+            name="Sensor Two",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert new_entry_two is not None
+    assert new_entry_two.id == entry_two.id
+    assert new_entry_two.unique_id == entry_two.unique_id
+    assert actions_two == []
+
+    # Sensor One is gone and the renamed entity is brand new
+    assert entity_registry.async_get("binary_sensor.test_sensor_one") is None
+    assert actions_one == ["remove"]
+    entry_renamed = entity_registry.async_get("binary_sensor.test_sensor_renamed")
+    assert entry_renamed is not None
+    assert entry_renamed.id != entry_one.id
+
+    # Each entity must follow its own key with its own identity
+    device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
+    device.set_state(BinarySensorState(key=2, state=True, missing_state=False))
+    await hass.async_block_till_done()
+    state_two = hass.states.get("binary_sensor.test_sensor_two")
+    state_renamed = hass.states.get("binary_sensor.test_sensor_renamed")
+    assert state_two.state == STATE_OFF
+    assert state_two.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor Two"
+    assert state_renamed.state == STATE_ON

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -10,6 +10,7 @@ from aioesphomeapi import (
     BinarySensorInfo,
     BinarySensorState,
     DeviceInfo,
+    EntityInfo,
     SensorInfo,
     SensorState,
     SubDeviceInfo,
@@ -20,6 +21,7 @@ import pytest
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_RESTORED,
     EVENT_HOMEASSISTANT_STOP,
     STATE_OFF,
@@ -29,13 +31,46 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    async_track_entity_registry_updated_event,
+    async_track_state_change_event,
+)
 
 from .conftest import (
     MockESPHomeDevice,
     MockESPHomeDeviceType,
     MockGenericDeviceEntryType,
 )
+
+
+def track_entity_registry_actions(hass: HomeAssistant, entity_id: str) -> list[str]:
+    """Track entity registry actions for an entity."""
+    events: list[str] = []
+
+    @callback
+    def add_event(event: Event[er.EventEntityRegistryUpdatedData]) -> None:
+        """Add entity registry updated event to the list."""
+        events.append(event.data["action"])
+
+    async_track_entity_registry_updated_event(hass, entity_id, add_event)
+
+    return events
+
+
+async def _reconnect_with_updated_entity_info(
+    hass: HomeAssistant,
+    device: MockESPHomeDevice,
+    mock_client: APIClient,
+    entity_info: list[EntityInfo],
+) -> None:
+    """Reconnect the mock device with updated entity info."""
+    mock_client.list_entities_services = AsyncMock(return_value=(entity_info, []))
+    mock_client.device_info_and_list_entities = AsyncMock(
+        return_value=(device.device_info, entity_info, [])
+    )
+    await device.mock_disconnect(expected_disconnect=False)
+    await device.mock_connect()
+    await hass.async_block_till_done()
 
 
 async def test_entities_removed(
@@ -1742,3 +1777,585 @@ async def test_entity_without_name_uses_device_name_only(
     state = hass.states.get(expected_entity_id)
     assert state is not None, f"Entity {expected_entity_id} should exist"
     assert state.state == STATE_ON
+
+
+async def test_entities_rekeyed_after_firmware_update(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test entities survive the key changing when the name stays the same.
+
+    The API key is only stable for a session; a firmware update may
+    re-derive every key. The registry entries must be preserved so
+    helpers pointing at the entities are not deleted.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_ON
+    assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_ON
+
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    # Firmware update re-derives every key, names unchanged
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=102,
+            name="Sensor Two",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert new_entry_one.unique_id == entry_one.unique_id
+    assert new_entry_two.unique_id == entry_two.unique_id
+    assert actions_one == []
+    assert actions_two == []
+
+    # State updates must follow the new key
+    device.set_state(BinarySensorState(key=101, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_OFF
+
+    # The old key must be ignored
+    device.set_state(BinarySensorState(key=1, state=True, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_OFF
+
+    # Reconnect again with stable keys, static info updates must
+    # reach the entity under the new key
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+            icon="mdi:motion-sensor",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=102,
+            name="Sensor Two",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    device.set_state(BinarySensorState(key=101, state=True, missing_state=False))
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_sensor_one")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_ICON] == "mdi:motion-sensor"
+    assert actions_one == []
+    assert actions_two == []
+
+
+async def test_entities_rekeyed_after_reload(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test entities restored from storage survive a key change on connect.
+
+    Covers the path where entities are created from stored static infos
+    with the old keys and the first connect delivers the new keys.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry = device.entry
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=102,
+            name="Sensor Two",
+        ),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=updated_entity_info,
+        entry=entry,
+    )
+    await hass.async_block_till_done()
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert "remove" not in actions_one
+    assert "remove" not in actions_two
+
+    device.set_state(BinarySensorState(key=101, state=True, missing_state=False))
+    device.set_state(BinarySensorState(key=102, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_ON
+    assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_OFF
+
+
+async def test_entity_rekeyed_and_another_removed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a key change combined with a genuine entity removal."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert entry_one is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    # Sensor One is re-keyed, Sensor Two is gone from the config
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert new_entry_one is not None
+    assert new_entry_one.id == entry_one.id
+    assert actions_one == []
+
+    assert entity_registry.async_get("binary_sensor.test_sensor_two") is None
+    assert actions_two == ["remove"]
+
+
+async def test_entity_rekeyed_to_another_entities_old_key(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a re-key that collides with an unrelated entity's old key.
+
+    Sensor One takes over the key that used to belong to Sensor Two,
+    which is removed at the same time. The unique_id match must win so
+    the entities do not swap identities.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert entry_one is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=2,
+            name="Sensor One",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert new_entry_one is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_one.unique_id == entry_one.unique_id
+    assert actions_one == []
+
+    assert entity_registry.async_get("binary_sensor.test_sensor_two") is None
+    assert actions_two == ["remove"]
+
+    # Sensor One must follow its new key and keep its own identity
+    device.set_state(BinarySensorState(key=2, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_sensor_one")
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor One"
+
+
+async def test_entity_renamed_with_stable_key(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a rename on firmware where the key is not name derived.
+
+    The key stays the same so the entity is updated in place without
+    touching the registry.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert entry_one is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One Renamed",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert new_entry_one is not None
+    assert new_entry_one.id == entry_one.id
+    assert "remove" not in actions_one
+
+    device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_sensor_one")
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor One Renamed"
+
+
+async def test_entity_renamed_and_rekeyed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a rename on firmware where the key is derived from the name.
+
+    Both the name and the key change so this is treated as a new entity.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert entity_registry.async_get("binary_sensor.test_sensor_one") is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one_renamed",
+            key=101,
+            name="Sensor One Renamed",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    assert entity_registry.async_get("binary_sensor.test_sensor_one") is None
+    assert actions_one == ["remove"]
+    assert (
+        entity_registry.async_get("binary_sensor.test_sensor_one_renamed") is not None
+    )
+
+    device.set_state(BinarySensorState(key=101, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_sensor_one_renamed").state == STATE_OFF
+
+
+async def test_entities_rekeyed_on_sub_devices_with_same_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test re-keying entities with the same name on different sub devices."""
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=2,
+            name="Battery",
+            device_id=22222222,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
+        BinarySensorState(key=2, state=True, missing_state=False, device_id=22222222),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.sub_one_battery")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.sub_two_battery")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=101,
+            name="Battery",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=102,
+            name="Battery",
+            device_id=22222222,
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.sub_one_battery")
+    new_entry_two = entity_registry.async_get("binary_sensor.sub_two_battery")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert actions_one == []
+    assert actions_two == []
+
+    # Each entity must follow its own new key
+    device.set_state(
+        BinarySensorState(key=101, state=False, missing_state=False, device_id=11111111)
+    )
+    device.set_state(
+        BinarySensorState(key=102, state=True, missing_state=False, device_id=22222222)
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.sub_one_battery").state == STATE_OFF
+    assert hass.states.get("binary_sensor.sub_two_battery").state == STATE_ON
+
+
+async def test_entities_swap_keys(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test two entities swapping keys in the same update.
+
+    Keys are not collision safe; a firmware update may hand one
+    entity's old key to another entity. Each entity must follow its
+    own unique_id and never adopt the other's identity.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert entry_one is not None
+    assert entry_two is not None
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+    actions_two = track_entity_registry_actions(hass, "binary_sensor.test_sensor_two")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=2,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=1,
+            name="Sensor Two",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    new_entry_two = entity_registry.async_get("binary_sensor.test_sensor_two")
+    assert new_entry_one is not None
+    assert new_entry_two is not None
+    assert new_entry_one.id == entry_one.id
+    assert new_entry_two.id == entry_two.id
+    assert new_entry_one.unique_id == entry_one.unique_id
+    assert new_entry_two.unique_id == entry_two.unique_id
+    assert actions_one == []
+    assert actions_two == []
+
+    # Each entity must follow its swapped key with its own identity
+    device.set_state(BinarySensorState(key=2, state=False, missing_state=False))
+    device.set_state(BinarySensorState(key=1, state=True, missing_state=False))
+    await hass.async_block_till_done()
+    state_one = hass.states.get("binary_sensor.test_sensor_one")
+    state_two = hass.states.get("binary_sensor.test_sensor_two")
+    assert state_one.state == STATE_OFF
+    assert state_two.state == STATE_ON
+    assert state_one.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor One"
+    assert state_two.attributes[ATTR_FRIENDLY_NAME] == "Test Sensor Two"

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -1893,7 +1893,6 @@ async def test_entities_rekeyed_after_reload(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_client: APIClient,
-    hass_storage: dict[str, Any],
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test entities restored from storage survive a key change on connect.
@@ -2364,13 +2363,14 @@ async def test_entities_swap_keys(
 async def test_entity_rekeyed_and_moved_between_devices(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test an entity changing key and device in the same update.
 
-    Neither the unique_id nor the key matches, so this is treated as a
-    remove and add; a device move changes the unique_id anyway.
+    The name is the device independent identity, so the entity is
+    migrated to the new device instead of being removed and recreated.
     """
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
@@ -2394,7 +2394,8 @@ async def test_entity_rekeyed_and_moved_between_devices(
         entity_info=entity_info,
         states=states,
     )
-    assert entity_registry.async_get("binary_sensor.test_sensor_one") is not None
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert entry_one is not None
 
     actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
 
@@ -2410,13 +2411,144 @@ async def test_entity_rekeyed_and_moved_between_devices(
         hass, device, mock_client, updated_entity_info
     )
 
-    assert entity_registry.async_get("binary_sensor.test_sensor_one") is None
-    assert actions_one == ["remove"]
-    new_entry = entity_registry.async_get("binary_sensor.sub_one_sensor_one")
+    new_entry = entity_registry.async_get("binary_sensor.test_sensor_one")
     assert new_entry is not None
+    assert new_entry.id == entry_one.id
+    assert "remove" not in actions_one
+
+    sub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
+    )
+    assert sub_device is not None
+    assert new_entry.device_id == sub_device.id
 
     device.set_state(
         BinarySensorState(key=101, state=False, missing_state=False, device_id=11111111)
     )
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.sub_one_sensor_one").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_OFF
+
+
+async def test_entity_new_key_reuses_removed_entity_key_on_other_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a new entity reusing a removed entity's key on another device.
+
+    The names differ, so the new entity must not steal the removed
+    entity's registry entry through the cross device key match.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_two",
+            key=2,
+            name="Sensor Two",
+            device_id=11111111,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False, device_id=11111111),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_two = entity_registry.async_get("binary_sensor.sub_one_sensor_two")
+    assert entry_two is not None
+
+    actions_two = track_entity_registry_actions(
+        hass, "binary_sensor.sub_one_sensor_two"
+    )
+
+    # Sensor Two is removed while a new Sensor Three on the main
+    # device reuses its key
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+        ),
+        BinarySensorInfo(
+            object_id="sensor_three",
+            key=2,
+            name="Sensor Three",
+        ),
+    ]
+    await _reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
+    )
+
+    assert entity_registry.async_get("binary_sensor.sub_one_sensor_two") is None
+    assert actions_two == ["remove"]
+    entry_three = entity_registry.async_get("binary_sensor.test_sensor_three")
+    assert entry_three is not None
+    assert entry_three.id != entry_two.id
+
+    device.set_state(BinarySensorState(key=2, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_sensor_three").state == STATE_OFF
+
+
+async def test_entities_with_duplicate_names_not_removed_on_reconnect(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test two entities with the same name are stable across a reconnect.
+
+    Duplicate names produce duplicate unique_ids, which is already a
+    broken configuration, but they must not be matched by identity or
+    the shared registry entry would be removed on every reconnect.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=1,
+            name="Duplicate",
+        ),
+        BinarySensorInfo(
+            object_id="duplicate",
+            key=2,
+            name="Duplicate",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry = entity_registry.async_get("binary_sensor.test_duplicate")
+    assert entry is not None
+
+    actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
+
+    await _reconnect_with_updated_entity_info(hass, device, mock_client, entity_info)
+
+    new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
+    assert new_entry is not None
+    assert new_entry.id == entry.id
+    assert actions == []
+
+    device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3273,9 +3273,9 @@ async def test_entity_move_with_claimed_unique_id(
 ) -> None:
     """Test a device move whose target unique_id is already claimed.
 
-    A stale orphan claiming the target unique_id is removed so the
-    moved entity keeps its identity, and the rest of the entities are
-    still processed.
+    An orphaned registry entry holding the target unique_id must not
+    abort the update; the move keeps its old unique_id and the rest of
+    the entities are still processed.
     """
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
@@ -3343,14 +3343,7 @@ async def test_entity_move_with_claimed_unique_id(
 
     # The update completed: the sibling still processes states
     assert hass.states.get("binary_sensor.test_other").state == STATE_OFF
-    # The orphan was removed and the moved entity kept its identity
-    # with the new unique_id
-    assert entity_registry.async_get(orphan.entity_id) is None
-    moved_entry = entity_registry.async_get("binary_sensor.test_foo")
-    assert moved_entry is not None
-    assert moved_entry.unique_id == build_device_unique_id(
-        device.device_info.mac_address, moved_info
-    )
+    assert entity_registry.async_get(orphan.entity_id) is not None
 
 
 async def test_mover_does_not_adopt_other_movers_state(
@@ -3403,65 +3396,3 @@ async def test_mover_does_not_adopt_other_movers_state(
 
     assert hass.states.get("binary_sensor.test_sensor_one").state == STATE_UNKNOWN
     assert hass.states.get("binary_sensor.test_sensor_two").state == STATE_UNKNOWN
-
-
-async def test_entity_move_with_disabled_claimant(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_client: APIClient,
-    mock_esphome_device: MockESPHomeDeviceType,
-) -> None:
-    """Test a device move whose target unique_id is claimed by a disabled entry.
-
-    The disabled entry is kept so the disable preference survives; the
-    moved entity binds to it and stays disabled.
-    """
-    sub_devices = [
-        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
-    ]
-    device_info = {
-        "devices": sub_devices,
-    }
-    entity_info = [
-        BinarySensorInfo(
-            object_id="foo",
-            key=1,
-            name="Foo",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-    ]
-    device = await mock_esphome_device(
-        mock_client=mock_client,
-        device_info=device_info,
-        entity_info=entity_info,
-        states=states,
-    )
-    assert hass.states.get("binary_sensor.test_foo").state == STATE_ON
-
-    # A disabled registry entry claims Foo's post move unique_id
-    moved_info = BinarySensorInfo(
-        object_id="foo",
-        key=1,
-        name="Foo",
-        device_id=11111111,
-    )
-    claimant = entity_registry.async_get_or_create(
-        "binary_sensor",
-        DOMAIN,
-        build_device_unique_id(device.device_info.mac_address, moved_info),
-        config_entry=device.entry,
-    )
-    entity_registry.async_update_entity(
-        claimant.entity_id, disabled_by=er.RegistryEntryDisabler.USER
-    )
-
-    await reconnect_with_updated_entity_info(hass, device, [moved_info], states=[])
-
-    # The disabled claimant survives with its disable preference and
-    # the moved entity is not added
-    kept = entity_registry.async_get(claimant.entity_id)
-    assert kept is not None
-    assert kept.disabled_by is er.RegistryEntryDisabler.USER
-    assert hass.states.get("binary_sensor.test_foo").state == STATE_UNAVAILABLE

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2927,3 +2927,103 @@ async def test_disabled_entity_rekeyed(
     assert new_entry_one is not None
     assert new_entry_one.id == entry_one.id
     assert actions_one == []
+
+
+async def test_entity_renamed_while_same_named_sibling_moves(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a stable key rename while a same named sibling moves devices.
+
+    The mover must claim the sibling on sub_one, not the rename
+    candidate on the main device, and both registry entries must be
+    preserved.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="sub_two", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=11111111,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_main = entity_registry.async_get("binary_sensor.test_battery")
+    entry_sub = entity_registry.async_get("binary_sensor.sub_one_battery")
+    assert entry_main is not None
+    assert entry_sub is not None
+
+    actions_main = track_entity_registry_actions(hass, "binary_sensor.test_battery")
+    actions_sub = track_entity_registry_actions(hass, "binary_sensor.sub_one_battery")
+
+    # Case only rename on the main device while the sub_one sibling
+    # moves to sub_two; the renamed entity is listed first
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="BATTERY",
+        ),
+        BinarySensorInfo(
+            object_id="battery",
+            key=1,
+            name="Battery",
+            device_id=22222222,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    new_entry_main = entity_registry.async_get("binary_sensor.test_battery")
+    new_entry_sub = entity_registry.async_get("binary_sensor.sub_one_battery")
+    assert new_entry_main is not None
+    assert new_entry_sub is not None
+    assert new_entry_main.id == entry_main.id
+    assert new_entry_sub.id == entry_sub.id
+    assert "remove" not in actions_main
+    assert "remove" not in actions_sub
+
+    # The rename followed the new unique_id and stayed on the main device
+    assert new_entry_main.unique_id == build_device_unique_id(
+        device.device_info.mac_address, updated_entity_info[0]
+    )
+    # The sibling migrated to sub_two
+    sub_two = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
+    )
+    assert sub_two is not None
+    assert new_entry_sub.device_id == sub_two.id
+
+    device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
+    device.set_state(
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=22222222)
+    )
+    await hass.async_block_till_done()
+    state_main = hass.states.get("binary_sensor.test_battery")
+    state_sub = hass.states.get("binary_sensor.sub_one_battery")
+    assert state_main.state == STATE_OFF
+    assert state_main.attributes[ATTR_FRIENDLY_NAME] == "Test BATTERY"
+    assert state_sub.state == STATE_ON

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3205,3 +3205,143 @@ async def test_unnamed_entities_do_not_pair_across_devices(
     entry_sub = entity_registry.async_get("binary_sensor.sub_one")
     assert entry_sub is not None
     assert entry_sub.id != entry_main.id
+
+
+async def test_moved_entity_does_not_adopt_removed_entities_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a mover landing on a removed entity's key starts unknown.
+
+    The removed entity's cached state sits under the mover's new key
+    and must be dropped, or the re-added mover would adopt it.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="foo",
+            key=5,
+            name="Foo",
+        ),
+        BinarySensorInfo(
+            object_id="bar",
+            key=9,
+            name="Bar",
+            device_id=11111111,
+        ),
+    ]
+    states = [
+        BinarySensorState(key=5, state=True, missing_state=False),
+        BinarySensorState(key=9, state=False, missing_state=False, device_id=11111111),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_ON
+    assert hass.states.get("binary_sensor.sub_one_bar").state == STATE_OFF
+
+    # Foo is removed while Bar moves to the main device and a firmware
+    # rebuild hands it Foo's old key; no states are streamed
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="bar",
+            key=5,
+            name="Bar",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, updated_entity_info, states=[]
+    )
+
+    assert hass.states.get("binary_sensor.test_foo") is None
+    assert hass.states.get("binary_sensor.sub_one_bar").state == STATE_UNKNOWN
+
+
+async def test_entity_move_with_claimed_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a device move whose target unique_id is already claimed.
+
+    An orphaned registry entry holding the target unique_id must not
+    abort the update; the move keeps its old unique_id and the rest of
+    the entities are still processed.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="foo",
+            key=1,
+            name="Foo",
+        ),
+        BinarySensorInfo(
+            object_id="other",
+            key=2,
+            name="Other",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_foo").state == STATE_ON
+
+    # An orphaned registry entry already claims Foo's post move unique_id
+    moved_info = BinarySensorInfo(
+        object_id="foo",
+        key=1,
+        name="Foo",
+        device_id=11111111,
+    )
+    orphan = entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        build_device_unique_id(device.device_info.mac_address, moved_info),
+        config_entry=device.entry,
+    )
+
+    updated_entity_info = [
+        moved_info,
+        BinarySensorInfo(
+            object_id="other",
+            key=2,
+            name="Other",
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass,
+        device,
+        updated_entity_info,
+        states=[
+            BinarySensorState(
+                key=1, state=True, missing_state=False, device_id=11111111
+            ),
+            BinarySensorState(key=2, state=False, missing_state=False),
+        ],
+    )
+
+    # The update completed: the sibling still processes states
+    assert hass.states.get("binary_sensor.test_other").state == STATE_OFF
+    assert entity_registry.async_get(orphan.entity_id) is not None

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import asdict
+import logging
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -2877,3 +2878,52 @@ async def test_entity_renamed_with_stable_key_and_same_named_sibling(
     state = hass.states.get("binary_sensor.sub_one_battery")
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "sub_one BATTERY"
+
+
+async def test_disabled_entity_rekeyed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a key change for a disabled entity.
+
+    A disabled entity has no live object and no key subscriptions, so
+    the key change has no subscriber; the registry entry must still be
+    preserved.
+    """
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=1,
+            name="Sensor One",
+            disabled_by_default=True,
+        ),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+    )
+    entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert entry_one is not None
+    assert entry_one.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    actions_one = track_entity_registry_actions(hass, "binary_sensor.test_sensor_one")
+
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sensor_one",
+            key=101,
+            name="Sensor One",
+            disabled_by_default=True,
+        ),
+    ]
+    with caplog.at_level(logging.DEBUG, "homeassistant.components.esphome"):
+        await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+
+    assert "no subscriber for key change 1 -> 101" in caplog.text
+    new_entry_one = entity_registry.async_get("binary_sensor.test_sensor_one")
+    assert new_entry_one is not None
+    assert new_entry_one.id == entry_one.id
+    assert actions_one == []

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -2159,14 +2159,14 @@ async def test_entities_rekeyed_on_sub_devices_with_same_name(
         ),
         BinarySensorInfo(
             object_id="battery",
-            key=2,
+            key=1,
             name="Battery",
             device_id=22222222,
         ),
     ]
     states = [
         BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
-        BinarySensorState(key=2, state=True, missing_state=False, device_id=22222222),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=22222222),
     ]
     device = await mock_esphome_device(
         mock_client=mock_client,
@@ -2191,7 +2191,7 @@ async def test_entities_rekeyed_on_sub_devices_with_same_name(
         ),
         BinarySensorInfo(
             object_id="battery",
-            key=102,
+            key=101,
             name="Battery",
             device_id=22222222,
         ),
@@ -2207,12 +2207,12 @@ async def test_entities_rekeyed_on_sub_devices_with_same_name(
     assert actions_one == []
     assert actions_two == []
 
-    # Each entity must follow its own new key
+    # Each entity must follow the new key on its own device
     device.set_state(
         BinarySensorState(key=101, state=False, missing_state=False, device_id=11111111)
     )
     device.set_state(
-        BinarySensorState(key=102, state=True, missing_state=False, device_id=22222222)
+        BinarySensorState(key=101, state=True, missing_state=False, device_id=22222222)
     )
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.sub_one_battery").state == STATE_OFF
@@ -2423,60 +2423,6 @@ async def test_entity_new_key_reuses_removed_entity_key_on_other_device(
     assert hass.states.get("binary_sensor.test_sensor_three").state == STATE_OFF
 
 
-async def test_entities_with_duplicate_names_not_removed_on_reconnect(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_client: APIClient,
-    mock_esphome_device: MockESPHomeDeviceType,
-) -> None:
-    """Test two entities with the same name are stable across a reconnect.
-
-    Duplicate names produce duplicate unique_ids, which is already a
-    broken configuration, but they must not be matched by identity or
-    the shared registry entry would be removed on every reconnect.
-    """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=1,
-            name="Duplicate",
-        ),
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=2,
-            name="Duplicate",
-        ),
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=3,
-            name="Duplicate",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-    ]
-    device = await mock_esphome_device(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-    entry = entity_registry.async_get("binary_sensor.test_duplicate")
-    assert entry is not None
-
-    actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
-
-    await reconnect_with_updated_entity_info(hass, device, entity_info)
-
-    new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
-    assert new_entry is not None
-    assert new_entry.id == entry.id
-    assert actions == []
-
-    device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
-    await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF
-
-
 async def test_entities_with_same_name_moved_between_devices(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -2508,21 +2454,21 @@ async def test_entities_with_same_name_moved_between_devices(
         ),
         BinarySensorInfo(
             object_id="battery",
-            key=2,
+            key=1,
             name="Battery",
             device_id=22222222,
         ),
         BinarySensorInfo(
             object_id="battery",
-            key=5,
+            key=1,
             name="Battery",
             device_id=55555555,
         ),
     ]
     states = [
         BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
-        BinarySensorState(key=2, state=True, missing_state=False, device_id=22222222),
-        BinarySensorState(key=5, state=True, missing_state=False, device_id=55555555),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=22222222),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=55555555),
     ]
     device = await mock_esphome_device(
         mock_client=mock_client,
@@ -2551,7 +2497,7 @@ async def test_entities_with_same_name_moved_between_devices(
         ),
         BinarySensorInfo(
             object_id="battery",
-            key=2,
+            key=1,
             name="Battery",
             device_id=44444444,
         ),
@@ -2581,12 +2527,12 @@ async def test_entities_with_same_name_moved_between_devices(
     assert new_entry_one.device_id == sub_three.id
     assert new_entry_two.device_id == sub_four.id
 
-    # Each entity must follow its key on the new device
+    # Each entity must follow the key on its new device
     device.set_state(
         BinarySensorState(key=1, state=False, missing_state=False, device_id=33333333)
     )
     device.set_state(
-        BinarySensorState(key=2, state=True, missing_state=False, device_id=44444444)
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=44444444)
     )
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.sub_one_battery").state == STATE_OFF
@@ -2745,62 +2691,6 @@ async def test_entity_moved_into_removed_entities_key_slot(
     state = hass.states.get("binary_sensor.sub_one_batt")
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_FRIENDLY_NAME] == "sub_two Batt"
-
-
-async def test_duplicate_name_entity_rekeyed_and_other_removed(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_client: APIClient,
-    mock_esphome_device: MockESPHomeDeviceType,
-) -> None:
-    """Test duplicate named entities where one is removed and one re-keyed.
-
-    Both old infos share a unique_id and one registry entry; the entry
-    is claimed by the surviving entity, so it must not be removed even
-    though both old infos are leftovers.
-    """
-    entity_info = [
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=1,
-            name="Duplicate",
-        ),
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=2,
-            name="Duplicate",
-        ),
-    ]
-    states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-    ]
-    device = await mock_esphome_device(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-    entry = entity_registry.async_get("binary_sensor.test_duplicate")
-    assert entry is not None
-
-    actions = track_entity_registry_actions(hass, "binary_sensor.test_duplicate")
-
-    updated_entity_info = [
-        BinarySensorInfo(
-            object_id="duplicate",
-            key=5,
-            name="Duplicate",
-        ),
-    ]
-    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
-
-    new_entry = entity_registry.async_get("binary_sensor.test_duplicate")
-    assert new_entry is not None
-    assert new_entry.id == entry.id
-    assert "remove" not in actions
-
-    device.set_state(BinarySensorState(key=5, state=False, missing_state=False))
-    await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_duplicate").state == STATE_OFF
 
 
 async def test_entity_moved_while_new_entity_takes_old_slot_listed_first(

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3145,3 +3145,63 @@ async def test_new_entity_on_other_device_reusing_removed_entities_key(
 
     assert hass.states.get("binary_sensor.test_volt") is None
     assert hass.states.get("binary_sensor.sub_one_batt").state == STATE_UNKNOWN
+
+
+async def test_unnamed_entities_do_not_pair_across_devices(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test unnamed entities are not matched as moves across devices.
+
+    An unnamed entity's identity is its device derived object_id, so a
+    removed unnamed entity must not hand its registry entry to an
+    unrelated unnamed entity appearing on another device.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="test",
+            key=1,
+            name="",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    entry_main = entity_registry.async_get("binary_sensor.test")
+    assert entry_main is not None
+
+    actions_main = track_entity_registry_actions(hass, "binary_sensor.test")
+
+    # The main device's unnamed entity is removed while an unrelated
+    # unnamed entity appears on sub_one
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="sub_one",
+            key=2,
+            name="",
+            device_id=11111111,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, updated_entity_info, states=[]
+    )
+
+    assert entity_registry.async_get("binary_sensor.test") is None
+    assert actions_main == ["remove"]
+    entry_sub = entity_registry.async_get("binary_sensor.sub_one")
+    assert entry_sub is not None
+    assert entry_sub.id != entry_main.id

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -3092,3 +3092,56 @@ async def test_new_entities_reusing_retired_keys_do_not_adopt_stale_states(
 
     assert hass.states.get("binary_sensor.test_sensor_three").state == STATE_UNKNOWN
     assert hass.states.get("binary_sensor.test_sensor_four").state == STATE_UNKNOWN
+
+
+async def test_new_entity_on_other_device_reusing_removed_entities_key(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a new entity on another device reusing a removed entity's key.
+
+    The key stays live on the other device, so the removed entity's
+    cached state must be dropped by slot, not by key, or the new
+    entity would adopt it.
+    """
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="sub_one", area_id=0),
+    ]
+    device_info = {
+        "devices": sub_devices,
+    }
+    entity_info = [
+        BinarySensorInfo(
+            object_id="volt",
+            key=2,
+            name="Volt",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("binary_sensor.test_volt").state == STATE_ON
+
+    # Volt is removed while a new Batt on sub_one reuses key 2;
+    # no state is streamed for Batt
+    updated_entity_info = [
+        BinarySensorInfo(
+            object_id="batt",
+            key=2,
+            name="Batt",
+            device_id=11111111,
+        ),
+    ]
+    await reconnect_with_updated_entity_info(
+        hass, device, updated_entity_info, states=[]
+    )
+
+    assert hass.states.get("binary_sensor.test_volt") is None
+    assert hass.states.get("binary_sensor.sub_one_batt").state == STATE_UNKNOWN

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -11,6 +11,7 @@ from aioesphomeapi import (
     MediaPlayerState,
     MediaPlayerSupportedFormat,
     UserService,
+    build_device_unique_id,
 )
 import pytest
 
@@ -38,7 +39,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import MockESPHomeDeviceType, MockGenericDeviceEntryType
@@ -667,3 +668,109 @@ async def test_media_player_formats_reload_preserves_data(
         ".wav" in call_args.kwargs["media_url"]
     )  # Should use wav format for announcement
     assert call_args.kwargs["announcement"] is True
+
+
+async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test formats survive an entity taking over a removed entity's key.
+
+    The removed media player briefly receives the surviving entity's
+    info through the shared key before its teardown runs, so its
+    cleanup must not delete the surviving entity's formats.
+    """
+    formats_one = [
+        MediaPlayerSupportedFormat(
+            format="mp3",
+            sample_rate=48000,
+            num_channels=2,
+            purpose=MediaPlayerFormatPurpose.DEFAULT,
+        ),
+    ]
+    formats_two = [
+        MediaPlayerSupportedFormat(
+            format="wav",
+            sample_rate=16000,
+            num_channels=1,
+            purpose=MediaPlayerFormatPurpose.ANNOUNCEMENT,
+            sample_bytes=2,
+        ),
+    ]
+    entity_info = [
+        MediaPlayerInfo(
+            object_id="player_one",
+            key=1,
+            name="Player One",
+            supports_pause=True,
+            supported_formats=formats_one,
+        ),
+        MediaPlayerInfo(
+            object_id="player_two",
+            key=2,
+            name="Player Two",
+            supports_pause=True,
+            supported_formats=formats_two,
+        ),
+    ]
+    states = [
+        MediaPlayerEntityState(
+            key=1, volume=50, muted=False, state=MediaPlayerState.IDLE
+        ),
+        MediaPlayerEntityState(
+            key=2, volume=50, muted=False, state=MediaPlayerState.IDLE
+        ),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    await hass.async_block_till_done()
+
+    entry_data = device.entry.runtime_data
+    mac = device.device_info.mac_address
+    unique_id_one = build_device_unique_id(mac, entity_info[0])
+    unique_id_two = build_device_unique_id(mac, entity_info[1])
+    assert entry_data.media_player_formats == {
+        unique_id_one: formats_one,
+        unique_id_two: formats_two,
+    }
+
+    # Player One takes over Player Two's key, Player Two is removed
+    updated_entity_info = [
+        MediaPlayerInfo(
+            object_id="player_one",
+            key=2,
+            name="Player One",
+            supports_pause=True,
+            supported_formats=formats_one,
+        ),
+    ]
+    mock_client.list_entities_services = AsyncMock(
+        return_value=(updated_entity_info, [])
+    )
+    mock_client.device_info_and_list_entities = AsyncMock(
+        return_value=(device.device_info, updated_entity_info, [])
+    )
+    await device.mock_disconnect(expected_disconnect=False)
+    await device.mock_connect()
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            MEDIA_PLAYER_DOMAIN, "esphome", unique_id_one
+        )
+        is not None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            MEDIA_PLAYER_DOMAIN, "esphome", unique_id_two
+        )
+        is None
+    )
+    # The surviving entity's formats must not have been removed by the
+    # removed entity's cleanup
+    assert entry_data.media_player_formats == {unique_id_one: formats_one}

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -793,3 +793,112 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
     mock_client.media_player_command.assert_called_once()
     call_args = mock_client.media_player_command.call_args
     assert "/api/esphome/ffmpeg_proxy/" in call_args.kwargs["media_url"]
+
+
+async def test_media_player_formats_not_shared_with_sibling_taking_old_name(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test formats are not shared with a player adopting this one's old name.
+
+    After a stable key rename the old name based unique_id is free; a
+    new player claiming it must keep its own formats entry, or its
+    formats would replace the renamed player's.
+    """
+    default_formats = [
+        MediaPlayerSupportedFormat(
+            format="mp3",
+            sample_rate=48000,
+            num_channels=2,
+            purpose=MediaPlayerFormatPurpose.DEFAULT,
+        ),
+    ]
+    announcement_formats = [
+        MediaPlayerSupportedFormat(
+            format="wav",
+            sample_rate=16000,
+            num_channels=1,
+            purpose=MediaPlayerFormatPurpose.ANNOUNCEMENT,
+            sample_bytes=2,
+        ),
+    ]
+    entity_info = [
+        MediaPlayerInfo(
+            object_id="p_one",
+            key=1,
+            name="Alpha",
+            supports_pause=True,
+            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+            feature_flags=1200653,
+            supported_formats=default_formats,
+        ),
+    ]
+    states = [
+        MediaPlayerEntityState(
+            key=1, volume=50, muted=False, state=MediaPlayerState.IDLE
+        ),
+    ]
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    assert hass.states.get("media_player.test_alpha") is not None
+
+    # Rename with a stable key, then a new player with announcement
+    # only formats claims the old name
+    renamed = MediaPlayerInfo(
+        object_id="p_one",
+        key=1,
+        name="Beta",
+        supports_pause=True,
+        feature_flags=1200653,
+        supported_formats=default_formats,
+    )
+    new_player = MediaPlayerInfo(
+        object_id="alpha",
+        key=2,
+        name="Alpha",
+        supports_pause=True,
+        feature_flags=1200653,
+        supported_formats=announcement_formats,
+    )
+    await reconnect_with_updated_entity_info(hass, device, [renamed])
+    await reconnect_with_updated_entity_info(hass, device, [renamed, new_player])
+    assert hass.states.get("media_player.test_alpha_2") is not None
+
+    # The renamed player must still use its own default format proxy,
+    # not the new player's announcement only formats
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: "media_player.test_alpha",
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://127.0.0.1/test.mp3",
+        },
+        blocking=True,
+    )
+    mock_client.media_player_command.assert_called_once()
+    call_args = mock_client.media_player_command.call_args
+    assert "/api/esphome/ffmpeg_proxy/" in call_args.kwargs["media_url"]
+    assert ".mp3" in call_args.kwargs["media_url"]
+    mock_client.media_player_command.reset_mock()
+
+    # The new player has no default format, so it must not proxy; a
+    # shared formats entry would hand it the renamed player's mp3
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: "media_player.test_alpha_2",
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://127.0.0.1/test.mp3",
+        },
+        blocking=True,
+    )
+    mock_client.media_player_command.assert_called_once()
+    call_args = mock_client.media_player_command.call_args
+    assert call_args.kwargs["media_url"] == "http://127.0.0.1/test.mp3"

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -709,6 +709,9 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             key=1,
             name="Player One",
             supports_pause=True,
+            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+            feature_flags=1200653,
             supported_formats=formats_one,
         ),
         MediaPlayerInfo(
@@ -734,14 +737,9 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
     )
     await hass.async_block_till_done()
 
-    entry_data = device.entry.runtime_data
     mac = device.device_info.mac_address
     unique_id_one = build_device_unique_id(mac, entity_info[0])
     unique_id_two = build_device_unique_id(mac, entity_info[1])
-    assert entry_data.media_player_formats == {
-        unique_id_one: formats_one,
-        unique_id_two: formats_two,
-    }
 
     # Player One takes over Player Two's key, Player Two is removed
     updated_entity_info = [
@@ -750,10 +748,22 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             key=2,
             name="Player One",
             supports_pause=True,
+            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+            feature_flags=1200653,
             supported_formats=formats_one,
         ),
     ]
-    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
+    await reconnect_with_updated_entity_info(
+        hass,
+        device,
+        updated_entity_info,
+        states=[
+            MediaPlayerEntityState(
+                key=2, volume=50, muted=False, state=MediaPlayerState.IDLE
+            )
+        ],
+    )
 
     assert (
         entity_registry.async_get_entity_id(
@@ -767,6 +777,19 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
         )
         is None
     )
+
     # The surviving entity's formats must not have been removed by the
-    # removed entity's cleanup
-    assert entry_data.media_player_formats == {unique_id_one: formats_one}
+    # removed entity's cleanup: playing media must still use the proxy
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: "media_player.test_player_one",
+            ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            ATTR_MEDIA_CONTENT_ID: "http://127.0.0.1/test.mp3",
+        },
+        blocking=True,
+    )
+    mock_client.media_player_command.assert_called_once()
+    call_args = mock_client.media_player_command.call_args
+    assert "/api/esphome/ffmpeg_proxy/" in call_args.kwargs["media_url"]

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -753,9 +753,7 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             supported_formats=formats_one,
         ),
     ]
-    await reconnect_with_updated_entity_info(
-        hass, device, mock_client, updated_entity_info
-    )
+    await reconnect_with_updated_entity_info(hass, device, updated_entity_info)
 
     assert (
         entity_registry.async_get_entity_id(

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -51,6 +51,10 @@ from .conftest import (
 from tests.common import mock_platform
 from tests.typing import WebSocketGenerator
 
+# PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+# VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+PROXY_FEATURE_FLAGS = 1200653
+
 
 async def test_media_player_entity(
     hass: HomeAssistant,
@@ -321,9 +325,7 @@ async def test_media_player_entity_with_source(
             key=1,
             name="my media_player",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-            feature_flags=1200653,
+            feature_flags=PROXY_FEATURE_FLAGS,
         )
     ]
     states = [
@@ -441,7 +443,7 @@ async def test_media_player_proxy(
                 supports_pause=True,
                 # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
                 # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-                feature_flags=1200653,
+                feature_flags=PROXY_FEATURE_FLAGS,
                 supported_formats=[
                     MediaPlayerSupportedFormat(
                         format="flac",
@@ -603,7 +605,7 @@ async def test_media_player_formats_reload_preserves_data(
                 supports_pause=True,
                 # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
                 # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-                feature_flags=1200653,
+                feature_flags=PROXY_FEATURE_FLAGS,
                 supported_formats=supported_formats,
             )
         ],
@@ -709,9 +711,7 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             key=1,
             name="Player One",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-            feature_flags=1200653,
+            feature_flags=PROXY_FEATURE_FLAGS,
             supported_formats=formats_one,
         ),
         MediaPlayerInfo(
@@ -748,9 +748,7 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             key=2,
             name="Player One",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-            feature_flags=1200653,
+            feature_flags=PROXY_FEATURE_FLAGS,
             supported_formats=formats_one,
         ),
     ]
@@ -829,9 +827,7 @@ async def test_media_player_formats_not_shared_with_sibling_taking_old_name(
             key=1,
             name="Alpha",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
-            feature_flags=1200653,
+            feature_flags=PROXY_FEATURE_FLAGS,
             supported_formats=default_formats,
         ),
     ]
@@ -854,7 +850,7 @@ async def test_media_player_formats_not_shared_with_sibling_taking_old_name(
         key=1,
         name="Beta",
         supports_pause=True,
-        feature_flags=1200653,
+        feature_flags=PROXY_FEATURE_FLAGS,
         supported_formats=default_formats,
     )
     new_player = MediaPlayerInfo(
@@ -862,7 +858,7 @@ async def test_media_player_formats_not_shared_with_sibling_taking_old_name(
         key=2,
         name="Alpha",
         supports_pause=True,
-        feature_flags=1200653,
+        feature_flags=PROXY_FEATURE_FLAGS,
         supported_formats=announcement_formats,
     )
     await reconnect_with_updated_entity_info(hass, device, [renamed])

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -441,8 +441,6 @@ async def test_media_player_proxy(
                 key=1,
                 name="my media_player",
                 supports_pause=True,
-                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-                # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
                 feature_flags=PROXY_FEATURE_FLAGS,
                 supported_formats=[
                     MediaPlayerSupportedFormat(
@@ -603,8 +601,6 @@ async def test_media_player_formats_reload_preserves_data(
                 key=1,
                 name="Test Media Player",
                 supports_pause=True,
-                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
-                # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
                 feature_flags=PROXY_FEATURE_FLAGS,
                 supported_formats=supported_formats,
             )

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -42,7 +42,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from .conftest import MockESPHomeDeviceType, MockGenericDeviceEntryType
+from .conftest import (
+    MockESPHomeDeviceType,
+    MockGenericDeviceEntryType,
+    reconnect_with_updated_entity_info,
+)
 
 from tests.common import mock_platform
 from tests.typing import WebSocketGenerator
@@ -749,15 +753,9 @@ async def test_media_player_formats_survive_rekey_onto_removed_entity_key(
             supported_formats=formats_one,
         ),
     ]
-    mock_client.list_entities_services = AsyncMock(
-        return_value=(updated_entity_info, [])
+    await reconnect_with_updated_entity_info(
+        hass, device, mock_client, updated_entity_info
     )
-    mock_client.device_info_and_list_entities = AsyncMock(
-        return_value=(device.device_info, updated_entity_info, [])
-    )
-    await device.mock_disconnect(expected_disconnect=False)
-    await device.mock_connect()
-    await hass.async_block_till_done()
 
     assert (
         entity_registry.async_get_entity_id(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The ESPHome native API entity key is only stable for a session, but the integration was using it as the long term identity. This bug forced us to revert the entity key collision fix in ESPHome (esphome/esphome#18361), since the new name derived keys changed every key on the first connect after a firmware update; once this fix ships the collision fix can land again. When esphome/esphome#17949 changed how keys are derived, every entity got a new key after a firmware update, so the integration removed every entity registry entry and recreated it. The registry removal events caused helpers such as statistics, history stats, trend and switch_as_x to delete their own config entries, which meant users lost all helpers pointing at ESPHome entities.

The long term identity is the unique_id, which is built from the mac, device id, entity type and name, so entities are now matched by unique_id first; a key change leaves the registry entry untouched and the live entity moves its subscriptions to the new key. Key change notifications are dispatched from a snapshot of the old key subscriptions taken before any entity resubscribes, so swapped or reused keys cannot deliver an info to the wrong entity. Moves between devices are matched by name, the device independent identity, so a move now survives a key change as well; moves are resolved before renames so the two can never claim each other's entity. States cached under retired keys are pruned after a key change. Renames with a stable key now also migrate the registry unique_id so the entry is not orphaned on the next restart; real removals behave the same as before. The media player now keys its cached supported formats by a stable per entity value, since the unique_id can change while an entity is pending removal and its cleanup could delete a surviving entity's formats.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: esphome/esphome#17949, sibling revert PR esphome/esphome#18361
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr








