### PR TITLE
Add support for max_history = -1

### DIFF
--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -497,7 +497,7 @@ def ollama_config_option_schema(
                 },
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=0, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
+                    min=-1, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
                 )
             ),
             vol.Optional(

--- a/homeassistant/components/ollama/entity.py
+++ b/homeassistant/components/ollama/entity.py
@@ -298,7 +298,6 @@ class OllamaBaseLLMEntity(Entity):
             # Keep all messages
             return
 
-        # -1 means keep no previous rounds
         max_rounds = max(max_messages, 0)
 
         # Ignore the in progress user message

--- a/homeassistant/components/ollama/entity.py
+++ b/homeassistant/components/ollama/entity.py
@@ -287,21 +287,27 @@ class OllamaBaseLLMEntity(Entity):
         This sets the max history to allow a configurable size history may take
         up in the context window.
 
+        A value of 0 keeps all messages; -1 keeps no previous rounds (only the
+        system prompt and the in progress user message are sent).
+
         Note that some messages in the history may not be from ollama only, and
         may come from other anents, so the assumptions here may not strictly hold,
         but generally should be effective.
         """
-        if max_messages < 1:
+        if max_messages == 0:
             # Keep all messages
             return
 
+        # -1 means keep no previous rounds
+        max_rounds = max(max_messages, 0)
+
         # Ignore the in progress user message
         num_previous_rounds = message_history.num_user_messages - 1
-        if num_previous_rounds >= max_messages:
+        if num_previous_rounds >= max_rounds:
             # Trim history but keep system prompt (first message).
             # Every other message should be an assistant message, so keep 2x
             # message objects. Also keep the last in progress user message
-            num_keep = 2 * max_messages + 1
+            num_keep = 2 * max_rounds + 1
             drop_index = len(message_history.messages) - num_keep
             message_history.messages = [
                 message_history.messages[0],

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -58,6 +58,7 @@
           },
           "data_description": {
             "keep_alive": "[%key:component::ollama::config_subentries::conversation::step::set_options::data_description::keep_alive%]",
+            "max_history": "[%key:component::ollama::config_subentries::conversation::step::set_options::data_description::max_history%]",
             "num_ctx": "[%key:component::ollama::config_subentries::conversation::step::set_options::data_description::num_ctx%]",
             "prompt": "[%key:component::ollama::config_subentries::conversation::step::set_options::data_description::prompt%]",
             "think": "[%key:component::ollama::config_subentries::conversation::step::set_options::data_description::think%]"
@@ -97,6 +98,7 @@
           },
           "data_description": {
             "keep_alive": "Duration in seconds for Ollama to keep model in memory. -1 = indefinite, 0 = never.",
+            "max_history": "Number of previous conversation rounds (question and answer) to send with each request. 0 = send the entire conversation history, -1 = send no history (only the current message).",
             "num_ctx": "Maximum number of text tokens the model can process. Lower to reduce Ollama RAM, or increase for a large number of exposed entities.",
             "prompt": "Instruct how the LLM should respond. This can be a template.",
             "think": "If enabled, the LLM will think before responding. This can improve response quality but may increase latency."

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -740,6 +740,49 @@ async def test_message_history_unlimited(
         assert message_count == 100
 
 
+async def test_message_history_no_history(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_init_component
+) -> None:
+    """Test that no previous rounds are sent when max_history = -1."""
+    conversation_id = "1234"
+
+    def stream(*args, **kwargs) -> AsyncGenerator[dict]:
+        return stream_generator(
+            {"message": {"role": "assistant", "content": "test response"}}
+        )
+
+    with (
+        patch("ollama.AsyncClient.chat", side_effect=stream) as mock_chat,
+    ):
+        subentry = next(iter(mock_config_entry.subentries.values()))
+        hass.config_entries.async_update_subentry(
+            mock_config_entry,
+            subentry,
+            data={**subentry.data, ollama.CONF_MAX_HISTORY: -1},
+        )
+        await hass.async_block_till_done()
+        for i in range(3):
+            result = await conversation.async_converse(
+                hass,
+                f"message {i + 1}",
+                conversation_id=conversation_id,
+                context=Context(),
+                agent_id=mock_config_entry.entry_id,
+            )
+            assert (
+                result.response.response_type is intent.IntentResponseType.ACTION_DONE
+            ), result
+
+        args = mock_chat.call_args_list
+        assert len(args) == 3
+        # Only the system prompt and the current user message are sent
+        recorded_messages = args[-1].kwargs["messages"]
+        assert len(recorded_messages) == 2
+        assert recorded_messages[0]["role"] == "system"
+        assert recorded_messages[1]["role"] == "user"
+        assert recorded_messages[1]["content"] == "message 3"
+
+
 async def test_error_handling(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_init_component
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This should not be a breaking change, since it allows the value to be set to -1.
I could have made this a breaking change by introducing new semantics where 0 would mean no history, and -1 would mean infinite history, which would be more accurate.
If that's better, we can do that, but it's currently non breaking, which seems better.

## Proposed change
Add support for setting max_history to '-1' to have _no_ conversation history.
In my testing, no history yields much, much better results when it comes to tool calling in LLM's. It seems that LLM's think that previous results of tools or their own previous responses are accurate to reuse in future answers regarding home automation.
I've tried to fix this with system prompting, but for smaller models (llama3.2:3b, qwen2.5:7b, and gemma4:12b) it doesn't seem fixable.
The results after restarting HA, and forcing a new conversation ID, are much better.

After testing this, it works locally, and works as expected with the assist feature, as it forgets what you were saying instantly. This is a bit quirky if you test it in a conversation window, but it's technically correct.

Maybe we should add a warning to the conversation window that if the value is set to `-1` it's shows an active banner that this conversation agent is configured without history.

My take on how people would configure this, is using multiple agents, and set some devices to use the one without history, and some with history. I'm not really sure if using multiple agents is a good thing, but my Sat1 speaker supports it.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: no previous issue
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47407
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
