### PR TITLE
Use PH device class for hortimax pH readouts instead of a custom unit

### DIFF
--- a/homeassistant/components/hortimax/const.py
+++ b/homeassistant/components/hortimax/const.py
@@ -144,7 +144,6 @@ UNIT_DESCRIPTIONS: Final[dict[str, SensorEntityDescription]] = {
         (LIGHT_LUX, SensorDeviceClass.ILLUMINANCE, 0),
         (UnitOfConductivity.MILLISIEMENS_PER_CM, SensorDeviceClass.CONDUCTIVITY, 2),
         (UnitOfConductivity.MICROSIEMENS_PER_CM, SensorDeviceClass.CONDUCTIVITY, 0),
-        ("pH", None, 1),
         (UnitOfPressure.BAR, SensorDeviceClass.PRESSURE, 2),
         (UnitOfPressure.MBAR, SensorDeviceClass.PRESSURE, 0),
         (UnitOfPressure.HPA, SensorDeviceClass.PRESSURE, 0),
@@ -157,7 +156,9 @@ UNIT_DESCRIPTIONS: Final[dict[str, SensorEntityDescription]] = {
         (UnitOfMass.KILOGRAMS, SensorDeviceClass.WEIGHT, 1),
         (UnitOfMass.GRAMS, SensorDeviceClass.WEIGHT, 0),
     )
+} | {
+    # pH is dimensionless (a logarithmic ratio), so SensorDeviceClass.PH takes no unit.
+    "pH": SensorEntityDescription(
+        key="pH", device_class=SensorDeviceClass.PH, suggested_display_precision=1
+    )
 }
-
-# pH has no device class on purpose: SensorDeviceClass.PH accepts no unit, and
-# keeping the "pH" unit is worth more than the class.

--- a/tests/components/hortimax/fixtures/readouts.json
+++ b/tests/components/hortimax/fixtures/readouts.json
@@ -308,6 +308,25 @@
     ]
   },
   {
+    "name": "Ph",
+    "readoutIdentifier": "Ph-Measured",
+    "readoutValueType": "Double",
+    "unitIdentifier": "PH",
+    "device": "HOR00000000.000",
+    "source": {
+      "sourceName": "Valve group 003",
+      "sourceType": "IrrigationValveGroup",
+      "userDefinedName": null,
+      "sourceGroups": ["Irrigation"]
+    },
+    "values": [
+      {
+        "timestampUTC": "2026-06-12T08:00:00Z",
+        "value": 6.2
+      }
+    ]
+  },
+  {
     "name": "CO2 level",
     "readoutIdentifier": "CO2Level-Measured",
     "readoutValueType": "Double",

--- a/tests/components/hortimax/snapshots/test_sensor.ambr
+++ b/tests/components/hortimax/snapshots/test_sensor.ambr
@@ -564,6 +564,63 @@
     'state': '1.75',
   })
 # ---
+# name: test_all_entities[sensor.valve_group_003_ph-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.valve_group_003_ph',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ph',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PH: 'ph'>,
+    'original_icon': None,
+    'original_name': 'Ph',
+    'platform': 'hortimax',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'HOR00000000.000::IrrigationValveGroup::Valve group 003::Ph-Measured',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.valve_group_003_ph-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ph',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Valve group 003 Ph',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.valve_group_003_ph',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.2',
+  })
+# ---
 # name: test_all_entities[sensor.valve_group_003_substrate_conductivity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/hortimax/test_sensor.py
+++ b/tests/components/hortimax/test_sensor.py
@@ -9,7 +9,13 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -75,6 +81,20 @@ async def test_unclassified_readouts_are_disabled(
     )
     assert conductivity is not None
     assert conductivity.disabled_by is None
+
+
+@pytest.mark.usefixtures("mock_hortos_client")
+async def test_ph_has_a_device_class_but_no_unit(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test pH gets its device class rather than a unit, since pH is dimensionless."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.valve_group_003_ph")
+    assert state is not None
+    assert state.state == "6.2"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.PH
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
 
 
 @pytest.mark.usefixtures("mock_hortos_client")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Give `hortimax` pH readouts `SensorDeviceClass.PH` instead of a custom `"pH"`
unit string, per @joostlek  [review feedback on #177247][comment]:

> I would disagree here, the class is important as that allows you to compare pH
> units from one integration with pH units from other integrations. If there's a
> case where all pH device classes should use pH as a unit, you can open an arch
> proposal and we can decide about that. I don't think we should do differently
> for 1 integration

[comment]: https://github.com/home-assistant/core/pull/177247#discussion_r3719784343

The previous combination was not a valid one anyway: pH is dimensionless (a
logarithmic ratio), and `DEVICE_CLASS_UNITS[SensorDeviceClass.PH]` is `{None}`,
so the device class could never have been paired with the `"pH"` unit it was
omitted for. The readout keeps its `suggested_display_precision=1`, so it still
displays as `6.2`, now without a unit suffix.

No pH readout was covered by the tests at all, so this adds one to
`fixtures/readouts.json` plus a test asserting the device class is set and no
unit is reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

`native_unit_of_measurement` changes from `"pH"` to `None` for these sensors.
The integration is young and I have not found an installation that actually has
a pH readout (my own 621-readout installation has none), so I filed this as a
bugfix rather than a breaking change. Happy to reclassify if you prefer.

#178553 touches the same table and will be rebased on top of this once it lands.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
