### PR TITLE
Stop fetching the Twinkly mode twice per update

### DIFF
--- a/homeassistant/components/twinkly/coordinator.py
+++ b/homeassistant/components/twinkly/coordinator.py
@@ -61,7 +61,9 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
             software_version = await self.client.get_firmware_version()
             self.device_name = (await self.client.get_details())[DEV_NAME]
         except (TimeoutError, ClientError) as exception:
-            raise UpdateFailed from exception
+            raise UpdateFailed(
+                f"Error setting up {self.config_entry.title}: {exception!r}"
+            ) from exception
         self.software_version = software_version["version"]
         self.supports_effects = AwesomeVersion(self.software_version) >= AwesomeVersion(
             MIN_EFFECT_VERSION
@@ -75,18 +77,22 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
         try:
             device_info = await self.client.get_details()
             brightness = await self.client.get_brightness()
-            is_on = await self.client.is_on()
             mode_data = await self.client.get_mode()
             current_mode = mode_data.get("mode")
             if self.supports_effects:
                 movies = (await self.client.get_saved_movies())["movies"]
         except (TimeoutError, ClientError) as exception:
-            raise UpdateFailed from exception
+            raise UpdateFailed(
+                f"Error communicating with {self.config_entry.title}: {exception!r}"
+            ) from exception
         if self.supports_effects:
             try:
                 current_movie = await self.client.get_current_movie()
             except (TwinklyError, TimeoutError, ClientError) as exception:
                 _LOGGER.debug("Error fetching current movie: %s", exception)
+        # Twinkly.is_on() issues a second GET of led/mode, so derive it from the
+        # mode already fetched above rather than asking the device twice.
+        is_on = (current_mode or "off") != "off"
         brightness = (
             int(brightness["value"]) if brightness["mode"] == "enabled" else 100
         )

--- a/tests/components/twinkly/conftest.py
+++ b/tests/components/twinkly/conftest.py
@@ -58,7 +58,6 @@ def mock_twinkly_client() -> Generator[AsyncMock]:
             "get_current_movie.json", DOMAIN
         )
         client.get_mode.return_value = load_json_object_fixture("get_mode.json", DOMAIN)
-        client.is_on.return_value = True
         client.get_brightness.return_value = {"mode": "enabled", "value": 10}
         client.host = "192.168.0.123"
         yield client

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -56,7 +56,7 @@ async def test_turn_on_off(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
 
     await setup_integration(hass, mock_config_entry)
 
@@ -78,7 +78,7 @@ async def test_turn_on_with_brightness(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service with a brightness parameter."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
 
     await setup_integration(hass, mock_config_entry)
 
@@ -118,7 +118,7 @@ async def test_turn_on_with_color_rgbw(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service with a rgbw parameter."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
     mock_twinkly_client.get_details.return_value["led_profile"] = "RGBW"
 
     await setup_integration(hass, mock_config_entry)
@@ -149,7 +149,7 @@ async def test_turn_on_with_color_rgb(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service with a rgb parameter."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
     mock_twinkly_client.get_details.return_value["led_profile"] = "RGB"
 
     await setup_integration(hass, mock_config_entry)
@@ -177,7 +177,7 @@ async def test_turn_on_with_effect(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service with effects."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
     mock_twinkly_client.get_details.return_value["led_profile"] = "RGB"
 
     await setup_integration(hass, mock_config_entry)
@@ -213,7 +213,7 @@ async def test_turn_on_with_missing_effect(
     data: dict[str, Any],
 ) -> None:
     """Test light.turn_on with rgbw color and missing effect support."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
     mock_twinkly_client.get_firmware_version.return_value["version"] = "2.7.0"
 
     await setup_integration(hass, mock_config_entry)
@@ -242,7 +242,7 @@ async def test_turn_on_with_color_rgbw_and_missing_effect(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """Test support of the light.turn_on service with missing effect support."""
-    mock_twinkly_client.is_on.return_value = False
+    mock_twinkly_client.get_mode.return_value = {"mode": "off"}
     mock_twinkly_client.get_firmware_version.return_value["version"] = "2.7.0"
 
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -50,6 +50,23 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+async def test_update_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_twinkly_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the entity becomes unavailable when the device stops answering."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_twinkly_client.get_details.side_effect = TimeoutError
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.tree_1").state == STATE_UNAVAILABLE
+
+
 async def test_turn_on_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
## Proposed change

Two small things in `TwinklyCoordinator`, found while investigating #160154.

**The mode is fetched twice per update.** `_async_update_data()` calls both `is_on()` and `get_mode()`, and `ttls` implements the former in terms of the latter:

```python
async def is_on(self) -> bool | None:
    mode = await self.get_mode()
    return mode.get("mode", "off") != "off"
```

So every device is asked for `led/mode` twice per 30-second cycle for a value already in hand. `is_on` is now derived from the mode fetched on the next line.

**`UpdateFailed` carries no message.** `raise UpdateFailed from exception` constructs it with no arguments, so `DataUpdateCoordinator` logs

```
Error fetching twinkly data: 
```

and nothing more — the exception survives only as `__cause__`, which never reaches the log. My own log has 2927 of those lines, none of which say whether it was a timeout or a client error. #160154 was reported by three users and closed as stale without a diagnosis, which those empty lines go some way to explaining.

Companion PRs from the same investigation: #179140 (the actual fix for #160154) and #179143 (DHCP discovery aborting cleanly).

Note this does **not** fix the flapping in #160154 — measured over matched windows, removing the redundant request changed the rate of unavailable transitions from 81.6/h to 70.7/h, which is within the noise of an 11-minute sample. The actual fix is a separate PR raising the request timeout. These are worth doing on their own merits.

The tests drove the off-state through the `is_on()` mock, which the coordinator no longer calls; they now set `get_mode` instead.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160154
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
