### PR TITLE
Add Lyric leak detector entities

### DIFF
--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -23,7 +23,12 @@ from .entity import create_thermostat_device_info
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SELECT, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LyricConfigEntry) -> bool:
@@ -67,6 +72,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LyricConfigEntry) -> boo
     device_registry = dr.async_get(hass)
     for location in coordinator.data.locations:
         for device in location.devices:
+            if device.device_class != "Thermostat":
+                continue
             device_registry.async_get_or_create(
                 config_entry_id=entry.entry_id,
                 **create_thermostat_device_info(device),

--- a/homeassistant/components/lyric/binary_sensor.py
+++ b/homeassistant/components/lyric/binary_sensor.py
@@ -1,0 +1,54 @@
+"""Support for Honeywell Lyric binary sensors."""
+
+from typing import override
+
+from aiolyric.objects.device import LyricDevice
+from aiolyric.objects.location import LyricLocation
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LyricConfigEntry, LyricDataUpdateCoordinator
+from .entity import LyricLeakDetectorEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LyricConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Honeywell Lyric binary sensors."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        LyricLeakDetectorBinarySensor(coordinator, location, device)
+        for location in coordinator.data.locations
+        for device in location.devices
+        if device.device_class == "LeakDetector" and device.device_id
+    )
+
+
+class LyricLeakDetectorBinarySensor(LyricLeakDetectorEntity, BinarySensorEntity):
+    """Define a Honeywell Lyric leak detector binary sensor."""
+
+    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+    _attr_translation_key = "water_leak"
+
+    def __init__(
+        self,
+        coordinator: LyricDataUpdateCoordinator,
+        location: LyricLocation,
+        device: LyricDevice,
+    ) -> None:
+        """Initialize the leak detector binary sensor."""
+        super().__init__(coordinator, location, device, "water_leak")
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return whether water is detected."""
+        return self.device.water_present

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -137,6 +137,7 @@ async def async_setup_entry(
             )
             for location in coordinator.data.locations
             for device in location.devices
+            if device.device_class == "Thermostat"
         ),
         True,
     )

--- a/homeassistant/components/lyric/entity.py
+++ b/homeassistant/components/lyric/entity.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import LyricDataUpdateCoordinator
 
 
@@ -69,6 +70,57 @@ class LyricDeviceEntity(LyricEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this Honeywell Lyric instance."""
         return create_thermostat_device_info(self.device)
+
+
+class LyricLeakDetectorEntity(CoordinatorEntity[LyricDataUpdateCoordinator]):
+    """Define a Honeywell Lyric leak detector entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: LyricDataUpdateCoordinator,
+        location: LyricLocation,
+        device: LyricDevice,
+        key: str,
+    ) -> None:
+        """Initialize the Honeywell Lyric leak detector entity."""
+        super().__init__(coordinator)
+        self._location_id = location.location_id
+        self._device_id = device.device_id
+        self._attr_unique_id = f"{device.device_id}_{key}"
+
+    @property
+    def location(self) -> LyricLocation:
+        """Return the Lyric location."""
+        return self.coordinator.data.locations_dict[self._location_id]
+
+    @property
+    def device(self) -> LyricDevice:
+        """Return the Lyric leak detector."""
+        return self.location.devices_by_id[self._device_id]
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the leak detector is available."""
+        return (
+            super().available
+            and self.device.is_alive
+            and not self.device.is_device_offline
+        )
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information for the leak detector."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            manufacturer="Honeywell",
+            model=self.device.device_variant or self.device.device_type,
+            name=self.device.name,
+            sw_version=self.device.device_os_version,
+        )
 
 
 class LyricAccessoryEntity(LyricDeviceEntity):

--- a/homeassistant/components/lyric/manifest.json
+++ b/homeassistant/components/lyric/manifest.json
@@ -22,5 +22,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["aiolyric"],
-  "requirements": ["aiolyric==2.1.2"]
+  "requirements": ["aiolyric==2.1.3"]
 }

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -15,7 +15,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -29,7 +34,7 @@ from .const import (
     PRESET_VACATION_HOLD,
 )
 from .coordinator import LyricConfigEntry, LyricDataUpdateCoordinator
-from .entity import LyricAccessoryEntity, LyricDeviceEntity
+from .entity import LyricAccessoryEntity, LyricDeviceEntity, LyricLeakDetectorEntity
 
 LYRIC_SETPOINT_STATUS_NAMES = {
     PRESET_NO_HOLD: "Following Schedule",
@@ -143,6 +148,50 @@ ACCESSORY_SENSORS: list[LyricSensorAccessoryEntityDescription] = [
     ),
 ]
 
+LEAK_DETECTOR_SENSORS: tuple[LyricSensorEntityDescription, ...] = (
+    LyricSensorEntityDescription(
+        key="temperature",
+        translation_key="leak_detector_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.current_sensor_readings.temperature,
+        suitable_fn=lambda device: (
+            device.current_sensor_readings.temperature is not None
+        ),
+    ),
+    LyricSensorEntityDescription(
+        key="humidity",
+        translation_key="leak_detector_humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda device: device.current_sensor_readings.humidity,
+        suitable_fn=lambda device: device.current_sensor_readings.humidity is not None,
+    ),
+    LyricSensorEntityDescription(
+        key="battery",
+        translation_key="leak_detector_battery",
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.battery_remaining,
+        suitable_fn=lambda device: device.battery_remaining is not None,
+    ),
+    LyricSensorEntityDescription(
+        key="signal_strength",
+        translation_key="leak_detector_signal_strength",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda device: device.wifi_signal_strength,
+        suitable_fn=lambda device: device.wifi_signal_strength not in (None, 0),
+    ),
+)
+
 
 def get_setpoint_status(status: str, time: str) -> str | None:
     """Get status of the setpoint."""
@@ -181,6 +230,7 @@ async def async_setup_entry(
         )
         for location in coordinator.data.locations
         for device in location.devices
+        if device.device_class == "Thermostat"
         for device_sensor in DEVICE_SENSORS
         if device_sensor.suitable_fn(device)
     )
@@ -191,10 +241,25 @@ async def async_setup_entry(
         )
         for location in coordinator.data.locations
         for device in location.devices
+        if device.device_class == "Thermostat"
         for room in coordinator.data.rooms_dict.get(device.mac_id, {}).values()
         for accessory in room.accessories
         for accessory_sensor in ACCESSORY_SENSORS
         if accessory_sensor.suitable_fn(room, accessory)
+    )
+
+    async_add_entities(
+        LyricLeakDetectorSensor(
+            coordinator,
+            description,
+            location,
+            device,
+        )
+        for location in coordinator.data.locations
+        for device in location.devices
+        if device.device_class == "LeakDetector" and device.device_id
+        for description in LEAK_DETECTOR_SENSORS
+        if description.suitable_fn(device)
     )
 
 
@@ -266,3 +331,26 @@ class LyricAccessorySensor(LyricAccessoryEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         return self.entity_description.value_fn(self.room, self.accessory)
+
+
+class LyricLeakDetectorSensor(LyricLeakDetectorEntity, SensorEntity):
+    """Define a Honeywell Lyric leak detector sensor."""
+
+    entity_description: LyricSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LyricDataUpdateCoordinator,
+        description: LyricSensorEntityDescription,
+        location: LyricLocation,
+        device: LyricDevice,
+    ) -> None:
+        """Initialize the leak detector sensor."""
+        super().__init__(coordinator, location, device, description.key)
+        self.entity_description = description
+
+    @property
+    @override
+    def native_value(self) -> StateType | datetime:
+        """Return the state."""
+        return self.entity_description.value_fn(self.device)

--- a/homeassistant/components/lyric/strings.json
+++ b/homeassistant/components/lyric/strings.json
@@ -37,6 +37,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "water_leak": {
+        "name": "Water leak"
+      }
+    },
     "select": {
       "room_priority": {
         "name": "Room priority",
@@ -51,6 +56,18 @@
       },
       "indoor_temperature": {
         "name": "Indoor temperature"
+      },
+      "leak_detector_battery": {
+        "name": "Battery"
+      },
+      "leak_detector_humidity": {
+        "name": "Humidity"
+      },
+      "leak_detector_signal_strength": {
+        "name": "Signal strength"
+      },
+      "leak_detector_temperature": {
+        "name": "Temperature"
       },
       "next_period_time": {
         "name": "Next period time"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -339,7 +339,7 @@ aiolifx==1.2.2
 aiolookin==1.0.0
 
 # homeassistant.components.lyric
-aiolyric==2.1.2
+aiolyric==2.1.3
 
 # homeassistant.components.mealie
 aiomealie==2.0.0

--- a/tests/components/lyric/conftest.py
+++ b/tests/components/lyric/conftest.py
@@ -1,0 +1,152 @@
+"""Fixtures for Honeywell Lyric tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiolyric import Lyric
+from aiolyric.objects.location import LyricLocation
+from aiolyric.objects.priority import LyricPriority, LyricRoom
+import pytest
+
+from homeassistant.components.lyric.api import LyricLocalOAuth2Implementation
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MAC = "AABBCCDDEEFF"
+WLD3_ID = "a481b5a7-47cf-4a68-9374-b181b7f55452"
+L1_ID = "74d0c5c2-5cab-4425-936b-855c132b9d75"
+
+
+@pytest.fixture
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a Honeywell Lyric config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": 9999999999,
+                "token_type": "Bearer",
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_lyric() -> Generator[MagicMock]:
+    """Mock an account containing a thermostat and leak detectors."""
+    client = MagicMock()
+    location = LyricLocation(
+        client,
+        {
+            "locationID": 1234,
+            "name": "Home",
+            "devices": [
+                {
+                    "deviceID": f"LCC-{MAC}",
+                    "deviceClass": "Thermostat",
+                    "macID": MAC,
+                    "name": "Thermostat",
+                    "deviceModel": "T9",
+                    "units": "Fahrenheit",
+                    "allowedModes": ["Heat", "Cool", "Off"],
+                    "indoorTemperature": 70,
+                    "changeableValues": {
+                        "mode": "Heat",
+                        "heatSetpoint": 68,
+                        "coolSetpoint": 75,
+                        "thermostatSetpointStatus": "NoHold",
+                    },
+                    "operationStatus": {"mode": "EquipmentOff"},
+                },
+                {
+                    "waterPresent": False,
+                    "currentSensorReadings": {
+                        "time": "2024-05-12T12:46:18",
+                        "temperature": 20.85,
+                        "humidity": 57.7,
+                    },
+                    "currentAlarms": [],
+                    "lastCheckin": "2024-05-12T12:46:20",
+                    "batteryRemaining": 29,
+                    "hasDeviceCheckedIn": True,
+                    "isDeviceOffline": False,
+                    "wifiSignalStrength": -48,
+                    "deviceClass": "LeakDetector",
+                    "deviceType": "Water Leak Detector",
+                    "deviceID": WLD3_ID,
+                    "userDefinedDeviceName": "Laundry",
+                    "isAlive": True,
+                    "deviceVariant": "WLD3",
+                },
+                {
+                    "waterPresent": True,
+                    "currentSensorReadings": {
+                        "time": "2024-09-20T15:00:37",
+                        "temperature": 25.39,
+                        "humidity": 56.5,
+                    },
+                    "currentAlarms": [],
+                    "lastCheckin": "2024-09-20T15:00:42",
+                    "batteryRemaining": 100,
+                    "hasDeviceCheckedIn": True,
+                    "isDeviceOffline": False,
+                    "wifiSignalStrength": 0,
+                    "deviceClass": "LeakDetector",
+                    "deviceType": "Water Leak Detector",
+                    "deviceID": L1_ID,
+                    "userDefinedDeviceName": "Water Heater",
+                    "isAlive": True,
+                    "deviceVariant": "L1_SmartWaterSensor_Retail",
+                },
+            ],
+        },
+    )
+    room = LyricRoom(
+        {
+            "id": 1,
+            "name": "Living Room",
+            "avgTemperature": 71,
+            "avgHumidity": 40,
+            "accessories": [
+                {"id": 1, "sensorType": "IndoorAirSensor", "temperature": 71}
+            ],
+        }
+    )
+    priority = LyricPriority(
+        {
+            "deviceId": MAC,
+            "priority": {
+                "priorityType": "FollowMe",
+                "selectedRooms": [],
+            },
+        }
+    )
+
+    lyric = MagicMock(spec=Lyric)
+    lyric.get_locations = AsyncMock()
+    lyric.get_thermostat_rooms = AsyncMock()
+    lyric.update_priority = AsyncMock()
+    lyric.locations = [location]
+    lyric.locations_dict = {1234: location}
+    lyric.priorities_dict = {MAC: priority}
+    lyric.rooms_dict = {MAC: {1: room}}
+
+    implementation = MagicMock(spec=LyricLocalOAuth2Implementation)
+    implementation.client_id = "client-id"
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow."
+            "async_get_config_entry_implementation",
+            return_value=implementation,
+        ),
+        patch("homeassistant.components.lyric.Lyric", return_value=lyric),
+    ):
+        yield lyric

--- a/tests/components/lyric/test_binary_sensor.py
+++ b/tests/components/lyric/test_binary_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for the Honeywell Lyric binary sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .conftest import L1_ID, WLD3_ID
+
+from tests.common import MockConfigEntry
+
+
+async def test_leak_detector_binary_sensors(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_lyric: MagicMock,
+) -> None:
+    """Test WLD3 and L1 leak detector binary sensors."""
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    for device_id, expected_state, expected_model in (
+        (WLD3_ID, STATE_OFF, "WLD3"),
+        (L1_ID, STATE_ON, "L1_SmartWaterSensor_Retail"),
+    ):
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, f"{device_id}_water_leak"
+        )
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == expected_state
+        assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOISTURE
+
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
+        )
+        assert device is not None
+        assert device.model == expected_model
+        assert not device.connections
+
+    mock_lyric.locations[0].attributes["devices"][1]["isDeviceOffline"] = True
+    mock_config_entry.runtime_data.async_set_updated_data(mock_lyric)
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{WLD3_ID}_water_leak"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/lyric/test_leak_sensor.py
+++ b/tests/components/lyric/test_leak_sensor.py
@@ -1,0 +1,95 @@
+"""Tests for Honeywell Lyric leak detector sensors."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    Platform,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import L1_ID, WLD3_ID
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_lyric")
+async def test_leak_detector_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test WLD3 and L1 leak detector sensors."""
+    entity_registry.async_get_or_create(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{WLD3_ID}_signal_strength",
+        suggested_object_id="laundry_signal_strength",
+    )
+
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    expected_sensors = {
+        "temperature": (
+            "20.85",
+            SensorDeviceClass.TEMPERATURE,
+            UnitOfTemperature.CELSIUS,
+        ),
+        "humidity": ("57.7", SensorDeviceClass.HUMIDITY, PERCENTAGE),
+        "battery": ("29", SensorDeviceClass.BATTERY, PERCENTAGE),
+    }
+    for key, (expected_state, device_class, unit) in expected_sensors.items():
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SENSOR, DOMAIN, f"{WLD3_ID}_{key}"
+        )
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == expected_state
+        assert state.attributes[ATTR_DEVICE_CLASS] == device_class
+        assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == unit
+
+    signal_entity_id = entity_registry.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{WLD3_ID}_signal_strength"
+    )
+    assert signal_entity_id is not None
+    signal_state = hass.states.get(signal_entity_id)
+    assert signal_state is not None
+    assert signal_state.state == "-48"
+    assert (
+        signal_state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.SIGNAL_STRENGTH
+    )
+    assert (
+        signal_state.attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    )
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SENSOR, DOMAIN, f"{L1_ID}_signal_strength"
+        )
+        is None
+    )
+
+    l1_battery_entity_id = entity_registry.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{L1_ID}_battery"
+    )
+    assert l1_battery_entity_id is not None
+    l1_battery_state = hass.states.get(l1_battery_entity_id)
+    assert l1_battery_state is not None
+    assert l1_battery_state.state == "100"
+    assert l1_battery_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE

--- a/tests/components/lyric/test_select.py
+++ b/tests/components/lyric/test_select.py
@@ -1,0 +1,39 @@
+"""Tests for the Honeywell Lyric select platform."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.lyric.const import DOMAIN
+from homeassistant.components.select import ATTR_OPTIONS
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_lyric")
+async def test_room_priority_with_non_thermostat_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test room priority remains available with non-thermostat devices."""
+    with patch("homeassistant.components.lyric.PLATFORMS", [Platform.SELECT]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, f"{MAC}_room_priority"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "follow_me"
+    assert state.attributes[ATTR_OPTIONS] == ["follow_me", "Living Room"]

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -54,7 +54,12 @@ def _mock_lyric() -> MagicMock:
                     "macID": _MAC,
                     "name": "Thermostat",
                     "deviceModel": "T5-T6",
-                }
+                },
+                {
+                    "deviceID": "leak-detector-id",
+                    "deviceClass": "LeakDetector",
+                    "userDefinedDeviceName": "Leak detector",
+                },
             ],
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Not applicable.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Add Honeywell Lyric leak detector entities for API devices whose `deviceClass` is `LeakDetector`.

Each supported detector receives a moisture binary sensor plus temperature, humidity, and battery sensors when those readings are present. A non-zero Wi-Fi signal reading is available as a disabled-by-default diagnostic sensor. Leak detectors use their stable API `deviceID` for device and entity identifiers because WLD3 and L1 payloads do not provide a MAC address. Device availability reflects both coordinator state and the API's alive/offline flags.

The existing thermostat climate entities, room sensors, accessory relationships, and room-priority select remain covered by regression tests in mixed-device accounts.

This draft depends on aiolyric 2.1.3 being released before it can be marked ready. Validation: `pytest -q tests/components/lyric` (11 passed), translation generation, Ruff check/format, and `git diff --check`.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #117335
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
