### PR TITLE
Mark Blebox sensor and climate entities unavailable on error state

### DIFF
--- a/homeassistant/components/blebox/climate.py
+++ b/homeassistant/components/blebox/climate.py
@@ -61,6 +61,12 @@ class BleBoxClimateEntity(BleBoxEntity[blebox_uniapi.climate.Climate], ClimateEn
 
     @property
     @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and not self._feature.is_error
+
+    @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return list of supported HVAC modes."""
         if self._feature.mode is None:

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -240,6 +240,12 @@ class BleBoxSensorEntity(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], SensorEn
 
     @property
     @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and not self._feature.is_error
+
+    @property
+    @override
     def native_value(self) -> StateType:
         """Return the state."""
         return self.entity_description.value_fn(self._feature.native_value)

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -42,7 +42,28 @@ def setup_product_mock(category, feature_mocks, path=None):
 
 def mock_only_feature(spec, set_spec: bool = True, **kwargs):
     """Mock just the feature, without the product setup."""
+    if issubclass(spec, blebox_uniapi.sensor.BaseSensor):
+        # Autospec would leave is_error as a truthy Mock, making entities unavailable.
+        kwargs.setdefault("is_error", False)
     return mock.create_autospec(spec, set_spec, True, **kwargs)
+
+
+def setup_multi_feature_product(category, features, name, model):
+    """Mock a product exposing several features of the same category."""
+    product = setup_product_mock(category, features)
+    type(product).name = PropertyMock(return_value=name)
+    type(product).model = PropertyMock(return_value=model)
+    type(product).product = PropertyMock(return_value=model)
+    type(product).brand = PropertyMock(return_value="BleBox")
+    type(product).firmware_version = PropertyMock(return_value="1.23")
+    type(product).unique_id = PropertyMock(return_value="aabbcc112233")
+
+    for feature in features:
+        type(feature).product = PropertyMock(return_value=product)
+        type(feature).name = PropertyMock(return_value=None)
+        feature.async_update = AsyncMock()
+
+    return product
 
 
 def mock_feature(category, spec, set_spec: bool = True, **kwargs):

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -1,7 +1,7 @@
 """BleBox climate entities tests."""
 
 import logging
-from unittest.mock import AsyncMock, PropertyMock
+from unittest.mock import AsyncMock, Mock, PropertyMock
 
 import blebox_uniapi
 import pytest
@@ -25,6 +25,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
@@ -135,6 +136,20 @@ async def test_update(saunabox, hass: HomeAssistant, config) -> None:
     assert state.attributes[ATTR_TEMPERATURE] == 64.3
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 40.9
     assert state.state == HVACMode.OFF
+
+
+async def test_update_with_safety_off_state_is_unavailable(
+    hass: HomeAssistant, thermobox: tuple[Mock, str]
+) -> None:
+    """A thermostat switched off by its safety system must become unavailable."""
+
+    feature_mock, entity_id = thermobox
+    feature_mock.is_error = True
+    feature_mock.current = None
+    await async_setup_entity(hass, entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_set_hvac_mode_heat(saunabox, hass: HomeAssistant) -> None:

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -1,7 +1,7 @@
 """Blebox sensors tests."""
 
 import logging
-from unittest.mock import AsyncMock, PropertyMock
+from unittest.mock import AsyncMock, Mock, PropertyMock
 
 import blebox_uniapi
 import pytest
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfDensity,
     UnitOfTemperature,
@@ -25,7 +26,7 @@ from .conftest import (
     async_setup_entity,
     mock_feature,
     mock_only_feature,
-    setup_product_mock,
+    setup_multi_feature_product,
 )
 
 from tests.common import MockConfigEntry
@@ -133,6 +134,41 @@ async def test_update_failure(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_update_with_error_state_is_unavailable(
+    hass: HomeAssistant, tempsensor: tuple[Mock, str]
+) -> None:
+    """A sensor reporting an error state must become unavailable."""
+
+    feature_mock, entity_id = tempsensor
+    feature_mock.is_error = True
+    feature_mock.native_value = None
+    await async_setup_entity(hass, entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_update_recovers_after_error_state_clears(
+    hass: HomeAssistant, tempsensor: tuple[Mock, str], config_entry: MockConfigEntry
+) -> None:
+    """Entity becomes available again once the sensor reports a valid state."""
+
+    feature_mock, entity_id = tempsensor
+    feature_mock.is_error = True
+    feature_mock.native_value = None
+    await async_setup_config_entry(hass, config_entry)
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    feature_mock.is_error = False
+    feature_mock.native_value = 21.5
+    await config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "21.5"
+
+
 async def test_airsensor_init(
     airsensor, hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -201,18 +237,7 @@ async def test_multi_sensor_multiple_have_channel_suffix(
         for i in range(4)
     ]
 
-    product = setup_product_mock("sensors", features)
-    type(product).name = PropertyMock(return_value="My smart meter")
-    type(product).model = PropertyMock(return_value="smartMeter")
-    type(product).product = PropertyMock(return_value="smartMeter")
-    type(product).brand = PropertyMock(return_value="BleBox")
-    type(product).firmware_version = PropertyMock(return_value="1.23")
-    type(product).unique_id = PropertyMock(return_value="aabbcc112233")
-
-    for feature in features:
-        type(feature).product = PropertyMock(return_value=product)
-        type(feature).name = PropertyMock(return_value=None)
-        feature.async_update = AsyncMock()
+    setup_multi_feature_product("sensors", features, "My smart meter", "smartMeter")
 
     entity_ids = [
         "sensor.my_smart_meter_voltage",
@@ -226,6 +251,44 @@ async def test_multi_sensor_multiple_have_channel_suffix(
     assert hass.states.get(entity_ids[1]).name == "My smart meter Voltage 1"
     assert hass.states.get(entity_ids[2]).name == "My smart meter Voltage 2"
     assert hass.states.get(entity_ids[3]).name == "My smart meter Voltage 3"
+
+
+async def test_sensor_error_does_not_affect_sibling_sensors(
+    hass: HomeAssistant,
+) -> None:
+    """A single errored sensor must not make sibling sensors unavailable."""
+    ok_feature = mock_only_feature(
+        blebox_uniapi.sensor.GenericSensor,
+        unique_id="BleBox-multiSensor-aabbcc-humidity_0",
+        full_name="multiSensor-humidity_0",
+        device_class="humidity",
+        unit="percentage",
+        native_value=42,
+        sensor_id=0,
+        index=0,
+    )
+    error_feature = mock_only_feature(
+        blebox_uniapi.sensor.Temperature,
+        unique_id="BleBox-multiSensor-aabbcc-temperature_1",
+        full_name="multiSensor-temperature_1",
+        device_class="temperature",
+        unit="celsius",
+        current=None,
+        native_value=None,
+        is_error=True,
+        sensor_id=1,
+        index=1,
+    )
+    setup_multi_feature_product(
+        "sensors", [ok_feature, error_feature], "My multi sensor", "multiSensor"
+    )
+
+    ok_entity_id = "sensor.my_multi_sensor_humidity"
+    error_entity_id = "sensor.my_multi_sensor_temperature"
+    await async_setup_entities(hass, [ok_entity_id, error_entity_id])
+
+    assert hass.states.get(ok_entity_id).state == "42"
+    assert hass.states.get(error_entity_id).state == STATE_UNAVAILABLE
 
 
 async def test_airsensor_update(airsensor, hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to the recent blebox-uniapi bump, which made the library expose whether a sensor or climate feature is in an error state. Here I'd like to act on it and mark these entities as unavailable. For sensors this matters because a sensor reports an unknown value both when it fails and while it's initialising, so on its own that state doesn't tell the user which of the two is happening. For climate it covers thermostats switched off by their safety system, which otherwise show as off, exactly like a thermostat the user turned off themselves.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/179050
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
