### PR TITLE
Report a refused alarm activation in homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -11,6 +11,7 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -88,20 +89,43 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
     def _security_and_alarm(self) -> SecurityAndAlarmHome:
         return self._home.get_functionalHome(SecurityAndAlarmHome)
 
+    async def _async_set_zones_activation(
+        self, *, internal: bool, external: bool
+    ) -> None:
+        """Set the zone activation and raise when the panel refuses it."""
+        result = await self._home.set_security_zones_activation_async(
+            internal, external
+        )
+        # a request-based panel answers 200 without arming when a sensor blocks it
+        if result.success:
+            return
+
+        problems = self._home.get_security_zone_activation_problems(result)
+        if not problems:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="alarm_activation_failed",
+            )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="alarm_activation_blocked",
+            translation_placeholders={"devices": ", ".join(sorted(problems))},
+        )
+
     @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        await self._home.set_security_zones_activation_async(False, False)
+        await self._async_set_zones_activation(internal=False, external=False)
 
     @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        await self._home.set_security_zones_activation_async(False, True)
+        await self._async_set_zones_activation(internal=False, external=True)
 
     @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        await self._home.set_security_zones_activation_async(True, True)
+        await self._async_set_zones_activation(internal=True, external=True)
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -112,6 +112,12 @@
   "exceptions": {
     "access_point_not_found": {
       "message": "No matching access point found for access point ID {id}"
+    },
+    "alarm_activation_blocked": {
+      "message": "The alarm system was not armed because the following devices report a problem: {devices}"
+    },
+    "alarm_activation_failed": {
+      "message": "The alarm system did not accept the requested state"
     }
   },
   "services": {

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -1,9 +1,13 @@
 """Tests for HomematicIP Cloud alarm control panel."""
 
+from unittest.mock import Mock
+
 from homematicip.async_home import AsyncHome
+import pytest
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from .helper import HomeFactory, get_and_check_entity_basics
 
@@ -53,6 +57,8 @@ async def test_hmip_alarm_control_panel(
     assert not hmip_device
 
     home = mock_hap.home
+    # the mocked connection answers every call with a tuple, not a RestResult
+    home.set_security_zones_activation_async.return_value = Mock(success=True)
 
     await hass.services.async_call(
         "alarm_control_panel", "alarm_arm_away", {"entity_id": entity_id}, blocking=True
@@ -99,3 +105,53 @@ async def test_hmip_alarm_control_panel(
         hass, home, external_active=True, alarm_triggered=True
     )
     assert hass.states.get(entity_id).state == AlarmControlPanelState.TRIGGERED
+
+
+async def test_hmip_alarm_control_panel_activation_blocked(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test that a refused activation names the blocking devices."""
+    entity_id = "alarm_control_panel.hmip_alarm_control_panel"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=["EXTERNAL", "INTERNAL"]
+    )
+    home = mock_hap.home
+    home.set_security_zones_activation_async.return_value = Mock(
+        success=False,
+        json={
+            "channelActivationProblems": {
+                "3014F7110000000000000001:1": ["WINDOW_OPEN"],
+                "3014F7110000000000000005:1": ["WINDOW_OPEN"],
+            }
+        },
+    )
+
+    with pytest.raises(HomeAssistantError, match="Fenster, Wohnzimmer"):
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_arm_away",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert hass.states.get(entity_id).state == AlarmControlPanelState.DISARMED
+
+
+async def test_hmip_alarm_control_panel_activation_failed(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test a refusal that does not name any device."""
+    entity_id = "alarm_control_panel.hmip_alarm_control_panel"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=["EXTERNAL", "INTERNAL"]
+    )
+    home = mock_hap.home
+    home.set_security_zones_activation_async.return_value = Mock(success=False, json={})
+
+    with pytest.raises(HomeAssistantError, match="did not accept"):
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_arm_home",
+            {"entity_id": entity_id},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On the request-based alarm panel, `setZonesActivation` answers HTTP 200 without arming when a sensor blocks it. Since homematicip 2.14.0 the library marks that result unsuccessful and resolves the blocking channels to device labels, but the alarm control panel discarded the result: pressing arm did nothing, left the state unchanged and raised no error.

Arming and disarming now share one helper that raises a translated `HomeAssistantError`, naming the blocking devices when the cloud reports them and falling back to a generic message when it does not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177173, which fixed the arming itself
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
