### PR TITLE
Fix Twinkly devices going unavailable by giving them longer to respond

### DIFF
--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DEVICE_TIMEOUT, DOMAIN
 from .coordinator import TwinklyConfigEntry, TwinklyCoordinator
 
 PLATFORMS = [Platform.LIGHT, Platform.SELECT]
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> b
     # we will be able to properly share the connection.
     host = entry.data[CONF_HOST]
 
-    client = Twinkly(host, async_get_clientsession(hass))
+    client = Twinkly(host, async_get_clientsession(hass), timeout=DEVICE_TIMEOUT)
 
     coordinator = TwinklyCoordinator(hass, entry, client)
 
@@ -47,7 +47,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> bool:
     """Migrate old entry."""
     if entry.minor_version == 1:
-        client = Twinkly(entry.data[CONF_HOST], async_get_clientsession(hass))
+        client = Twinkly(
+            entry.data[CONF_HOST],
+            async_get_clientsession(hass),
+            timeout=DEVICE_TIMEOUT,
+        )
         try:
             device_info = await client.get_details()
         except (TimeoutError, ClientError) as exception:

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_ID, CONF_MODEL, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DEV_ID, DEV_MODEL, DEV_NAME, DOMAIN
+from .const import DEV_ID, DEV_MODEL, DEV_NAME, DEVICE_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
         if host is not None:
             try:
                 device_info = await Twinkly(
-                    host, async_get_clientsession(self.hass)
+                    host, async_get_clientsession(self.hass), timeout=DEVICE_TIMEOUT
                 ).get_details()
             except TimeoutError, ClientError:
                 errors[CONF_HOST] = "cannot_connect"
@@ -64,7 +64,9 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: discovery_info.ip})
         try:
             device_info = await Twinkly(
-                discovery_info.ip, async_get_clientsession(self.hass)
+                discovery_info.ip,
+                async_get_clientsession(self.hass),
+                timeout=DEVICE_TIMEOUT,
             ).get_details()
         except TimeoutError, ClientError:
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -17,3 +17,9 @@ DEV_PROFILE_RGBW = "RGBW"
 
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
+
+# ttls defaults to a 3 second total timeout, which covers connection setup as
+# well as the response. Devices poll every 30 seconds and their radio is idle
+# in between, so the first request of a cycle has to wake it inside that
+# budget - and frequently does not. See https://github.com/home-assistant/core/issues/160154
+DEVICE_TIMEOUT = 10

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -18,8 +18,5 @@ DEV_PROFILE_RGBW = "RGBW"
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
 
-# ttls defaults to a 3 second total timeout, which covers connection setup as
-# well as the response. Devices poll every 30 seconds and their radio is idle
-# in between, so the first request of a cycle has to wake it inside that
-# budget - and frequently does not. See https://github.com/home-assistant/core/issues/160154
+# The library default of 3 seconds is too short for a device waking its radio.
 DEVICE_TIMEOUT = 10

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock
 from aiohttp import ClientConnectionError
 import pytest
 
+from homeassistant.components import twinkly
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.twinkly.const import DOMAIN
+from homeassistant.components.twinkly.const import DEVICE_TIMEOUT, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -16,6 +17,16 @@ from . import setup_integration
 from .const import TEST_MAC, TEST_MODEL
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_twinkly_client")
+async def test_client_is_given_a_longer_timeout(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the client is given a longer timeout than the library default."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert twinkly.Twinkly.call_args.kwargs["timeout"] == DEVICE_TIMEOUT
 
 
 @pytest.mark.usefixtures("mock_twinkly_client")


### PR DESCRIPTION
## Proposed change

`ttls` defaults to `ClientTimeout(total=3)`, which covers connection setup as well as the response, and the integration never overrides it. Devices are polled every 30 seconds and their radio idles in between, so the first request of each cycle has to wake it inside that budget. Often it doesn't, and the device is marked unavailable until the next cycle.

Timeouts by endpoint, in the order the coordinator sends them, measured on three devices:

| endpoint | position | timed out |
|---|---|---|
| `gestalt` | 1st | **61.4 %** |
| `led/out/brightness` | 2nd | 11.4 % |
| `led/mode` | 3rd | 2.9 % |
| `movies` | 4th | 3.3 % |
| `movies/current` | 5th | 13.3 % |

It is the first request that fails, not the last: once the radio is awake the device answers in well under a second. Responses over three seconds are normal otherwise — a `get_current_movie()` on a device rendering a movie answered in 5.003 s.

Unavailable transitions over matched 24-minute windows, same three devices: **78.2/h before, 0.0/h after**.

Also applied in `config_flow.py`, where discovery probes the same devices.

`ttls`' own default was arguably too low for this hardware. jschlyter/ttls#51 has since been merged and released as 1.11.1, and #179147 bumps to it — that alone fixes the issue, making this PR redundant unless an explicit timeout is preferred to relying on the library default. Either resolves it; I am happy for the maintainers to take whichever they prefer.

Two related PRs from the same investigation, both independent of this one:

- #179143 aborts DHCP discovery cleanly when the device does not answer. It touches the same lines in `config_flow.py`, so whichever merges second needs a trivial rebase.
- #179141 removes a redundant request per update cycle and gives `UpdateFailed` a message. Measured separately, it does not affect the flapping.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #160154
- This PR is related to issue: #129467, #130206, #133146
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
