### PR TITLE
Add SDevices ZHA entity translations

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -258,6 +258,18 @@
       "consumer_connected": {
         "name": "Consumer connected"
       },
+      "emergency_overcurrent": {
+        "name": "Emergency overcurrent"
+      },
+      "emergency_overheat": {
+        "name": "Emergency overheat"
+      },
+      "emergency_overvoltage": {
+        "name": "Emergency overvoltage"
+      },
+      "emergency_undervoltage": {
+        "name": "Emergency undervoltage"
+      },
       "error_or_battery_low": {
         "name": "Error or battery low"
       },
@@ -311,6 +323,9 @@
       },
       "muted": {
         "name": "Muted"
+      },
+      "neutral_presence": {
+        "name": "Neutral presence"
       },
       "open_window_detection_status": {
         "name": "Open window detection status"
@@ -515,6 +530,9 @@
       }
     },
     "number": {
+      "acceleration_time": {
+        "name": "Acceleration time"
+      },
       "additional_steps": {
         "name": "Additional steps"
       },
@@ -577,6 +595,9 @@
       },
       "calibration_rotation_run_time_up": {
         "name": "Calibration rotation run time up"
+      },
+      "calibration_time": {
+        "name": "Calibration time"
       },
       "calibration_vertical_run_time_down": {
         "name": "Calibration vertical run time down"
@@ -643,6 +664,9 @@
       },
       "deadzone_temperature": {
         "name": "Deadzone temperature"
+      },
+      "deceleration_time": {
+        "name": "Deceleration time"
       },
       "default_level_local": {
         "name": "Local default dimming level"
@@ -794,6 +818,42 @@
       "led_color_when_on": {
         "name": "Default all LED on color"
       },
+      "led_indicator_off_b": {
+        "name": "LED brightness (off)"
+      },
+      "led_indicator_off_b_id": {
+        "name": "LED brightness (off) {id}"
+      },
+      "led_indicator_off_h": {
+        "name": "LED hue (off)"
+      },
+      "led_indicator_off_h_id": {
+        "name": "LED hue (off) {id}"
+      },
+      "led_indicator_off_s": {
+        "name": "LED saturation (off)"
+      },
+      "led_indicator_off_s_id": {
+        "name": "LED saturation (off) {id}"
+      },
+      "led_indicator_on_b": {
+        "name": "LED brightness (on)"
+      },
+      "led_indicator_on_b_id": {
+        "name": "LED brightness (on) {id}"
+      },
+      "led_indicator_on_h": {
+        "name": "LED hue (on)"
+      },
+      "led_indicator_on_h_id": {
+        "name": "LED hue (on) {id}"
+      },
+      "led_indicator_on_s": {
+        "name": "LED saturation (on)"
+      },
+      "led_indicator_on_s_id": {
+        "name": "LED saturation (on) {id}"
+      },
       "led_intensity_when_off": {
         "name": "Default all LED off intensity"
       },
@@ -826,6 +886,9 @@
       },
       "long_press_duration": {
         "name": "Long press duration"
+      },
+      "lower_voltage_threshold": {
+        "name": "Lower voltage threshold"
       },
       "max_brightness": {
         "name": "Maximum brightness"
@@ -916,6 +979,9 @@
       },
       "motor_start_delay": {
         "name": "Motor start delay"
+      },
+      "motor_timeout": {
+        "name": "Motor timeout"
       },
       "move_sensitivity": {
         "name": "Motion sensitivity"
@@ -1118,6 +1184,9 @@
       "temperature_sensitivity": {
         "name": "Temperature sensitivity"
       },
+      "temperature_threshold": {
+        "name": "Overtemperature threshold"
+      },
       "temporary_mode_duration": {
         "name": "Temporary mode duration"
       },
@@ -1181,6 +1250,12 @@
       "update_frequency": {
         "name": "Update frequency"
       },
+      "upper_current_threshold": {
+        "name": "Upper current threshold"
+      },
+      "upper_voltage_threshold": {
+        "name": "Upper voltage threshold"
+      },
       "valve_closing_degree": {
         "name": "Valve closing degree"
       },
@@ -1204,6 +1279,9 @@
       },
       "valve_state_auto_shutdown": {
         "name": "Valve state auto-shutdown"
+      },
+      "velocity": {
+        "name": "Velocity"
       },
       "water_duration": {
         "name": "Water duration"
@@ -1260,6 +1338,9 @@
       },
       "breaker_status": {
         "name": "Breaker status"
+      },
+      "buttons_mode": {
+        "name": "Buttons mode"
       },
       "calibration_mode": {
         "name": "Calibration mode"
@@ -1318,6 +1399,15 @@
       "eco_mode": {
         "name": "Eco mode"
       },
+      "emergency_shutoff_recovery": {
+        "name": "Emergency recovery"
+      },
+      "event_mode": {
+        "name": "Event mode"
+      },
+      "event_mode_id": {
+        "name": "Event mode {id}"
+      },
       "exercise_day_of_week": {
         "name": "Exercise day of the week"
       },
@@ -1371,6 +1461,9 @@
       },
       "led_brightness": {
         "name": "LED brightness"
+      },
+      "led_indication_type": {
+        "name": "LED indication type"
       },
       "led_scaling_mode": {
         "name": "LED scaling mode"
@@ -1444,6 +1537,9 @@
       "power_on_state": {
         "name": "Power on state"
       },
+      "power_profile": {
+        "name": "Power profile"
+      },
       "presence_sensitivity": {
         "name": "Presence sensitivity"
       },
@@ -1455,6 +1551,12 @@
       },
       "regulator_period": {
         "name": "Regulator period"
+      },
+      "relay_mode": {
+        "name": "Relay mode"
+      },
+      "relay_mode_id": {
+        "name": "Relay mode {id}"
       },
       "reverse": {
         "name": "Reverse"
@@ -1599,6 +1701,9 @@
       "brightness_level": {
         "name": "Brightness level"
       },
+      "button_clicks_1": {
+        "name": "Button 1 clicks"
+      },
       "calibrated": {
         "name": "Calibrated"
       },
@@ -1607,6 +1712,9 @@
       },
       "control_status": {
         "name": "Control status"
+      },
+      "cover_mode": {
+        "name": "Cover mode"
       },
       "dc_current": {
         "name": "DC current"
@@ -1628,6 +1736,9 @@
       },
       "distance": {
         "name": "Target distance"
+      },
+      "emergency_shutoff_state": {
+        "name": "Emergency shutoff state"
       },
       "energy_ph_a": {
         "name": "Energy phase A"
@@ -1751,6 +1862,9 @@
       "leaf_wetness": {
         "name": "Leaf wetness"
       },
+      "left_button_clicks": {
+        "name": "Left button clicks"
+      },
       "lifetime": {
         "name": "Lifetime"
       },
@@ -1799,6 +1913,9 @@
       "overheated": {
         "name": "Overheat protection"
       },
+      "pairing_button_clicks": {
+        "name": "Pairing button clicks"
+      },
       "pi_heating_demand": {
         "name": "Pi heating demand"
       },
@@ -1826,11 +1943,23 @@
       "rejoined_count": {
         "name": "Rejoined count"
       },
+      "relay_switches_1": {
+        "name": "Relay 1 switches"
+      },
+      "relay_switches_2": {
+        "name": "Relay 2 switches"
+      },
       "remaining_watering_time": {
         "name": "Remaining watering time"
       },
       "reported_packages": {
         "name": "Reported packages"
+      },
+      "resets_count": {
+        "name": "Reset count"
+      },
+      "right_button_clicks": {
+        "name": "Right button clicks"
       },
       "rms_current_ph_b": {
         "name": "Current phase B"
@@ -1970,6 +2099,9 @@
       "total_volatile_organic_compounds": {
         "name": "Total volatile organic compounds"
       },
+      "uptime": {
+        "name": "Uptime"
+      },
       "uv_index": {
         "name": "UV index"
       },
@@ -1994,6 +2126,9 @@
       "voc_index": {
         "name": "VOC index"
       },
+      "wall_button_clicks": {
+        "name": "Wall button clicks"
+      },
       "water_flow": {
         "name": "Water flow"
       },
@@ -2016,6 +2151,12 @@
       },
       "alarm_switch": {
         "name": "Alarm switch"
+      },
+      "allow_double_click": {
+        "name": "Allow double click"
+      },
+      "allow_double_click_id": {
+        "name": "Allow double click {id}"
       },
       "auto_clean": {
         "name": "Autoclean"
@@ -2043,6 +2184,15 @@
       },
       "child_lock": {
         "name": "Child lock"
+      },
+      "cover_calibration_mode": {
+        "name": "Cover calibration mode"
+      },
+      "cover_led_feedback": {
+        "name": "Cover LED feedback"
+      },
+      "cover_maintenance_mode": {
+        "name": "Cover maintenance mode"
       },
       "detach_relay": {
         "name": "Detach relay"
@@ -2152,6 +2302,18 @@
       "led_indicator": {
         "name": "LED indicator"
       },
+      "led_indicator_off_enable": {
+        "name": "LED indicator (off)"
+      },
+      "led_indicator_off_enable_id": {
+        "name": "LED indicator (off) {id}"
+      },
+      "led_indicator_on_enable": {
+        "name": "LED indicator (on)"
+      },
+      "led_indicator_on_enable_id": {
+        "name": "LED indicator (on) {id}"
+      },
       "linkage_alarm": {
         "name": "Linkage alarm"
       },
@@ -2196,6 +2358,9 @@
       },
       "relay_click_in_on_off_mode": {
         "name": "Disable relay click in on off mode"
+      },
+      "relay_id": {
+        "name": "Switch {id}"
       },
       "remote_protection": {
         "name": "Remote protection"


### PR DESCRIPTION
<!--
    You are amazing! Thanks for contributing to our project!
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  -->
  ## Breaking change
  <!--
    If your PR contains a breaking change for existing users, it is important
    to tell them what breaks, how to make it work again and why we did this.
    This piece of text is published with the release notes, so it helps if you
    write it towards our users, not us.
    Note: Remove this section if this PR is NOT a breaking change.
  -->

  Not a breaking change.

  ## Proposed change
  <!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
  -->

  Add English source translations for the custom entity names introduced by the SDevices ZHA quirks.

  This covers the custom `binary_sensor`, `number`, `select`, `sensor`, and `switch` entities, including numbered entities with `{id}` placeholders. Entity behavior, entity IDs, unique IDs, and device communication are unchanged.

  The source strings are added to `zha/strings.json`. Localized strings will be provided through the Home Assistant backend Lokalise project after this PR is merged.

  ## Type of change
  <!--
    What type of change does your PR introduce to Home Assistant?
    NOTE: Please, check only 1! box!
    If your PR requires multiple boxes to be checked, you'll most likely need to
    split it into multiple PRs. This makes things easier and faster to code review.
  -->

  - [ ] Dependency upgrade
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New integration (thank you!)
  - [ ] New feature (which adds functionality to an existing integration)
  - [ ] Deprecation (breaking change to happen in the future)
  - [ ] Breaking change (fix/feature causing existing functionality to break)
  - [x] Code quality improvements to existing code or addition of tests

  ## Additional information
  <!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
  -->

  - This PR fixes or closes issue: fixes #
  - Link to documentation pull request:
  - Link to developer documentation pull request:
  - Link to frontend pull request:

  ## Checklist
  <!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.

    AI tools are welcome, but contributors are responsible for *fully*
    understanding the code before submitting the PR. Please follow our AI policy:
    https://developers.home-assistant.io/docs/ai_policy
  -->

  - [x] I understand the code I am submitting and can explain how it works.
  - [x] The code change is tested and works locally.
  - [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] I have followed the [perfect PR recommendations][perfect-pr]
  - [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - [ ] Tests have been added to verify that the new code works.
  - [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

  If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

  If the code communicates with devices, web services, or third-party tools:

  - [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
        Updated and included derived files by running: `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt`.
        Updated by running: `python3 -m script.gen_requirements_all`.
  - [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

  <!--
    This project is very active and we have a high turnover of pull requests.

    Unfortunately, the number of incoming pull requests is higher than what our
    reviewers can review and merge so there is a long backlog of pull requests
    waiting for review. You can help here!

    By reviewing another pull request, you will help raise the code quality of that
    pull request and the final review will be faster. This way the general
    pace of pull request reviews will go up and your wait time will go down.

    When picking a pull request to review, try to choose one that hasn't yet been
    reviewed.

    Thanks for helping out!
  -->

  To help with the load of incoming pull requests:

  - [ ] I have reviewed two other [open pull requests][prs] in this repository.

  [prs]:
  https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

  <!--
    Thank you for contributing <3

    Below, some useful links you could explore:
  -->
  [dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
  [manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
  [quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
  [docs-repository]: https://github.com/home-assistant/home-assistant.io
  [perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr