### PR TITLE
Add multi-home support to YoLink integration via UAC authentication

### DIFF
--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+import logging
 from typing import Any
 
 from yolink.const import ATTR_DEVICE_SMART_REMOTER, ATTR_DEVICE_SWITCH
@@ -27,10 +28,23 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from homeassistant.helpers.typing import ConfigType
 
 from . import api
-from .const import ATTR_LORA_INFO, DOMAIN, SUPPORTED_REMOTERS, YOLINK_EVENT
+from .const import (
+    ATTR_LORA_INFO,
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+    SUPPORTED_REMOTERS,
+    YOLINK_EVENT,
+)
 from .coordinator import YoLinkConfigEntry, YoLinkCoordinator, YoLinkHomeStore
 from .device_trigger import CONF_LONG_PRESS, CONF_SHORT_PRESS
 from .services import async_setup_services
+
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
@@ -108,19 +122,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: YoLinkConfigEntry) -> bool:
     """Set up yolink from a config entry."""
-    try:
-        implementation = await async_get_config_entry_implementation(hass, entry)
-    except ImplementationUnavailableError as err:
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="oauth2_implementation_unavailable",
-        ) from err
+    # Entries created before UAC support was added do not store an auth type.
+    if entry.data.get(CONF_AUTH_TYPE, AUTH_TYPE_OAUTH) == AUTH_TYPE_UAC:
+        auth_mgr = api.UACAuth(
+            aiohttp_client.async_get_clientsession(hass),
+            entry.data[CONF_UAID],
+            entry.data[CONF_SECRET_KEY],
+        )
+    else:
+        try:
+            implementation = await async_get_config_entry_implementation(hass, entry)
+        except ImplementationUnavailableError as err:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_implementation_unavailable",
+            ) from err
 
-    session = OAuth2Session(hass, entry, implementation)
+        session = OAuth2Session(hass, entry, implementation)
+        auth_mgr = api.ConfigEntryAuth(
+            hass, aiohttp_client.async_get_clientsession(hass), session
+        )
 
-    auth_mgr = api.ConfigEntryAuth(
-        hass, aiohttp_client.async_get_clientsession(hass), session
-    )
     yolink_home = YoLinkHome()
     try:
         async with asyncio.timeout(10):
@@ -131,6 +153,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: YoLinkConfigEntry) -> bo
         raise ConfigEntryAuthFailed from yl_auth_err
     except (YoLinkClientError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
+
+    if CONF_HOME_ID not in entry.data:
+        # Recorded for entries created before the home id was stored, so that
+        # the same home cannot be added again through the other authentication
+        # method. The home is up at this point, so a failure of this call is
+        # left for a later start to retry rather than undoing a working setup.
+        try:
+            async with asyncio.timeout(10):
+                home_info = await yolink_home.async_get_home_info()
+        except (YoLinkClientError, TimeoutError) as err:
+            # YoLinkAuthFailError is a YoLinkClientError: credentials that just
+            # set up the home are not worth a reauthentication flow over.
+            _LOGGER.debug("Could not determine the home of the entry: %s", err)
+        else:
+            if home_id := (home_info.data or {}).get("id"):
+                hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, CONF_HOME_ID: home_id}
+                )
 
     device_coordinators = {}
 

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -130,13 +130,31 @@ class UACAuth(YoLinkAuthMgr):
     async def check_and_refresh_token(self) -> str:
         """Check and refresh the token if needed."""
         async with self._token_lock:
-            if self._token is None or self._token["refresh_at"] <= time.time():
+            cached = self._token
+            if cached is not None and time.time() < cached["refresh_at"]:
+                return cached["access_token"]
+            try:
                 token = await self._token_request()
-                # Refresh once half the lifetime has passed, so a failing token
-                # endpoint can be retried while the current token still works.
-                token["refresh_at"] = time.time() + token["expires_in"] / 2
-                self._token = token
-            return self._token["access_token"]
+            except YoLinkAuthFailError:
+                # The credentials were refused, retrying cannot fix that.
+                raise
+            except YoLinkClientError as err:
+                # A cached token stays usable for the rest of its lifetime, so a
+                # transient failure of the token endpoint interrupts nothing.
+                if cached is None or time.time() >= cached["expires_at"]:
+                    raise
+                _LOGGER.debug(
+                    "UAC token refresh failed, keeping the cached token: %s",
+                    err.message,
+                )
+                return cached["access_token"]
+            now = time.time()
+            # Refresh once half the lifetime has passed, so a failing token
+            # endpoint can be retried while the current token still works.
+            token["refresh_at"] = now + token["expires_in"] / 2
+            token["expires_at"] = now + token["expires_in"]
+            self._token = token
+            return token["access_token"]
 
     async def _token_request(self) -> dict[str, Any]:
         """Request a new access token from the yolink token endpoint."""
@@ -156,6 +174,9 @@ class UACAuth(YoLinkAuthMgr):
                     try:
                         error_response = await resp.json()
                     except ClientError, ValueError:
+                        error_response = None
+                    if not isinstance(error_response, dict):
+                        # A body that is not a JSON object carries no error.
                         error_response = {}
                     error_code = error_response.get("error", "unknown")
                     error_desc = error_response.get(

--- a/homeassistant/components/yolink/api.py
+++ b/homeassistant/components/yolink/api.py
@@ -1,10 +1,58 @@
-"""API for yolink bound to Home Assistant OAuth."""
+"""API for yolink."""
 
-from aiohttp import ClientSession
+import asyncio
+from http import HTTPStatus
+import logging
+import time
+from typing import Any
+
+from aiohttp import ClientError, ClientSession, ClientTimeout
 from yolink.auth_mgr import YoLinkAuthMgr
+from yolink.const import OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+
+_LOGGER = logging.getLogger(__name__)
+
+# Fields a token response carries when it reports an error instead of a token.
+_TOKEN_ERROR_FIELDS = ("code", "desc", "error", "error_description")
+
+
+def _parse_token_response(payload: Any) -> dict[str, Any]:
+    """Return the token of a successful token response, or raise."""
+    if not isinstance(payload, dict):
+        raise YoLinkClientError("invalid_response", "Token response is not an object")
+
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        if not any(field in payload for field in _TOKEN_ERROR_FIELDS):
+            # Nothing was refused, the response is simply unusable. Reporting it
+            # as an authentication failure would ask the user to reauthenticate
+            # over what the next request may well answer correctly.
+            raise YoLinkClientError(
+                "invalid_response", "Token response has no usable access token"
+            )
+        # Invalid credentials are reported with HTTP 200 and an error body.
+        raise YoLinkAuthFailError(
+            payload.get("code", payload.get("error", "unknown")),
+            payload.get("desc", payload.get("error_description", "unknown error")),
+        )
+
+    expires_in = payload.get("expires_in")
+    if (
+        # A bool is an int, but not a lifetime.
+        isinstance(expires_in, bool)
+        or not isinstance(expires_in, int | float)
+        or expires_in <= 0
+    ):
+        raise YoLinkClientError(
+            "invalid_response",
+            f"Token response has an invalid lifetime: {expires_in!r}",
+        )
+
+    return payload
 
 
 class ConfigEntryAuth(YoLinkAuthMgr):
@@ -14,18 +62,119 @@ class ConfigEntryAuth(YoLinkAuthMgr):
         self,
         hass: HomeAssistant,
         websession: ClientSession,
-        oauth2Session: config_entry_oauth2_flow.OAuth2Session,
+        oauth_session: OAuth2Session,
     ) -> None:
         """Initialize yolink Auth."""
-        self.hass = hass
-        self.oauth_session = oauth2Session
         super().__init__(websession)
+        self.hass = hass
+        self._oauth_session = oauth_session
 
     def access_token(self) -> str:
         """Return the access token."""
-        return self.oauth_session.token["access_token"]
+        return self._oauth_session.token["access_token"]
 
     async def check_and_refresh_token(self) -> str:
-        """Check the token."""
-        await self.oauth_session.async_ensure_token_valid()
+        """Check and refresh the token if needed."""
+        await self._oauth_session.async_ensure_token_valid()
         return self.access_token()
+
+
+class StaticTokenAuth(YoLinkAuthMgr):
+    """Provide yolink authentication with an already obtained access token.
+
+    Used by the config flow, where an OAuth2 token has been resolved but no
+    config entry exists yet to refresh it from.
+    """
+
+    def __init__(self, websession: ClientSession, access_token: str) -> None:
+        """Initialize yolink static token Auth."""
+        super().__init__(websession)
+        self._access_token = access_token
+
+    def access_token(self) -> str:
+        """Return the access token."""
+        return self._access_token
+
+    async def check_and_refresh_token(self) -> str:
+        """Return the access token, which cannot be refreshed."""
+        return self._access_token
+
+
+class UACAuth(YoLinkAuthMgr):
+    """Provide yolink authentication using User Access Credentials.
+
+    Extends YoLinkAuthMgr instead of the library's YoLinkLocalAuthMgr because
+    the library's MQTT client uses isinstance(auth_mgr, YoLinkLocalAuthMgr) to
+    select local hub credentials, while UAC connects to the cloud broker.
+    """
+
+    def __init__(
+        self,
+        websession: ClientSession,
+        uaid: str,
+        secret_key: str,
+    ) -> None:
+        """Initialize yolink UAC Auth."""
+        super().__init__(websession)
+        self._client_id = uaid
+        self._client_secret = secret_key
+        self._token: dict[str, Any] | None = None
+        self._token_lock = asyncio.Lock()
+
+    def access_token(self) -> str | None:
+        """Return the access token."""
+        if self._token is None:
+            return None
+        return self._token["access_token"]
+
+    async def check_and_refresh_token(self) -> str:
+        """Check and refresh the token if needed."""
+        async with self._token_lock:
+            if self._token is None or self._token["refresh_at"] <= time.time():
+                token = await self._token_request()
+                # Refresh once half the lifetime has passed, so a failing token
+                # endpoint can be retried while the current token still works.
+                token["refresh_at"] = time.time() + token["expires_in"] / 2
+                self._token = token
+            return self._token["access_token"]
+
+    async def _token_request(self) -> dict[str, Any]:
+        """Request a new access token from the yolink token endpoint."""
+        try:
+            async with self._session.post(
+                url=OAUTH2_TOKEN,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "client_credentials",
+                    "scope": "create",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+                timeout=ClientTimeout(total=10),
+            ) as resp:
+                if resp.status >= HTTPStatus.BAD_REQUEST:
+                    try:
+                        error_response = await resp.json()
+                    except ClientError, ValueError:
+                        error_response = {}
+                    error_code = error_response.get("error", "unknown")
+                    error_desc = error_response.get(
+                        "error_description", f"HTTP {resp.status}"
+                    )
+                    _LOGGER.debug(
+                        "UAC token request failed (%s): %s", error_code, error_desc
+                    )
+                    if resp.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                        raise YoLinkAuthFailError(error_code, error_desc)
+                    raise YoLinkClientError(error_code, error_desc)
+                try:
+                    payload = await resp.json()
+                except (ClientError, ValueError) as err:
+                    raise YoLinkClientError(
+                        "invalid_response", "Token response is not valid JSON"
+                    ) from err
+        except (ClientError, OSError) as err:
+            _LOGGER.debug("UAC token request failed: %s", err)
+            raise YoLinkClientError("request_failed", str(err)) from err
+
+        return _parse_token_response(payload)

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -1,19 +1,66 @@
 """Config flow for yolink."""
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import Any, override
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
-from homeassistant.helpers import config_entry_oauth2_flow
+import voluptuous as vol
+from yolink.auth_mgr import YoLinkAuthMgr
+from yolink.client import YoLinkClient
+from yolink.endpoint import Endpoints
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
-from .const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, selector
+
+from .api import StaticTokenAuth, UACAuth
+from .const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_fetch_home_info(auth_mgr: YoLinkAuthMgr) -> dict[str, Any]:
+    """Return the general information of the home the credentials belong to.
+
+    Only the home information is requested, so unlike YoLinkHome.async_setup
+    this neither loads the devices nor opens an MQTT connection.
+    """
+    async with asyncio.timeout(10):
+        home_info = await YoLinkClient(auth_mgr).execute(
+            url=Endpoints.US.value.url, bsdp={"method": "Home.getGeneralInfo"}
+        )
+    if not isinstance(home_info.data, dict):
+        # The data of a response is optional: an accepted request that answered
+        # without any is as unusable as a refused one.
+        raise YoLinkClientError(
+            "invalid_response", "Response carries no home information"
+        )
+    return home_info.data
+
+
+UAC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_UAID): selector.TextSelector(),
+        vol.Required(CONF_SECRET_KEY): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+    }
+)
 
 
 class OAuth2FlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
 ):
-    """Config flow to handle yolink OAuth2 authentication."""
+    """Config flow to handle yolink OAuth2 and UAC authentication."""
 
     DOMAIN = DOMAIN
 
@@ -25,10 +72,99 @@ class OAuth2FlowHandler(
 
     @property
     @override
-    def extra_authorize_data(self) -> dict:
+    def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
-        scopes = ["create"]
-        return {"scope": " ".join(scopes)}
+        return {"scope": "create"}
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow start."""
+        if self._async_oauth_entry_exists():
+            # Only one OAuth2 entry is supported, so UAC is the only way left
+            # to add another home.
+            return await self.async_step_uac()
+
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["pick_implementation", "uac"],
+        )
+
+    @override
+    async def async_step_pick_implementation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle selection of an OAuth2 implementation."""
+        # Reauthenticating the existing OAuth2 entry must remain possible.
+        if self.source != SOURCE_REAUTH and self._async_oauth_entry_exists():
+            return self.async_abort(reason="already_configured")
+
+        return await super().async_step_pick_implementation(user_input)
+
+    async def async_step_uac(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle UAC credential input."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                home_info = await _async_fetch_home_info(
+                    UACAuth(
+                        aiohttp_client.async_get_clientsession(self.hass),
+                        user_input[CONF_UAID],
+                        user_input[CONF_SECRET_KEY],
+                    )
+                )
+            except YoLinkAuthFailError:
+                errors["base"] = "invalid_auth"
+            except YoLinkClientError, TimeoutError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during UAC validation")
+                errors["base"] = "unknown"
+            else:
+                home_id = home_info.get("id")
+                if not home_id:
+                    errors["base"] = "unknown"
+                else:
+                    # Keying on the home id allows one entry per home instead
+                    # of one per account.
+                    await self.async_set_unique_id(home_id)
+
+                    if self.source == SOURCE_REAUTH:
+                        self._abort_if_unique_id_mismatch(reason="wrong_account")
+                        return self.async_update_reload_and_abort(
+                            self._get_reauth_entry(),
+                            data_updates={
+                                CONF_UAID: user_input[CONF_UAID],
+                                CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                                CONF_HOME_ID: home_id,
+                            },
+                        )
+
+                    self._abort_if_unique_id_configured()
+                    if self._async_home_id_configured(home_id):
+                        # The home is managed by the OAuth2 entry, whose unique
+                        # id is the domain rather than the home id.
+                        return self.async_abort(reason="already_configured")
+
+                    return self.async_create_entry(
+                        title=home_info.get("name", "YoLink Home"),
+                        data={
+                            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+                            CONF_UAID: user_input[CONF_UAID],
+                            CONF_SECRET_KEY: user_input[CONF_SECRET_KEY],
+                            CONF_HOME_ID: home_id,
+                        },
+                    )
+
+        return self.async_show_form(
+            step_id="uac",
+            data_schema=UAC_SCHEMA,
+            errors=errors,
+        )
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -36,27 +172,106 @@ class OAuth2FlowHandler(
         """Perform reauth upon an API authentication error."""
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None) -> ConfigFlowResult:
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
-        return await self.async_step_user()
+
+        if self._get_reauth_entry().data.get(CONF_AUTH_TYPE) == AUTH_TYPE_UAC:
+            return await self.async_step_uac()
+
+        return await super().async_step_user()
 
     @override
-    async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
+        data[CONF_AUTH_TYPE] = AUTH_TYPE_OAUTH
+
         if self.source == SOURCE_REAUTH:
-            return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), data_updates=data
-            )
+            return await self._async_reauth_oauth_entry(data)
+
+        # Entries created before UAC support use the domain as unique id, which
+        # limits OAuth2 to a single entry.
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        try:
+            home_id = await self._async_lookup_home_id(data["token"]["access_token"])
+        except YoLinkAuthFailError:
+            return self.async_abort(reason="oauth_unauthorized")
+
+        if home_id:
+            if self._async_home_id_configured(home_id):
+                return self.async_abort(reason="already_configured")
+            data[CONF_HOME_ID] = home_id
+
         return self.async_create_entry(title="YoLink", data=data)
 
-    @override
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow start."""
-        existing_entry = await self.async_set_unique_id(DOMAIN)
-        if existing_entry and self.source != SOURCE_REAUTH:
+    async def _async_reauth_oauth_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+        """Update the reauthenticated entry with the token that was resolved."""
+        reauth_entry = self._get_reauth_entry()
+
+        try:
+            home_id = await self._async_lookup_home_id(data["token"]["access_token"])
+        except YoLinkAuthFailError:
+            return self.async_abort(reason="oauth_unauthorized")
+
+        if not home_id:
+            # The account may have changed, so the recorded home id can no
+            # longer be trusted. Dropping it lets setup record the home again,
+            # which a merge of data updates could not do.
+            entry_data = {**reauth_entry.data, **data}
+            entry_data.pop(CONF_HOME_ID, None)
+            return self.async_update_reload_and_abort(reauth_entry, data=entry_data)
+
+        if self._async_home_id_configured(
+            home_id, ignore_entry_id=reauth_entry.entry_id
+        ):
             return self.async_abort(reason="already_configured")
-        return await super().async_step_user(user_input)
+
+        return self.async_update_reload_and_abort(
+            reauth_entry, data_updates={**data, CONF_HOME_ID: home_id}
+        )
+
+    async def _async_lookup_home_id(self, access_token: str) -> str | None:
+        """Return the id of the home the account owns, or None if unknown.
+
+        Recording the home is a best effort enhancement of an account the API
+        already accepted, so every failure other than a refused token leaves the
+        home unknown instead of ending the flow.
+        """
+        try:
+            home_info = await _async_fetch_home_info(
+                StaticTokenAuth(
+                    aiohttp_client.async_get_clientsession(self.hass), access_token
+                )
+            )
+        except YoLinkAuthFailError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            # Deliberately broad: an unreachable API, a malformed response and a
+            # bug in the lookup all cost no more than the home id, and none of
+            # them may keep an authorized account from being set up.
+            _LOGGER.debug("Could not determine the home of the account: %s", err)
+            return None
+        return home_info.get("id")
+
+    def _async_home_id_configured(
+        self, home_id: str, ignore_entry_id: str | None = None
+    ) -> bool:
+        """Return if an entry other than ignore_entry_id manages the home."""
+        return any(
+            entry.data.get(CONF_HOME_ID) == home_id
+            for entry in self._async_current_entries()
+            if entry.entry_id != ignore_entry_id
+        )
+
+    def _async_oauth_entry_exists(self) -> bool:
+        """Return if an OAuth2 based entry is already configured."""
+        return any(
+            # Entries created before UAC support was added have no auth type.
+            entry.data.get(CONF_AUTH_TYPE, AUTH_TYPE_OAUTH) == AUTH_TYPE_OAUTH
+            for entry in self._async_current_entries()
+        )

--- a/homeassistant/components/yolink/config_flow.py
+++ b/homeassistant/components/yolink/config_flow.py
@@ -206,6 +206,12 @@ class OAuth2FlowHandler(
             if self._async_home_id_configured(home_id):
                 return self.async_abort(reason="already_configured")
             data[CONF_HOME_ID] = home_id
+        elif self._async_other_entry_configured():
+            # Only UAC entries can be left here, and any of them may manage the
+            # home of this account. An unknown home cannot be told apart from
+            # theirs, so setup would record it on two entries instead of the
+            # flow refusing the duplicate.
+            return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(title="YoLink", data=data)
 
@@ -219,6 +225,13 @@ class OAuth2FlowHandler(
             return self.async_abort(reason="oauth_unauthorized")
 
         if not home_id:
+            if self._async_other_entry_configured(
+                ignore_entry_id=reauth_entry.entry_id
+            ):
+                # As in async_oauth_create_entry: the home another entry manages
+                # cannot be ruled out without the home id, so the token is left
+                # unwritten rather than bypassing the duplicate check.
+                return self.async_abort(reason="cannot_connect")
             # The account may have changed, so the recorded home id can no
             # longer be trusted. Dropping it lets setup record the home again,
             # which a merge of data updates could not do.
@@ -266,6 +279,12 @@ class OAuth2FlowHandler(
             entry.data.get(CONF_HOME_ID) == home_id
             for entry in self._async_current_entries()
             if entry.entry_id != ignore_entry_id
+        )
+
+    def _async_other_entry_configured(self, ignore_entry_id: str | None = None) -> bool:
+        """Return if an entry other than ignore_entry_id is configured."""
+        return any(
+            entry.entry_id != ignore_entry_id for entry in self._async_current_entries()
         )
 
     def _async_oauth_entry_exists(self) -> bool:

--- a/homeassistant/components/yolink/const.py
+++ b/homeassistant/components/yolink/const.py
@@ -51,3 +51,11 @@ SUPPORTED_REMOTERS = [
     DEV_MODEL_FLEX_FOB_YS3614_EC,
     DEV_MODEL_FLEX_FOB_YS3614_UC,
 ]
+
+CONF_AUTH_TYPE = "auth_type"
+AUTH_TYPE_OAUTH = "oauth"
+AUTH_TYPE_UAC = "uac"
+
+CONF_UAID = "uaid"
+CONF_SECRET_KEY = "secret_key"
+CONF_HOME_ID = "home_id"

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -12,10 +12,16 @@
       "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "The credentials provided are for a different YoLink home than the one configured. Use the UAC credentials for the home you want to re-authenticate, or remove this integration entry and add it again if you want to change homes."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "pick_implementation": {
@@ -30,6 +36,25 @@
       "reauth_confirm": {
         "description": "The YoLink integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "uac": {
+        "data": {
+          "secret_key": "Secret key",
+          "uaid": "UAID (User Access ID)"
+        },
+        "data_description": {
+          "secret_key": "The secret key associated with your UAID",
+          "uaid": "The User Access ID from your YoLink app"
+        },
+        "description": "Enter your User Access Credentials from the YoLink app.\n\nTo find these: YoLink App -> Settings -> Account -> Advanced Settings -> User Access Credentials",
+        "title": "Enter UAC credentials"
+      },
+      "user": {
+        "description": "Choose how you want to authenticate with YoLink.",
+        "menu_options": {
+          "pick_implementation": "Sign in with YoLink account",
+          "uac": "Use UAC credentials (recommended for multiple homes)"
+        }
       }
     }
   },

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -4,6 +4,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "missing_credentials": "[%key:common::config_flow::abort::oauth2_missing_credentials%]",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",

--- a/tests/components/yolink/conftest.py
+++ b/tests/components/yolink/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from yolink.home_manager import YoLinkHome
+from yolink.model import BRDP
 
 from homeassistant.components.application_credentials import (
     DOMAIN as APPLICATION_CREDENTIALS_DOMAIN,
@@ -13,6 +14,14 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.yolink.api import ConfigEntryAuth
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -20,7 +29,28 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
-DOMAIN = "yolink"
+
+TEST_UAID = "test-uaid-12345"
+TEST_SECRET_KEY = "test-secret-key-6789"
+TEST_HOME_ID = "home_12345"
+TEST_HOME_NAME = "My Test Home"
+
+
+def home_info_response(
+    home_id: str = TEST_HOME_ID, name: str | None = TEST_HOME_NAME
+) -> BRDP:
+    """Return a Home.getGeneralInfo response for a home."""
+    data: dict[str, Any] = {"id": home_id}
+    if name is not None:
+        data["name"] = name
+    return BRDP(code="000000", data=data)
+
+
+def build_yolink_home() -> AsyncMock:
+    """Return a mocked YoLink home instance."""
+    home_instance = AsyncMock(spec=YoLinkHome)
+    home_instance.async_get_home_info.return_value = home_info_response()
+    return home_instance
 
 
 @pytest.fixture
@@ -40,6 +70,15 @@ async def setup_credentials(hass: HomeAssistant) -> None:
     )
 
 
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.yolink.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
+
+
 @pytest.fixture(name="mock_auth_manager")
 def mock_auth_manager() -> Generator[MagicMock]:
     """Mock the authentication manager."""
@@ -56,13 +95,26 @@ def mock_yolink_home() -> Generator[AsyncMock]:
     with patch(
         "homeassistant.components.yolink.YoLinkHome", autospec=True
     ) as mock_home:
-        mock_home.return_value = AsyncMock(spec=YoLinkHome)
+        mock_home.return_value = build_yolink_home()
         yield mock_home
+
+
+@pytest.fixture(name="mock_yolink_client")
+def mock_yolink_client() -> Generator[AsyncMock]:
+    """Mock the YoLink API client used by the config flow."""
+    with patch(
+        "homeassistant.components.yolink.config_flow.YoLinkClient", autospec=True
+    ) as mock_client:
+        mock_client.return_value.execute.return_value = home_info_response()
+        yield mock_client
 
 
 @pytest.fixture
 def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Mock a config entry for YoLink."""
+    """Mock an OAuth2 config entry for YoLink.
+
+    Predates UAC support, so it carries no auth type.
+    """
     config_entry = MockConfigEntry(
         unique_id=DOMAIN,
         domain=DOMAIN,
@@ -76,6 +128,25 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
                 "expires_in": 60,
                 "scope": "create",
             },
+        },
+        options={},
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.fixture
+def mock_uac_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Mock a UAC config entry for YoLink."""
+    config_entry = MockConfigEntry(
+        unique_id=TEST_HOME_ID,
+        domain=DOMAIN,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
         },
         options={},
     )

--- a/tests/components/yolink/test_api.py
+++ b/tests/components/yolink/test_api.py
@@ -1,0 +1,366 @@
+"""Test the yolink authentication managers."""
+
+import asyncio
+import time
+from typing import Any
+
+from aiohttp import ClientError
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from yarl import URL
+from yolink.const import OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+
+from homeassistant.components.yolink.api import (
+    ConfigEntryAuth,
+    StaticTokenAuth,
+    UACAuth,
+)
+from homeassistant.components.yolink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .conftest import TEST_SECRET_KEY, TEST_UAID
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+def _uac_auth(hass: HomeAssistant) -> UACAuth:
+    """Return a UAC authentication manager."""
+    return UACAuth(async_get_clientsession(hass), TEST_UAID, TEST_SECRET_KEY)
+
+
+async def _oauth_auth(hass: HomeAssistant, token: dict[str, Any]) -> ConfigEntryAuth:
+    """Return an OAuth2 authentication manager for an entry holding token."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"auth_implementation": DOMAIN, "token": token},
+    )
+    config_entry.add_to_hass(hass)
+    implementation = (
+        await config_entry_oauth2_flow.async_get_config_entry_implementation(
+            hass, config_entry
+        )
+    )
+    return ConfigEntryAuth(
+        hass,
+        async_get_clientsession(hass),
+        config_entry_oauth2_flow.OAuth2Session(hass, config_entry, implementation),
+    )
+
+
+async def test_uac_token_refreshed_after_half_its_lifetime(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the token is reused until half its lifetime has passed."""
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
+    )
+    auth = _uac_auth(hass)
+
+    assert auth.access_token() is None
+
+    assert await auth.check_and_refresh_token() == "token-1"
+    assert auth.access_token() == "token-1"
+    assert aioclient_mock.call_count == 1
+
+    freezer.tick(3599)
+    assert await auth.check_and_refresh_token() == "token-1"
+    assert aioclient_mock.call_count == 1
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-2", "expires_in": 7200}
+    )
+
+    freezer.tick(2)
+    assert await auth.check_and_refresh_token() == "token-2"
+    assert auth.access_token() == "token-2"
+    assert aioclient_mock.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_error"),
+    [
+        pytest.param(401, YoLinkAuthFailError, id="unauthorized"),
+        pytest.param(403, YoLinkAuthFailError, id="forbidden"),
+        pytest.param(500, YoLinkClientError, id="server_error"),
+    ],
+)
+async def test_uac_token_request_http_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    status: int,
+    expected_error: type[YoLinkClientError],
+) -> None:
+    """Test an HTTP error from the token endpoint."""
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        status=status,
+        json={"error": "invalid_client", "error_description": "Bad credentials"},
+    )
+    auth = _uac_auth(hass)
+
+    with pytest.raises(expected_error) as err:
+        await auth.check_and_refresh_token()
+
+    assert type(err.value) is expected_error
+    assert err.value.code == "invalid_client"
+    assert err.value.message == "Bad credentials"
+
+
+async def test_uac_token_request_http_error_without_json_body(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test an HTTP error carrying an unparsable body."""
+    aioclient_mock.post(OAUTH2_TOKEN, status=502, text="<html>Bad gateway</html>")
+    auth = _uac_auth(hass)
+
+    with pytest.raises(YoLinkClientError) as err:
+        await auth.check_and_refresh_token()
+
+    assert err.value.code == "unknown"
+    assert err.value.message == "HTTP 502"
+
+
+@pytest.mark.parametrize(
+    ("response", "code", "message"),
+    [
+        pytest.param(
+            {"code": "000103", "desc": "Client is not exist"},
+            "000103",
+            "Client is not exist",
+            id="yolink_error_body",
+        ),
+        pytest.param(
+            {"error": "invalid_client", "error_description": "Bad secret key"},
+            "invalid_client",
+            "Bad secret key",
+            id="oauth_error_body",
+        ),
+        pytest.param(
+            {"desc": "Client is not exist"},
+            "unknown",
+            "Client is not exist",
+            id="described_error_body",
+        ),
+        pytest.param(
+            {"access_token": "", "code": "000103", "desc": "Client is not exist"},
+            "000103",
+            "Client is not exist",
+            id="empty_access_token_with_error",
+        ),
+    ],
+)
+async def test_uac_token_request_error_body(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    response: dict[str, Any],
+    code: str,
+    message: str,
+) -> None:
+    """Test the token endpoint reporting an error with HTTP 200."""
+    aioclient_mock.post(OAUTH2_TOKEN, json=response)
+    auth = _uac_auth(hass)
+
+    with pytest.raises(YoLinkAuthFailError) as err:
+        await auth.check_and_refresh_token()
+
+    assert err.value.code == code
+    assert err.value.message == message
+
+
+@pytest.mark.parametrize(
+    "response_kwargs",
+    [
+        pytest.param({"text": "<html>Not JSON</html>"}, id="undecodable_body"),
+        pytest.param({"json": ["token"]}, id="body_is_not_an_object"),
+        # A body that reports no error is malformed rather than a refusal, so it
+        # must not be reported as one and start a reauthentication.
+        pytest.param({"json": {}}, id="empty_body"),
+        pytest.param(
+            {"json": {"access_token": "", "expires_in": 7200}},
+            id="empty_access_token",
+        ),
+        pytest.param(
+            {"json": {"access_token": 12345, "expires_in": 7200}},
+            id="non_string_access_token",
+        ),
+        pytest.param({"json": {"access_token": "token-1"}}, id="missing_expires_in"),
+        pytest.param(
+            {"json": {"access_token": "token-1", "expires_in": "7200"}},
+            id="non_numeric_expires_in",
+        ),
+        pytest.param(
+            {"json": {"access_token": "token-1", "expires_in": True}},
+            id="boolean_expires_in",
+        ),
+        pytest.param(
+            {"json": {"access_token": "token-1", "expires_in": 0}},
+            id="zero_expires_in",
+        ),
+        pytest.param(
+            {"json": {"access_token": "token-1", "expires_in": -60}},
+            id="negative_expires_in",
+        ),
+    ],
+)
+async def test_uac_token_request_unusable_success_body(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    response_kwargs: dict[str, Any],
+) -> None:
+    """Test an HTTP 200 body that cannot be used as a token."""
+    aioclient_mock.post(OAUTH2_TOKEN, **response_kwargs)
+    auth = _uac_auth(hass)
+
+    with pytest.raises(YoLinkClientError) as err:
+        await auth.check_and_refresh_token()
+
+    assert type(err.value) is YoLinkClientError
+    assert err.value.code == "invalid_response"
+    assert auth.access_token() is None
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(ClientError("Connection reset"), id="client_error"),
+        pytest.param(OSError("Network unreachable"), id="os_error"),
+    ],
+)
+async def test_uac_token_request_network_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    exception: Exception,
+) -> None:
+    """Test a failing connection to the token endpoint."""
+    aioclient_mock.post(OAUTH2_TOKEN, exc=exception)
+    auth = _uac_auth(hass)
+
+    with pytest.raises(YoLinkClientError) as err:
+        await auth.check_and_refresh_token()
+
+    assert type(err.value) is YoLinkClientError
+    assert err.value.code == "request_failed"
+
+
+async def test_uac_token_request_is_single_flight(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test concurrent callers share a single token request."""
+    release = asyncio.Event()
+
+    async def _blocked_token(
+        method: str, url: URL, data: Any
+    ) -> AiohttpClientMockResponse:
+        await release.wait()
+        return AiohttpClientMockResponse(
+            method, url, json={"access_token": "token-1", "expires_in": 7200}
+        )
+
+    aioclient_mock.post(OAUTH2_TOKEN, side_effect=_blocked_token)
+    auth = _uac_auth(hass)
+
+    tasks = [asyncio.create_task(auth.check_and_refresh_token()) for _ in range(5)]
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    # Only the first caller reaches the token endpoint, the rest wait for it.
+    assert aioclient_mock.call_count == 1
+    release.set()
+
+    assert await asyncio.gather(*tasks) == ["token-1"] * 5
+    assert aioclient_mock.call_count == 1
+
+
+async def test_uac_failed_refresh_keeps_cached_token(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a failing refresh leaves the cached token usable."""
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
+    )
+    auth = _uac_auth(hass)
+
+    assert await auth.check_and_refresh_token() == "token-1"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(OAUTH2_TOKEN, status=500, text="<html>Bad gateway</html>")
+
+    freezer.tick(3601)
+    with pytest.raises(YoLinkClientError):
+        await auth.check_and_refresh_token()
+
+    assert auth.access_token() == "token-1"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-2", "expires_in": 7200}
+    )
+
+    assert await auth.check_and_refresh_token() == "token-2"
+
+
+async def test_static_token_auth(hass: HomeAssistant) -> None:
+    """Test the authentication manager for an already resolved token."""
+    auth = StaticTokenAuth(async_get_clientsession(hass), "mock-access-token")
+
+    assert auth.access_token() == "mock-access-token"
+    assert await auth.check_and_refresh_token() == "mock-access-token"
+    assert auth.http_auth_header() == "Bearer mock-access-token"
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_oauth_valid_token_is_kept(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test a valid OAuth2 token is returned without refreshing."""
+    auth = await _oauth_auth(
+        hass,
+        {
+            "access_token": "mock-access-token",
+            "refresh_token": "mock-refresh-token",
+            "expires_at": time.time() + 3600,
+        },
+    )
+
+    assert auth.access_token() == "mock-access-token"
+    assert await auth.check_and_refresh_token() == "mock-access-token"
+    assert aioclient_mock.call_count == 0
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_oauth_expired_token_is_refreshed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test an expired OAuth2 token is refreshed."""
+    auth = await _oauth_auth(
+        hass,
+        {
+            "access_token": "outdated-access-token",
+            "refresh_token": "mock-refresh-token",
+            "expires_at": time.time() - 3600,
+        },
+    )
+
+    assert auth.access_token() == "outdated-access-token"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 3600,
+        },
+    )
+
+    assert await auth.check_and_refresh_token() == "new-access-token"
+    assert auth.access_token() == "new-access-token"
+    assert aioclient_mock.call_count == 1

--- a/tests/components/yolink/test_api.py
+++ b/tests/components/yolink/test_api.py
@@ -113,18 +113,29 @@ async def test_uac_token_request_http_error(
     assert err.value.message == "Bad credentials"
 
 
-async def test_uac_token_request_http_error_without_json_body(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+@pytest.mark.parametrize(
+    ("status", "response_kwargs"),
+    [
+        pytest.param(502, {"text": "<html>Bad gateway</html>"}, id="undecodable_body"),
+        pytest.param(500, {"json": []}, id="body_is_not_an_object"),
+    ],
+)
+async def test_uac_token_request_http_error_without_usable_body(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    status: int,
+    response_kwargs: dict[str, Any],
 ) -> None:
-    """Test an HTTP error carrying an unparsable body."""
-    aioclient_mock.post(OAUTH2_TOKEN, status=502, text="<html>Bad gateway</html>")
+    """Test an HTTP error whose body reports no error."""
+    aioclient_mock.post(OAUTH2_TOKEN, status=status, **response_kwargs)
     auth = _uac_auth(hass)
 
     with pytest.raises(YoLinkClientError) as err:
         await auth.check_and_refresh_token()
 
+    assert type(err.value) is YoLinkClientError
     assert err.value.code == "unknown"
-    assert err.value.message == "HTTP 502"
+    assert err.value.message == f"HTTP {status}"
 
 
 @pytest.mark.parametrize(
@@ -283,7 +294,7 @@ async def test_uac_failed_refresh_keeps_cached_token(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test a failing refresh leaves the cached token usable."""
+    """Test a failing refresh keeps serving the cached token until it expires."""
     aioclient_mock.post(
         OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
     )
@@ -295,10 +306,13 @@ async def test_uac_failed_refresh_keeps_cached_token(
     aioclient_mock.post(OAUTH2_TOKEN, status=500, text="<html>Bad gateway</html>")
 
     freezer.tick(3601)
-    with pytest.raises(YoLinkClientError):
-        await auth.check_and_refresh_token()
-
+    assert await auth.check_and_refresh_token() == "token-1"
     assert auth.access_token() == "token-1"
+    assert aioclient_mock.call_count == 1
+
+    freezer.tick(3598)
+    assert await auth.check_and_refresh_token() == "token-1"
+    assert aioclient_mock.call_count == 2
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
@@ -306,6 +320,58 @@ async def test_uac_failed_refresh_keeps_cached_token(
     )
 
     assert await auth.check_and_refresh_token() == "token-2"
+    assert auth.access_token() == "token-2"
+
+
+async def test_uac_failed_refresh_raises_once_the_token_expired(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a failing refresh is raised once the cached token is worthless."""
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
+    )
+    auth = _uac_auth(hass)
+
+    assert await auth.check_and_refresh_token() == "token-1"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(OAUTH2_TOKEN, status=500, text="<html>Bad gateway</html>")
+
+    freezer.tick(7201)
+    with pytest.raises(YoLinkClientError) as err:
+        await auth.check_and_refresh_token()
+
+    assert type(err.value) is YoLinkClientError
+    assert err.value.message == "HTTP 500"
+
+
+async def test_uac_refresh_refused_is_raised_with_a_cached_token(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test refused credentials are raised even while the cached token is valid."""
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
+    )
+    auth = _uac_auth(hass)
+
+    assert await auth.check_and_refresh_token() == "token-1"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        status=401,
+        json={"error": "invalid_client", "error_description": "Bad credentials"},
+    )
+
+    freezer.tick(3601)
+    with pytest.raises(YoLinkAuthFailError) as err:
+        await auth.check_and_refresh_token()
+
+    assert err.value.message == "Bad credentials"
 
 
 async def test_static_token_auth(hass: HomeAssistant) -> None:

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -1,66 +1,315 @@
 """Test yolink config flow."""
 
 from http import HTTPStatus
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
+from pydantic import ValidationError
 import pytest
 from yolink.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from yolink.endpoint import Endpoints
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+from yolink.model import BRDP
 
-from homeassistant import config_entries, setup
-from homeassistant.components import application_credentials
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState, ConfigFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.setup import async_setup_component
+
+from .conftest import (
+    CLIENT_ID,
+    TEST_HOME_ID,
+    TEST_HOME_NAME,
+    TEST_SECRET_KEY,
+    TEST_UAID,
+    home_info_response,
+)
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
-CLIENT_ID = "12345"
-CLIENT_SECRET = "6789"
-DOMAIN = "yolink"
+
+def _validation_error() -> ValidationError:
+    """Return the error the library raises for a malformed API response."""
+    with pytest.raises(ValidationError) as err:
+        BRDP.model_validate_json("[]")
+    return err.value
+
+
+# Everything the home lookup can fail with, other than a refused token.
+HOME_LOOKUP_FAILURES = [
+    pytest.param(YoLinkClientError("-1003", "Request failed"), id="client_error"),
+    pytest.param(TimeoutError(), id="timeout"),
+    pytest.param(_validation_error(), id="validation_error"),
+    pytest.param(AttributeError("'NoneType' object has no attribute 'get'"), id="bug"),
+]
+
+# Responses that are accepted but do not name a home.
+UNUSABLE_HOME_INFO = [
+    pytest.param(BRDP(code="000000"), id="response_without_data"),
+    pytest.param(
+        BRDP(code="000000", data={"name": TEST_HOME_NAME}), id="response_without_id"
+    ),
+]
+
+
+async def _async_start_uac_flow(hass: HomeAssistant) -> str:
+    """Start a user flow, pick UAC from the menu and return the flow id."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "uac"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+    return result["flow_id"]
+
+
+async def _async_complete_oauth_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> ConfigFlowResult:
+    """Run the OAuth2 flow from the menu through the token exchange."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    return await hass.config_entries.flow.async_configure(result["flow_id"])
+
+
+def _mock_oauth_entry(
+    hass: HomeAssistant, data: dict[str, Any] | None = None
+) -> MockConfigEntry:
+    """Add an OAuth2 entry holding an outdated token to hass."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=DOMAIN,
+        data={
+            **(data or {}),
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "outdated-refresh-token",
+                "access_token": "outdated-access-token",
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _async_complete_oauth_reauth_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    entry: MockConfigEntry,
+) -> ConfigFlowResult:
+    """Run the OAuth2 reauthentication of entry through the token exchange."""
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    return await hass.config_entries.flow.async_configure(result["flow_id"])
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_user_flow_shows_menu(hass: HomeAssistant) -> None:
+    """Test the user flow offers both authentication methods."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+    assert result["menu_options"] == ["pick_implementation", "uac"]
+
+
+@pytest.mark.parametrize(
+    "entry_data",
+    [
+        pytest.param({CONF_AUTH_TYPE: AUTH_TYPE_OAUTH}, id="oauth_entry"),
+        pytest.param({}, id="entry_without_auth_type"),
+    ],
+)
+@pytest.mark.usefixtures("setup_credentials")
+async def test_user_flow_skips_menu_with_oauth_entry(
+    hass: HomeAssistant, entry_data: dict[str, str]
+) -> None:
+    """Test the menu is skipped when OAuth2 is already configured."""
+    MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
+
+
+@pytest.mark.usefixtures("setup_credentials", "current_request_with_host")
+async def test_user_flow_shows_menu_with_uac_entry(hass: HomeAssistant) -> None:
+    """Test a UAC entry does not prevent adding an OAuth2 entry."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
 
 
 async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
-    """Check flow abort when no configuration."""
+    """Test picking OAuth2 without application credentials aborts."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
-async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
-    """Check flow abort when an entry already exist."""
-    MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN).add_to_hass(hass)
+@pytest.mark.usefixtures("setup_credentials", "current_request_with_host")
+async def test_pick_implementation_aborts_with_oauth_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test picking OAuth2 aborts when an OAuth2 entry appeared meanwhile."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.MENU
+
+    MockConfigEntry(
+        domain=DOMAIN, unique_id=DOMAIN, data={CONF_AUTH_TYPE: AUTH_TYPE_OAUTH}
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("current_request_with_host")
-async def test_full_flow(
+@pytest.mark.usefixtures("setup_credentials", "current_request_with_host")
+async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
+    """Test the OAuth2 authorization timeout is handled."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.LocalOAuth2Implementation.async_generate_authorize_url",
+        side_effect=TimeoutError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "pick_implementation"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "authorize_url_timeout"
+
+
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_yolink_client"
+)
+async def test_full_oauth_flow(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
+    mock_setup_entry: AsyncMock,
 ) -> None:
-    """Check full flow."""
-    assert await setup.async_setup_component(
-        hass,
-        DOMAIN,
-        {},
-    )
-    await application_credentials.async_import_client_credential(
-        hass,
-        DOMAIN,
-        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
-    )
+    """Test the OAuth2 flow reached through the menu."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "pick_implementation"}
+    )
+
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -90,15 +339,14 @@ async def test_full_flow(
         },
     )
 
-    with (
-        patch("homeassistant.components.yolink.api.ConfigEntryAuth"),
-        patch(
-            "homeassistant.components.yolink.async_setup_entry", return_value=True
-        ) as mock_setup,
-    ):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "YoLink"
     assert result["data"]["auth_implementation"] == DOMAIN
+    assert result["data"][CONF_AUTH_TYPE] == AUTH_TYPE_OAUTH
+    # Recorded so the same home cannot also be added through UAC.
+    assert result["data"][CONF_HOME_ID] == TEST_HOME_ID
 
     result["data"]["token"].pop("expires_at")
     assert result["data"]["token"] == {
@@ -108,108 +356,580 @@ async def test_full_flow(
         "expires_in": 60,
     }
 
-    assert DOMAIN in hass.config.components
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state is ConfigEntryState.LOADED
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].unique_id == DOMAIN
+    assert entries[0].state is ConfigEntryState.LOADED
+    assert len(mock_setup_entry.mock_calls) == 1
 
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert len(mock_setup.mock_calls) == 1
 
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_flow_uses_resolved_token_for_home_lookup(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+) -> None:
+    """Test the home is looked up with the token that was just resolved."""
+    result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
 
-@pytest.mark.usefixtures("current_request_with_host")
-async def test_abort_if_authorization_timeout(hass: HomeAssistant) -> None:
-    """Check yolink authorization timeout."""
-    assert await setup.async_setup_component(
-        hass,
-        DOMAIN,
-        {},
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    auth_mgr = mock_yolink_client.call_args.args[0]
+    assert auth_mgr.access_token() == "mock-access-token"
+    mock_yolink_client.return_value.execute.assert_awaited_once_with(
+        url=Endpoints.US.value.url, bsdp={"method": "Home.getGeneralInfo"}
     )
-    await application_credentials.async_import_client_credential(
-        hass,
-        DOMAIN,
-        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+
+
+@pytest.mark.parametrize("exception", HOME_LOOKUP_FAILURES)
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_flow_creates_entry_when_home_lookup_fails(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+    exception: Exception,
+) -> None:
+    """Test a failing home lookup does not block OAuth2 setup."""
+    mock_yolink_client.return_value.execute.side_effect = exception
+
+    result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_HOME_ID not in result["data"]
+
+
+@pytest.mark.parametrize("home_info", UNUSABLE_HOME_INFO)
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_flow_creates_entry_without_home_id_in_response(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+    home_info: BRDP,
+) -> None:
+    """Test an unusable home lookup response does not block OAuth2 setup."""
+    mock_yolink_client.return_value.execute.return_value = home_info
+
+    result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_HOME_ID not in result["data"]
+
+
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_flow_aborts_when_token_is_rejected(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+) -> None:
+    """Test an account the API refuses does not become an entry."""
+    mock_yolink_client.return_value.execute.side_effect = YoLinkAuthFailError(
+        "000103", "Client is not exist"
     )
-    with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.LocalOAuth2Implementation.async_generate_authorize_url",
-        side_effect=TimeoutError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
+
+    result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "authorize_url_timeout"
+    assert result["reason"] == "oauth_unauthorized"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 0
 
 
-@pytest.mark.usefixtures("current_request_with_host")
-async def test_reauthentication(
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_flow_aborts_when_home_configured_by_uac(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+) -> None:
+    """Test OAuth2 is refused for a home already added through UAC."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+@pytest.mark.parametrize(
+    "entry_data",
+    [
+        pytest.param({CONF_AUTH_TYPE: AUTH_TYPE_OAUTH}, id="oauth_entry"),
+        pytest.param({}, id="entry_without_auth_type"),
+    ],
+)
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_yolink_client"
+)
+async def test_oauth_reauthentication(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_setup_entry: AsyncMock,
+    entry_data: dict[str, str],
+) -> None:
+    """Test OAuth2 reauthentication is not blocked by the existing entry."""
+    old_entry = _mock_oauth_entry(hass, entry_data)
+
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert old_entry.data[CONF_AUTH_TYPE] == AUTH_TYPE_OAUTH
+    assert old_entry.data["token"]["access_token"] == "mock-access-token"
+    assert old_entry.data["token"]["refresh_token"] == "mock-refresh-token"
+    # The home of the reauthenticated account is recorded along the way.
+    assert old_entry.data[CONF_HOME_ID] == TEST_HOME_ID
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_reauthentication_updates_home_id(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+) -> None:
+    """Test reauthenticating against another account records its home."""
+    old_entry = _mock_oauth_entry(
+        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: "home_99999"}
+    )
+
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert old_entry.data[CONF_HOME_ID] == TEST_HOME_ID
+    auth_mgr = mock_yolink_client.call_args.args[0]
+    assert auth_mgr.access_token() == "mock-access-token"
+
+
+@pytest.mark.usefixtures(
+    "setup_credentials",
+    "current_request_with_host",
+    "mock_setup_entry",
+    "mock_yolink_client",
+)
+async def test_oauth_reauthentication_aborts_when_home_configured(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test yolink reauthentication."""
-    await setup.async_setup_component(
-        hass,
-        DOMAIN,
-        {},
+    """Test reauthenticating into a home another entry manages is refused."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+    old_entry = _mock_oauth_entry(
+        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: "home_99999"}
     )
 
-    await application_credentials.async_import_client_credential(
-        hass,
-        DOMAIN,
-        application_credentials.ClientCredential(CLIENT_ID, CLIENT_SECRET),
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
     )
 
-    old_entry = MockConfigEntry(
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert old_entry.data[CONF_HOME_ID] == "home_99999"
+    assert old_entry.data["token"]["access_token"] == "outdated-access-token"
+
+
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_reauthentication_aborts_when_token_is_rejected(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+) -> None:
+    """Test an account the API refuses does not update the entry."""
+    old_entry = _mock_oauth_entry(hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH})
+    mock_yolink_client.return_value.execute.side_effect = YoLinkAuthFailError(
+        "000103", "Client is not exist"
+    )
+
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_unauthorized"
+    assert old_entry.data["token"]["access_token"] == "outdated-access-token"
+
+
+@pytest.mark.parametrize("exception", HOME_LOOKUP_FAILURES)
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_reauthentication_drops_stale_home_id(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+    exception: Exception,
+) -> None:
+    """Test a failing home lookup forgets the home of the previous account."""
+    old_entry = _mock_oauth_entry(
+        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: TEST_HOME_ID}
+    )
+    mock_yolink_client.return_value.execute.side_effect = exception
+
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    # Setup records the home of the new account on the next load.
+    assert CONF_HOME_ID not in old_entry.data
+    assert old_entry.data["token"]["access_token"] == "mock-access-token"
+
+
+@pytest.mark.parametrize("home_info", UNUSABLE_HOME_INFO)
+@pytest.mark.usefixtures(
+    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+)
+async def test_oauth_reauthentication_drops_home_id_without_home_info(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yolink_client: AsyncMock,
+    home_info: BRDP,
+) -> None:
+    """Test an unusable home lookup response forgets the recorded home."""
+    old_entry = _mock_oauth_entry(
+        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: TEST_HOME_ID}
+    )
+    mock_yolink_client.return_value.execute.return_value = home_info
+
+    result = await _async_complete_oauth_reauth_flow(
+        hass, hass_client_no_auth, aioclient_mock, old_entry
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert CONF_HOME_ID not in old_entry.data
+
+
+async def test_uac_flow(
+    hass: HomeAssistant,
+    mock_yolink_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the UAC flow creates an entry keyed by home id."""
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_HOME_NAME
+    assert result["data"] == {
+        CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+        CONF_UAID: TEST_UAID,
+        CONF_SECRET_KEY: TEST_SECRET_KEY,
+        CONF_HOME_ID: TEST_HOME_ID,
+    }
+    assert result["result"].unique_id == TEST_HOME_ID
+    assert len(mock_setup_entry.mock_calls) == 1
+    # Validating the credentials must not load the devices or open MQTT.
+    mock_yolink_client.return_value.execute.assert_awaited_once_with(
+        url=Endpoints.US.value.url, bsdp={"method": "Home.getGeneralInfo"}
+    )
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_uac_flow_unnamed_home(
+    hass: HomeAssistant, mock_yolink_client: AsyncMock
+) -> None:
+    """Test the UAC flow falls back to a default title for an unnamed home."""
+    mock_yolink_client.return_value.execute.return_value = home_info_response(name=None)
+
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "YoLink Home"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        pytest.param(
+            YoLinkAuthFailError("000103", "Invalid credentials"),
+            "invalid_auth",
+            id="invalid_auth",
+        ),
+        pytest.param(
+            YoLinkClientError("000201", "Connection failed"),
+            "cannot_connect",
+            id="client_error",
+        ),
+        pytest.param(TimeoutError(), "cannot_connect", id="timeout"),
+        pytest.param(RuntimeError("Boom"), "unknown", id="unexpected_error"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_uac_flow_errors(
+    hass: HomeAssistant,
+    mock_yolink_client: AsyncMock,
+    side_effect: Exception,
+    error: str,
+) -> None:
+    """Test the UAC flow reports errors and recovers."""
+    mock_yolink_client.return_value.execute.side_effect = side_effect
+
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_yolink_client.return_value.execute.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.parametrize(
+    ("home_info", "error"),
+    [
+        pytest.param(
+            BRDP(code="000000", data={"name": TEST_HOME_NAME}),
+            "unknown",
+            id="response_without_id",
+        ),
+        # A response without a payload is classified like a failed request.
+        pytest.param(BRDP(code="000000"), "cannot_connect", id="response_without_data"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_uac_flow_unusable_home_info(
+    hass: HomeAssistant,
+    mock_yolink_client: AsyncMock,
+    home_info: BRDP,
+    error: str,
+) -> None:
+    """Test the UAC flow reports an error when no home is named."""
+    mock_yolink_client.return_value.execute.return_value = home_info
+
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+
+@pytest.mark.usefixtures("mock_yolink_client")
+async def test_uac_flow_duplicate_home(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test a second entry for the same home is rejected."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: TEST_UAID,
+            CONF_SECRET_KEY: TEST_SECRET_KEY,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: "other-uaid", CONF_SECRET_KEY: "other-secret"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+@pytest.mark.usefixtures("mock_yolink_client", "setup_credentials")
+async def test_uac_flow_aborts_when_home_configured_by_oauth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test UAC is refused for a home already added through OAuth2."""
+    MockConfigEntry(
         domain=DOMAIN,
         unique_id=DOMAIN,
-        version=1,
+        title="YoLink",
         data={
-            "refresh_token": "outdated_fresh_token",
-            "access_token": "outdated_access_token",
+            CONF_AUTH_TYPE: AUTH_TYPE_OAUTH,
+            "auth_implementation": DOMAIN,
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    ).add_to_hass(hass)
+
+    # An OAuth2 entry exists, so the user flow goes straight to UAC.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_UAID: TEST_UAID, CONF_SECRET_KEY: TEST_SECRET_KEY}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_uac_flow_multiple_homes(
+    hass: HomeAssistant, mock_yolink_client: AsyncMock
+) -> None:
+    """Test entries for different homes coexist."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="home_11111",
+        title="First Home",
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "first-uaid",
+            CONF_SECRET_KEY: "first-secret",
+            CONF_HOME_ID: "home_11111",
+        },
+    ).add_to_hass(hass)
+
+    mock_yolink_client.return_value.execute.return_value = home_info_response(
+        "home_22222", "Second Home"
+    )
+
+    flow_id = await _async_start_uac_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_UAID: "second-uaid", CONF_SECRET_KEY: "second-secret"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Second Home"
+    assert result["result"].unique_id == "home_22222"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+@pytest.mark.usefixtures("mock_yolink_client")
+async def test_uac_reauthentication(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test UAC reauthentication updates the credentials and reloads."""
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
         },
     )
     old_entry.add_to_hass(hass)
 
     result = await old_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
 
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "uac"
 
-    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
-
-    state = config_entry_oauth2_flow._encode_jwt(
-        hass,
-        {
-            "flow_id": result["flow_id"],
-            "redirect_uri": "https://example.com/auth/external/callback",
-        },
-    )
-    client = await hass_client_no_auth()
-    await client.get(f"/auth/external/callback?code=abcd&state={state}")
-
-    aioclient_mock.post(
-        OAUTH2_TOKEN,
-        json={
-            "refresh_token": "mock-refresh-token",
-            "access_token": "mock-access-token",
-            "type": "Bearer",
-            "expires_in": 60,
-        },
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_UAID: "new-uaid", CONF_SECRET_KEY: "new-secret"}
     )
 
-    with (
-        patch("homeassistant.components.yolink.api.ConfigEntryAuth"),
-        patch(
-            "homeassistant.components.yolink.async_setup_entry", return_value=True
-        ) as mock_setup,
-    ):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    token_data = old_entry.data["token"]
-    assert token_data["access_token"] == "mock-access-token"
-    assert token_data["refresh_token"] == "mock-refresh-token"
-    assert token_data["type"] == "Bearer"
-    assert token_data["expires_in"] == 60
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert len(mock_setup.mock_calls) == 1
+    assert old_entry.data == {
+        CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+        CONF_UAID: "new-uaid",
+        CONF_SECRET_KEY: "new-secret",
+        CONF_HOME_ID: TEST_HOME_ID,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_uac_reauthentication_wrong_home(
+    hass: HomeAssistant, mock_yolink_client: AsyncMock
+) -> None:
+    """Test UAC reauthentication with credentials for another home."""
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_HOME_ID,
+        title=TEST_HOME_NAME,
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "old-uaid",
+            CONF_SECRET_KEY: "old-secret",
+            CONF_HOME_ID: TEST_HOME_ID,
+        },
+    )
+    old_entry.add_to_hass(hass)
+
+    mock_yolink_client.return_value.execute.return_value = home_info_response(
+        "home_99999", "Other Home"
+    )
+
+    result = await old_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_UAID: "other-uaid", CONF_SECRET_KEY: "other-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+    assert old_entry.data[CONF_UAID] == "old-uaid"

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -47,19 +47,23 @@ def _validation_error() -> ValidationError:
     return err.value
 
 
-# Everything the home lookup can fail with, other than a refused token.
-HOME_LOOKUP_FAILURES = [
-    pytest.param(YoLinkClientError("-1003", "Request failed"), id="client_error"),
-    pytest.param(TimeoutError(), id="timeout"),
-    pytest.param(_validation_error(), id="validation_error"),
-    pytest.param(AttributeError("'NoneType' object has no attribute 'get'"), id="bug"),
-]
-
-# Responses that are accepted but do not name a home.
-UNUSABLE_HOME_INFO = [
-    pytest.param(BRDP(code="000000"), id="response_without_data"),
+# Everything that leaves the home of an accepted account unknown, as the mock
+# configuration of the API call the lookup makes: a request that fails with
+# anything other than a refused token, and a response that names no home.
+UNKNOWN_HOME_LOOKUPS = [
     pytest.param(
-        BRDP(code="000000", data={"name": TEST_HOME_NAME}), id="response_without_id"
+        {"side_effect": YoLinkClientError("-1003", "Request failed")}, id="client_error"
+    ),
+    pytest.param({"side_effect": TimeoutError()}, id="timeout"),
+    pytest.param({"side_effect": _validation_error()}, id="validation_error"),
+    pytest.param(
+        {"side_effect": AttributeError("'NoneType' object has no attribute 'get'")},
+        id="bug",
+    ),
+    pytest.param({"return_value": BRDP(code="000000")}, id="response_without_data"),
+    pytest.param(
+        {"return_value": BRDP(code="000000", data={"name": TEST_HOME_NAME})},
+        id="response_without_id",
     ),
 ]
 
@@ -383,19 +387,19 @@ async def test_oauth_flow_uses_resolved_token_for_home_lookup(
     )
 
 
-@pytest.mark.parametrize("exception", HOME_LOOKUP_FAILURES)
+@pytest.mark.parametrize("home_lookup", UNKNOWN_HOME_LOOKUPS)
 @pytest.mark.usefixtures(
     "setup_credentials", "current_request_with_host", "mock_setup_entry"
 )
-async def test_oauth_flow_creates_entry_when_home_lookup_fails(
+async def test_oauth_flow_creates_entry_when_home_is_unknown(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     mock_yolink_client: AsyncMock,
-    exception: Exception,
+    home_lookup: dict[str, Any],
 ) -> None:
-    """Test a failing home lookup does not block OAuth2 setup."""
-    mock_yolink_client.return_value.execute.side_effect = exception
+    """Test a home that stays unknown does not block the first entry."""
+    mock_yolink_client.return_value.execute.configure_mock(**home_lookup)
 
     result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
 
@@ -403,24 +407,28 @@ async def test_oauth_flow_creates_entry_when_home_lookup_fails(
     assert CONF_HOME_ID not in result["data"]
 
 
-@pytest.mark.parametrize("home_info", UNUSABLE_HOME_INFO)
+@pytest.mark.parametrize("home_lookup", UNKNOWN_HOME_LOOKUPS)
 @pytest.mark.usefixtures(
-    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+    "setup_credentials",
+    "current_request_with_host",
+    "mock_setup_entry",
+    "mock_uac_config_entry",
 )
-async def test_oauth_flow_creates_entry_without_home_id_in_response(
+async def test_oauth_flow_aborts_when_home_is_unknown_and_entry_exists(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     mock_yolink_client: AsyncMock,
-    home_info: BRDP,
+    home_lookup: dict[str, Any],
 ) -> None:
-    """Test an unusable home lookup response does not block OAuth2 setup."""
-    mock_yolink_client.return_value.execute.return_value = home_info
+    """Test OAuth2 is refused while the home cannot be checked for duplicates."""
+    mock_yolink_client.return_value.execute.configure_mock(**home_lookup)
 
     result = await _async_complete_oauth_flow(hass, hass_client_no_auth, aioclient_mock)
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert CONF_HOME_ID not in result["data"]
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 @pytest.mark.usefixtures(
@@ -593,7 +601,7 @@ async def test_oauth_reauthentication_aborts_when_token_is_rejected(
     assert old_entry.data["token"]["access_token"] == "outdated-access-token"
 
 
-@pytest.mark.parametrize("exception", HOME_LOOKUP_FAILURES)
+@pytest.mark.parametrize("home_lookup", UNKNOWN_HOME_LOOKUPS)
 @pytest.mark.usefixtures(
     "setup_credentials", "current_request_with_host", "mock_setup_entry"
 )
@@ -602,13 +610,13 @@ async def test_oauth_reauthentication_drops_stale_home_id(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     mock_yolink_client: AsyncMock,
-    exception: Exception,
+    home_lookup: dict[str, Any],
 ) -> None:
-    """Test a failing home lookup forgets the home of the previous account."""
+    """Test a home that stays unknown forgets the home of the previous account."""
     old_entry = _mock_oauth_entry(
         hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: TEST_HOME_ID}
     )
-    mock_yolink_client.return_value.execute.side_effect = exception
+    mock_yolink_client.return_value.execute.configure_mock(**home_lookup)
 
     result = await _async_complete_oauth_reauth_flow(
         hass, hass_client_no_auth, aioclient_mock, old_entry
@@ -621,30 +629,33 @@ async def test_oauth_reauthentication_drops_stale_home_id(
     assert old_entry.data["token"]["access_token"] == "mock-access-token"
 
 
-@pytest.mark.parametrize("home_info", UNUSABLE_HOME_INFO)
+@pytest.mark.parametrize("home_lookup", UNKNOWN_HOME_LOOKUPS)
 @pytest.mark.usefixtures(
-    "setup_credentials", "current_request_with_host", "mock_setup_entry"
+    "setup_credentials", "current_request_with_host", "mock_uac_config_entry"
 )
-async def test_oauth_reauthentication_drops_home_id_without_home_info(
+async def test_oauth_reauthentication_aborts_when_home_is_unknown(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     mock_yolink_client: AsyncMock,
-    home_info: BRDP,
+    mock_setup_entry: AsyncMock,
+    home_lookup: dict[str, Any],
 ) -> None:
-    """Test an unusable home lookup response forgets the recorded home."""
+    """Test reauthentication is refused while another entry may own the home."""
     old_entry = _mock_oauth_entry(
-        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: TEST_HOME_ID}
+        hass, {CONF_AUTH_TYPE: AUTH_TYPE_OAUTH, CONF_HOME_ID: "home_99999"}
     )
-    mock_yolink_client.return_value.execute.return_value = home_info
+    mock_yolink_client.return_value.execute.configure_mock(**home_lookup)
 
     result = await _async_complete_oauth_reauth_flow(
         hass, hass_client_no_auth, aioclient_mock, old_entry
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reauth_successful"
-    assert CONF_HOME_ID not in old_entry.data
+    assert result["reason"] == "cannot_connect"
+    assert old_entry.data[CONF_HOME_ID] == "home_99999"
+    assert old_entry.data["token"]["access_token"] == "outdated-access-token"
+    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_uac_flow(

--- a/tests/components/yolink/test_init.py
+++ b/tests/components/yolink/test_init.py
@@ -1,19 +1,32 @@
 """Tests for the yolink integration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from yolink.const import OAUTH2_TOKEN
+from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+from yolink.model import BRDP
 
-from homeassistant.components.yolink import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.yolink.api import UACAuth
+from homeassistant.components.yolink.const import (
+    AUTH_TYPE_UAC,
+    CONF_AUTH_TYPE,
+    CONF_HOME_ID,
+    CONF_SECRET_KEY,
+    CONF_UAID,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
-from homeassistant.setup import async_setup_component
+
+from .conftest import TEST_SECRET_KEY, TEST_UAID, build_yolink_home, home_info_response
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.usefixtures("setup_credentials", "mock_auth_manager", "mock_yolink_home")
@@ -45,13 +58,26 @@ async def test_device_remove_devices(
     assert len(device_entries) == 0
 
 
-@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager", "mock_yolink_home")
+@pytest.mark.usefixtures("setup_credentials", "mock_yolink_home")
+async def test_oauth_setup_and_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an entry predating UAC support is set up over OAuth2."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_yolink_home")
 async def test_oauth_implementation_not_available(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test that an unavailable OAuth implementation raises ConfigEntryNotReady."""
-    assert await async_setup_component(hass, "cloud", {})
-
+    """Test that an unavailable OAuth2 implementation raises ConfigEntryNotReady."""
     with patch(
         "homeassistant.components.yolink.async_get_config_entry_implementation",
         side_effect=ImplementationUnavailableError,
@@ -60,3 +86,187 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_uac_setup_and_unload(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test UAC config entry setup and unload."""
+    assert await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.LOADED
+    # The home id is already known, so it is not looked up again.
+    mock_yolink_home.return_value.async_get_home_info.assert_not_awaited()
+
+    auth_mgr = mock_yolink_home.return_value.async_setup.await_args.args[0]
+    assert isinstance(auth_mgr, UACAuth)
+
+    # The credentials of the entry are the ones the manager authenticates with.
+    aioclient_mock.post(
+        OAUTH2_TOKEN, json={"access_token": "token-1", "expires_in": 7200}
+    )
+    assert await auth_mgr.check_and_refresh_token() == "token-1"
+    assert aioclient_mock.mock_calls[0][2] == {
+        "grant_type": "client_credentials",
+        "scope": "create",
+        "client_id": TEST_UAID,
+        "client_secret": TEST_SECRET_KEY,
+    }
+
+    assert await hass.config_entries.async_unload(mock_uac_config_entry.entry_id)
+    assert mock_uac_config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_yolink_home.return_value.async_unload.assert_awaited_once()
+
+
+async def test_uac_entries_are_isolated(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test loaded entries do not share their home or authentication."""
+    second_entry = MockConfigEntry(
+        unique_id="home_22222",
+        domain=DOMAIN,
+        title="Second Home",
+        data={
+            CONF_AUTH_TYPE: AUTH_TYPE_UAC,
+            CONF_UAID: "second-uaid",
+            CONF_SECRET_KEY: "second-secret",
+            CONF_HOME_ID: "home_22222",
+        },
+    )
+    second_entry.add_to_hass(hass)
+    mock_yolink_home.side_effect = build_yolink_home
+
+    # Setting up the component loads every entry of the domain.
+    assert await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.LOADED
+    assert second_entry.state is ConfigEntryState.LOADED
+
+    first_home = mock_uac_config_entry.runtime_data.home_instance
+    second_home = second_entry.runtime_data.home_instance
+    assert first_home is not second_home
+
+    first_auth = first_home.async_setup.await_args.args[0]
+    second_auth = second_home.async_setup.await_args.args[0]
+    assert first_auth is not second_auth
+
+    assert await hass.config_entries.async_unload(second_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert second_entry.state is ConfigEntryState.NOT_LOADED
+    second_home.async_unload.assert_awaited_once()
+    assert mock_uac_config_entry.state is ConfigEntryState.LOADED
+    first_home.async_unload.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_records_home_id_of_legacy_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test an entry predating the home id records it on setup."""
+    mock_yolink_home.return_value.async_get_home_info.return_value = home_info_response(
+        "home_99999"
+    )
+    assert CONF_HOME_ID not in mock_config_entry.data
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.data[CONF_HOME_ID] == "home_99999"
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(YoLinkClientError("-1003", "Request failed"), id="client_error"),
+        pytest.param(
+            YoLinkAuthFailError("000103", "Invalid credentials"), id="auth_error"
+        ),
+        pytest.param(TimeoutError(), id="timeout"),
+    ],
+)
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_survives_failing_home_id_lookup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+    side_effect: Exception,
+) -> None:
+    """Test recording the home id does not fail an otherwise working setup."""
+    mock_yolink_home.return_value.async_get_home_info.side_effect = side_effect
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    # A later start records the home again.
+    assert CONF_HOME_ID not in mock_config_entry.data
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_setup_without_home_info_in_response(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test a home info response naming no home does not fail setup."""
+    mock_yolink_home.return_value.async_get_home_info.return_value = BRDP(code="000000")
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert CONF_HOME_ID not in mock_config_entry.data
+
+
+async def test_uac_setup_auth_failure(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+) -> None:
+    """Test a UAC authentication failure starts a reauthentication flow."""
+    mock_yolink_home.return_value.async_setup.side_effect = YoLinkAuthFailError(
+        "000103", "Invalid credentials"
+    )
+
+    await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["context"]["entry_id"] == mock_uac_config_entry.entry_id
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(YoLinkClientError("000201", "Connection failed"), id="client"),
+        pytest.param(TimeoutError(), id="timeout"),
+    ],
+)
+async def test_uac_setup_connection_failure(
+    hass: HomeAssistant,
+    mock_uac_config_entry: MockConfigEntry,
+    mock_yolink_home: AsyncMock,
+    side_effect: Exception,
+) -> None:
+    """Test a UAC connection failure is retried."""
+    mock_yolink_home.return_value.async_setup.side_effect = side_effect
+
+    await hass.config_entries.async_setup(mock_uac_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_uac_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change

Add support for multiple YoLink homes by adding UAC (User Access Credentials) authentication alongside the existing OAuth2 flow.

YoLink OAuth2 tokens only give access to the account's default home, so the integration is currently limited to a single home. UAC credentials are issued per home in the YoLink app (Settings > Account > Advanced Settings > User Access Credentials) and authenticate against a specific home, which makes one config entry per home possible.

The config flow now starts with a menu to pick the authentication method: the existing OAuth2 login, or UAC credentials. If an OAuth2 entry already exists the menu is skipped and the flow goes directly to the UAC form, since UAC is the only remaining option.

UAC entries use the YoLink home id as unique id (one entry per home, as many homes as needed). OAuth2 entries keep the integration domain as unique id, unchanged and still limited to a single entry.

`UACAuth` implements the yolink-api `YoLinkAuthMgr` contract with a client_credentials token flow. Tokens are refreshed once past half their lifetime, under a lock (single flight), and the previous token stays usable while a refresh fails transiently. The YoLink token endpoint reports invalid credentials with HTTP 200 and an error body; this and malformed success payloads are mapped to the library exception types.

To prevent the same home from being added through both authentication methods, the home id is stored in the entry data for both entry types (fetched at entry creation, backfilled at setup for entries created before this PR), and both flows abort with `already_configured` when another entry already manages the home.

Reauthentication works for both entry types. OAuth2 reauth refreshes the stored home id, and UAC reauth rejects credentials belonging to a different home (`wrong_account`).

Answers to the open review questions from the previous PR (#160267):

- "Should we migrate the unique ID of existing entries?" No. Keeping the domain as the OAuth2 unique id is zero risk for existing users, and a per home unique id for OAuth2 would buy nothing since OAuth2 cannot reach non-default homes (API limitation, not a code one). Cross auth duplicate detection is done with the stored home ids instead.
- "Should we even show the menu if there's already an oauth entry?" No, the menu is now skipped in that case (see above).

All other review comments from #160267 are addressed: token refresh at half lifetime, deduplicated auth methods, log severity lowered to debug in the token path, explicit `TextSelector` for both UAC fields (password type for the secret key), merged `cannot_connect` except clause, comment cleanups.

Known limitation: an OAuth2 entry created before this PR only gets its home id recorded the first time it loads successfully after upgrading. Until then, adding the same home via UAC is not detected. Once recorded, the guard applies.

Tested with 106 unit tests (100% line and branch coverage of config_flow.py and api.py, including token lock concurrency, multi entry isolation, both reauth paths and malformed API responses) and validated on a real 3 homes setup: simultaneous UAC entries, per home real-time MQTT updates, duplicate and cross auth guards, reauthentication, fresh install.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #136855, fixes #96882
- This PR is related to issue: #160267 (previous submission, reviewed by @emontnemery, closed for inactivity; all review feedback from it is addressed here)
- Link to documentation pull request: home-assistant/home-assistant.io#47400
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
