### PR TITLE
reuse results through smlight config entry flow tests

### DIFF
--- a/tests/components/smlight/test_config_flow.py
+++ b/tests/components/smlight/test_config_flow.py
@@ -61,19 +61,19 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_HOST: MOCK_HOSTNAME,
         },
     )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "SLZB-06p7"
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SLZB-06p7"
+    assert result["data"] == {
         CONF_HOST: MOCK_HOSTNAME,
     }
-    assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -90,30 +90,30 @@ async def test_user_flow_auth(
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_HOST: MOCK_HOSTNAME,
         },
     )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "auth"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "auth"
 
-    result3 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
             CONF_PASSWORD: MOCK_PASSWORD,
         },
     )
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "SLZB-06p7"
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SLZB-06p7"
+    assert result["data"] == {
         CONF_USERNAME: MOCK_USERNAME,
         CONF_PASSWORD: MOCK_PASSWORD,
         CONF_HOST: MOCK_HOSTNAME,
     }
-    assert result3["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -141,15 +141,15 @@ async def test_zeroconf_flow(
     assert progress[0]["flow_id"] == result["flow_id"]
     assert progress[0]["context"]["confirm_only"] is True
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["context"]["source"] == "zeroconf"
-    assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result2["title"] == "slzb-06"
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["source"] == "zeroconf"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["title"] == "slzb-06"
+    assert result["data"] == {
         CONF_HOST: MOCK_HOST,
     }
 
@@ -182,12 +182,12 @@ async def test_zeroconf_flow_auth(
     assert progress[0]["flow_id"] == result["flow_id"]
     assert progress[0]["context"]["confirm_only"] is True
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "auth"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "auth"
 
     progress2 = [
         flow
@@ -197,7 +197,7 @@ async def test_zeroconf_flow_auth(
     assert len(progress2) == 1
     assert progress2[0]["flow_id"] == result["flow_id"]
 
-    result3 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
             CONF_USERNAME: MOCK_USERNAME,
@@ -205,11 +205,11 @@ async def test_zeroconf_flow_auth(
         },
     )
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["context"]["source"] == "zeroconf"
-    assert result3["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result3["title"] == "SLZB-06p7"
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["source"] == "zeroconf"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["title"] == "SLZB-06p7"
+    assert result["data"] == {
         CONF_USERNAME: MOCK_USERNAME,
         CONF_PASSWORD: MOCK_PASSWORD,
         CONF_HOST: MOCK_HOST,
@@ -236,12 +236,12 @@ async def test_zeroconf_unsupported_abort(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm_discovery"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "unsupported_device"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_device"
 
 
 async def test_user_unsupported_abort(
@@ -260,15 +260,15 @@ async def test_user_unsupported_abort(
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_HOST: MOCK_HOST,
         },
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "unsupported_device"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_device"
 
 
 async def test_user_unsupported_device_abort_auth(
@@ -361,19 +361,19 @@ async def test_user_flow_can_override_discovery(
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_HOST: MOCK_HOST,
         },
     )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["context"]["source"] == SOURCE_USER
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["source"] == SOURCE_USER
+    assert result["data"] == {
         CONF_HOST: MOCK_HOST,
     }
-    assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -477,15 +477,15 @@ async def test_user_cannot_connect(
 
     mock_smlight_client.check_auth_needed.side_effect = None
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_HOST: MOCK_HOST,
         },
     )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "SLZB-06p7"
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SLZB-06p7"
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_smlight_client.get_info.mock_calls) == 2
@@ -513,7 +513,7 @@ async def test_auth_cannot_connect(
 
     mock_smlight_client.check_auth_needed.side_effect = SmlightConnectionError
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
@@ -521,8 +521,8 @@ async def test_auth_cannot_connect(
         },
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "cannot_connect"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_zeroconf_cannot_connect(
@@ -539,13 +539,13 @@ async def test_zeroconf_cannot_connect(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm_discovery"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {},
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "cannot_connect"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_zeroconf_legacy_cannot_connect(
@@ -577,15 +577,15 @@ async def test_zeroconf_legacy_mac(
 
     assert result["description_placeholders"] == {"host": MOCK_DEVICE_NAME}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["context"]["source"] == "zeroconf"
-    assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result2["title"] == "slzb-06"
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["source"] == "zeroconf"
+    assert result["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+    assert result["title"] == "slzb-06"
+    assert result["data"] == {
         CONF_HOST: MOCK_HOST,
     }
 
@@ -672,7 +672,7 @@ async def test_reauth_flow(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
@@ -680,8 +680,8 @@ async def test_reauth_flow(
         },
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
     assert mock_config_entry.data == {
         CONF_USERNAME: MOCK_USERNAME,
         CONF_PASSWORD: MOCK_PASSWORD,
@@ -708,7 +708,7 @@ async def test_reauth_auth_error(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
@@ -716,11 +716,11 @@ async def test_reauth_auth_error(
         },
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "reauth_confirm"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
 
     mock_smlight_client.authenticate.side_effect = None
-    result3 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
@@ -728,8 +728,8 @@ async def test_reauth_auth_error(
         },
     )
 
-    assert result3["type"] is FlowResultType.ABORT
-    assert result3["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
 
     assert mock_config_entry.data == {
         CONF_USERNAME: MOCK_USERNAME,
@@ -757,7 +757,7 @@ async def test_reauth_connect_error(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             CONF_USERNAME: MOCK_USERNAME,
@@ -765,8 +765,8 @@ async def test_reauth_connect_error(
         },
     )
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "cannot_connect"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
     assert len(mock_smlight_client.authenticate.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--  Describe the big picture o your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reuse flow results across subsequent steps. This keeps the config-flow tests aligned with real user behaviour by following the active flow result through each step. In before a future #epic ;)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X]  I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
