### PR TITLE
Debounce temperature changes in Google Nest integration

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -30,7 +30,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
@@ -80,6 +80,7 @@ MAX_TEMP = 32
 MIN_TEMP_RANGE = 1.66667
 # Avoid Google's aggressive API rate limits when making incremental adjustments.
 TEMPERATURE_DEBOUNCE_SECONDS = 10
+TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS = 30
 
 
 @dataclass(frozen=True)
@@ -126,8 +127,10 @@ class ThermostatEntity(ClimateEntity):
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._command_lock = Lock()
         self._cancel_temperature_timer: CALLBACK_TYPE | None = None
+        self._cancel_temperature_confirmation_timer: CALLBACK_TYPE | None = None
         self._pending_temperature: _PendingTemperature | None = None
         self._executing_temperature: _PendingTemperature | None = None
+        self._unconfirmed_temperature: _PendingTemperature | None = None
         if mode_trait := device.traits.get(ThermostatModeTrait.NAME):
             self._attr_hvac_modes = [
                 THERMOSTAT_MODE_MAP[mode]
@@ -148,7 +151,7 @@ class ThermostatEntity(ClimateEntity):
         """Run when entity is added to register update signal handler."""
         self._attr_supported_features = self._get_supported_features()
         self.async_on_remove(
-            self._device.add_update_listener(self.async_write_ha_state)
+            self._device.add_update_listener(self._handle_device_update)
         )
         self.async_on_remove(self._async_cancel_pending_temperature)
 
@@ -217,7 +220,11 @@ class ThermostatEntity(ClimateEntity):
     @property
     def _optimistic_temperature(self) -> _PendingTemperature | None:
         """Return the newest queued or in-flight temperature command."""
-        return self._pending_temperature or self._executing_temperature
+        return (
+            self._pending_temperature
+            or self._executing_temperature
+            or self._unconfirmed_temperature
+        )
 
     @property
     def _target_temperature_trait(
@@ -366,13 +373,17 @@ class ThermostatEntity(ClimateEntity):
             pending_kwargs[ATTR_TARGET_TEMP_HIGH] = high_temp
 
         self._cancel_scheduled_temperature()
+        self._clear_unconfirmed_temperature()
         pending = self._pending_temperature = _PendingTemperature(
             pending_kwargs, hvac_mode
         )
         self.async_write_ha_state()
 
+        cancel_timer: CALLBACK_TYPE | None = None
+
         async def async_send_temperature(_now: datetime) -> None:
-            self._cancel_temperature_timer = None
+            if self._cancel_temperature_timer is cancel_timer:
+                self._cancel_temperature_timer = None
             try:
                 await self._async_execute_pending_temperature(pending)
             except HomeAssistantError:
@@ -381,9 +392,10 @@ class ThermostatEntity(ClimateEntity):
                     self.entity_id,
                 )
 
-        self._cancel_temperature_timer = async_call_later(
+        cancel_timer = async_call_later(
             self.hass, TEMPERATURE_DEBOUNCE_SECONDS, async_send_temperature
         )
+        self._cancel_temperature_timer = cancel_timer
 
     def _cancel_scheduled_temperature(self) -> None:
         """Cancel the scheduled temperature callback, if any."""
@@ -394,9 +406,72 @@ class ThermostatEntity(ClimateEntity):
     def _async_cancel_pending_temperature(self) -> None:
         """Cancel and discard the pending temperature command, if any."""
         self._cancel_scheduled_temperature()
+        self._clear_unconfirmed_temperature()
         if self._pending_temperature:
             self._pending_temperature = None
             self.async_write_ha_state()
+
+    def _clear_unconfirmed_temperature(self) -> None:
+        """Clear a temperature command awaiting device confirmation."""
+        if self._cancel_temperature_confirmation_timer:
+            self._cancel_temperature_confirmation_timer()
+            self._cancel_temperature_confirmation_timer = None
+        self._unconfirmed_temperature = None
+
+    @callback
+    def _handle_device_update(self) -> None:
+        """Reconcile optimistic temperature state with a device update."""
+        if self._unconfirmed_temperature and self._temperature_matches_device(
+            self._unconfirmed_temperature
+        ):
+            self._clear_unconfirmed_temperature()
+        self.async_write_ha_state()
+
+    def _temperature_matches_device(self, expected: _PendingTemperature) -> bool:
+        """Return whether the device traits confirm a temperature command."""
+        trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
+        low_temp = expected.kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_temp = expected.kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        if low_temp is not None and high_temp is not None:
+            return (
+                trait.heat_celsius is not None
+                and trait.cool_celsius is not None
+                and abs(trait.heat_celsius - low_temp) < 0.01
+                and abs(trait.cool_celsius - high_temp) < 0.01
+            )
+        temperature = expected.kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return False
+        if expected.hvac_mode == HVACMode.HEAT:
+            actual_temperature = trait.heat_celsius
+        elif expected.hvac_mode == HVACMode.COOL:
+            actual_temperature = trait.cool_celsius
+        else:
+            return False
+        return (
+            actual_temperature is not None
+            and abs(actual_temperature - temperature) < 0.01
+        )
+
+    def _await_temperature_confirmation(self, expected: _PendingTemperature) -> None:
+        """Retain optimistic state until confirmed or timed out."""
+        if self._pending_temperature:
+            return
+        self._clear_unconfirmed_temperature()
+        self._unconfirmed_temperature = expected
+
+        @callback
+        def clear_unconfirmed_temperature(_now: datetime) -> None:
+            self._cancel_temperature_confirmation_timer = None
+            if self._unconfirmed_temperature is expected:
+                self._unconfirmed_temperature = None
+                self.async_write_ha_state()
+
+        self._cancel_temperature_confirmation_timer = async_call_later(
+            self.hass,
+            TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS,
+            clear_unconfirmed_temperature,
+        )
 
     async def _async_flush_pending_temperature(self) -> None:
         """Immediately send pending temperature while holding the command lock."""
@@ -434,11 +509,15 @@ class ThermostatEntity(ClimateEntity):
         # cannot execute it a second time.
         self._pending_temperature = None
         self._executing_temperature = expected
+        succeeded = False
         try:
             await self._async_execute_temperature(expected.kwargs, expected.hvac_mode)
+            succeeded = True
         finally:
             if self._executing_temperature is expected:
                 self._executing_temperature = None
+                if succeeded:
+                    self._await_temperature_confirmation(expected)
                 self.async_write_ha_state()
 
     async def _async_execute_temperature(

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -80,12 +80,12 @@ MAX_TEMP = 32
 MIN_TEMP_RANGE = 1.66667
 # Avoid Google's aggressive API rate limits when making incremental adjustments.
 TEMPERATURE_DEBOUNCE_SECONDS = 10
-TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS = 30
+TEMPERATURE_PENDING_TIMEOUT_SECONDS = 10
 
 
 @dataclass
 class _PendingTemperature:
-    """A temperature command pending delivery or confirmation."""
+    """A temperature command pending delivery or expiration."""
 
     kwargs: dict[str, Any]
     hvac_mode: HVACMode
@@ -148,7 +148,7 @@ class ThermostatEntity(ClimateEntity):
         """Run when entity is added to register update signal handler."""
         self._attr_supported_features = self._get_supported_features()
         self.async_on_remove(
-            self._device.add_update_listener(self._handle_device_update)
+            self._device.add_update_listener(self.async_write_ha_state)
         )
         self.async_on_remove(lambda: setattr(self, "_pending_temperature", None))
 
@@ -365,43 +365,6 @@ class ThermostatEntity(ClimateEntity):
             self.hass, TEMPERATURE_DEBOUNCE_SECONDS, async_send_temperature
         )
 
-    @callback
-    def _handle_device_update(self) -> None:
-        """Reconcile optimistic temperature state with a device update."""
-        if (
-            (pending := self._pending_temperature)
-            and pending.sent
-            and (
-                self.hvac_mode != pending.hvac_mode
-                or self._temperature_matches_device(pending)
-            )
-        ):
-            self._pending_temperature = None
-        self.async_write_ha_state()
-
-    def _temperature_matches_device(self, expected: _PendingTemperature) -> bool:
-        """Return whether the device traits confirm a temperature command."""
-        trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
-        temperatures: tuple[tuple[float | None, float], ...]
-        if ATTR_TARGET_TEMP_LOW in expected.kwargs:
-            temperatures = (
-                (trait.heat_celsius, expected.kwargs[ATTR_TARGET_TEMP_LOW]),
-                (trait.cool_celsius, expected.kwargs[ATTR_TARGET_TEMP_HIGH]),
-            )
-        elif expected.hvac_mode in (HVACMode.HEAT, HVACMode.COOL):
-            actual = (
-                trait.heat_celsius
-                if expected.hvac_mode == HVACMode.HEAT
-                else trait.cool_celsius
-            )
-            temperatures = ((actual, expected.kwargs[ATTR_TEMPERATURE]),)
-        else:
-            return False
-        return all(
-            actual is not None and abs(actual - target) < 0.01
-            for actual, target in temperatures
-        )
-
     async def _async_send_pending_temperature(
         self, expected: _PendingTemperature
     ) -> None:
@@ -439,15 +402,15 @@ class ThermostatEntity(ClimateEntity):
                 if succeeded:
 
                     @callback
-                    def clear_unconfirmed_temperature(_now: datetime) -> None:
+                    def clear_pending_temperature(_now: datetime) -> None:
                         if self._pending_temperature is expected:
                             self._pending_temperature = None
                             self.async_write_ha_state()
 
                     async_call_later(
                         self.hass,
-                        TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS,
-                        clear_unconfirmed_temperature,
+                        TEMPERATURE_PENDING_TIMEOUT_SECONDS,
+                        clear_pending_temperature,
                     )
                 else:
                     self._pending_temperature = None

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -1,5 +1,6 @@
 """Support for Google Nest SDM climate devices."""
 
+from asyncio import Lock
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
@@ -123,8 +124,10 @@ class ThermostatEntity(ClimateEntity):
         self._attr_unique_id = device.name
         self._attr_device_info = self._device_info.device_info
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._command_lock = Lock()
         self._cancel_temperature_timer: CALLBACK_TYPE | None = None
         self._pending_temperature: _PendingTemperature | None = None
+        self._executing_temperature: _PendingTemperature | None = None
         if mode_trait := device.traits.get(ThermostatModeTrait.NAME):
             self._attr_hvac_modes = [
                 THERMOSTAT_MODE_MAP[mode]
@@ -172,10 +175,9 @@ class ThermostatEntity(ClimateEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature currently set to be reached."""
         if (
-            self._pending_temperature
-            and ATTR_TEMPERATURE in self._pending_temperature.kwargs
-        ):
-            return cast(float, self._pending_temperature.kwargs[ATTR_TEMPERATURE])
+            temperature := self._optimistic_temperature
+        ) and ATTR_TEMPERATURE in temperature.kwargs:
+            return cast(float, temperature.kwargs[ATTR_TEMPERATURE])
         if not (trait := self._target_temperature_trait):
             return None
         if self.hvac_mode == HVACMode.HEAT:
@@ -189,10 +191,9 @@ class ThermostatEntity(ClimateEntity):
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature."""
         if (
-            self._pending_temperature
-            and ATTR_TARGET_TEMP_HIGH in self._pending_temperature.kwargs
-        ):
-            return cast(float, self._pending_temperature.kwargs[ATTR_TARGET_TEMP_HIGH])
+            temperature := self._optimistic_temperature
+        ) and ATTR_TARGET_TEMP_HIGH in temperature.kwargs:
+            return cast(float, temperature.kwargs[ATTR_TARGET_TEMP_HIGH])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
@@ -204,15 +205,19 @@ class ThermostatEntity(ClimateEntity):
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature."""
         if (
-            self._pending_temperature
-            and ATTR_TARGET_TEMP_LOW in self._pending_temperature.kwargs
-        ):
-            return cast(float, self._pending_temperature.kwargs[ATTR_TARGET_TEMP_LOW])
+            temperature := self._optimistic_temperature
+        ) and ATTR_TARGET_TEMP_LOW in temperature.kwargs:
+            return cast(float, temperature.kwargs[ATTR_TARGET_TEMP_LOW])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
             return None
         return trait.heat_celsius
+
+    @property
+    def _optimistic_temperature(self) -> _PendingTemperature | None:
+        """Return the newest queued or in-flight temperature command."""
+        return self._pending_temperature or self._executing_temperature
 
     @property
     def _target_temperature_trait(
@@ -318,20 +323,21 @@ class ThermostatEntity(ClimateEntity):
         """Set new target hvac mode."""
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
-        await self._async_flush_pending_temperature()
-        try:
-            await trait.set_mode(api_mode)
-        except ApiException as err:
-            raise HomeAssistantError(
-                f"Error setting {self.entity_id} HVAC mode to {hvac_mode}: {err}"
-            ) from err
+        async with self._command_lock:
+            await self._async_flush_pending_temperature()
+            try:
+                await trait.set_mode(api_mode)
+            except ApiException as err:
+                raise HomeAssistantError(
+                    f"Error setting {self.entity_id} HVAC mode to {hvac_mode}: {err}"
+                ) from err
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Schedule a new target temperature after a trailing-edge debounce."""
         hvac_mode = (
-            self._pending_temperature.hvac_mode
-            if self._pending_temperature
+            temperature.hvac_mode
+            if (temperature := self._optimistic_temperature)
             else self.hvac_mode
         )
         includes_hvac_mode = kwargs.get(ATTR_HVAC_MODE) is not None
@@ -393,14 +399,14 @@ class ThermostatEntity(ClimateEntity):
             self.async_write_ha_state()
 
     async def _async_flush_pending_temperature(self) -> None:
-        """Immediately send and clear the pending temperature command."""
+        """Immediately send pending temperature while holding the command lock."""
         self._cancel_scheduled_temperature()
         pending = self._pending_temperature
         if not pending:
             return
 
         try:
-            await self._async_execute_pending_temperature(pending)
+            await self._async_execute_pending_temperature_locked(pending)
         except HomeAssistantError:
             # An older setpoint failure must not block the newer mode request.
             _LOGGER.exception(
@@ -412,6 +418,13 @@ class ThermostatEntity(ClimateEntity):
         self, expected: _PendingTemperature
     ) -> None:
         """Claim and execute a pending temperature command."""
+        async with self._command_lock:
+            await self._async_execute_pending_temperature_locked(expected)
+
+    async def _async_execute_pending_temperature_locked(
+        self, expected: _PendingTemperature
+    ) -> None:
+        """Execute pending temperature while holding the command lock."""
         # Cancelling a timer cannot retract a callback already queued on the
         # event loop. Only let that callback execute the command it scheduled.
         if expected is not self._pending_temperature:
@@ -420,8 +433,13 @@ class ThermostatEntity(ClimateEntity):
         # Claim the command before awaiting Google so a racing timer or flush
         # cannot execute it a second time.
         self._pending_temperature = None
-        self.async_write_ha_state()
-        await self._async_execute_temperature(expected.kwargs, expected.hvac_mode)
+        self._executing_temperature = expected
+        try:
+            await self._async_execute_temperature(expected.kwargs, expected.hvac_mode)
+        finally:
+            if self._executing_temperature is expected:
+                self._executing_temperature = None
+                self.async_write_ha_state()
 
     async def _async_execute_temperature(
         self, kwargs: dict[str, Any], hvac_mode: HVACMode
@@ -452,13 +470,14 @@ class ThermostatEntity(ClimateEntity):
         if self.preset_mode == preset_mode:  # API doesn't like duplicate preset modes
             return
         trait = self._device.traits[ThermostatEcoTrait.NAME]
-        await self._async_flush_pending_temperature()
-        try:
-            await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
-        except ApiException as err:
-            raise HomeAssistantError(
-                f"Error setting {self.entity_id} preset mode to {preset_mode}: {err}"
-            ) from err
+        async with self._command_lock:
+            await self._async_flush_pending_temperature()
+            try:
+                await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
+            except ApiException as err:
+                raise HomeAssistantError(
+                    f"Error setting {self.entity_id} preset mode to {preset_mode}: {err}"
+                ) from err
 
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -462,18 +462,22 @@ class ThermostatEntity(ClimateEntity):
         self._clear_unconfirmed_temperature()
         self._unconfirmed_temperature = expected
 
+        cancel_timer: CALLBACK_TYPE | None = None
+
         @callback
         def clear_unconfirmed_temperature(_now: datetime) -> None:
-            self._cancel_temperature_confirmation_timer = None
+            if self._cancel_temperature_confirmation_timer is cancel_timer:
+                self._cancel_temperature_confirmation_timer = None
             if self._unconfirmed_temperature is expected:
                 self._unconfirmed_temperature = None
                 self.async_write_ha_state()
 
-        self._cancel_temperature_confirmation_timer = async_call_later(
+        cancel_timer = async_call_later(
             self.hass,
             TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS,
             clear_unconfirmed_temperature,
         )
+        self._cancel_temperature_confirmation_timer = cancel_timer
 
     async def _async_flush_pending_temperature(self) -> None:
         """Immediately send pending temperature while holding the command lock."""

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -1,6 +1,8 @@
 """Support for Google Nest SDM climate devices."""
 
-from datetime import timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
 from typing import Any, cast, override
 
 from google_nest_sdm.device import Device
@@ -27,12 +29,15 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .device_info import NestDeviceInfo
 from .types import NestConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
 
 # Mapping for sdm.devices.traits.ThermostatMode mode field
 THERMOSTAT_MODE_MAP: dict[str, HVACMode] = {
@@ -72,6 +77,16 @@ MAX_FAN_DURATION = 43200  # 12 hours is the max in the SDM API
 MIN_TEMP = 10
 MAX_TEMP = 32
 MIN_TEMP_RANGE = 1.66667
+# Avoid Google's aggressive API rate limits when making incremental adjustments.
+TEMPERATURE_DEBOUNCE_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class _PendingTemperature:
+    """A temperature command waiting for its debounce period."""
+
+    kwargs: dict[str, Any]
+    hvac_mode: HVACMode
 
 
 async def async_setup_entry(
@@ -108,6 +123,8 @@ class ThermostatEntity(ClimateEntity):
         self._attr_unique_id = device.name
         self._attr_device_info = self._device_info.device_info
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._cancel_temperature_timer: CALLBACK_TYPE | None = None
+        self._pending_temperature: _PendingTemperature | None = None
         if mode_trait := device.traits.get(ThermostatModeTrait.NAME):
             self._attr_hvac_modes = [
                 THERMOSTAT_MODE_MAP[mode]
@@ -130,6 +147,7 @@ class ThermostatEntity(ClimateEntity):
         self.async_on_remove(
             self._device.add_update_listener(self.async_write_ha_state)
         )
+        self.async_on_remove(self._async_cancel_pending_temperature)
 
     @property
     @override
@@ -153,6 +171,11 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature(self) -> float | None:
         """Return the temperature currently set to be reached."""
+        if (
+            self._pending_temperature
+            and ATTR_TEMPERATURE in self._pending_temperature.kwargs
+        ):
+            return self._pending_temperature.kwargs[ATTR_TEMPERATURE]
         if not (trait := self._target_temperature_trait):
             return None
         if self.hvac_mode == HVACMode.HEAT:
@@ -165,6 +188,11 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature."""
+        if (
+            self._pending_temperature
+            and ATTR_TARGET_TEMP_HIGH in self._pending_temperature.kwargs
+        ):
+            return self._pending_temperature.kwargs[ATTR_TARGET_TEMP_HIGH]
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
@@ -175,6 +203,11 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature."""
+        if (
+            self._pending_temperature
+            and ATTR_TARGET_TEMP_LOW in self._pending_temperature.kwargs
+        ):
+            return self._pending_temperature.kwargs[ATTR_TARGET_TEMP_LOW]
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
@@ -285,6 +318,7 @@ class ThermostatEntity(ClimateEntity):
         """Set new target hvac mode."""
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
+        await self._async_flush_pending_temperature()
         try:
             await trait.set_mode(api_mode)
         except ApiException as err:
@@ -294,30 +328,112 @@ class ThermostatEntity(ClimateEntity):
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature."""
-        hvac_mode = self.hvac_mode
-        if kwargs.get(ATTR_HVAC_MODE) is not None:
+        """Schedule a new target temperature after a trailing-edge debounce."""
+        hvac_mode = (
+            self._pending_temperature.hvac_mode
+            if self._pending_temperature
+            else self.hvac_mode
+        )
+        includes_hvac_mode = kwargs.get(ATTR_HVAC_MODE) is not None
+        if includes_hvac_mode:
             hvac_mode = kwargs[ATTR_HVAC_MODE]
             await self.async_set_hvac_mode(hvac_mode)
-        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        temp = kwargs.get(ATTR_TEMPERATURE)
         if ThermostatTemperatureSetpointTrait.NAME not in self._device.traits:
             raise HomeAssistantError(
                 f"Error setting {self.entity_id} temperature to {kwargs}: "
                 "Unable to find setpoint trait."
             )
+
+        # Normalize a too-narrow range now, while the device's previous target is
+        # still available. This also makes the optimistic state match what will
+        # eventually be sent to the API.
+        pending_kwargs = dict(kwargs)
+        low_temp = pending_kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_temp = pending_kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        if low_temp and high_temp and high_temp - low_temp < MIN_TEMP_RANGE:
+            current_high = self.target_temperature_high
+            if current_high and abs(high_temp - current_high) < 0.01:
+                high_temp = low_temp + MIN_TEMP_RANGE
+            else:
+                low_temp = high_temp - MIN_TEMP_RANGE
+            pending_kwargs[ATTR_TARGET_TEMP_LOW] = low_temp
+            pending_kwargs[ATTR_TARGET_TEMP_HIGH] = high_temp
+
+        self._cancel_scheduled_temperature()
+        pending = self._pending_temperature = _PendingTemperature(
+            pending_kwargs, hvac_mode
+        )
+        self.async_write_ha_state()
+
+        async def async_send_temperature(_now: datetime) -> None:
+            self._cancel_temperature_timer = None
+            try:
+                await self._async_execute_pending_temperature(pending)
+            except HomeAssistantError:
+                _LOGGER.exception(
+                    "Error sending debounced temperature command for %s",
+                    self.entity_id,
+                )
+
+        self._cancel_temperature_timer = async_call_later(
+            self.hass, TEMPERATURE_DEBOUNCE_SECONDS, async_send_temperature
+        )
+
+    def _cancel_scheduled_temperature(self) -> None:
+        """Cancel the scheduled temperature callback, if any."""
+        if self._cancel_temperature_timer:
+            self._cancel_temperature_timer()
+            self._cancel_temperature_timer = None
+
+    def _async_cancel_pending_temperature(self) -> None:
+        """Cancel and discard the pending temperature command, if any."""
+        self._cancel_scheduled_temperature()
+        if self._pending_temperature:
+            self._pending_temperature = None
+            self.async_write_ha_state()
+
+    async def _async_flush_pending_temperature(self) -> None:
+        """Immediately send and clear the pending temperature command."""
+        self._cancel_scheduled_temperature()
+        pending = self._pending_temperature
+        if not pending:
+            return
+
+        try:
+            await self._async_execute_pending_temperature(pending)
+        except HomeAssistantError:
+            # An older setpoint failure must not block the newer mode request.
+            _LOGGER.exception(
+                "Error flushing pending temperature before changing mode on %s",
+                self.entity_id,
+            )
+
+    async def _async_execute_pending_temperature(
+        self, expected: _PendingTemperature
+    ) -> None:
+        """Claim and execute a pending temperature command."""
+        # Cancelling a timer cannot retract a callback already queued on the
+        # event loop. Only let that callback execute the command it scheduled.
+        if expected is not self._pending_temperature:
+            return
+
+        # Claim the command before awaiting Google so a racing timer or flush
+        # cannot execute it a second time.
+        self._pending_temperature = None
+        self.async_write_ha_state()
+        await self._async_execute_temperature(expected.kwargs, expected.hvac_mode)
+
+    async def _async_execute_temperature(
+        self, kwargs: dict[str, Any], hvac_mode: HVACMode
+    ) -> None:
+        """Send a temperature command to the Nest API."""
+        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        temp = kwargs.get(ATTR_TEMPERATURE)
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         try:
             if self.preset_mode == PRESET_ECO or hvac_mode == HVACMode.HEAT_COOL:
                 if low_temp and high_temp:
-                    if high_temp - low_temp < MIN_TEMP_RANGE:
-                        # Ensure there is a minimum gap from the new temp. Pick
-                        # the temp that is not changing as the one to move.
-                        if abs(high_temp - self.target_temperature_high) < 0.01:
-                            high_temp = low_temp + MIN_TEMP_RANGE
-                        else:
-                            low_temp = high_temp - MIN_TEMP_RANGE
                     await trait.set_range(low_temp, high_temp)
             elif hvac_mode == HVACMode.COOL and temp:
                 await trait.set_cool(temp)
@@ -336,6 +452,7 @@ class ThermostatEntity(ClimateEntity):
         if self.preset_mode == preset_mode:  # API doesn't like duplicate preset modes
             return
         trait = self._device.traits[ThermostatEcoTrait.NAME]
+        await self._async_flush_pending_temperature()
         try:
             await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
         except ApiException as err:

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -422,8 +422,9 @@ class ThermostatEntity(ClimateEntity):
     @callback
     def _handle_device_update(self) -> None:
         """Reconcile optimistic temperature state with a device update."""
-        if self._unconfirmed_temperature and self._temperature_matches_device(
-            self._unconfirmed_temperature
+        if self._unconfirmed_temperature and (
+            self.hvac_mode != self._unconfirmed_temperature.hvac_mode
+            or self._temperature_matches_device(self._unconfirmed_temperature)
         ):
             self._clear_unconfirmed_temperature()
         self.async_write_ha_state()

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -407,6 +407,7 @@ class ThermostatEntity(ClimateEntity):
         """Cancel and discard the pending temperature command, if any."""
         self._cancel_scheduled_temperature()
         self._clear_unconfirmed_temperature()
+        self._executing_temperature = None
         if self._pending_temperature:
             self._pending_temperature = None
             self.async_write_ha_state()

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -175,7 +175,7 @@ class ThermostatEntity(ClimateEntity):
             self._pending_temperature
             and ATTR_TEMPERATURE in self._pending_temperature.kwargs
         ):
-            return self._pending_temperature.kwargs[ATTR_TEMPERATURE]
+            return cast(float, self._pending_temperature.kwargs[ATTR_TEMPERATURE])
         if not (trait := self._target_temperature_trait):
             return None
         if self.hvac_mode == HVACMode.HEAT:
@@ -192,7 +192,7 @@ class ThermostatEntity(ClimateEntity):
             self._pending_temperature
             and ATTR_TARGET_TEMP_HIGH in self._pending_temperature.kwargs
         ):
-            return self._pending_temperature.kwargs[ATTR_TARGET_TEMP_HIGH]
+            return cast(float, self._pending_temperature.kwargs[ATTR_TARGET_TEMP_HIGH])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
@@ -207,7 +207,7 @@ class ThermostatEntity(ClimateEntity):
             self._pending_temperature
             and ATTR_TARGET_TEMP_LOW in self._pending_temperature.kwargs
         ):
-            return self._pending_temperature.kwargs[ATTR_TARGET_TEMP_LOW]
+            return cast(float, self._pending_temperature.kwargs[ATTR_TARGET_TEMP_LOW])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -30,7 +30,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
@@ -83,12 +83,13 @@ TEMPERATURE_DEBOUNCE_SECONDS = 10
 TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS = 30
 
 
-@dataclass(frozen=True)
+@dataclass
 class _PendingTemperature:
-    """A temperature command waiting for its debounce period."""
+    """A temperature command pending delivery or confirmation."""
 
     kwargs: dict[str, Any]
     hvac_mode: HVACMode
+    sent: bool = False
 
 
 async def async_setup_entry(
@@ -126,11 +127,7 @@ class ThermostatEntity(ClimateEntity):
         self._attr_device_info = self._device_info.device_info
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._command_lock = Lock()
-        self._cancel_temperature_timer: CALLBACK_TYPE | None = None
-        self._cancel_temperature_confirmation_timer: CALLBACK_TYPE | None = None
         self._pending_temperature: _PendingTemperature | None = None
-        self._executing_temperature: _PendingTemperature | None = None
-        self._unconfirmed_temperature: _PendingTemperature | None = None
         if mode_trait := device.traits.get(ThermostatModeTrait.NAME):
             self._attr_hvac_modes = [
                 THERMOSTAT_MODE_MAP[mode]
@@ -153,7 +150,7 @@ class ThermostatEntity(ClimateEntity):
         self.async_on_remove(
             self._device.add_update_listener(self._handle_device_update)
         )
-        self.async_on_remove(self._async_cancel_pending_temperature)
+        self.async_on_remove(lambda: setattr(self, "_pending_temperature", None))
 
     @property
     @override
@@ -177,9 +174,8 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature(self) -> float | None:
         """Return the temperature currently set to be reached."""
-        if (
-            temperature := self._optimistic_temperature
-        ) and ATTR_TEMPERATURE in temperature.kwargs:
+        temperature = self._pending_temperature
+        if temperature and ATTR_TEMPERATURE in temperature.kwargs:
             return cast(float, temperature.kwargs[ATTR_TEMPERATURE])
         if not (trait := self._target_temperature_trait):
             return None
@@ -193,9 +189,8 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature."""
-        if (
-            temperature := self._optimistic_temperature
-        ) and ATTR_TARGET_TEMP_HIGH in temperature.kwargs:
+        temperature = self._pending_temperature
+        if temperature and ATTR_TARGET_TEMP_HIGH in temperature.kwargs:
             return cast(float, temperature.kwargs[ATTR_TARGET_TEMP_HIGH])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
@@ -207,24 +202,14 @@ class ThermostatEntity(ClimateEntity):
     @override
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature."""
-        if (
-            temperature := self._optimistic_temperature
-        ) and ATTR_TARGET_TEMP_LOW in temperature.kwargs:
+        temperature = self._pending_temperature
+        if temperature and ATTR_TARGET_TEMP_LOW in temperature.kwargs:
             return cast(float, temperature.kwargs[ATTR_TARGET_TEMP_LOW])
         if self.hvac_mode != HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
             return None
         return trait.heat_celsius
-
-    @property
-    def _optimistic_temperature(self) -> _PendingTemperature | None:
-        """Return the newest queued or in-flight temperature command."""
-        return (
-            self._pending_temperature
-            or self._executing_temperature
-            or self._unconfirmed_temperature
-        )
 
     @property
     def _target_temperature_trait(
@@ -331,7 +316,8 @@ class ThermostatEntity(ClimateEntity):
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
         async with self._command_lock:
-            await self._async_flush_pending_temperature()
+            if (pending := self._pending_temperature) and not pending.sent:
+                await self._async_send_pending_temperature(pending)
             try:
                 await trait.set_mode(api_mode)
             except ApiException as err:
@@ -344,12 +330,11 @@ class ThermostatEntity(ClimateEntity):
         """Schedule a new target temperature after a trailing-edge debounce."""
         hvac_mode = (
             temperature.hvac_mode
-            if (temperature := self._optimistic_temperature)
+            if (temperature := self._pending_temperature)
             else self.hvac_mode
         )
-        includes_hvac_mode = kwargs.get(ATTR_HVAC_MODE) is not None
-        if includes_hvac_mode:
-            hvac_mode = kwargs[ATTR_HVAC_MODE]
+        if (new_hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
+            hvac_mode = new_hvac_mode
             await self.async_set_hvac_mode(hvac_mode)
         if ThermostatTemperatureSetpointTrait.NAME not in self._device.traits:
             raise HomeAssistantError(
@@ -357,195 +342,116 @@ class ThermostatEntity(ClimateEntity):
                 "Unable to find setpoint trait."
             )
 
-        # Normalize a too-narrow range now, while the device's previous target is
-        # still available. This also makes the optimistic state match what will
-        # eventually be sent to the API.
-        pending_kwargs = dict(kwargs)
-        low_temp = pending_kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = pending_kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        # Normalize narrow ranges before optimistic state hides the previous target.
+        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         if low_temp and high_temp and high_temp - low_temp < MIN_TEMP_RANGE:
             current_high = self.target_temperature_high
             if current_high and abs(high_temp - current_high) < 0.01:
                 high_temp = low_temp + MIN_TEMP_RANGE
             else:
                 low_temp = high_temp - MIN_TEMP_RANGE
-            pending_kwargs[ATTR_TARGET_TEMP_LOW] = low_temp
-            pending_kwargs[ATTR_TARGET_TEMP_HIGH] = high_temp
+            kwargs[ATTR_TARGET_TEMP_LOW] = low_temp
+            kwargs[ATTR_TARGET_TEMP_HIGH] = high_temp
 
-        self._cancel_scheduled_temperature()
-        self._clear_unconfirmed_temperature()
-        pending = self._pending_temperature = _PendingTemperature(
-            pending_kwargs, hvac_mode
-        )
+        pending = self._pending_temperature = _PendingTemperature(kwargs, hvac_mode)
         self.async_write_ha_state()
 
-        cancel_timer: CALLBACK_TYPE | None = None
-
         async def async_send_temperature(_now: datetime) -> None:
-            if self._cancel_temperature_timer is cancel_timer:
-                self._cancel_temperature_timer = None
-            try:
-                await self._async_execute_pending_temperature(pending)
-            except HomeAssistantError:
-                _LOGGER.exception(
-                    "Error sending debounced temperature command for %s",
-                    self.entity_id,
-                )
+            async with self._command_lock:
+                await self._async_send_pending_temperature(pending)
 
-        cancel_timer = async_call_later(
+        async_call_later(
             self.hass, TEMPERATURE_DEBOUNCE_SECONDS, async_send_temperature
         )
-        self._cancel_temperature_timer = cancel_timer
-
-    def _cancel_scheduled_temperature(self) -> None:
-        """Cancel the scheduled temperature callback, if any."""
-        if self._cancel_temperature_timer:
-            self._cancel_temperature_timer()
-            self._cancel_temperature_timer = None
-
-    def _async_cancel_pending_temperature(self) -> None:
-        """Cancel and discard the pending temperature command, if any."""
-        self._cancel_scheduled_temperature()
-        self._clear_unconfirmed_temperature()
-        self._executing_temperature = None
-        if self._pending_temperature:
-            self._pending_temperature = None
-            self.async_write_ha_state()
-
-    def _clear_unconfirmed_temperature(self) -> None:
-        """Clear a temperature command awaiting device confirmation."""
-        if self._cancel_temperature_confirmation_timer:
-            self._cancel_temperature_confirmation_timer()
-            self._cancel_temperature_confirmation_timer = None
-        self._unconfirmed_temperature = None
 
     @callback
     def _handle_device_update(self) -> None:
         """Reconcile optimistic temperature state with a device update."""
-        if self._unconfirmed_temperature and (
-            self.hvac_mode != self._unconfirmed_temperature.hvac_mode
-            or self._temperature_matches_device(self._unconfirmed_temperature)
+        if (
+            (pending := self._pending_temperature)
+            and pending.sent
+            and (
+                self.hvac_mode != pending.hvac_mode
+                or self._temperature_matches_device(pending)
+            )
         ):
-            self._clear_unconfirmed_temperature()
+            self._pending_temperature = None
         self.async_write_ha_state()
 
     def _temperature_matches_device(self, expected: _PendingTemperature) -> bool:
         """Return whether the device traits confirm a temperature command."""
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
-        low_temp = expected.kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = expected.kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if low_temp is not None and high_temp is not None:
-            return (
-                trait.heat_celsius is not None
-                and trait.cool_celsius is not None
-                and abs(trait.heat_celsius - low_temp) < 0.01
-                and abs(trait.cool_celsius - high_temp) < 0.01
+        temperatures: tuple[tuple[float | None, float], ...]
+        if ATTR_TARGET_TEMP_LOW in expected.kwargs:
+            temperatures = (
+                (trait.heat_celsius, expected.kwargs[ATTR_TARGET_TEMP_LOW]),
+                (trait.cool_celsius, expected.kwargs[ATTR_TARGET_TEMP_HIGH]),
             )
-        temperature = expected.kwargs.get(ATTR_TEMPERATURE)
-        if temperature is None:
-            return False
-        if expected.hvac_mode == HVACMode.HEAT:
-            actual_temperature = trait.heat_celsius
-        elif expected.hvac_mode == HVACMode.COOL:
-            actual_temperature = trait.cool_celsius
+        elif expected.hvac_mode in (HVACMode.HEAT, HVACMode.COOL):
+            actual = (
+                trait.heat_celsius
+                if expected.hvac_mode == HVACMode.HEAT
+                else trait.cool_celsius
+            )
+            temperatures = ((actual, expected.kwargs[ATTR_TEMPERATURE]),)
         else:
             return False
-        return (
-            actual_temperature is not None
-            and abs(actual_temperature - temperature) < 0.01
+        return all(
+            actual is not None and abs(actual - target) < 0.01
+            for actual, target in temperatures
         )
 
-    def _await_temperature_confirmation(self, expected: _PendingTemperature) -> None:
-        """Retain optimistic state until confirmed or timed out."""
-        if self._pending_temperature:
-            return
-        self._clear_unconfirmed_temperature()
-        self._unconfirmed_temperature = expected
-
-        cancel_timer: CALLBACK_TYPE | None = None
-
-        @callback
-        def clear_unconfirmed_temperature(_now: datetime) -> None:
-            if self._cancel_temperature_confirmation_timer is cancel_timer:
-                self._cancel_temperature_confirmation_timer = None
-            if self._unconfirmed_temperature is expected:
-                self._unconfirmed_temperature = None
-                self.async_write_ha_state()
-
-        cancel_timer = async_call_later(
-            self.hass,
-            TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS,
-            clear_unconfirmed_temperature,
-        )
-        self._cancel_temperature_confirmation_timer = cancel_timer
-
-    async def _async_flush_pending_temperature(self) -> None:
-        """Immediately send pending temperature while holding the command lock."""
-        self._cancel_scheduled_temperature()
-        pending = self._pending_temperature
-        if not pending:
-            return
-
-        try:
-            await self._async_execute_pending_temperature_locked(pending)
-        except HomeAssistantError:
-            # An older setpoint failure must not block the newer mode request.
-            _LOGGER.exception(
-                "Error flushing pending temperature before changing mode on %s",
-                self.entity_id,
-            )
-
-    async def _async_execute_pending_temperature(
+    async def _async_send_pending_temperature(
         self, expected: _PendingTemperature
     ) -> None:
-        """Claim and execute a pending temperature command."""
-        async with self._command_lock:
-            await self._async_execute_pending_temperature_locked(expected)
-
-    async def _async_execute_pending_temperature_locked(
-        self, expected: _PendingTemperature
-    ) -> None:
-        """Execute pending temperature while holding the command lock."""
-        # Cancelling a timer cannot retract a callback already queued on the
-        # event loop. Only let that callback execute the command it scheduled.
-        if expected is not self._pending_temperature:
+        """Send a pending temperature while holding the command lock."""
+        # Only let a callback execute the command it scheduled.
+        if expected is not self._pending_temperature or expected.sent:
             return
 
-        # Claim the command before awaiting Google so a racing timer or flush
-        # cannot execute it a second time.
-        self._pending_temperature = None
-        self._executing_temperature = expected
-        succeeded = False
-        try:
-            await self._async_execute_temperature(expected.kwargs, expected.hvac_mode)
-            succeeded = True
-        finally:
-            if self._executing_temperature is expected:
-                self._executing_temperature = None
-                if succeeded:
-                    self._await_temperature_confirmation(expected)
-                self.async_write_ha_state()
-
-    async def _async_execute_temperature(
-        self, kwargs: dict[str, Any], hvac_mode: HVACMode
-    ) -> None:
-        """Send a temperature command to the Nest API."""
+        # Claim before awaiting so a timer and flush cannot both execute the command.
+        expected.sent = True
+        kwargs = expected.kwargs
         low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temp = kwargs.get(ATTR_TEMPERATURE)
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
+        succeeded = False
         try:
-            if self.preset_mode == PRESET_ECO or hvac_mode == HVACMode.HEAT_COOL:
+            if (
+                self.preset_mode == PRESET_ECO
+                or expected.hvac_mode == HVACMode.HEAT_COOL
+            ):
                 if low_temp and high_temp:
                     await trait.set_range(low_temp, high_temp)
-            elif hvac_mode == HVACMode.COOL and temp:
+            elif expected.hvac_mode == HVACMode.COOL and temp:
                 await trait.set_cool(temp)
-            elif hvac_mode == HVACMode.HEAT and temp:
+            elif expected.hvac_mode == HVACMode.HEAT and temp:
                 await trait.set_heat(temp)
-        except ApiException as err:
-            raise HomeAssistantError(
-                f"Error setting {self.entity_id} temperature to {kwargs}: {err}"
-            ) from err
+            succeeded = True
+        except ApiException:
+            _LOGGER.exception(
+                "Error setting %s temperature to %s", self.entity_id, kwargs
+            )
+        finally:
+            if self._pending_temperature is expected:
+                if succeeded:
+
+                    @callback
+                    def clear_unconfirmed_temperature(_now: datetime) -> None:
+                        if self._pending_temperature is expected:
+                            self._pending_temperature = None
+                            self.async_write_ha_state()
+
+                    async_call_later(
+                        self.hass,
+                        TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS,
+                        clear_unconfirmed_temperature,
+                    )
+                else:
+                    self._pending_temperature = None
+                self.async_write_ha_state()
 
     @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -556,7 +462,8 @@ class ThermostatEntity(ClimateEntity):
             return
         trait = self._device.traits[ThermostatEcoTrait.NAME]
         async with self._command_lock:
-            await self._async_flush_pending_temperature()
+            if (pending := self._pending_temperature) and not pending.sent:
+                await self._async_send_pending_temperature(pending)
             try:
                 await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
             except ApiException as err:

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -789,12 +789,12 @@ async def test_thermostat_temperature_changes_use_trailing_debounce(
     assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
 
 
-async def test_unconfirmed_temperature_times_out(
+async def test_sent_temperature_times_out(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,
     create_device: CreateDevice,
 ) -> None:
-    """Test optimistic temperature expires without a matching device update."""
+    """Test optimistic temperature expires after a sent command."""
     create_device.create(
         {
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
@@ -819,7 +819,7 @@ async def test_unconfirmed_temperature_times_out(
     async_fire_time_changed(
         hass,
         dt_util.utcnow()
-        + timedelta(seconds=nest_climate.TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS),
+        + timedelta(seconds=nest_climate.TEMPERATURE_PENDING_TIMEOUT_SECONDS),
     )
     await hass.async_block_till_done()
 
@@ -828,13 +828,13 @@ async def test_unconfirmed_temperature_times_out(
     assert thermostat.attributes[ATTR_TEMPERATURE] == 19.0
 
 
-async def test_unconfirmed_temperature_clears_on_mode_update(
+async def test_sent_temperature_persists_until_timeout_after_mode_update(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,
     create_device: CreateDevice,
     create_event: CreateEvent,
 ) -> None:
-    """Test a confirmed mode change clears an obsolete optimistic temperature."""
+    """Test optimistic temperature persists after updates until its timeout."""
     create_device.create(
         {
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
@@ -869,6 +869,17 @@ async def test_unconfirmed_temperature_clears_on_mode_update(
             },
         }
     )
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 20.0
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow()
+        + timedelta(seconds=nest_climate.TEMPERATURE_PENDING_TIMEOUT_SECONDS),
+    )
+    await hass.async_block_till_done()
 
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -4,6 +4,7 @@ These tests fake out the subscriber/devicemanager, and are not using a real
 pubsub subscriber.
 """
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from http import HTTPStatus
@@ -34,6 +35,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.nest import climate as nest_climate
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
@@ -758,6 +760,74 @@ async def test_thermostat_temperature_changes_use_trailing_debounce(
         "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
         "params": {"heatCelsius": 22.0},
     }
+
+
+async def test_temperature_and_mode_commands_are_serialized(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test optimistic state remains while a mode command waits for temperature."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    temperature_started = asyncio.Event()
+    release_temperature = asyncio.Event()
+    mode_started = asyncio.Event()
+    command_order: list[str] = []
+
+    async def async_set_heat(
+        _trait: nest_climate.ThermostatTemperatureSetpointTrait, temperature: float
+    ) -> None:
+        assert temperature == 20.0
+        command_order.append("temperature_started")
+        temperature_started.set()
+        await release_temperature.wait()
+        command_order.append("temperature_finished")
+
+    async def async_set_mode(
+        _trait: nest_climate.ThermostatModeTrait, mode: str
+    ) -> None:
+        assert mode == "COOL"
+        command_order.append("mode_started")
+        mode_started.set()
+
+    monkeypatch.setattr(
+        nest_climate.ThermostatTemperatureSetpointTrait, "set_heat", async_set_heat
+    )
+    monkeypatch.setattr(nest_climate.ThermostatModeTrait, "set_mode", async_set_mode)
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    temperature_task = asyncio.create_task(async_fire_temperature_debounce(hass))
+    await temperature_started.wait()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 20.0
+
+    mode_task = asyncio.create_task(common.async_set_hvac_mode(hass, HVACMode.COOL))
+    await asyncio.sleep(0)
+    assert not mode_started.is_set()
+
+    release_temperature.set()
+    await asyncio.gather(temperature_task, mode_task)
+    assert command_order == [
+        "temperature_started",
+        "temperature_finished",
+        "mode_started",
+    ]
 
 
 async def test_thermostat_set_temperature_hvac_mode(

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -875,6 +875,53 @@ async def test_unconfirmed_temperature_times_out(
     assert thermostat.attributes[ATTR_TEMPERATURE] == 19.0
 
 
+async def test_unconfirmed_temperature_clears_on_mode_update(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    create_event: CreateEvent,
+) -> None:
+    """Test a confirmed mode change clears an obsolete optimistic temperature."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+                "coolCelsius": 18.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    await async_fire_temperature_debounce(hass)
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 20.0
+
+    await create_event(
+        {
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "OFF"],
+                "mode": "COOL",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+                "coolCelsius": 18.0,
+            },
+        }
+    )
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 18.0
+
+
 async def test_temperature_and_mode_commands_are_serialized(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -875,6 +875,63 @@ async def test_unconfirmed_temperature_times_out(
     assert thermostat.attributes[ATTR_TEMPERATURE] == 19.0
 
 
+async def test_stale_confirmation_callback_preserves_new_timer(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    create_event: CreateEvent,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a stale confirmation callback does not orphan a newer timer."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    confirmation_callbacks: list[Callable[[datetime], None]] = []
+    confirmation_cancel_timers: list[Mock] = []
+    real_async_call_later = nest_climate.async_call_later
+
+    def async_call_later(
+        timer_hass: HomeAssistant,
+        delay: float,
+        action: Callable[[datetime], None],
+    ) -> Mock:
+        if delay != nest_climate.TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS:
+            return real_async_call_later(timer_hass, delay, action)
+        confirmation_callbacks.append(action)
+        cancel_timer = Mock()
+        confirmation_cancel_timers.append(cancel_timer)
+        return cancel_timer
+
+    monkeypatch.setattr(nest_climate, "async_call_later", async_call_later)
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    await async_fire_temperature_debounce(hass)
+    await common.async_set_temperature(hass, temperature=21.0)
+    await async_fire_temperature_debounce(hass)
+
+    confirmation_callbacks[0](dt_util.utcnow())
+    await create_event(
+        {
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 21.0,
+            }
+        }
+    )
+
+    confirmation_cancel_timers[1].assert_called_once_with()
+
+
 async def test_unconfirmed_temperature_clears_on_mode_update(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -59,7 +59,7 @@ from .common import (
 )
 from .conftest import FakeAuth
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.climate import common
 
 type CreateEvent = Callable[[dict[str, Any]], Awaitable[None]]
@@ -941,6 +941,56 @@ async def test_temperature_and_mode_commands_are_serialized(
         "temperature_finished",
         "mode_started",
     ]
+
+
+async def test_entity_removal_during_temperature_command(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    config_entry: MockConfigEntry,
+    create_device: CreateDevice,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test command completion does not schedule a timer after entity removal."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    temperature_started = asyncio.Event()
+    release_temperature = asyncio.Event()
+
+    async def async_set_heat(
+        _trait: nest_climate.ThermostatTemperatureSetpointTrait, temperature: float
+    ) -> None:
+        assert temperature == 20.0
+        temperature_started.set()
+        await release_temperature.wait()
+
+    monkeypatch.setattr(
+        nest_climate.ThermostatTemperatureSetpointTrait, "set_heat", async_set_heat
+    )
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    temperature_task = asyncio.create_task(async_fire_temperature_debounce(hass))
+    await temperature_started.wait()
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    mock_call_later = Mock()
+    monkeypatch.setattr(nest_climate, "async_call_later", mock_call_later)
+
+    release_temperature.set()
+    await temperature_task
+
+    mock_call_later.assert_not_called()
 
 
 async def test_thermostat_set_temperature_hvac_mode(

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -6,10 +6,10 @@ pubsub subscriber.
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import aiohttp
 import pytest
@@ -727,6 +727,7 @@ async def test_thermostat_temperature_changes_use_trailing_debounce(
     setup_platform: PlatformSetup,
     auth: FakeAuth,
     create_device: CreateDevice,
+    create_event: CreateEvent,
 ) -> None:
     """Test only the final temperature is sent after the debounce period."""
     create_device.create(
@@ -760,6 +761,118 @@ async def test_thermostat_temperature_changes_use_trailing_debounce(
         "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
         "params": {"heatCelsius": 22.0},
     }
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
+
+    await create_event(
+        {
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 21.0,
+            }
+        }
+    )
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
+
+    await create_event(
+        {
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 22.0,
+            }
+        }
+    )
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
+
+
+async def test_stale_temperature_callback_preserves_new_timer(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a stale callback does not clear a newer timer's cancel handle."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    callbacks: list[Callable[[datetime], Awaitable[None]]] = []
+    cancel_timers: list[Mock] = []
+
+    def async_call_later(
+        _hass: HomeAssistant,
+        delay: float,
+        action: Callable[[datetime], Awaitable[None]],
+    ) -> Mock:
+        assert delay == nest_climate.TEMPERATURE_DEBOUNCE_SECONDS
+        callbacks.append(action)
+        cancel_timer = Mock()
+        cancel_timers.append(cancel_timer)
+        return cancel_timer
+
+    monkeypatch.setattr(nest_climate, "async_call_later", async_call_later)
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    await common.async_set_temperature(hass, temperature=21.0)
+    cancel_timers[0].assert_called_once_with()
+
+    await callbacks[0](dt_util.utcnow())
+    await common.async_set_temperature(hass, temperature=22.0)
+
+    cancel_timers[1].assert_called_once_with()
+
+
+async def test_unconfirmed_temperature_times_out(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+) -> None:
+    """Test optimistic temperature expires without a matching device update."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    await async_fire_temperature_debounce(hass)
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 20.0
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow()
+        + timedelta(seconds=nest_climate.TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS),
+    )
+    await hass.async_block_till_done()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 19.0
 
 
 async def test_temperature_and_mode_commands_are_serialized(

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -5,6 +5,7 @@ pubsub subscriber.
 """
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import AsyncMock
@@ -44,6 +45,7 @@ from homeassistant.exceptions import (
     ServiceNotSupported,
     ServiceValidationError,
 )
+from homeassistant.util import dt as dt_util
 
 from .common import (
     DEVICE_COMMAND,
@@ -55,11 +57,18 @@ from .common import (
 )
 from .conftest import FakeAuth
 
+from tests.common import async_fire_time_changed
 from tests.components.climate import common
 
 type CreateEvent = Callable[[dict[str, Any]], Awaitable[None]]
 
 EVENT_ID = "some-event-id"
+
+
+async def async_fire_temperature_debounce(hass: HomeAssistant) -> None:
+    """Fire the pending temperature debounce timer."""
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
 
 
 @pytest.fixture
@@ -663,6 +672,7 @@ async def test_thermostat_set_cool(
 
     await common.async_set_temperature(hass, temperature=24.0)
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -700,12 +710,53 @@ async def test_thermostat_set_heat(
 
     await common.async_set_temperature(hass, temperature=20.0)
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
     assert auth.json == {
         "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
         "params": {"heatCelsius": 20.0},
+    }
+
+
+async def test_thermostat_temperature_changes_use_trailing_debounce(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test only the final temperature is sent after the debounce period."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "heatCelsius": 19.0,
+            },
+        }
+    )
+    await setup_platform()
+
+    await common.async_set_temperature(hass, temperature=20.0)
+    await common.async_set_temperature(hass, temperature=21.0)
+    await common.async_set_temperature(hass, temperature=22.0)
+    await hass.async_block_till_done()
+
+    assert auth.captured_requests == []
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
+
+    await async_fire_temperature_debounce(hass)
+
+    assert len(auth.captured_requests) == 1
+    assert auth.json == {
+        "command": "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
+        "params": {"heatCelsius": 22.0},
     }
 
 
@@ -737,6 +788,7 @@ async def test_thermostat_set_temperature_hvac_mode(
 
     await common.async_set_temperature(hass, temperature=24.0, hvac_mode=HVACMode.COOL)
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -747,6 +799,7 @@ async def test_thermostat_set_temperature_hvac_mode(
 
     await common.async_set_temperature(hass, temperature=26.0, hvac_mode=HVACMode.HEAT)
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -759,6 +812,7 @@ async def test_thermostat_set_temperature_hvac_mode(
         hass, target_temp_low=20.0, target_temp_high=24.0, hvac_mode=HVACMode.HEAT_COOL
     )
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -828,6 +882,7 @@ async def test_thermostat_set_temperature_range_too_close(
         target_temp_high=target_high,
     )
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -868,6 +923,7 @@ async def test_thermostat_set_heat_cool(
         hass, target_temp_low=20.0, target_temp_high=24.0
     )
     await hass.async_block_till_done()
+    await async_fire_temperature_debounce(hass)
 
     assert auth.method == "post"
     assert auth.url == DEVICE_COMMAND
@@ -1711,6 +1767,7 @@ async def test_thermostat_hvac_mode_failure(
     setup_platform: PlatformSetup,
     auth: FakeAuth,
     create_device: CreateDevice,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setting an hvac_mode that is not supported."""
     create_device.create(
@@ -1751,11 +1808,12 @@ async def test_thermostat_hvac_mode_failure(
     assert HVACMode.HEAT in str(e_info)
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
-    with pytest.raises(HomeAssistantError) as e_info:
-        await common.async_set_temperature(hass, temperature=25.0)
-    assert "temperature" in str(e_info)
-    assert "climate.my_thermostat" in str(e_info)
-    assert "25.0" in str(e_info)
+    await common.async_set_temperature(hass, temperature=25.0)
+    await async_fire_temperature_debounce(hass)
+    assert (
+        "Error sending debounced temperature command for climate.my_thermostat"
+        in caplog.text
+    )
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
     with pytest.raises(HomeAssistantError) as e_info:

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -6,7 +6,7 @@ pubsub subscriber.
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta
+from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import AsyncMock, Mock
@@ -789,53 +789,6 @@ async def test_thermostat_temperature_changes_use_trailing_debounce(
     assert thermostat.attributes[ATTR_TEMPERATURE] == 22.0
 
 
-async def test_stale_temperature_callback_preserves_new_timer(
-    hass: HomeAssistant,
-    setup_platform: PlatformSetup,
-    create_device: CreateDevice,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test a stale callback does not clear a newer timer's cancel handle."""
-    create_device.create(
-        {
-            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
-            "sdm.devices.traits.ThermostatMode": {
-                "availableModes": ["HEAT", "OFF"],
-                "mode": "HEAT",
-            },
-            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
-                "heatCelsius": 19.0,
-            },
-        }
-    )
-    await setup_platform()
-
-    callbacks: list[Callable[[datetime], Awaitable[None]]] = []
-    cancel_timers: list[Mock] = []
-
-    def async_call_later(
-        _hass: HomeAssistant,
-        delay: float,
-        action: Callable[[datetime], Awaitable[None]],
-    ) -> Mock:
-        assert delay == nest_climate.TEMPERATURE_DEBOUNCE_SECONDS
-        callbacks.append(action)
-        cancel_timer = Mock()
-        cancel_timers.append(cancel_timer)
-        return cancel_timer
-
-    monkeypatch.setattr(nest_climate, "async_call_later", async_call_later)
-
-    await common.async_set_temperature(hass, temperature=20.0)
-    await common.async_set_temperature(hass, temperature=21.0)
-    cancel_timers[0].assert_called_once_with()
-
-    await callbacks[0](dt_util.utcnow())
-    await common.async_set_temperature(hass, temperature=22.0)
-
-    cancel_timers[1].assert_called_once_with()
-
-
 async def test_unconfirmed_temperature_times_out(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,
@@ -873,63 +826,6 @@ async def test_unconfirmed_temperature_times_out(
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
     assert thermostat.attributes[ATTR_TEMPERATURE] == 19.0
-
-
-async def test_stale_confirmation_callback_preserves_new_timer(
-    hass: HomeAssistant,
-    setup_platform: PlatformSetup,
-    create_device: CreateDevice,
-    create_event: CreateEvent,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test a stale confirmation callback does not orphan a newer timer."""
-    create_device.create(
-        {
-            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
-            "sdm.devices.traits.ThermostatMode": {
-                "availableModes": ["HEAT", "OFF"],
-                "mode": "HEAT",
-            },
-            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
-                "heatCelsius": 19.0,
-            },
-        }
-    )
-    await setup_platform()
-
-    confirmation_callbacks: list[Callable[[datetime], None]] = []
-    confirmation_cancel_timers: list[Mock] = []
-    real_async_call_later = nest_climate.async_call_later
-
-    def async_call_later(
-        timer_hass: HomeAssistant,
-        delay: float,
-        action: Callable[[datetime], None],
-    ) -> Mock:
-        if delay != nest_climate.TEMPERATURE_CONFIRMATION_TIMEOUT_SECONDS:
-            return real_async_call_later(timer_hass, delay, action)
-        confirmation_callbacks.append(action)
-        cancel_timer = Mock()
-        confirmation_cancel_timers.append(cancel_timer)
-        return cancel_timer
-
-    monkeypatch.setattr(nest_climate, "async_call_later", async_call_later)
-
-    await common.async_set_temperature(hass, temperature=20.0)
-    await async_fire_temperature_debounce(hass)
-    await common.async_set_temperature(hass, temperature=21.0)
-    await async_fire_temperature_debounce(hass)
-
-    confirmation_callbacks[0](dt_util.utcnow())
-    await create_event(
-        {
-            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
-                "heatCelsius": 21.0,
-            }
-        }
-    )
-
-    confirmation_cancel_timers[1].assert_called_once_with()
 
 
 async def test_unconfirmed_temperature_clears_on_mode_update(
@@ -2147,10 +2043,7 @@ async def test_thermostat_hvac_mode_failure(
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
     await common.async_set_temperature(hass, temperature=25.0)
     await async_fire_temperature_debounce(hass)
-    assert (
-        "Error sending debounced temperature command for climate.my_thermostat"
-        in caplog.text
-    )
+    assert "Error setting climate.my_thermostat temperature" in caplog.text
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
     with pytest.raises(HomeAssistantError) as e_info:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Google Nest integration has a usability flaw. Moving a temperature dial inside home assistant generates several incremental temperature changes, which subsequently hit the google server. Those repeated API hits trigger rate limiting from Google's end, and cause errors during totally reasonable interactions.

This change adds a 10 second "debounce" to any temperature setpoint changes. The integration holds off on pushing temperature changes to Google until the user is done making changes. The pending changes are internally reported back within home assistant, keeping the user experience consistent with expectations. Mode changes are still commanded immediately, and also flush previously pending commands, so that the integration remains compatible with automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
