### PR TITLE
Add battery sensor to Xiaomi Miio vacuums

### DIFF
--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -734,7 +734,7 @@ def _setup_vacuum_sensors(
     """Set up the Xiaomi vacuum sensors."""
     device = config_entry.runtime_data.device
     coordinator = config_entry.runtime_data.device_coordinator
-    # Keep battery registered even when its initial value is unavailable.
+    # Keep battery registered even when its initial value is unknown.
     entities: list[SensorEntity] = [
         XiaomiMiioVacuumBatterySensor(
             device,
@@ -879,12 +879,6 @@ class XiaomiMiioVacuumBatterySensor(
             return self.coordinator.data.status.battery
         except KeyError, TypeError, ValueError:
             return None
-
-    @property
-    @override
-    def available(self) -> bool:
-        """Return whether the sensor is available."""
-        return super().available and self.native_value is not None
 
 
 class XiaomiGenericSensor(

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -46,7 +46,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from . import VacuumCoordinatorDataAttributes
+from . import VacuumCoordinatorData, VacuumCoordinatorDataAttributes
 from .const import (
     CONF_FLOW_TYPE,
     CONF_GATEWAY,
@@ -734,7 +734,15 @@ def _setup_vacuum_sensors(
     """Set up the Xiaomi vacuum sensors."""
     device = config_entry.runtime_data.device
     coordinator = config_entry.runtime_data.device_coordinator
-    entities = []
+    # Keep battery registered even when its initial value is unavailable.
+    entities: list[SensorEntity] = [
+        XiaomiMiioVacuumBatterySensor(
+            device,
+            config_entry,
+            f"{ATTR_BATTERY}_{config_entry.unique_id}",
+            coordinator,
+        )
+    ]
 
     for sensor, description in VACUUM_SENSORS.items():
         if TYPE_CHECKING:
@@ -853,6 +861,30 @@ async def async_setup_entry(
                 )
 
     async_add_entities(entities)
+
+
+class XiaomiMiioVacuumBatterySensor(
+    XiaomiCoordinatedMiioEntity[DataUpdateCoordinator[VacuumCoordinatorData]],
+    SensorEntity,
+):
+    """Representation of a Xiaomi vacuum battery sensor."""
+
+    entity_description = SENSOR_TYPES[ATTR_BATTERY]
+
+    @property
+    @override
+    def native_value(self) -> int | None:
+        """Return the battery level."""
+        try:
+            return self.coordinator.data.status.battery
+        except KeyError, TypeError, ValueError:
+            return None
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the sensor is available."""
+        return super().available and self.native_value is not None
 
 
 class XiaomiGenericSensor(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -8,6 +8,11 @@ from unittest.mock import MagicMock, patch
 from miio import DeviceException
 import pytest
 
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
     ATTR_FAN_SPEED_LIST,
@@ -38,16 +43,21 @@ from homeassistant.components.xiaomi_miio.services import (
 )
 from homeassistant.components.xiaomi_miio.vacuum import ATTR_ERROR, ATTR_TIMERS
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICE,
     CONF_HOST,
     CONF_MAC,
     CONF_MODEL,
     CONF_TOKEN,
     STATE_UNAVAILABLE,
+    EntityCategory,
+    UnitOfRatio,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import TEST_MAC
@@ -220,17 +230,118 @@ def mirobo_is_on_fixture():
         yield mock_vacuum
 
 
-async def test_xiaomi_exceptions(hass: HomeAssistant, mock_mirobo_is_on) -> None:
+async def test_xiaomi_vacuum_battery_sensor(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_mirobo_is_on: MagicMock,
+) -> None:
+    """Test the Xiaomi vacuum battery sensor."""
+    entity_name = "test_vacuum_cleaner"
+    vacuum_entity_id = await setup_component(hass, entity_name)
+    battery_entity_id = f"sensor.{entity_name}_battery"
+
+    state = hass.states.get(battery_entity_id)
+    assert state is not None
+    assert state.state == "32"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.BATTERY
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfRatio.PERCENTAGE
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    entity_entry = entity_registry.async_get(battery_entity_id)
+    assert entity_entry is not None
+    assert entity_entry.unique_id == "battery_123456"
+    assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entity_entry.config_entry_id == config_entry.entry_id
+
+    vacuum_entity_entry = entity_registry.async_get(vacuum_entity_id)
+    assert vacuum_entity_entry is not None
+    assert entity_entry.device_id == vacuum_entity_entry.device_id
+    assert entity_entry.device_id is not None
+    device_entry = device_registry.async_get(entity_entry.device_id)
+    assert device_entry is not None
+    assert device_entry.identifiers == {(DOMAIN, "123456")}
+
+    vacuum_state = hass.states.get(vacuum_entity_id)
+    assert vacuum_state is not None
+    assert "battery_level" not in vacuum_state.attributes
+    assert "battery_icon" not in vacuum_state.attributes
+    assert vacuum_state.attributes[ATTR_SUPPORTED_FEATURES] == 14140
+
+    mock_mirobo_is_on.status().battery = 64
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(battery_entity_id)
+    assert state is not None
+    assert state.state == "64"
+
+
+async def test_xiaomi_vacuum_battery_sensor_unavailable(
+    hass: HomeAssistant, mock_mirobo_is_on: MagicMock
+) -> None:
+    """Test the battery sensor becomes unavailable for an invalid value."""
+    mock_mirobo_is_on.status().battery = None
+    entity_name = "test_vacuum_cleaner_battery_unavailable"
+    await setup_component(hass, entity_name)
+    battery_entity_id = f"sensor.{entity_name}_battery"
+
+    state = hass.states.get(battery_entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    future = dt_util.utcnow() + timedelta(seconds=60)
+    mock_mirobo_is_on.status().battery = 48
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(battery_entity_id)
+    assert state is not None
+    assert state.state == "48"
+
+    mock_mirobo_is_on.status().battery = None
+    async_fire_time_changed(hass, future + timedelta(seconds=60))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(battery_entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_xiaomi_vacuum_battery_sensor_missing(
+    hass: HomeAssistant, mock_mirobo_is_on: MagicMock
+) -> None:
+    """Test the battery sensor handles a missing battery value."""
+    status = mock_mirobo_is_on.status.return_value
+    with patch.object(
+        type(status), "battery", new_callable=mock.PropertyMock, create=True
+    ) as battery_property:
+        battery_property.side_effect = KeyError("battery")
+        entity_name = "test_vacuum_cleaner_battery_missing"
+        await setup_component(hass, entity_name)
+
+    state = hass.states.get(f"sensor.{entity_name}_battery")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_xiaomi_exceptions(
+    hass: HomeAssistant, mock_mirobo_is_on: MagicMock
+) -> None:
     """Test error logging on exceptions."""
     entity_name = "test_vacuum_cleaner_error"
-    entity_id = await setup_component(hass, entity_name)
+    vacuum_entity_id = await setup_component(hass, entity_name)
+    battery_entity_id = f"sensor.{entity_name}_battery"
 
-    def is_available():
-        state = hass.states.get(entity_id)
-        return state.state != STATE_UNAVAILABLE
+    def assert_availability(expected: bool) -> None:
+        for entity_id in (vacuum_entity_id, battery_entity_id):
+            state = hass.states.get(entity_id)
+            assert state is not None
+            assert (state.state != STATE_UNAVAILABLE) is expected
 
     # The initial setup has to be done successfully
-    assert is_available()
+    assert_availability(True)
 
     # Second update causes an exception, which should be logged
     mock_mirobo_is_on.status.side_effect = DeviceException("dummy exception")
@@ -238,7 +349,7 @@ async def test_xiaomi_exceptions(hass: HomeAssistant, mock_mirobo_is_on) -> None
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert not is_available()
+    assert_availability(False)
 
     # Third update does not get logged as the device is already unavailable,
     # so we clear the log and reset the status to test that
@@ -247,7 +358,7 @@ async def test_xiaomi_exceptions(hass: HomeAssistant, mock_mirobo_is_on) -> None
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert not is_available()
+    assert_availability(False)
     assert mock_mirobo_is_on.status.call_count == 1
 
 

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -53,6 +53,7 @@ from homeassistant.const import (
     CONF_MODEL,
     CONF_TOKEN,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     EntityCategory,
     UnitOfRatio,
 )
@@ -278,18 +279,18 @@ async def test_xiaomi_vacuum_battery_sensor(
     assert state.state == "64"
 
 
-async def test_xiaomi_vacuum_battery_sensor_unavailable(
+async def test_xiaomi_vacuum_battery_sensor_unknown(
     hass: HomeAssistant, mock_mirobo_is_on: MagicMock
 ) -> None:
-    """Test the battery sensor becomes unavailable for an invalid value."""
+    """Test the battery sensor becomes unknown for an invalid value."""
     mock_mirobo_is_on.status().battery = None
-    entity_name = "test_vacuum_cleaner_battery_unavailable"
+    entity_name = "test_vacuum_cleaner_battery_unknown"
     await setup_component(hass, entity_name)
     battery_entity_id = f"sensor.{entity_name}_battery"
 
     state = hass.states.get(battery_entity_id)
     assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     future = dt_util.utcnow() + timedelta(seconds=60)
     mock_mirobo_is_on.status().battery = 48
@@ -306,7 +307,7 @@ async def test_xiaomi_vacuum_battery_sensor_unavailable(
 
     state = hass.states.get(battery_entity_id)
     assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_xiaomi_vacuum_battery_sensor_missing(
@@ -323,7 +324,7 @@ async def test_xiaomi_vacuum_battery_sensor_missing(
 
     state = hass.states.get(f"sensor.{entity_name}_battery")
     assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_xiaomi_exceptions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a dedicated, default-enabled battery sensor for Xiaomi Miio vacuum devices. The sensor uses the existing vacuum coordinator data, remains registered when a battery value is temporarily unavailable, and becomes available again when a valid value is received. The removed vacuum battery attributes and feature are not restored.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178290
- This PR is related to issue: #175687
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47399
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
