### PR TITLE
Add electric vehicle charging as a dedicated energy consumer

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -155,6 +155,25 @@ class SolarSourceType(TypedDict):
     name: NotRequired[str]
 
 
+class EVSourceType(TypedDict):
+    """Dictionary holding the source of electric vehicle charging.
+
+    An EV is a consumer rather than a producer: its energy is deducted from
+    the home consumption total and shown as its own consumer in the energy
+    graphs. It is configured as a source (not as a device consumption entry)
+    because device consumption entries are, by definition, a breakdown of
+    home consumption.
+    """
+
+    type: Literal["ev"]
+
+    stat_energy_from: str
+    stat_rate: NotRequired[str]
+
+    # An optional custom name for display in energy graphs
+    name: NotRequired[str]
+
+
 class BatterySourceType(TypedDict):
     """Dictionary holding the source of battery storage."""
 
@@ -229,6 +248,7 @@ type SourceType = (
     GridSourceType
     | SolarSourceType
     | BatterySourceType
+    | EVSourceType
     | GasSourceType
     | WaterSourceType
 )
@@ -499,6 +519,14 @@ SOLAR_SOURCE_SCHEMA = vol.Schema(
         vol.Optional("name"): str,
     }
 )
+EV_SOURCE_SCHEMA = vol.Schema(
+    {
+        vol.Required("type"): "ev",
+        vol.Required("stat_energy_from"): str,
+        vol.Optional("stat_rate"): str,
+        vol.Optional("name"): str,
+    }
+)
 BATTERY_SOURCE_SCHEMA = vol.Schema(
     {
         vol.Required("type"): "battery",
@@ -604,6 +632,7 @@ ENERGY_SOURCE_SCHEMA = vol.All(
                     "grid": GRID_SOURCE_SCHEMA,
                     "solar": SOLAR_SOURCE_SCHEMA,
                     "battery": BATTERY_SOURCE_SCHEMA,
+                    "ev": EV_SOURCE_SCHEMA,
                     "gas": GAS_SOURCE_SCHEMA,
                     "water": WATER_SOURCE_SCHEMA,
                 },

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -186,6 +186,31 @@ class EnergyPreferencesValidation:
 
 
 @callback
+def _register_usage_stat_validation(
+    hass: HomeAssistant,
+    stat_id: str,
+    statistics_metadata: dict[str, tuple[int, recorder.models.StatisticMetaData]],
+    wanted_statistics_metadata: set[str],
+    validate_calls: list[functools.partial[None]],
+    source_result: ValidationIssues,
+) -> None:
+    """Queue validation of a stat_energy_from-style usage statistic."""
+    wanted_statistics_metadata.add(stat_id)
+    validate_calls.append(
+        functools.partial(
+            _async_validate_usage_stat,
+            hass,
+            statistics_metadata,
+            stat_id,
+            ENERGY_USAGE_DEVICE_CLASSES,
+            ENERGY_USAGE_UNITS,
+            ENERGY_UNIT_ERROR,
+            source_result,
+        )
+    )
+
+
+@callback
 def _async_validate_stat_common(
     hass: HomeAssistant,
     metadata: dict[str, tuple[int, recorder.models.StatisticMetaData]],
@@ -745,61 +770,55 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
             )
 
         elif source["type"] == "solar":
-            wanted_statistics_metadata.add(source["stat_energy_from"])
-            validate_calls.append(
-                functools.partial(
-                    _async_validate_usage_stat,
-                    hass,
-                    statistics_metadata,
-                    source["stat_energy_from"],
-                    ENERGY_USAGE_DEVICE_CLASSES,
-                    ENERGY_USAGE_UNITS,
-                    ENERGY_UNIT_ERROR,
-                    source_result,
-                )
+            _register_usage_stat_validation(
+                hass,
+                source["stat_energy_from"],
+                statistics_metadata,
+                wanted_statistics_metadata,
+                validate_calls,
+                source_result,
             )
 
         elif source["type"] == "ev":
-            wanted_statistics_metadata.add(source["stat_energy_from"])
-            validate_calls.append(
-                functools.partial(
-                    _async_validate_usage_stat,
-                    hass,
-                    statistics_metadata,
-                    source["stat_energy_from"],
-                    ENERGY_USAGE_DEVICE_CLASSES,
-                    ENERGY_USAGE_UNITS,
-                    ENERGY_UNIT_ERROR,
-                    source_result,
-                )
+            _register_usage_stat_validation(
+                hass,
+                source["stat_energy_from"],
+                statistics_metadata,
+                wanted_statistics_metadata,
+                validate_calls,
+                source_result,
             )
+            if stat_rate := source.get("stat_rate"):
+                wanted_statistics_metadata.add(stat_rate)
+                validate_calls.append(
+                    functools.partial(
+                        _async_validate_power_stat,
+                        hass,
+                        statistics_metadata,
+                        stat_rate,
+                        POWER_USAGE_DEVICE_CLASSES,
+                        POWER_USAGE_UNITS,
+                        POWER_UNIT_ERROR,
+                        source_result,
+                    )
+                )
 
         elif source["type"] == "battery":
-            wanted_statistics_metadata.add(source["stat_energy_from"])
-            validate_calls.append(
-                functools.partial(
-                    _async_validate_usage_stat,
-                    hass,
-                    statistics_metadata,
-                    source["stat_energy_from"],
-                    ENERGY_USAGE_DEVICE_CLASSES,
-                    ENERGY_USAGE_UNITS,
-                    ENERGY_UNIT_ERROR,
-                    source_result,
-                )
+            _register_usage_stat_validation(
+                hass,
+                source["stat_energy_from"],
+                statistics_metadata,
+                wanted_statistics_metadata,
+                validate_calls,
+                source_result,
             )
-            wanted_statistics_metadata.add(source["stat_energy_to"])
-            validate_calls.append(
-                functools.partial(
-                    _async_validate_usage_stat,
-                    hass,
-                    statistics_metadata,
-                    source["stat_energy_to"],
-                    ENERGY_USAGE_DEVICE_CLASSES,
-                    ENERGY_USAGE_UNITS,
-                    ENERGY_UNIT_ERROR,
-                    source_result,
-                )
+            _register_usage_stat_validation(
+                hass,
+                source["stat_energy_to"],
+                statistics_metadata,
+                wanted_statistics_metadata,
+                validate_calls,
+                source_result,
             )
 
     for device in manager.data["device_consumption"]:

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -759,6 +759,21 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                 )
             )
 
+        elif source["type"] == "ev":
+            wanted_statistics_metadata.add(source["stat_energy_from"])
+            validate_calls.append(
+                functools.partial(
+                    _async_validate_usage_stat,
+                    hass,
+                    statistics_metadata,
+                    source["stat_energy_from"],
+                    ENERGY_USAGE_DEVICE_CLASSES,
+                    ENERGY_USAGE_UNITS,
+                    ENERGY_UNIT_ERROR,
+                    source_result,
+                )
+            )
+
         elif source["type"] == "battery":
             wanted_statistics_metadata.add(source["stat_energy_from"])
             validate_calls.append(

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -53,7 +53,13 @@ async def test_validation(
     extra,
 ) -> None:
     """Test validating success."""
-    for key in ("device_cons", "battery_import", "battery_export", "solar_production"):
+    for key in (
+        "device_cons",
+        "battery_import",
+        "battery_export",
+        "solar_production",
+        "ev_charging",
+    ):
         hass.states.async_set(
             f"sensor.{key}",
             "123",
@@ -74,12 +80,13 @@ async def test_validation(
                     "stat_energy_to": "sensor.battery_export",
                 },
                 {"type": "solar", "stat_energy_from": "sensor.solar_production"},
+                {"type": "ev", "stat_energy_from": "sensor.ev_charging"},
             ],
             "device_consumption": [{"stat_consumption": "sensor.device_cons"}],
         }
     )
     assert (await validate.async_validate(hass)).as_dict() == {
-        "energy_sources": [[], []],
+        "energy_sources": [[], [], []],
         "device_consumption": [[]],
         "device_consumption_water": [],
     }

--- a/tests/components/energy/test_validate_power.py
+++ b/tests/components/energy/test_validate_power.py
@@ -401,3 +401,95 @@ async def test_validation_grid_power_recorder_untracked(
         "device_consumption": [],
         "device_consumption_water": [],
     }
+
+
+async def test_validation_ev_power_valid(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating EV with valid power sensor."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "ev",
+                    "stat_energy_from": "sensor.ev_charging",
+                    "stat_rate": "sensor.ev_power",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.ev_charging",
+        "123",
+        {
+            "device_class": "energy",
+            "unit_of_measurement": "kWh",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.ev_power",
+        "1.5",
+        {
+            "device_class": "power",
+            "unit_of_measurement": UnitOfPower.KILO_WATT,
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_ev_power_wrong_unit(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating EV with power sensor having wrong unit."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "ev",
+                    "stat_energy_from": "sensor.ev_charging",
+                    "stat_rate": "sensor.ev_power",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.ev_charging",
+        "123",
+        {
+            "device_class": "energy",
+            "unit_of_measurement": "kWh",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.ev_power",
+        "1.5",
+        {
+            "device_class": "power",
+            "unit_of_measurement": "beers",
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "entity_unexpected_unit_power",
+                    "affected_entities": {("sensor.ev_power", "beers")},
+                    "translation_placeholders": {"power_units": POWER_UNITS_STRING},
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }


### PR DESCRIPTION
## Proposed change

Lets electric vehicle charging be tracked as its own consumer on the energy
dashboard — deducted from home consumption and shown as its own line item —
instead of being folded into "Home" via a `device_consumption` entry.

EV charging is conceptually a **consumer**, not a producer: it doesn't supply
energy to the home the way grid/solar/battery do. It's still added as a new
`energy_sources` type (`EVSourceType`, `type: "ev"`), alongside
`grid`/`solar`/`battery`/`gas`/`water`, purely for architectural reasons — it
needs its own top-level, independently-configurable entry rather than living
under `device_consumption`, which is by definition a breakdown *of* home
consumption. A device hidden from the "Individual Devices" list this way can
never be un-configured, which isn't what we want for an EV that should be
easy to add or remove from tracking.

- `homeassistant/components/energy/data.py`: new `EVSourceType` TypedDict
  (`stat_energy_from`, optional `stat_rate`, optional `name`) and
  `EV_SOURCE_SCHEMA`, added to the `SourceType` union and the
  `ENERGY_SOURCE_SCHEMA` discriminated-union mapping.
- `homeassistant/components/energy/validate.py`: validates the EV source's
  `stat_energy_from` the same way usage statistics are validated for the
  other source types (existence, device class, unit).

This is a schema/validation-only change. All of the actual math (splitting
existing sources proportionally between Home and EV so
`used_home + used_ev == used_total`) lives in the frontend, in
`computeConsumptionSingle`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is a **dependency for a companion [`home-assistant/frontend`](https://github.com/home-assistant/frontend/pull/53650) PR**
**This PR should land/be available first** — the frontend writes `type: "ev"` energy source configs, and a
  core version older than 2026.7 rejects the unknown source type outright
  when saving energy preferences.


## Testing

- Manually validated `ENERGY_SOURCE_SCHEMA` against an `energy_sources` list
  containing an `"ev"` entry (voluptuous accepts it; previously raised on the
  unknown discriminator).
- Manually exercised `async_validate` with an EV source pointing at a valid
  energy statistic and confirmed it surfaces the same class of validation
  issues (missing statistic, wrong device class/unit) that grid/battery
  sources already get.
- **No automated tests were added for this change** — flagging this
  explicitly since `tests/components/energy/test_data.py` and
  `test_validate.py` would be the natural place to add EV-source coverage
  mirroring the existing battery-source tests before this is ready for
  review.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and
      compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for www.home-assistant.io

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to requirements_all.txt.
- [ ] For the updated dependencies a diff between library versions and
      ideally a link to the changelog/release notes is added to the PR
      description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other open pull requests in this repository.