### PR TITLE
Fix Lyric setup with non-thermostat devices

### DIFF
--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -67,6 +67,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LyricConfigEntry) -> boo
     device_registry = dr.async_get(hass)
     for location in coordinator.data.locations:
         for device in location.devices:
+            if device.device_class != "Thermostat":
+                continue
             device_registry.async_get_or_create(
                 config_entry_id=entry.entry_id,
                 **create_thermostat_device_info(device),

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -137,6 +137,7 @@ async def async_setup_entry(
             )
             for location in coordinator.data.locations
             for device in location.devices
+            if device.device_class == "Thermostat"
         ),
         True,
     )

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -181,6 +181,7 @@ async def async_setup_entry(
         )
         for location in coordinator.data.locations
         for device in location.devices
+        if device.device_class == "Thermostat"
         for device_sensor in DEVICE_SENSORS
         if device_sensor.suitable_fn(device)
     )
@@ -191,6 +192,7 @@ async def async_setup_entry(
         )
         for location in coordinator.data.locations
         for device in location.devices
+        if device.device_class == "Thermostat"
         for room in coordinator.data.rooms_dict.get(device.mac_id, {}).values()
         for accessory in room.accessories
         for accessory_sensor in ACCESSORY_SENSORS

--- a/tests/components/lyric/conftest.py
+++ b/tests/components/lyric/conftest.py
@@ -1,0 +1,118 @@
+"""Fixtures for Honeywell Lyric tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiolyric import Lyric
+from aiolyric.objects.location import LyricLocation
+from aiolyric.objects.priority import LyricPriority, LyricRoom
+import pytest
+
+from homeassistant.components.lyric.api import LyricLocalOAuth2Implementation
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MAC = "AABBCCDDEEFF"
+
+
+@pytest.fixture
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a Honeywell Lyric config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": 9999999999,
+                "token_type": "Bearer",
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_lyric() -> Generator[MagicMock]:
+    """Mock an account containing a thermostat, room sensor, and leak detector."""
+    client = MagicMock()
+    location = LyricLocation(
+        client,
+        {
+            "locationID": 1234,
+            "name": "Home",
+            "devices": [
+                {
+                    "deviceID": f"LCC-{MAC}",
+                    "deviceClass": "Thermostat",
+                    "macID": MAC,
+                    "name": "Thermostat",
+                    "deviceModel": "T9",
+                    "units": "Fahrenheit",
+                    "allowedModes": ["Heat", "Cool", "Off"],
+                    "indoorTemperature": 70,
+                    "changeableValues": {
+                        "mode": "Heat",
+                        "heatSetpoint": 68,
+                        "coolSetpoint": 75,
+                        "thermostatSetpointStatus": "NoHold",
+                    },
+                    "operationStatus": {"mode": "EquipmentOff"},
+                },
+                {
+                    "deviceID": "leak-detector-id",
+                    "deviceClass": "LeakDetector",
+                    "deviceType": "Water Leak Detector",
+                    "deviceVariant": "WLD3",
+                    "name": "Basement Leak Detector",
+                    "waterPresent": False,
+                },
+            ],
+        },
+    )
+    room = LyricRoom(
+        {
+            "id": 1,
+            "name": "Living Room",
+            "avgTemperature": 71,
+            "avgHumidity": 40,
+            "accessories": [
+                {"id": 1, "sensorType": "IndoorAirSensor", "temperature": 71}
+            ],
+        }
+    )
+    priority = LyricPriority(
+        {
+            "deviceId": MAC,
+            "priority": {
+                "priorityType": "FollowMe",
+                "selectedRooms": [],
+            },
+        }
+    )
+
+    lyric = MagicMock(spec=Lyric)
+    lyric.get_locations = AsyncMock()
+    lyric.get_thermostat_rooms = AsyncMock()
+    lyric.update_priority = AsyncMock()
+    lyric.locations = [location]
+    lyric.locations_dict = {1234: location}
+    lyric.priorities_dict = {MAC: priority}
+    lyric.rooms_dict = {MAC: {1: room}}
+
+    implementation = MagicMock(spec=LyricLocalOAuth2Implementation)
+    implementation.client_id = "client-id"
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow."
+            "async_get_config_entry_implementation",
+            return_value=implementation,
+        ),
+        patch("homeassistant.components.lyric.Lyric", return_value=lyric),
+    ):
+        yield lyric

--- a/tests/components/lyric/test_init.py
+++ b/tests/components/lyric/test_init.py
@@ -2,14 +2,48 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.lyric.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
 
+from .conftest import MAC
+
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_lyric")
+async def test_non_thermostat_device_not_setup_as_climate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a non-thermostat device is not set up as a climate entity."""
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.CLIMATE]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.CLIMATE, DOMAIN, f"{MAC}_thermostat"
+        )
+        is not None
+    )
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == 1
+    )
 
 
 async def test_oauth_implementation_not_available(

--- a/tests/components/lyric/test_select.py
+++ b/tests/components/lyric/test_select.py
@@ -1,0 +1,39 @@
+"""Tests for the Honeywell Lyric select platform."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.components.select import ATTR_OPTIONS
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_lyric")
+async def test_room_priority_with_non_thermostat_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test room priority remains available with a non-thermostat in the account."""
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.SELECT]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, f"{MAC}_room_priority"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "follow_me"
+    assert state.attributes[ATTR_OPTIONS] == ["follow_me", "Living Room"]

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -1,23 +1,20 @@
 """Tests for the Honeywell Lyric sensor platform."""
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
-from aiolyric import Lyric
-from aiolyric.objects.location import LyricLocation
-from aiolyric.objects.priority import LyricRoom
+import pytest
 
-from homeassistant.components.lyric.api import LyricLocalOAuth2Implementation
 from homeassistant.components.lyric.const import DOMAIN
 from homeassistant.components.lyric.sensor import get_datetime_from_future_time
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .conftest import MAC
 
 from tests.common import MockConfigEntry
-
-_MAC = "AABBCCDDEEFF"
 
 
 def test_get_datetime_from_future_time_none() -> None:
@@ -36,92 +33,42 @@ def test_get_datetime_from_future_time_valid() -> None:
     assert isinstance(result, datetime)
 
 
-def _mock_lyric() -> MagicMock:
-    """Build a fake aiolyric Lyric client with one thermostat and one room accessory."""
-    client = MagicMock()
-    location = LyricLocation(
-        client,
-        {
-            "locationID": 1234,
-            "name": "Home",
-            "devices": [
-                # A thermostat with no device-level sensors: the sensor platform
-                # creates no thermostat entity, so the thermostat device can only
-                # come from the up-front registration in async_setup_entry.
-                {
-                    "deviceID": f"LCC-{_MAC}",
-                    "deviceClass": "Thermostat",
-                    "macID": _MAC,
-                    "name": "Thermostat",
-                    "deviceModel": "T5-T6",
-                }
-            ],
-        },
-    )
-    room = LyricRoom(
-        {
-            "id": 1,
-            "name": "Living Room",
-            "avgTemperature": 21,
-            "avgHumidity": 40,
-            "accessories": [
-                {"id": 1, "sensorType": "IndoorAirSensor", "temperature": 21}
-            ],
-        }
-    )
-
-    lyric = MagicMock(spec=Lyric)
-    lyric.get_locations = AsyncMock()
-    lyric.get_thermostat_rooms = AsyncMock()
-    lyric.locations = [location]
-    lyric.locations_dict = {1234: location}
-    lyric.rooms_dict = {_MAC: {1: room}}
-    return lyric
-
-
+@pytest.mark.usefixtures("mock_lyric")
 async def test_accessory_links_to_thermostat_via_device(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test room accessory devices resolve the thermostat as their via_device."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "auth_implementation": DOMAIN,
-            "token": {
-                "access_token": "mock-access-token",
-                "refresh_token": "mock-refresh-token",
-                "expires_at": 9999999999,
-                "token_type": "Bearer",
-            },
-        },
-    )
-    entry.add_to_hass(hass)
-
-    implementation = MagicMock(spec=LyricLocalOAuth2Implementation)
-    implementation.client_id = "client-id"
-
-    with (
-        patch(
-            "homeassistant.helpers.config_entry_oauth2_flow."
-            "async_get_config_entry_implementation",
-            return_value=implementation,
-        ),
-        patch("homeassistant.components.lyric.PLATFORMS", [Platform.SENSOR]),
-        patch("homeassistant.components.lyric.Lyric", return_value=_mock_lyric()),
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
+    """Test room sensors remain linked with a non-thermostat in the account."""
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     thermostat = device_registry.async_get_device_by_identifier(
-        (dr.CONNECTION_NETWORK_MAC, _MAC), entry.entry_id
+        (dr.CONNECTION_NETWORK_MAC, MAC), mock_config_entry.entry_id
     )
     assert thermostat is not None
 
     accessory = device_registry.async_get_device_by_identifier(
-        (f"{dr.CONNECTION_NETWORK_MAC}_room_accessory", f"{_MAC}_room1_accessory1"),
-        entry.entry_id,
+        (f"{dr.CONNECTION_NETWORK_MAC}_room_accessory", f"{MAC}_room1_accessory1"),
+        mock_config_entry.entry_id,
     )
     assert accessory is not None
     assert accessory.via_device_id == thermostat.id
+
+    for sensor_key in (
+        "room_temperature",
+        "room_humidity",
+        "room_average_temperature",
+    ):
+        assert (
+            entity_registry.async_get_entity_id(
+                Platform.SENSOR,
+                DOMAIN,
+                f"{MAC}_room1_acc1_{sensor_key}",
+            )
+            is not None
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Not applicable.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Honeywell's location response can contain leak detectors alongside thermostats. Leak detectors do not provide a MAC address, but Lyric setup registered every returned device as a thermostat and passed the missing MAC address to the device registry. This caused config entry setup to fail with a `TypeError` before any entities loaded.

This change limits thermostat-specific registration, climate entities, device sensors, and room-accessory traversal to devices whose API `deviceClass` is `Thermostat`. It does not limit thermostat room data: regression tests cover the existing climate entity, room temperature/humidity sensors, accessory `via_device` relationship, and room-priority select when a leak detector is present.

Validation: `pytest -q tests/components/lyric` (10 passed), Ruff check/format, and `git diff --check`.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117335
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
