### PR TITLE
Support Refoss discovery across VLANs

### DIFF
--- a/homeassistant/components/refoss/__init__.py
+++ b/homeassistant/components/refoss/__init__.py
@@ -3,13 +3,13 @@
 from datetime import timedelta
 from typing import Final
 
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
 
 from .bridge import DiscoveryService, RefossConfigEntry
 from .const import DISCOVERY_SCAN_INTERVAL
-from .util import refoss_discovery_server
+from .util import configured_hosts, refoss_discovery_server
 
 PLATFORMS: Final = [
     Platform.SENSOR,
@@ -26,7 +26,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: RefossConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _async_scan_update(_=None):
-        await refoss_discovery.discovery.broadcast_msg(host=entry.data.get(CONF_HOST))
+        hosts = configured_hosts(entry.data)
+        if not hosts:
+            await refoss_discovery.discovery.broadcast_msg()
+            return
+        for host in hosts:
+            await refoss_discovery.discovery.broadcast_msg(host=host)
 
     await _async_scan_update()
 

--- a/homeassistant/components/refoss/__init__.py
+++ b/homeassistant/components/refoss/__init__.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from typing import Final
 
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
 
@@ -26,7 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RefossConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _async_scan_update(_=None):
-        await refoss_discovery.discovery.broadcast_msg()
+        await refoss_discovery.discovery.broadcast_msg(host=entry.data.get(CONF_HOST))
 
     await _async_scan_update()
 

--- a/homeassistant/components/refoss/bridge.py
+++ b/homeassistant/components/refoss/bridge.py
@@ -5,6 +5,7 @@ from refoss_ha.device_manager import async_build_base_device
 from refoss_ha.discovery import Discovery, Listener
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -23,6 +24,7 @@ class DiscoveryService(Listener):
         """Init discovery service."""
         self.hass = hass
         self.config_entry = config_entry
+        self.host = config_entry.data.get(CONF_HOST)
 
         self.discovery = discovery
         self.discovery.add_listener(self)
@@ -31,6 +33,9 @@ class DiscoveryService(Listener):
 
     async def device_found(self, device_info: DeviceInfo) -> None:
         """Handle new device found on the network."""
+
+        if self.host is not None and device_info.inner_ip != self.host:
+            return
 
         device = await async_build_base_device(device_info)
         if device is None:
@@ -49,6 +54,9 @@ class DiscoveryService(Listener):
 
     async def device_update(self, device_info: DeviceInfo) -> None:
         """Handle updates in device information, update if ip has changed."""
+        if self.host is not None and device_info.inner_ip != self.host:
+            return
+
         for coordinator in self.coordinators:
             if coordinator.device.device_info.mac == device_info.mac:
                 LOGGER.debug(

--- a/homeassistant/components/refoss/bridge.py
+++ b/homeassistant/components/refoss/bridge.py
@@ -5,12 +5,12 @@ from refoss_ha.device_manager import async_build_base_device
 from refoss_ha.discovery import Discovery, Listener
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DISPATCH_DEVICE_DISCOVERED, LOGGER
 from .coordinator import RefossDataUpdateCoordinator
+from .util import configured_hosts
 
 type RefossConfigEntry = ConfigEntry[DiscoveryService]
 
@@ -24,7 +24,7 @@ class DiscoveryService(Listener):
         """Init discovery service."""
         self.hass = hass
         self.config_entry = config_entry
-        self.host = config_entry.data.get(CONF_HOST)
+        self.hosts = set(configured_hosts(config_entry.data))
 
         self.discovery = discovery
         self.discovery.add_listener(self)
@@ -34,7 +34,7 @@ class DiscoveryService(Listener):
     async def device_found(self, device_info: DeviceInfo) -> None:
         """Handle new device found on the network."""
 
-        if self.host is not None and device_info.inner_ip != self.host:
+        if self.hosts and device_info.inner_ip not in self.hosts:
             return
 
         device = await async_build_base_device(device_info)
@@ -54,7 +54,7 @@ class DiscoveryService(Listener):
 
     async def device_update(self, device_info: DeviceInfo) -> None:
         """Handle updates in device information, update if ip has changed."""
-        if self.host is not None and device_info.inner_ip != self.host:
+        if self.hosts and device_info.inner_ip not in self.hosts:
             return
 
         for coordinator in self.coordinators:

--- a/homeassistant/components/refoss/config_flow.py
+++ b/homeassistant/components/refoss/config_flow.py
@@ -1,47 +1,63 @@
 """Config flow for the Refoss integration."""
 
+import asyncio
 from ipaddress import AddressValueError, IPv4Address
 from typing import Any, override
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOSTS
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.selector import TextSelector
+from homeassistant.helpers.selector import TextSelector, TextSelectorConfig
 
 from .const import DISCOVERY_TIMEOUT, DOMAIN, LOGGER
-from .util import refoss_discovery_server
+from .util import configured_hosts, refoss_discovery_server
 
 
-def _optional_ipv4_address(value: str) -> str:
-    """Validate an optional IPv4 address."""
-    value = value.strip()
-    if not value:
-        return value
-    try:
-        return str(IPv4Address(value))
-    except AddressValueError as err:
-        raise vol.Invalid("invalid IPv4 address") from err
+def _ipv4_addresses(values: list[str]) -> list[str]:
+    """Validate and normalize IPv4 addresses."""
+    hosts: list[str] = []
+    for value in values:
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            host = str(IPv4Address(value))
+        except AddressValueError as err:
+            raise vol.Invalid("invalid IPv4 address") from err
+        if host not in hosts:
+            hosts.append(host)
+    return hosts
 
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_HOST, default=""): TextSelector()}
+    {
+        vol.Optional(CONF_HOSTS, default=[]): TextSelector(
+            TextSelectorConfig(multiple=True)
+        )
+    }
 )
 
 
-async def _async_has_devices(hass: HomeAssistant, host: str | None = None) -> bool:
+async def _async_has_devices(hass: HomeAssistant, hosts: list[str]) -> bool:
     """Return whether devices can be discovered."""
     refoss_discovery = await refoss_discovery_server(hass)
-    devices = await refoss_discovery.broadcast_msg(
-        wait_for=DISCOVERY_TIMEOUT, host=host
+    results = await asyncio.gather(
+        *(
+            refoss_discovery.broadcast_msg(wait_for=DISCOVERY_TIMEOUT, host=host)
+            for host in hosts or [None]
+        )
     )
-    if host is not None:
-        devices = [device for device in devices if device.inner_ip == host]
+    devices = {device.uuid: device for result in results for device in result}.values()
+    if hosts:
+        devices = [device for device in devices if device.inner_ip in hosts]
     LOGGER.debug(
         "Discovered devices: [%s]", ", ".join(info.dev_name for info in devices)
     )
-    return bool(devices)
+    if not hosts:
+        return bool(devices)
+    return set(hosts) <= {device.inner_ip for device in devices}
 
 
 class RefossConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -59,14 +75,14 @@ class RefossConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                host = _optional_ipv4_address(user_input[CONF_HOST]) or None
+                hosts = _ipv4_addresses(user_input[CONF_HOSTS])
             except vol.Invalid:
-                errors[CONF_HOST] = "invalid_ipv4_address"
+                errors[CONF_HOSTS] = "invalid_ipv4_address"
             else:
-                if await _async_has_devices(self.hass, host):
+                if await _async_has_devices(self.hass, hosts):
                     return self.async_update_reload_and_abort(
                         reconfigure_entry,
-                        data={CONF_HOST: host} if host else {},
+                        data={CONF_HOSTS: hosts} if hosts else {},
                     )
                 errors["base"] = "cannot_connect"
 
@@ -74,7 +90,7 @@ class RefossConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 STEP_USER_DATA_SCHEMA,
-                user_input or {CONF_HOST: reconfigure_entry.data.get(CONF_HOST, "")},
+                user_input or {CONF_HOSTS: configured_hosts(reconfigure_entry.data)},
             ),
             errors=errors,
         )
@@ -90,16 +106,16 @@ class RefossConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                host = _optional_ipv4_address(user_input[CONF_HOST]) or None
+                hosts = _ipv4_addresses(user_input[CONF_HOSTS])
             except vol.Invalid:
-                errors[CONF_HOST] = "invalid_ipv4_address"
+                errors[CONF_HOSTS] = "invalid_ipv4_address"
             else:
-                if await _async_has_devices(self.hass, host):
+                if await _async_has_devices(self.hass, hosts):
                     await self.async_set_unique_id(DOMAIN)
                     return self.async_create_entry(
-                        title="Refoss", data={CONF_HOST: host} if host else {}
+                        title="Refoss", data={CONF_HOSTS: hosts} if hosts else {}
                     )
-                if host:
+                if hosts:
                     errors["base"] = "cannot_connect"
                 else:
                     return self.async_abort(reason="no_devices_found")

--- a/homeassistant/components/refoss/config_flow.py
+++ b/homeassistant/components/refoss/config_flow.py
@@ -1,21 +1,113 @@
-"""Config Flow for Refoss integration."""
+"""Config flow for the Refoss integration."""
 
+from ipaddress import AddressValueError, IPv4Address
+from typing import Any, override
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_flow
+from homeassistant.helpers.selector import TextSelector
 
 from .const import DISCOVERY_TIMEOUT, DOMAIN, LOGGER
 from .util import refoss_discovery_server
 
 
-async def _async_has_devices(hass: HomeAssistant) -> bool:
-    """Return if there are devices that can be discovered."""
+def _optional_ipv4_address(value: str) -> str:
+    """Validate an optional IPv4 address."""
+    value = value.strip()
+    if not value:
+        return value
+    try:
+        return str(IPv4Address(value))
+    except AddressValueError as err:
+        raise vol.Invalid("invalid IPv4 address") from err
 
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {vol.Optional(CONF_HOST, default=""): TextSelector()}
+)
+
+
+async def _async_has_devices(hass: HomeAssistant, host: str | None = None) -> bool:
+    """Return whether devices can be discovered."""
     refoss_discovery = await refoss_discovery_server(hass)
-    devices = await refoss_discovery.broadcast_msg(wait_for=DISCOVERY_TIMEOUT)
-    LOGGER.debug(
-        "Discovered devices: [%s]", ", ".join([info.dev_name for info in devices])
+    devices = await refoss_discovery.broadcast_msg(
+        wait_for=DISCOVERY_TIMEOUT, host=host
     )
-    return len(devices) > 0
+    if host is not None:
+        devices = [device for device in devices if device.inner_ip == host]
+    LOGGER.debug(
+        "Discovered devices: [%s]", ", ".join(info.dev_name for info in devices)
+    )
+    return bool(devices)
 
 
-config_entry_flow.register_discovery_flow(DOMAIN, "Refoss", _async_has_devices)
+class RefossConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Refoss."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of Refoss discovery."""
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                host = _optional_ipv4_address(user_input[CONF_HOST]) or None
+            except vol.Invalid:
+                errors[CONF_HOST] = "invalid_ipv4_address"
+            else:
+                if await _async_has_devices(self.hass, host):
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry,
+                        data={CONF_HOST: host} if host else {},
+                    )
+                errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                user_input or {CONF_HOST: reconfigure_entry.data.get(CONF_HOST, "")},
+            ),
+            errors=errors,
+        )
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle user-initiated setup."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                host = _optional_ipv4_address(user_input[CONF_HOST]) or None
+            except vol.Invalid:
+                errors[CONF_HOST] = "invalid_ipv4_address"
+            else:
+                if await _async_has_devices(self.hass, host):
+                    await self.async_set_unique_id(DOMAIN)
+                    return self.async_create_entry(
+                        title="Refoss", data={CONF_HOST: host} if host else {}
+                    )
+                if host:
+                    errors["base"] = "cannot_connect"
+                else:
+                    return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/refoss/manifest.json
+++ b/homeassistant/components/refoss/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/refoss",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["refoss-ha==1.2.5"],
+  "requirements": ["refoss-ha==1.2.6"],
   "single_config_entry": true
 }

--- a/homeassistant/components/refoss/strings.json
+++ b/homeassistant/components/refoss/strings.json
@@ -11,21 +11,21 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Update how Home Assistant discovers Refoss devices.",
+        "description": "Add or remove Refoss devices, or leave the list empty to use automatic discovery.",
         "data": {
-          "host": "IP address"
+          "hosts": "IP addresses"
         },
         "data_description": {
-          "host": "The IPv4 address of a Refoss device on another network or VLAN. Leave blank to use automatic discovery."
+          "hosts": "Add the IPv4 address of each Refoss device on another network or VLAN."
         }
       },
       "user": {
-        "description": "Leave the IP address blank to discover Refoss devices automatically.",
+        "description": "Add the IP address of each Refoss device, or leave the list empty to discover devices automatically.",
         "data": {
-          "host": "IP address"
+          "hosts": "IP addresses"
         },
         "data_description": {
-          "host": "The IPv4 address of a Refoss device on another network or VLAN."
+          "hosts": "The IPv4 addresses of Refoss devices on another network or VLAN."
         }
       }
     }

--- a/homeassistant/components/refoss/strings.json
+++ b/homeassistant/components/refoss/strings.json
@@ -1,12 +1,32 @@
 {
   "config": {
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_ipv4_address": "Enter a valid IPv4 address"
+    },
     "abort": {
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "step": {
-      "confirm": {
-        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      "reconfigure": {
+        "description": "Update how Home Assistant discovers Refoss devices.",
+        "data": {
+          "host": "IP address"
+        },
+        "data_description": {
+          "host": "The IPv4 address of a Refoss device on another network or VLAN. Leave blank to use automatic discovery."
+        }
+      },
+      "user": {
+        "description": "Leave the IP address blank to discover Refoss devices automatically.",
+        "data": {
+          "host": "IP address"
+        },
+        "data_description": {
+          "host": "The IPv4 address of a Refoss device on another network or VLAN."
+        }
       }
     }
   },

--- a/homeassistant/components/refoss/util.py
+++ b/homeassistant/components/refoss/util.py
@@ -1,9 +1,22 @@
 """Refoss helpers functions."""
 
+from collections.abc import Mapping
+from typing import Any
+
 from refoss_ha.discovery import Discovery
 
+from homeassistant.const import CONF_HOST, CONF_HOSTS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import singleton
+
+
+def configured_hosts(data: Mapping[str, Any]) -> list[str]:
+    """Return the configured discovery targets."""
+    if CONF_HOSTS in data:
+        return list(data[CONF_HOSTS])
+    if host := data.get(CONF_HOST):
+        return [host]
+    return []
 
 
 @singleton.singleton("refoss_discovery_server")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2913,7 +2913,7 @@ raspyrfm-client==1.2.9
 redgtech-api==0.1.38
 
 # homeassistant.components.refoss
-refoss-ha==1.2.5
+refoss-ha==1.2.6
 
 # homeassistant.components.rainmachine
 regenmaschine==2024.03.0

--- a/tests/components/refoss/__init__.py
+++ b/tests/components/refoss/__init__.py
@@ -23,6 +23,7 @@ class FakeDiscovery:
         self.last_mock_infos = {}
         self._listeners = []
         self.sock = None
+        self.last_host = None
 
     def add_listener(self, listener: Listener) -> None:
         """Add an event listener."""
@@ -32,8 +33,10 @@ class FakeDiscovery:
         """Initialize socket server."""
         self.sock = Mock()
 
-    async def broadcast_msg(self, wait_for: int = 0):
+    async def broadcast_msg(self, wait_for: int = 0, host: str | None = None):
         """Search for devices, return mocked data."""
+
+        self.last_host = host
 
         mock_infos = self.mock_devices
         last_mock_infos = self.last_mock_infos

--- a/tests/components/refoss/__init__.py
+++ b/tests/components/refoss/__init__.py
@@ -24,6 +24,7 @@ class FakeDiscovery:
         self._listeners = []
         self.sock = None
         self.last_host = None
+        self.last_hosts = []
 
     def add_listener(self, listener: Listener) -> None:
         """Add an event listener."""
@@ -37,8 +38,13 @@ class FakeDiscovery:
         """Search for devices, return mocked data."""
 
         self.last_host = host
+        self.last_hosts.append(host)
 
-        mock_infos = self.mock_devices
+        mock_infos = {
+            uuid: info
+            for uuid, info in self.mock_devices.items()
+            if host is None or info.inner_ip == host
+        }
         last_mock_infos = self.last_mock_infos
 
         new_infos = []
@@ -53,7 +59,7 @@ class FakeDiscovery:
                 if info.inner_ip != last_info.inner_ip:
                     updated_infos.append(info)
 
-        self.last_mock_infos = mock_infos
+        self.last_mock_infos.update(mock_infos)
         for listener in self._listeners:
             [await listener.device_found(x) for x in new_infos]
             [await listener.device_update(x) for x in updated_infos]
@@ -64,10 +70,10 @@ class FakeDiscovery:
         return new_infos
 
 
-def build_device_mock(name="r10", ip="1.1.1.1", mac="aabbcc112233"):
+def build_device_mock(name="r10", ip="1.1.1.1", mac="aabbcc112233", uuid="abc"):
     """Build mock device object."""
     return Mock(
-        uuid="abc",
+        uuid=uuid,
         dev_name=name,
         device_type="r10",
         fmware_version="1.1.1",

--- a/tests/components/refoss/test_config_flow.py
+++ b/tests/components/refoss/test_config_flow.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.refoss.const import DOMAIN
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import FakeDiscovery, build_base_device_mock
+
+from tests.common import MockConfigEntry
 
 
 @patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
@@ -33,10 +36,11 @@ async def test_creating_entry_sets_up(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
         assert result["type"] is FlowResultType.FORM
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: ""}
+        )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
 
@@ -60,12 +64,123 @@ async def test_creating_entry_has_no_devices(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
         assert result["type"] is FlowResultType.FORM
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: ""}
+        )
         assert result["type"] is FlowResultType.ABORT
 
         await hass.async_block_till_done()
 
         assert len(mock_setup_entry.mock_calls) == 0
+
+
+@patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
+async def test_creating_entry_with_host(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test setting up Refoss using a configured host."""
+    discovery = FakeDiscovery()
+    discovery.mock_devices["abc"].inner_ip = "192.0.2.10"
+
+    with patch(
+        "homeassistant.components.refoss.util.Discovery", return_value=discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.0.2.10"}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_HOST: "192.0.2.10"}
+    assert discovery.last_host == "192.0.2.10"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
+async def test_creating_entry_with_unreachable_host(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test setting up Refoss using an unreachable host."""
+    discovery = FakeDiscovery()
+
+    with patch(
+        "homeassistant.components.refoss.util.Discovery", return_value=discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.0.2.20"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert discovery.last_host == "192.0.2.20"
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_invalid_host(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test rejecting an invalid host."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "not-an-ip-address"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_HOST: "invalid_ipv4_address"}
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+@patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
+async def test_reconfigure_host(hass: HomeAssistant) -> None:
+    """Test changing from automatic discovery to a configured host."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    discovery = FakeDiscovery()
+    discovery.mock_devices["abc"].inner_ip = "192.0.2.10"
+
+    with (
+        patch("homeassistant.components.refoss.util.Discovery", return_value=discovery),
+        patch.object(hass.config_entries, "async_reload") as mock_reload,
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.0.2.10"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {CONF_HOST: "192.0.2.10"}
+    assert discovery.last_host == "192.0.2.10"
+    mock_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
+async def test_reconfigure_automatic_discovery(hass: HomeAssistant) -> None:
+    """Test changing from a configured host to automatic discovery."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "192.0.2.10"})
+    entry.add_to_hass(hass)
+    discovery = FakeDiscovery()
+
+    with (
+        patch("homeassistant.components.refoss.util.Discovery", return_value=discovery),
+        patch.object(hass.config_entries, "async_reload") as mock_reload,
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: ""}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {}
+    assert discovery.last_host is None
+    mock_reload.assert_awaited_once_with(entry.entry_id)

--- a/tests/components/refoss/test_config_flow.py
+++ b/tests/components/refoss/test_config_flow.py
@@ -4,13 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.refoss.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_HOSTS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import FakeDiscovery, build_base_device_mock
+from . import FakeDiscovery, build_base_device_mock, build_device_mock
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 
 @patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
@@ -39,7 +39,7 @@ async def test_creating_entry_sets_up(
         assert result["type"] is FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: ""}
+            result["flow_id"], {CONF_HOSTS: []}
         )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -67,7 +67,7 @@ async def test_creating_entry_has_no_devices(
         assert result["type"] is FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: ""}
+            result["flow_id"], {CONF_HOSTS: []}
         )
         assert result["type"] is FlowResultType.ABORT
 
@@ -77,12 +77,15 @@ async def test_creating_entry_has_no_devices(
 
 
 @patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
-async def test_creating_entry_with_host(
+async def test_creating_entry_with_hosts(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test setting up Refoss using a configured host."""
+    """Test setting up Refoss using multiple configured hosts."""
     discovery = FakeDiscovery()
     discovery.mock_devices["abc"].inner_ip = "192.0.2.10"
+    discovery.mock_devices["def"] = build_device_mock(
+        ip="192.0.2.11", mac="aabbcc112244", uuid="def"
+    )
 
     with patch(
         "homeassistant.components.refoss.util.Discovery", return_value=discovery
@@ -91,12 +94,12 @@ async def test_creating_entry_with_host(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "192.0.2.10"}
+            result["flow_id"], {CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]}
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == {CONF_HOST: "192.0.2.10"}
-    assert discovery.last_host == "192.0.2.10"
+    assert result["data"] == {CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]}
+    assert discovery.last_hosts == ["192.0.2.10", "192.0.2.11"]
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -106,6 +109,7 @@ async def test_creating_entry_with_unreachable_host(
 ) -> None:
     """Test setting up Refoss using an unreachable host."""
     discovery = FakeDiscovery()
+    discovery.mock_devices["abc"].inner_ip = "192.0.2.10"
 
     with patch(
         "homeassistant.components.refoss.util.Discovery", return_value=discovery
@@ -114,12 +118,12 @@ async def test_creating_entry_with_unreachable_host(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "192.0.2.20"}
+            result["flow_id"], {CONF_HOSTS: ["192.0.2.10", "192.0.2.20"]}
         )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
-    assert discovery.last_host == "192.0.2.20"
+    assert discovery.last_hosts == ["192.0.2.10", "192.0.2.20"]
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -129,43 +133,51 @@ async def test_invalid_host(hass: HomeAssistant, mock_setup_entry: AsyncMock) ->
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "not-an-ip-address"}
+        result["flow_id"], {CONF_HOSTS: ["not-an-ip-address"]}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {CONF_HOST: "invalid_ipv4_address"}
+    assert result["errors"] == {CONF_HOSTS: "invalid_ipv4_address"}
     assert len(mock_setup_entry.mock_calls) == 0
 
 
 @patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
-async def test_reconfigure_host(hass: HomeAssistant) -> None:
-    """Test changing from automatic discovery to a configured host."""
-    entry = MockConfigEntry(domain=DOMAIN, data={})
+async def test_reconfigure_additional_host(hass: HomeAssistant) -> None:
+    """Test adding a host to a legacy single-host configuration."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "192.0.2.10"})
     entry.add_to_hass(hass)
     discovery = FakeDiscovery()
     discovery.mock_devices["abc"].inner_ip = "192.0.2.10"
+    discovery.mock_devices["def"] = build_device_mock(
+        ip="192.0.2.11", mac="aabbcc112244", uuid="def"
+    )
 
     with (
         patch("homeassistant.components.refoss.util.Discovery", return_value=discovery),
         patch.object(hass.config_entries, "async_reload") as mock_reload,
     ):
         result = await entry.start_reconfigure_flow(hass)
+        assert get_schema_suggested_value(result["data_schema"].schema, CONF_HOSTS) == [
+            "192.0.2.10"
+        ]
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "192.0.2.10"}
+            result["flow_id"], {CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]}
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.data == {CONF_HOST: "192.0.2.10"}
-    assert discovery.last_host == "192.0.2.10"
+    assert entry.data == {CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]}
+    assert discovery.last_hosts == ["192.0.2.10", "192.0.2.11"]
     mock_reload.assert_awaited_once_with(entry.entry_id)
 
 
 @patch("homeassistant.components.refoss.config_flow.DISCOVERY_TIMEOUT", 0)
 async def test_reconfigure_automatic_discovery(hass: HomeAssistant) -> None:
     """Test changing from a configured host to automatic discovery."""
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "192.0.2.10"})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]}
+    )
     entry.add_to_hass(hass)
     discovery = FakeDiscovery()
 
@@ -175,12 +187,12 @@ async def test_reconfigure_automatic_discovery(hass: HomeAssistant) -> None:
     ):
         result = await entry.start_reconfigure_flow(hass)
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: ""}
+            result["flow_id"], {CONF_HOSTS: []}
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert entry.data == {}
-    assert discovery.last_host is None
+    assert discovery.last_hosts == [None]
     mock_reload.assert_awaited_once_with(entry.entry_id)

--- a/tests/components/refoss/test_init.py
+++ b/tests/components/refoss/test_init.py
@@ -1,0 +1,67 @@
+"""Tests for the Refoss integration setup."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.refoss.const import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import FakeDiscovery, build_base_device_mock
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("entry_data", "device_ip", "expected_host", "expected_coordinators"),
+    [
+        pytest.param({}, "1.1.1.1", None, 1, id="broadcast"),
+        pytest.param(
+            {CONF_HOST: "192.0.2.10"},
+            "192.0.2.10",
+            "192.0.2.10",
+            1,
+            id="configured-host",
+        ),
+        pytest.param(
+            {CONF_HOST: "192.0.2.10"},
+            "192.0.2.20",
+            "192.0.2.10",
+            0,
+            id="ignore-other-host",
+        ),
+    ],
+)
+async def test_setup_discovery_target(
+    hass: HomeAssistant,
+    entry_data: dict[str, str],
+    device_ip: str,
+    expected_host: str | None,
+    expected_coordinators: int,
+) -> None:
+    """Test setup uses the configured discovery target."""
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data)
+    entry.add_to_hass(hass)
+    discovery = FakeDiscovery()
+    discovery.mock_devices["abc"].inner_ip = device_ip
+
+    with (
+        patch(
+            "homeassistant.components.refoss.refoss_discovery_server",
+            return_value=discovery,
+        ),
+        patch(
+            "homeassistant.components.refoss.bridge.async_build_base_device",
+            return_value=build_base_device_mock(),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    assert discovery.last_host == expected_host
+    assert len(entry.runtime_data.coordinators) == expected_coordinators

--- a/tests/components/refoss/test_init.py
+++ b/tests/components/refoss/test_init.py
@@ -5,29 +5,36 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.refoss.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_HOSTS
 from homeassistant.core import HomeAssistant
 
-from . import FakeDiscovery, build_base_device_mock
+from . import FakeDiscovery, build_base_device_mock, build_device_mock
 
 from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("entry_data", "device_ip", "expected_host", "expected_coordinators"),
+    ("entry_data", "device_ips", "expected_hosts", "expected_coordinators"),
     [
-        pytest.param({}, "1.1.1.1", None, 1, id="broadcast"),
+        pytest.param({}, ["1.1.1.1"], [None], 1, id="broadcast"),
         pytest.param(
             {CONF_HOST: "192.0.2.10"},
-            "192.0.2.10",
-            "192.0.2.10",
+            ["192.0.2.10"],
+            ["192.0.2.10"],
             1,
-            id="configured-host",
+            id="legacy-configured-host",
         ),
         pytest.param(
-            {CONF_HOST: "192.0.2.10"},
-            "192.0.2.20",
-            "192.0.2.10",
+            {CONF_HOSTS: ["192.0.2.10", "192.0.2.11"]},
+            ["192.0.2.10", "192.0.2.11"],
+            ["192.0.2.10", "192.0.2.11"],
+            2,
+            id="configured-hosts",
+        ),
+        pytest.param(
+            {CONF_HOSTS: ["192.0.2.10"]},
+            ["192.0.2.20"],
+            ["192.0.2.10"],
             0,
             id="ignore-other-host",
         ),
@@ -35,16 +42,23 @@ from tests.common import MockConfigEntry
 )
 async def test_setup_discovery_target(
     hass: HomeAssistant,
-    entry_data: dict[str, str],
-    device_ip: str,
-    expected_host: str | None,
+    entry_data: dict[str, str | list[str]],
+    device_ips: list[str],
+    expected_hosts: list[str | None],
     expected_coordinators: int,
 ) -> None:
     """Test setup uses the configured discovery target."""
     entry = MockConfigEntry(domain=DOMAIN, data=entry_data)
     entry.add_to_hass(hass)
     discovery = FakeDiscovery()
-    discovery.mock_devices["abc"].inner_ip = device_ip
+    discovery.mock_devices = {
+        str(index): build_device_mock(
+            ip=device_ip,
+            mac=f"aabbcc1122{index:02d}",
+            uuid=str(index),
+        )
+        for index, device_ip in enumerate(device_ips)
+    }
 
     with (
         patch(
@@ -63,5 +77,5 @@ async def test_setup_discovery_target(
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
 
-    assert discovery.last_host == expected_host
+    assert discovery.last_hosts == expected_hosts
     assert len(entry.runtime_data.coordinators) == expected_coordinators


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None. Existing Refoss entries continue to use automatic broadcast discovery.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refoss currently relies on UDP broadcast discovery. Broadcast traffic does not normally cross routed networks or VLANs, so Home Assistant cannot discover a reachable Refoss device in more complex network setups.

This change adds an optional list of IPv4 addresses to the Refoss setup and reconfiguration flows. When addresses are configured, Home Assistant sends the existing discovery request directly to each device and filters discovery events to those targets. People can add or remove devices through **Reconfigure**. Leaving the list empty preserves automatic broadcast discovery for existing and new installations.

This PR depends on [ashionky/refoss_ha#11](https://github.com/ashionky/refoss_ha/pull/11), which adds the targeted discovery argument used here. The two PRs are opened together so the Refoss library owner and Home Assistant reviewers can review both sides of the change in parallel. This PR remains blocked on the library PR being merged and version 1.2.6 being released.

The runtime still uses the same UDP discovery protocol on ports 9988 and 9989, followed by the existing local HTTP polling. This only changes how the discovery request is addressed.

Validation performed:

- `pytest -q tests/components/refoss` (11 passed)
- `ruff format --check homeassistant/components/refoss tests/components/refoss`
- `ruff check homeassistant/components/refoss tests/components/refoss`
- `pylint -j 1 homeassistant/components/refoss tests/components/refoss`
- Focused hassfest validation for the Refoss integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to dependency pull request and library diff: https://github.com/ashionky/refoss_ha/pull/11

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
