### PR TITLE
Discover hortimax controllers on every update instead of once during setup

### DIFF
--- a/homeassistant/components/hortimax/__init__.py
+++ b/homeassistant/components/hortimax/__init__.py
@@ -4,10 +4,8 @@ from aiohortos import HortosClient
 
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, MANUFACTURER
 from .coordinator import HortimaxConfigEntry, HortimaxCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -21,19 +19,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HortimaxConfigEntry) -> 
     coordinator = HortimaxCoordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
-
-    # Registered up front so the sensor platform's source devices can point at
-    # them through via_device.
-    device_registry = dr.async_get(hass)
-    for device in coordinator.devices:
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, device.name)},
-            manufacturer=MANUFACTURER,
-            name=device.label or device.name,
-            model="HortiMaX Pro",
-            serial_number=device.name,
-        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/hortimax/coordinator.py
+++ b/homeassistant/components/hortimax/coordinator.py
@@ -82,12 +82,6 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
                 translation_placeholders={"error": str(err)},
             ) from err
 
-        # The config flow refuses a key with no controllers, so an entry that
-        # suddenly has none is a change on the HortOS side. Retrying beats
-        # loading an integration with nothing in it.
-        if not self.devices:
-            raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_devices")
-
     @override
     async def _async_update_data(self) -> dict[str, HortimaxDeviceData]:
         """Fetch the latest value of every readout of every controller."""

--- a/homeassistant/components/hortimax/coordinator.py
+++ b/homeassistant/components/hortimax/coordinator.py
@@ -48,7 +48,6 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
     """Poll the latest readout values of every controller."""
 
     config_entry: HortimaxConfigEntry
-    devices: list[Device]
 
     def __init__(
         self,
@@ -65,7 +64,6 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
             update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
         self.client = client
-        self.devices = []
 
     @override
     async def _async_update_data(self) -> dict[str, HortimaxDeviceData]:
@@ -74,9 +72,8 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
         try:
             # Read the controller list every cycle, so a controller added in
             # HortiMaX Pro is picked up without reloading the entry.
-            self.devices = await self.client.get_devices()
-            self._register_controllers()
-            for device in self.devices:
+            devices = await self.client.get_devices()
+            for device in devices:
                 device_data = HortimaxDeviceData(device=device)
                 sources: dict[str, tuple[str, str, str]] = {}
                 for readout in await self.client.get_latest_readouts(device.name):
@@ -91,6 +88,9 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
                 device_data.source_names = disambiguate_source_names(sources)
                 data[device.name] = device_data
                 self._rename_changed_sources(device.name, device_data)
+            # Only once the whole poll succeeded, so a readout failure does not
+            # leave a registered controller behind for an update that is rejected.
+            self._register_controllers(devices)
         except HortosAuthenticationError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN, translation_key="invalid_auth"
@@ -104,7 +104,7 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
         return data
 
     @callback
-    def _register_controllers(self) -> None:
+    def _register_controllers(self, devices: list[Device]) -> None:
         """Register every controller, so its sources can point at it.
 
         Sources resolve their ``via_device_id`` from the registry when their
@@ -113,7 +113,7 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
         entities of its own, so nothing else would create it.
         """
         registry = dr.async_get(self.hass)
-        for device in self.devices:
+        for device in devices:
             registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 identifiers={(DOMAIN, device.name)},

--- a/homeassistant/components/hortimax/coordinator.py
+++ b/homeassistant/components/hortimax/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER, SCAN_INTERVAL
+from .const import DOMAIN, LOGGER, MANUFACTURER, SCAN_INTERVAL
 
 type HortimaxConfigEntry = ConfigEntry[HortimaxCoordinator]
 
@@ -65,28 +65,17 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
             update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
         self.client = client
-
-    @override
-    async def _async_setup(self) -> None:
-        """Discover the available controllers once."""
-        try:
-            self.devices = await self.client.get_devices()
-        except HortosAuthenticationError as err:
-            raise ConfigEntryAuthFailed(
-                translation_domain=DOMAIN, translation_key="invalid_auth"
-            ) from err
-        except HortosError as err:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="cannot_connect",
-                translation_placeholders={"error": str(err)},
-            ) from err
+        self.devices = []
 
     @override
     async def _async_update_data(self) -> dict[str, HortimaxDeviceData]:
         """Fetch the latest value of every readout of every controller."""
         data: dict[str, HortimaxDeviceData] = {}
         try:
+            # Read the controller list every cycle, so a controller added in
+            # HortiMaX Pro is picked up without reloading the entry.
+            self.devices = await self.client.get_devices()
+            self._register_controllers()
             for device in self.devices:
                 device_data = HortimaxDeviceData(device=device)
                 sources: dict[str, tuple[str, str, str]] = {}
@@ -113,6 +102,26 @@ class HortimaxCoordinator(DataUpdateCoordinator[dict[str, HortimaxDeviceData]]):
                 translation_placeholders={"error": str(err)},
             ) from err
         return data
+
+    @callback
+    def _register_controllers(self) -> None:
+        """Register every controller, so its sources can point at it.
+
+        Sources resolve their ``via_device_id`` from the registry when their
+        first entity is added, so a controller has to be registered before the
+        listeners that build those entities run. A controller carries no
+        entities of its own, so nothing else would create it.
+        """
+        registry = dr.async_get(self.hass)
+        for device in self.devices:
+            registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, device.name)},
+                manufacturer=MANUFACTURER,
+                name=device.label or device.name,
+                model="HortiMaX Pro",
+                serial_number=device.name,
+            )
 
     @callback
     def _rename_changed_sources(

--- a/homeassistant/components/hortimax/entity.py
+++ b/homeassistant/components/hortimax/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Ridder HortiMaX Pro (HortOS) integration."""
 
+from typing import override
+
 from aiohortos import Readout
 
 from homeassistant.helpers import device_registry as dr
@@ -45,6 +47,12 @@ class HortimaxEntity(CoordinatorEntity[HortimaxCoordinator]):
                 config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the controller this readout belongs to is known."""
+        return super().available and self._device_id in self.coordinator.data
 
     @property
     def readout(self) -> Readout | None:

--- a/homeassistant/components/hortimax/quality_scale.yaml
+++ b/homeassistant/components/hortimax/quality_scale.yaml
@@ -71,12 +71,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: todo
-  dynamic-devices:
-    status: todo
-    comment: |
-      Sources that appear on a known controller do become devices during
-      normal updates, but the controller list itself is only read once
-      during setup, so a newly added controller needs a reload.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done

--- a/homeassistant/components/hortimax/strings.json
+++ b/homeassistant/components/hortimax/strings.json
@@ -28,9 +28,6 @@
     },
     "invalid_auth": {
       "message": "The HortOS API rejected the API key"
-    },
-    "no_devices": {
-      "message": "The HortOS API reported no controllers for this API key"
     }
   }
 }

--- a/tests/components/hortimax/test_init.py
+++ b/tests/components/hortimax/test_init.py
@@ -4,7 +4,13 @@ from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
-from aiohortos import HortosAuthenticationError, HortosConnectionError
+from aiohortos import (
+    Device,
+    HortosAuthenticationError,
+    HortosConnectionError,
+    Readout,
+    Source,
+)
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -61,6 +67,71 @@ async def test_no_controllers_still_loads(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert not hass.states.async_entity_ids("sensor")
+
+
+async def test_new_controller_is_added(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hortos_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a controller that only shows up later is registered with its sources.
+
+    Sources resolve their controller from the registry when their first entity
+    is added, so the controller has to be there by then.
+    """
+    second_device = "HOR00000000.001"
+    await setup_integration(hass, mock_config_entry)
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, second_device), mock_config_entry.entry_id
+        )
+        is None
+    )
+
+    mock_hortos_client.get_devices.return_value = [
+        Device(name=DEVICE, label=DEVICE_LABEL, public_id="public-id"),
+        Device(name=second_device, label="Greenhouse Cabrio", public_id="public-id-2"),
+    ]
+    mock_hortos_client.get_latest_readouts.side_effect = lambda device_name: (
+        load_readouts()
+        if device_name == DEVICE
+        else [
+            Readout(
+                identifier="OutsideTemperature-Measured",
+                name="Outside temperature",
+                unit="DegreeCelsius",
+                source=Source(
+                    name="Weather station 001",
+                    type="WeatherStation",
+                    user_defined_name="Weerstation Cabrio",
+                ),
+                value=21.5,
+            )
+        ]
+    )
+
+    freezer.tick(timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    controller = device_registry.async_get_device_by_identifier(
+        (DOMAIN, second_device), mock_config_entry.entry_id
+    )
+    assert controller is not None
+    assert controller.name == "Greenhouse Cabrio"
+
+    source = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{second_device}::WeatherStation::Weather station 001"),
+        mock_config_entry.entry_id,
+    )
+    assert source is not None
+    assert source.via_device_id == controller.id
+
+    state = hass.states.get("sensor.weerstation_cabrio_outside_temperature")
+    assert state is not None
+    assert state.state == "21.5"
 
 
 async def test_auth_error_sets_error_state(

--- a/tests/components/hortimax/test_init.py
+++ b/tests/components/hortimax/test_init.py
@@ -162,6 +162,30 @@ async def test_readout_auth_error_sets_error_state(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+async def test_failed_poll_registers_no_controller(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hortos_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a poll that fails part way through registers no controller.
+
+    Controllers are discovered before their readouts are read, so registering
+    them early would leave devices behind for an update that is rejected.
+    """
+    mock_hortos_client.get_latest_readouts.side_effect = HortosConnectionError("boom")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, DEVICE), mock_config_entry.entry_id
+        )
+        is None
+    )
+
+
 @pytest.mark.usefixtures("mock_hortos_client")
 async def test_renamed_source_follows(
     hass: HomeAssistant,

--- a/tests/components/hortimax/test_init.py
+++ b/tests/components/hortimax/test_init.py
@@ -45,17 +45,21 @@ async def test_connection_error_retries(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_no_controllers_retries(
+async def test_no_controllers_still_loads(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hortos_client: AsyncMock,
 ) -> None:
-    """Test an entry whose controllers have gone retries instead of loading empty."""
+    """Test an entry whose controllers have gone loads empty instead of retrying.
+
+    A reachable API means setup succeeded, so failing it would retry a working
+    connection forever.
+    """
     mock_hortos_client.get_devices.return_value = []
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     assert not hass.states.async_entity_ids("sensor")
 
 

--- a/tests/components/hortimax/test_sensor.py
+++ b/tests/components/hortimax/test_sensor.py
@@ -180,6 +180,29 @@ async def test_disappearing_readout_becomes_unknown(
     )
 
 
+async def test_disappearing_device_becomes_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hortos_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an entity whose controller drops out of a good poll is unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    assert (
+        hass.states.get("sensor.weerstation_outside_temperature").state == "18.203125"
+    )
+
+    mock_hortos_client.get_devices.return_value = []
+    freezer.tick(timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.weerstation_outside_temperature").state
+        == STATE_UNAVAILABLE
+    )
+
+
 @pytest.mark.usefixtures("mock_hortos_client")
 @pytest.mark.parametrize(
     ("code", "expected"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Read the controller list on every update instead of once during setup, and stop
treating an empty list as a setup failure, per [review feedback on #177247][c]:

> However, this means if you don't have devices, it will retry forever, with
> expontential backoff, which the API might like less

[c]: https://github.com/home-assistant/core/pull/177247#discussion_r3719787920

`_async_setup` raised `UpdateFailed` when HortOS reported no controllers, which
HA turns into `ConfigEntryNotReady`, so a working connection retried forever.
Reading the list only at setup also meant that allowing the empty load on its
own would strand the user with an empty integration, so discovery moves into
`_async_update_data`. The sensor platform already listens for coordinator
updates, so no new callback was needed. Closes the `dynamic-devices` rule.

Controllers are registered from the coordinator now, which is the part worth
reviewing: sources resolve `via_device_id` from the registry when their first
entity is added, and a controller has no entities of its own, so it has to exist
before the platform listener runs.

The unused `exceptions.no_devices` string is removed. The config flow's
`no_devices` *error* is kept: a key with no controllers at all is probably the
wrong key.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Supersedes #178554, which documented the retry timings instead of fixing the
behaviour. 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
