### PR TITLE
Skip a sensor whose stored statistics unit is unusable

### DIFF
--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -363,10 +363,8 @@ def _normalize_states(
     valid_units = converter.VALID_UNITS
 
     if statistics_unit not in valid_units:
-        # The unit the statistics were compiled with is no longer one this
-        # converter knows. Converting into it raises, and the exception would
-        # travel up and abandon the whole compilation run, so every other
-        # sensor would lose this period too.
+        # Converting into a unit the converter does not know raises, which
+        # would abandon the whole run and cost every other sensor this period.
         if WARN_UNSUPPORTED_UNIT not in hass.data:
             hass.data[WARN_UNSUPPORTED_UNIT] = set()
         if entity_id not in hass.data[WARN_UNSUPPORTED_UNIT]:

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -362,6 +362,28 @@ def _normalize_states(
     last_unit: str | UndefinedType | None = UNDEFINED
     valid_units = converter.VALID_UNITS
 
+    if statistics_unit not in valid_units:
+        # The unit the statistics were compiled with is no longer one this
+        # converter knows. Converting into it raises, and the exception would
+        # travel up and abandon the whole compilation run, so every other
+        # sensor would lose this period too.
+        if WARN_UNSUPPORTED_UNIT not in hass.data:
+            hass.data[WARN_UNSUPPORTED_UNIT] = set()
+        if entity_id not in hass.data[WARN_UNSUPPORTED_UNIT]:
+            hass.data[WARN_UNSUPPORTED_UNIT].add(entity_id)
+            _LOGGER.warning(
+                (
+                    "The unit of the statistics of %s (%s) is not a valid %s unit."
+                    " Generation of long term statistics will be suppressed unless"
+                    " the unit is changed to a valid one. Go to %s to fix this"
+                ),
+                entity_id,
+                statistics_unit,
+                unit_class,
+                LINK_DEV_STATISTICS,
+            )
+        return None, None, []
+
     for fstate, state in fstates:
         state_unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         # Exclude states with unsupported unit from statistics

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -6924,3 +6924,63 @@ async def test_validate_statistics_mean_type_changed(
 
     # Issue should be resolved
     await assert_validation_result(hass, client, {}, {})
+
+
+@pytest.mark.parametrize("stored_unit", ["", "kWh"])
+@pytest.mark.usefixtures("recorder_mock")
+async def test_compile_statistics_with_unusable_stored_unit(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    stored_unit: str,
+) -> None:
+    """Test one sensor with an unusable stored unit does not stop the others.
+
+    The unit recorded in the metadata is fed to the converter as the target of
+    the conversion, and an unusable one makes it raise. That exception used to
+    travel up and abandon the whole run, so a single bad row took the statistics
+    of every other sensor down with it.
+    """
+    zero = get_start_time(dt_util.utcnow())
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    with session_scope(hass=hass) as session:
+        session.add(
+            StatisticsMeta.from_meta(
+                {
+                    "has_sum": False,
+                    "mean_type": StatisticMeanType.ARITHMETIC,
+                    "name": None,
+                    "source": "recorder",
+                    "statistic_id": "sensor.bad",
+                    "unit_class": "unitless",
+                    "unit_of_measurement": stored_unit,
+                }
+            )
+        )
+
+    attributes = {
+        "sensor.bad": {
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "unit_of_measurement": "%",
+        },
+        "sensor.good": {
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°C",
+        },
+    }
+    for entity_id, attrs in attributes.items():
+        with freeze_time(zero) as freezer:
+            await async_record_states(hass, freezer, zero, entity_id, attrs)
+    await async_wait_recording_done(hass)
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "sensor.good" in stats
+    assert "sensor.bad" not in stats
+    assert "is not a valid unitless unit" in caplog.text
+    assert "Error while processing event" not in caplog.text

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -6933,13 +6933,7 @@ async def test_compile_statistics_with_unusable_stored_unit(
     caplog: pytest.LogCaptureFixture,
     stored_unit: str,
 ) -> None:
-    """Test one sensor with an unusable stored unit does not stop the others.
-
-    The unit recorded in the metadata is fed to the converter as the target of
-    the conversion, and an unusable one makes it raise. That exception used to
-    travel up and abandon the whole run, so a single bad row took the statistics
-    of every other sensor down with it.
-    """
+    """Test one sensor with an unusable stored unit does not stop the others."""
     zero = get_start_time(dt_util.utcnow())
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)


### PR DESCRIPTION
## Proposed change

The unit stored in `statistics_meta` is the target of the unit conversion, and one the converter does not know makes `converter_factory` raise:

```
HomeAssistantError:  is not a recognized unitless unit.
```

Nothing catches that between `_normalize_states` and the recorder task, so a single unusable row abandons the whole compilation run. Every other sensor loses that period as well, which shows up as the statistics simply stopping rather than one entity going missing.

The state side of the same conversion is already checked against the converter valid units and skipped with a warning naming the entity. This does the same for the stored side, so the affected entity is skipped and named while the rest of the run continues.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178438
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
