### PR TITLE
Count Netatmo API calls in a trailing window

### DIFF
--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from itertools import islice
 import logging
-from time import time
+from time import monotonic, time
 from typing import Any
 
 import aiohttp
@@ -86,6 +86,7 @@ DEFAULT_INTERVALS = {
     EVENT: 600,
 }
 SCAN_INTERVAL = 60
+RATE_LIMIT_WINDOW = 3600
 UNAVAILABLE_AFTER_ERRORS = 3
 MAX_ERROR_BACKOFF = 3600
 
@@ -167,8 +168,7 @@ class NetatmoDataHandler:
         else:
             self._interval_factor = DEV_FACTOR
             self._rate_limit = DEV_LIMIT
-        self.poll_start = time()
-        self.poll_count = 0
+        self._calls: deque[float] = deque()
         self.persons: dict[str, dict[str, str | None]] = {}
         self.schedules: dict[str, dict[str, Schedule]] = {}
         self.device_ids: dict[str, str] = {}
@@ -230,14 +230,28 @@ class NetatmoDataHandler:
                     self.publisher[publisher].next_scan = time() + data_class.interval
 
         self._queue.rotate(BATCH_SIZE)
-        cph = self.poll_count / (time() - self.poll_start) * 3600
+        cph = self._calls_in_the_last_hour()
         _LOGGER.debug("Calls per hour: %i", cph)
         if cph > self._rate_limit:
             for publisher in self.publisher.values():
                 publisher.next_scan += 60
-        if (time() - self.poll_start) > 3600:
-            self.poll_start = time()
-            self.poll_count = 0
+
+    def _calls_in_the_last_hour(self) -> int:
+        """Return how many API calls were made over the trailing hour.
+
+        Counted, not extrapolated from a partial window: the calls every publisher
+        makes when it is first subscribed would otherwise scale up to several
+        times the rate limit and throttle the integration for the first minutes
+        after every restart.
+
+        Timed on the monotonic clock rather than the wall clock the schedule uses,
+        so that the NTP correction a host without a real time clock makes shortly
+        after booting cannot expire or retain the wrong calls.
+        """
+        cutoff = monotonic() - RATE_LIMIT_WINDOW
+        while self._calls and self._calls[0] < cutoff:
+            self._calls.popleft()
+        return len(self._calls)
 
     @callback
     def async_force_update(self, signal_name: str) -> None:
@@ -261,7 +275,7 @@ class NetatmoDataHandler:
 
     async def async_fetch_data(self, signal_name: str) -> bool:
         """Fetch data and notify."""
-        self.poll_count += 1
+        self._calls.append(monotonic())
         has_error = False
         try:
             await getattr(self.account, self.publisher[signal_name].method)(

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -1197,3 +1197,56 @@ async def test_failed_updates_are_retried_with_escalating_backoff(
     # scheduled update), the delay then doubles per consecutive error until the
     # patched cap of 600s is reached
     assert gaps == [180, 300, 600, 600]
+
+
+async def _drive_scheduled_updates(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, seconds: int
+) -> None:
+    """Fire every scheduled update falling in the given span."""
+    for _ in range(seconds // 30):
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_the_startup_burst_does_not_throttle_the_poll_schedule(
+    hass: HomeAssistant, config_entry: MockConfigEntry, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test that the calls made while subscribing cannot breach the rate limit."""
+    request_times: list[float] = []
+
+    async def fake_post(*args: Any, **kwargs: Any):
+        if (
+            kwargs.get("endpoint", "").endswith("homestatus")
+            and kwargs.get("params", {}).get("home_id") == HOME_ID
+        ):
+            request_times.append(time())
+        return await fake_post_request(hass, *args, **kwargs)
+
+    # Comfortably above the handful of calls subscribing makes, but far below what
+    # those same calls extrapolate to when spread over only the first minute
+    with patch.object(coordinator, "CLOUD_LIMIT", 10):
+        await _setup_switch_platform(hass, config_entry, fake_post)
+        await _drive_scheduled_updates(hass, freezer, 600)
+
+    gaps = [round(later - earlier) for earlier, later in pairwise(request_times)]
+
+    # Throttling adds 60s to every publisher on every scheduled update, so any
+    # would stretch these gaps well past the base cadence
+    assert len(gaps) >= 2
+    assert set(gaps) == {180}
+
+
+async def test_calls_stop_counting_once_they_leave_the_window(
+    hass: HomeAssistant, config_entry: MockConfigEntry, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test that the counter only reports the calls made in the trailing hour."""
+    await _setup_switch_platform(hass, config_entry, partial(fake_post_request, hass))
+    data_handler = config_entry.runtime_data
+
+    assert data_handler._calls_in_the_last_hour() > 0
+
+    # Advanced without firing the scheduled updates, so nothing is added back
+    freezer.tick(timedelta(seconds=coordinator.RATE_LIMIT_WINDOW + 1))
+
+    assert data_handler._calls_in_the_last_hour() == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The call rate was extrapolated from however long the integration had been running, so the burst of calls every publisher makes when it is first subscribed scaled up to several times the rate limit. That throttled the integration for the first minutes after every restart.

Keep the timestamps of the calls made in the last hour and count them instead, which is what the rate limit is expressed over anyway.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
