### PR TITLE
Separate energy endpoint MELCloud Home

### DIFF
--- a/homeassistant/components/melcloud_home/coordinator.py
+++ b/homeassistant/components/melcloud_home/coordinator.py
@@ -1,7 +1,7 @@
 """Coordinator for MELCloud Home."""
 
 from collections.abc import Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import override
 
@@ -104,44 +104,24 @@ class MelCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 _LOGGER.debug("Removing stale device: %s", device.identifiers)
                 registry.async_remove_device(device.id)
 
+    async def _async_get_energy(
+        self, unit_id: str, start_of_month: datetime, now: datetime
+    ) -> float | None:
+        """Fetch energy telemetry for a unit without failing the whole update."""
+        try:
+            energy = await self.client.get_energy_telemetry(
+                unit_id, from_dt=start_of_month, to_dt=now
+            )
+        except MelCloudHomeConnectionError, MelCloudHomeTimeoutError:
+            _LOGGER.warning("Failed to fetch energy telemetry for %s:", unit_id)
+            return None
+        return sum(float(e.value) for e in energy)
+
     @override
     async def _async_update_data(self) -> UserContext:
         """Fetch data from the MELCloud Home API."""
         try:
             data = await self.client.get_context()
-
-            start_of_month = utcnow().replace(
-                day=1, hour=0, minute=0, second=0, microsecond=0
-            )
-            for building in data.buildings:
-                for ata_unit in building.air_to_air_units:
-                    self.ata_units[ata_unit.id] = ata_unit
-                    if (
-                        ata_unit.capabilities
-                        and ata_unit.capabilities.has_energy_consumed_meter
-                    ):
-                        energy = await self.client.get_energy_telemetry(
-                            ata_unit.id,
-                            from_dt=start_of_month,
-                            to_dt=utcnow(),
-                        )
-                        self.ata_energy[ata_unit.id] = sum(
-                            float(e.value) for e in energy
-                        )
-                for atw_unit in building.air_to_water_units:
-                    self.atw_units[atw_unit.id] = atw_unit
-                    if (
-                        atw_unit.capabilities
-                        and atw_unit.capabilities.has_energy_consumed_meter
-                    ):
-                        energy = await self.client.get_energy_telemetry(
-                            atw_unit.id,
-                            from_dt=start_of_month,
-                            to_dt=utcnow(),
-                        )
-                        self.atw_energy[atw_unit.id] = sum(
-                            float(e.value) for e in energy
-                        )
         except MelCloudHomeAuthenticationError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
@@ -157,8 +137,32 @@ class MelCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 translation_domain=DOMAIN,
                 translation_key="timeout_connect",
             ) from err
-        else:
-            return data
+
+        start_of_month = utcnow().replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        now = utcnow()
+        for building in data.buildings:
+            for ata_unit in building.air_to_air_units:
+                self.ata_units[ata_unit.id] = ata_unit
+                if (
+                    ata_unit.capabilities
+                    and ata_unit.capabilities.has_energy_consumed_meter
+                ):
+                    self.ata_energy[ata_unit.id] = await self._async_get_energy(
+                        ata_unit.id, start_of_month, now
+                    )
+            for atw_unit in building.air_to_water_units:
+                self.atw_units[atw_unit.id] = atw_unit
+                if (
+                    atw_unit.capabilities
+                    and atw_unit.capabilities.has_energy_consumed_meter
+                ):
+                    self.atw_energy[atw_unit.id] = await self._async_get_energy(
+                        atw_unit.id, start_of_month, now
+                    )
+
+        return data
 
     @callback
     @override

--- a/tests/components/melcloud_home/test_init.py
+++ b/tests/components/melcloud_home/test_init.py
@@ -193,3 +193,42 @@ async def test_new_atw_unit_callback(
         if "heat_pump" in entity.entity_id
     ]
     assert atw_entities
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(MelCloudHomeConnectionError("cannot connect"), id="connection"),
+        pytest.param(MelCloudHomeTimeoutError("timeout"), id="timeout"),
+    ],
+)
+async def test_energy_update_cycle_fails(
+    hass: HomeAssistant,
+    mock_melcloud_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    exception: Exception,
+) -> None:
+    """Test that a failing energy fetch clears the value without unloading the entry."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    assert coordinator.ata_energy["ata-unit-uuid-1"] is not None
+    assert coordinator.atw_energy["atw-unit-uuid-1"] is not None
+
+    mock_melcloud_client.get_energy_telemetry.side_effect = exception
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator.ata_energy["ata-unit-uuid-1"] is None
+    assert coordinator.atw_energy["atw-unit-uuid-1"] is None
+
+    # Demonstrate a recovery
+    mock_melcloud_client.get_energy_telemetry.side_effect = None
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator.ata_energy["ata-unit-uuid-1"] is not None
+    assert coordinator.atw_energy["atw-unit-uuid-1"] is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in https://github.com/home-assistant/core/issues/179082, where the energy endpoint, upon my own testing, can indeed crash. The exact rootcause is still unknown, yet it happens on the end of MELCloud. The renders the entire integration unavailable. It will recover the next update cycle, still, this pollutes the history and logging.
This PR separates out the energy call as it can be treated as optional and not vital. As a more permanent fix I might introduce a separate coordinator to handle the optional energy endpoint with a lower interval (my suspicion is that it might be crashing if it's asked too frequently).

It would be nice this can still be in 2026.8.2.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
