### PR TITLE
Add Keep Accessory Power Mode buttons to Tessie

### DIFF
--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -36,6 +36,14 @@ DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
         key="enable_keyless_driving",
         func=lambda api: api.remote_start(),
     ),
+    TessieButtonEntityDescription(
+        key="enable_keep_accessory_power_mode",
+        func=lambda api: api.enable_keep_accessory_power_mode(),
+    ),
+    TessieButtonEntityDescription(
+        key="disable_keep_accessory_power_mode",
+        func=lambda api: api.disable_keep_accessory_power_mode(),
+    ),
     TessieButtonEntityDescription(key="boombox", func=lambda api: api.remote_boombox()),
 )
 

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -78,6 +78,12 @@
       "boombox": {
         "default": "mdi:volume-high"
       },
+      "disable_keep_accessory_power_mode": {
+        "default": "mdi:power-plug-off"
+      },
+      "enable_keep_accessory_power_mode": {
+        "default": "mdi:power-plug"
+      },
       "enable_keyless_driving": {
         "default": "mdi:car-key"
       },

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -137,6 +137,12 @@
       "boombox": {
         "name": "Play fart"
       },
+      "disable_keep_accessory_power_mode": {
+        "name": "Disable keep accessory power"
+      },
+      "enable_keep_accessory_power_mode": {
+        "name": "Enable keep accessory power"
+      },
       "enable_keyless_driving": {
         "name": "Keyless driving"
       },

--- a/tests/components/tessie/snapshots/test_button.ambr
+++ b/tests/components/tessie/snapshots/test_button.ambr
@@ -1,4 +1,104 @@
 # serializer version: 1
+# name: test_buttons[button.test_disable_keep_accessory_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_disable_keep_accessory_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Disable keep accessory power',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Disable keep accessory power',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'disable_keep_accessory_power_mode',
+    'unique_id': 'VINVINVIN-disable_keep_accessory_power_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.test_disable_keep_accessory_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Disable keep accessory power',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_disable_keep_accessory_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_buttons[button.test_enable_keep_accessory_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_enable_keep_accessory_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable keep accessory power',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Enable keep accessory power',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'enable_keep_accessory_power_mode',
+    'unique_id': 'VINVINVIN-enable_keep_accessory_power_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.test_enable_keep_accessory_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Enable keep accessory power',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_enable_keep_accessory_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_buttons[button.test_flash_lights-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -30,6 +30,14 @@ async def test_buttons(
         ("button.test_homelink", "tessie_trigger_homelink"),
         ("button.test_keyless_driving", "remote_start"),
         ("button.test_play_fart", "remote_boombox"),
+        (
+            "button.test_enable_keep_accessory_power",
+            "enable_keep_accessory_power_mode",
+        ),
+        (
+            "button.test_disable_keep_accessory_power",
+            "disable_keep_accessory_power_mode",
+        ),
     ):
         with patch(
             f"tesla_fleet_api.tessie.Vehicle.{func}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds two buttons to the Tessie integration for Tesla's Keep Accessory Power
Mode, which keeps the USB ports and 12V outlets powered while the vehicle is
parked and unoccupied (vehicle firmware 2025.38 or later).

Tessie exposes this as a pair of commands:

- `POST /{vin}/command/enable_keep_accessory_power_mode`
- `POST /{vin}/command/disable_keep_accessory_power_mode`

Both are already available as `Vehicle` methods in the pinned
`tesla-fleet-api==1.9.0`, so this needs no dependency change.

These are buttons rather than a switch because Tessie's vehicle state does not
report whether the mode is currently active. I checked the `/state` response of
a vehicle running firmware 2026.20.10 with the mode both off and on, and there
is no corresponding field in either case, so there is nothing to derive `is_on`
from. If Tessie starts reporting it, these can be replaced with a single switch.

Tested on a real vehicle by running this branch as a custom component: both
buttons are created on the vehicle device, and pressing them successfully
enables and disables the mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/2682
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47408
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
