### PR TITLE
Add missing state_class to Withings measurement sensors

### DIFF
--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -235,12 +235,14 @@ MEASUREMENT_SENSORS: dict[
         key="vascular_age",
         measurement_type=MeasurementType.VASCULAR_AGE,
         translation_key="vascular_age",
+        state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
     MeasurementType.VISCERAL_FAT: WithingsMeasurementSensorEntityDescription(
         key="visceral_fat",
         measurement_type=MeasurementType.VISCERAL_FAT,
         translation_key="visceral_fat_index",
+        state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
     MeasurementType.ELECTRODERMAL_ACTIVITY_FEET: (
@@ -249,6 +251,7 @@ MEASUREMENT_SENSORS: dict[
             measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_FEET,
             translation_key="electrodermal_activity_feet",
             native_unit_of_measurement=PERCENTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         )
     ),
@@ -258,6 +261,7 @@ MEASUREMENT_SENSORS: dict[
             measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_LEFT_FOOT,
             translation_key="electrodermal_activity_left_foot",
             native_unit_of_measurement=PERCENTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         )
     ),
@@ -267,6 +271,7 @@ MEASUREMENT_SENSORS: dict[
             measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_RIGHT_FOOT,
             translation_key="electrodermal_activity_right_foot",
             native_unit_of_measurement=PERCENTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         )
     ),

--- a/tests/components/withings/snapshots/test_sensor.ambr
+++ b/tests/components/withings/snapshots/test_sensor.ambr
@@ -751,7 +751,9 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -786,6 +788,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'henk Electrodermal activity feet',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
@@ -802,7 +805,9 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -837,6 +842,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'henk Electrodermal activity left foot',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
@@ -853,7 +859,9 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -888,6 +896,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'henk Electrodermal activity right foot',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
@@ -4053,7 +4062,9 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -4088,6 +4099,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'henk Vascular age',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.henk_vascular_age',
@@ -4103,7 +4115,9 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -4138,6 +4152,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'henk Visceral fat index',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.henk_visceral_fat_index',


### PR DESCRIPTION
## Proposed change

Five sensors in `MEASUREMENT_SENSORS` are defined without a `state_class`, so Home Assistant keeps no long-term statistics for them and they cannot be graphed or trended - `visceral_fat`, `vascular_age`, and the three `electrodermal_activity_*` sensors. The other 20 entries in the same table all set `SensorStateClass.MEASUREMENT`, and the three electrodermal ones already declare `native_unit_of_measurement=PERCENTAGE`, so they look like omissions rather than choices.

Left alone deliberately:

- `WORKOUT_SENSORS` - none of the seven has a `state_class`. That is consistent across the whole group rather than five outliers in one, and whether a per-workout value should carry statistics is a separate question.
- The device battery sensor, which is `SensorDeviceClass.ENUM` and must not have one.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
