### PR TITLE
Add support for inverted output in Shelly climate entity

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -773,13 +773,8 @@ class RpcClimate(ShellyRpcEntity, ClimateEntity):
     @override
     def hvac_action(self) -> HVACAction:
         """HVAC current action."""
-        output = self.status["output"]
-        if self._invert_output:
-            # Inverted output: the relay is on when the thermostat is idle
-            # and off when it is heating or cooling
-            output = not output
-
-        if not output:
+        # When inverted, relay on means idle; otherwise relay on means active.
+        if self.status["output"] == self._invert_output:
             return HVACAction.IDLE
 
         return (

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -727,6 +727,9 @@ class RpcClimate(ShellyRpcEntity, ClimateEntity):
         self._thermostat_type = coordinator.device.config[self.key].get(
             "type", "heating"
         )
+        self._invert_output = coordinator.device.config[self.key].get(
+            "invert_output", False
+        )
         if self._thermostat_type == "cooling":
             self._attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL]
         else:
@@ -770,7 +773,13 @@ class RpcClimate(ShellyRpcEntity, ClimateEntity):
     @override
     def hvac_action(self) -> HVACAction:
         """HVAC current action."""
-        if not self.status["output"]:
+        output = self.status["output"]
+        if self._invert_output:
+            # Inverted output: the relay is on when the thermostat is idle
+            # and off when it is heating or cooling
+            output = not output
+
+        if not output:
             return HVACAction.IDLE
 
         return (

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -736,6 +736,41 @@ async def test_rpc_climate_hvac_mode_cool(
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
 
 
+@pytest.mark.parametrize(
+    ("thermostat_type", "invert_output", "output", "expected_action"),
+    [
+        ("heating", False, True, HVACAction.HEATING),
+        ("heating", False, False, HVACAction.IDLE),
+        ("heating", True, True, HVACAction.IDLE),
+        ("heating", True, False, HVACAction.HEATING),
+        ("cooling", True, True, HVACAction.IDLE),
+        ("cooling", True, False, HVACAction.COOLING),
+    ],
+)
+async def test_rpc_climate_hvac_action_inverted_output(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    thermostat_type: str,
+    invert_output: bool,
+    output: bool,
+    expected_action: HVACAction,
+) -> None:
+    """Test climate hvac action with inverted output."""
+    entity_id = "climate.test_name"
+
+    new_config = deepcopy(mock_rpc_device.config)
+    new_config["thermostat:0"]["type"] = thermostat_type
+    new_config["thermostat:0"]["invert_output"] = invert_output
+    monkeypatch.setattr(mock_rpc_device, "config", new_config)
+    monkeypatch.setitem(mock_rpc_device.status["thermostat:0"], "output", output)
+
+    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
+
+    assert (state := hass.states.get(entity_id))
+    assert state.attributes[ATTR_HVAC_ACTION] == expected_action
+
+
 async def test_wall_display_thermostat_mode(
     hass: HomeAssistant,
     mock_rpc_device: Mock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Checks the value of `invert_output` and returns `hvac_action` based on it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178996
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
