### PR TITLE
Avoid a naive datetime.now() in broadlink

### DIFF
--- a/homeassistant/components/broadlink/heartbeat.py
+++ b/homeassistant/components/broadlink/heartbeat.py
@@ -8,6 +8,7 @@ import broadlink as blk
 from homeassistant.const import CONF_HOST
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import event
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -31,7 +32,7 @@ class BroadlinkHeartbeat:
     async def async_setup(self) -> None:
         """Set up the heartbeat."""
         if self._unsubscribe is None:
-            await self.async_heartbeat(dt.datetime.now())  # pylint: disable=home-assistant-enforce-naive-now
+            await self.async_heartbeat(dt_util.utcnow())
             self._unsubscribe = event.async_track_time_interval(
                 self._hass, self.async_heartbeat, self.HEARTBEAT_INTERVAL
             )


### PR DESCRIPTION
## Proposed change

The first heartbeat is invoked directly rather than through the interval tracker, and passes `datetime.now()` only to satisfy the callback signature. `async_heartbeat` names the parameter `_` and never reads it, so it can take the aware value `async_track_time_interval` passes on every later call.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177793
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
