### PR TITLE
fix: log OpenHome media player update errors

### DIFF
--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -167,7 +167,8 @@ class OpenhomeDevice(MediaPlayerEntity):
                 self._attr_state = MediaPlayerState.PLAYING
 
             self._attr_available = True
-        except TimeoutError, aiohttp.ClientError, UpnpError:
+        except (TimeoutError, aiohttp.ClientError, UpnpError) as err:
+            _LOGGER.debug("Error updating %s: %s", self.entity_id, err, exc_info=True)
             self._attr_available = False
 
     # pylint: disable-next=home-assistant-action-swallowed-exception

--- a/tests/components/openhome/test_media_player.py
+++ b/tests/components/openhome/test_media_player.py
@@ -1,0 +1,136 @@
+"""Tests for the Openhome media player platform."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from async_upnp_client.client import UpnpError
+
+from homeassistant.components.media_player import DATA_COMPONENT
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.const import CONF_HOST, STATE_PLAYING, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "media_player.friendly_name"
+
+TRACK_INFO = {
+    "albumArtwork": "http://artwork",
+    "albumTitle": "Album",
+    "title": "Title",
+    "artist": ["Artist"],
+}
+
+SOURCES = [
+    {"name": "Radio", "index": 1, "type": "Radio"},
+    {"name": "Playlist", "index": 2, "type": "Playlist"},
+]
+
+
+def _mock_device() -> MagicMock:
+    """Create a mocked Openhome device."""
+    device = MagicMock()
+    device.init = AsyncMock()
+    device.uuid = MagicMock(return_value="uuid")
+    device.manufacturer = MagicMock(return_value="manufacturer")
+    device.model_name = MagicMock(return_value="model_name")
+    device.friendly_name = MagicMock(return_value="friendly_name")
+    device.room = AsyncMock(return_value="friendly_name")
+    device.track_info = AsyncMock(return_value=TRACK_INFO)
+    device.volume_enabled = True
+    device.volume = AsyncMock(return_value=50)
+    device.is_muted = AsyncMock(return_value=False)
+    device.sources = AsyncMock(return_value=SOURCES)
+    device.source = AsyncMock(return_value={"name": "Radio", "type": "Radio"})
+    device.is_in_standby = AsyncMock(return_value=False)
+    device.transport_state = AsyncMock(return_value="Playing")
+    return device
+
+
+async def setup_integration(hass: HomeAssistant, device: MagicMock) -> None:
+    """Load the openhome media player platform with a mocked device."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "http://localhost"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.openhome.PLATFORMS", [Platform.MEDIA_PLAYER]),
+        patch("homeassistant.components.openhome.Device", return_value=device),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def _async_update_entity(hass: HomeAssistant) -> None:
+    """Force an update of the media player entity."""
+    entity = hass.data[DATA_COMPONENT].get_entity(ENTITY_ID)
+    assert entity is not None
+    await entity.async_update()
+    entity.async_write_ha_state()
+
+
+async def test_setup(hass: HomeAssistant) -> None:
+    """Test the entity stays available after a successful update."""
+    await setup_integration(hass, _mock_device())
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_PLAYING
+
+    await _async_update_entity(hass)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_PLAYING
+    assert state.attributes["media_title"] == "Title"
+    assert state.attributes["media_artist"] == "Artist"
+    assert state.attributes["source"] == "Radio"
+    assert state.attributes["volume_level"] == 0.5
+
+
+@pytest.mark.parametrize(
+    ("exc", "message"),
+    [
+        pytest.param(UpnpError("upnp error"), "upnp error", id="upnp_error"),
+        pytest.param(TimeoutError("timeout"), "timeout", id="timeout_error"),
+        pytest.param(
+            aiohttp.ClientError("client error"), "client error", id="client_error"
+        ),
+    ],
+)
+async def test_async_update_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    exc: Exception,
+    message: str,
+) -> None:
+    """Test the entity goes unavailable and logs the error on failure."""
+    device = _mock_device()
+    device.transport_state = AsyncMock(side_effect=exc)
+    await setup_integration(hass, device)
+
+    with caplog.at_level(logging.DEBUG, logger="homeassistant.components.openhome"):
+        await _async_update_entity(hass)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_UNAVAILABLE
+    assert f"Error updating {ENTITY_ID}" in caplog.text
+    assert message in caplog.text
+
+
+async def test_async_update_recovers(hass: HomeAssistant) -> None:
+    """Test the entity recovers after a failed update."""
+    device = _mock_device()
+    await setup_integration(hass, device)
+
+    # First update fails and the entity becomes unavailable
+    device.transport_state = AsyncMock(side_effect=UpnpError("device down"))
+    await _async_update_entity(hass)
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
+
+    # Second update succeeds and the entity recovers
+    device.transport_state = AsyncMock(return_value="Playing")
+    await _async_update_entity(hass)
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_PLAYING
+    assert state.attributes["source"] == "Radio"

--- a/tests/components/openhome/test_media_player.py
+++ b/tests/components/openhome/test_media_player.py
@@ -5,14 +5,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 from async_upnp_client.client import UpnpError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.media_player import DATA_COMPONENT
+from homeassistant.components.media_player import SCAN_INTERVAL
 from homeassistant.components.openhome.const import DOMAIN
 from homeassistant.const import CONF_HOST, STATE_PLAYING, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 ENTITY_ID = "media_player.friendly_name"
 
@@ -62,15 +63,14 @@ async def setup_integration(hass: HomeAssistant, device: MagicMock) -> None:
         await hass.async_block_till_done()
 
 
-async def _async_update_entity(hass: HomeAssistant) -> None:
-    """Force an update of the media player entity."""
-    entity = hass.data[DATA_COMPONENT].get_entity(ENTITY_ID)
-    assert entity is not None
-    await entity.async_update()
-    entity.async_write_ha_state()
+async def _trigger_update(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Advance time to trigger the platform polling update naturally."""
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistant) -> None:
+async def test_setup(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
     """Test the entity stays available after a successful update."""
     await setup_integration(hass, _mock_device())
 
@@ -78,7 +78,7 @@ async def test_setup(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state == STATE_PLAYING
 
-    await _async_update_entity(hass)
+    await _trigger_update(hass, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_PLAYING
@@ -100,6 +100,7 @@ async def test_setup(hass: HomeAssistant) -> None:
 )
 async def test_async_update_error(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
     exc: Exception,
     message: str,
@@ -110,7 +111,7 @@ async def test_async_update_error(
     await setup_integration(hass, device)
 
     with caplog.at_level(logging.DEBUG, logger="homeassistant.components.openhome"):
-        await _async_update_entity(hass)
+        await _trigger_update(hass, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_UNAVAILABLE
@@ -127,17 +128,19 @@ async def test_async_update_error(
     assert error_records[-1].exc_info is not None
 
 
-async def test_async_update_recovers(hass: HomeAssistant) -> None:
+async def test_async_update_recovers(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test the entity recovers after a failed update."""
     device = _mock_device()
     await setup_integration(hass, device)
 
     device.transport_state = AsyncMock(side_effect=UpnpError("device down"))
-    await _async_update_entity(hass)
+    await _trigger_update(hass, freezer)
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
 
     device.transport_state = AsyncMock(return_value="Playing")
-    await _async_update_entity(hass)
+    await _trigger_update(hass, freezer)
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_PLAYING
     assert state.attributes["source"] == "Radio"

--- a/tests/components/openhome/test_media_player.py
+++ b/tests/components/openhome/test_media_player.py
@@ -4,8 +4,8 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
-import pytest
 from async_upnp_client.client import UpnpError
+import pytest
 
 from homeassistant.components.media_player import DATA_COMPONENT
 from homeassistant.components.openhome.const import DOMAIN
@@ -116,6 +116,15 @@ async def test_async_update_error(
     assert state.state == STATE_UNAVAILABLE
     assert f"Error updating {ENTITY_ID}" in caplog.text
     assert message in caplog.text
+    error_records = [
+        record
+        for record in caplog.records
+        if record.name.startswith("homeassistant.components.openhome")
+        and "Error updating" in record.getMessage()
+    ]
+    assert error_records
+    assert error_records[-1].levelno == logging.DEBUG
+    assert error_records[-1].exc_info is not None
 
 
 async def test_async_update_recovers(hass: HomeAssistant) -> None:
@@ -123,12 +132,10 @@ async def test_async_update_recovers(hass: HomeAssistant) -> None:
     device = _mock_device()
     await setup_integration(hass, device)
 
-    # First update fails and the entity becomes unavailable
     device.transport_state = AsyncMock(side_effect=UpnpError("device down"))
     await _async_update_entity(hass)
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
 
-    # Second update succeeds and the entity recovers
     device.transport_state = AsyncMock(return_value="Playing")
     await _async_update_entity(hass)
     state = hass.states.get(ENTITY_ID)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Log OpenHome media player update failures at debug level so transient unavailability becomes diagnosable: the except branch in `OpenhomeDevice.async_update()` silently swallowed `TimeoutError` / `aiohttp.ClientError` / `UpnpError`; it now logs with `exc_info=True`. No behavior change.

Adds the first media player platform tests (success, three exception types, recovery), driven through the polling scheduler.

Fixes #175964

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175964
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
