### PR TITLE
Bump ttls to 1.11.1

### DIFF
--- a/homeassistant/components/twinkly/manifest.json
+++ b/homeassistant/components/twinkly/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["ttls"],
-  "requirements": ["ttls==1.10.0"]
+  "requirements": ["ttls==1.11.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3238,7 +3238,7 @@ triggercmd==0.0.36
 trmnl==0.1.1
 
 # homeassistant.components.twinkly
-ttls==1.10.0
+ttls==1.11.1
 
 # homeassistant.components.thethingsnetwork
 ttn_client==1.3.0


### PR DESCRIPTION
## Proposed change

Bumps `ttls` from 1.10.0 to 1.11.1.

The change that matters here is `DEFAULT_TIMEOUT` going from 3 to 10 seconds. `ClientTimeout(total=3)` covers connection setup as well as the response, and devices polled every 30 seconds have to wake an idle radio inside that budget. Measured on three devices, the first request of each cycle timed out 61.4 % of the time; unavailable transitions ran at 78.2/h and went to 0.0/h once the timeout was raised.

Full diff 1.10.0...1.11.1: https://github.com/jschlyter/ttls/compare/v1.10.0...v1.11.1

- `DEFAULT_TIMEOUT` 3 → 10 (jschlyter/ttls#51)
- new `send_frame_3()` for the v3 real-time protocol — additive
- changes to `colours.py` and `cli.py`, neither of which this integration imports

Nothing the integration uses changed: `get_details`, `get_brightness`, `get_mode`, `is_on`, `get_saved_movies`, `get_current_movie`, `get_firmware_version`, `turn_on`, `turn_off`, `set_brightness`, `set_current_movie`, `set_static_colour` and `interview` all keep their signatures, `TwinklyError` and `TWINKLY_MODES` are unchanged, and the new `api_version` argument to `Twinkly()` is optional.

This supersedes #179140, which passed an explicit timeout to work around the old default. Happy to close that one if this is preferred.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #160154
- This PR is related to issue: #129467, #130206, #133146
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
