### PR TITLE
Abort Twinkly DHCP discovery when the device does not answer

### DIFF
--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -62,9 +62,12 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle dhcp discovery for twinkly."""
         self._async_abort_entries_match({CONF_HOST: discovery_info.ip})
-        device_info = await Twinkly(
-            discovery_info.ip, async_get_clientsession(self.hass)
-        ).get_details()
+        try:
+            device_info = await Twinkly(
+                discovery_info.ip, async_get_clientsession(self.hass)
+            ).get_details()
+        except TimeoutError, ClientError:
+            return self.async_abort(reason="cannot_connect")
         await self.async_set_unique_id(device_info["mac"])
         self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
 

--- a/homeassistant/components/twinkly/strings.json
+++ b/homeassistant/components/twinkly/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -117,6 +117,26 @@ async def test_dhcp_full_flow(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == TEST_MAC
 
 
+async def test_dhcp_cannot_connect(
+    hass: HomeAssistant, mock_twinkly_client: AsyncMock
+) -> None:
+    """Test DHCP discovery aborts when the device does not answer."""
+    mock_twinkly_client.get_details.side_effect = TimeoutError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            hostname="Twinkly_XYZ",
+            ip="1.2.3.4",
+            macaddress="002d133baabb",
+        ),
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
 @pytest.mark.usefixtures("mock_twinkly_client")
 async def test_dhcp_already_configured(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry


### PR DESCRIPTION
## Proposed change

`async_step_dhcp` calls `get_details()` with no error handling, so a device that is slow to answer or has gone away raises `TimeoutError` or `ClientError` out of the config flow. Abort with `cannot_connect` instead, as the user step already does.

Noticed while working on #179140, which raises the request timeout — that makes the failure rarer but does not prevent it. That PR touches the same lines in `config_flow.py`, so whichever merges second needs a trivial rebase.

Also related: #179141.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
