### PR TITLE
Split user flow init and data submission in homematicip_cloud config flow tests

### DIFF
--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -23,6 +23,13 @@ IMPORT_CONFIG = {HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "123", HMIPC_NAME: "hmi
 async def test_flow_works(hass: HomeAssistant, simple_mock_home) -> None:
     """Test config flow."""
 
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
     with (
         patch(
             "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
@@ -33,10 +40,8 @@ async def test_flow_works(hass: HomeAssistant, simple_mock_home) -> None:
             return_value=True,
         ),
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=DEFAULT_CONFIG,
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEFAULT_CONFIG
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -79,22 +84,35 @@ async def test_flow_works(hass: HomeAssistant, simple_mock_home) -> None:
 
 async def test_flow_init_connection_error(hass: HomeAssistant) -> None:
     """Test config flow with accesspoint connection error."""
-    with patch(
-        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
-        return_value=False,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=DEFAULT_CONFIG,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEFAULT_CONFIG
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"base": "invalid_sgtin_or_pin"}
+
 
 async def test_flow_link_connection_error(hass: HomeAssistant) -> None:
     """Test config flow client registration connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
     with (
         patch(
             "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
@@ -109,10 +127,8 @@ async def test_flow_link_connection_error(hass: HomeAssistant) -> None:
             return_value=False,
         ),
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=DEFAULT_CONFIG,
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEFAULT_CONFIG
         )
 
     assert result["type"] is FlowResultType.ABORT
@@ -121,6 +137,13 @@ async def test_flow_link_connection_error(hass: HomeAssistant) -> None:
 
 async def test_flow_link_press_button(hass: HomeAssistant) -> None:
     """Test config flow ask for pressing the blue button."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
     with (
         patch(
             "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
@@ -131,10 +154,8 @@ async def test_flow_link_press_button(hass: HomeAssistant) -> None:
             return_value=True,
         ),
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=DEFAULT_CONFIG,
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEFAULT_CONFIG
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -155,14 +176,20 @@ async def test_init_flow_show_form(hass: HomeAssistant) -> None:
 async def test_init_already_configured(hass: HomeAssistant) -> None:
     """Test accesspoint is already configured."""
     MockConfigEntry(domain=DOMAIN, unique_id="ABC123").add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
         return_value=True,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=DEFAULT_CONFIG,
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEFAULT_CONFIG
         )
 
     assert result["type"] is FlowResultType.ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All five user-step `async_init` calls in the homematicip_cloud config flow tests passed `data=DEFAULT_CONFIG`, so the flow was started with the form already submitted. A real user cannot do that, and it meant no test asserted that the user step renders its form at all.

Each one now opens the flow with `async_init` and asserts the `init` form, then submits the config through a follow-up `async_configure`. The patched mocks moved to the submission call, since that is where the flow actually does its work.

`test_flow_init_connection_error` additionally asserts the resulting `invalid_sgtin_or_pin` error, which it never checked despite being named after that failure.

Test-only, no production code touched. The two remaining `data=` calls are `SOURCE_IMPORT`, which is legitimate and not flagged.

Note on the issue text: it asks to remove `# pylint: disable=home-assistant-tests-user-flow-no-data` suppressions. This file had none, and that rule does not exist in the repo yet, so there was nothing to remove.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178878
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
