### PR TITLE
Bump vallox-websocket-api to 6.1.0

### DIFF
--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["vallox_websocket_api"],
-  "requirements": ["vallox-websocket-api==6.0.0"]
+  "requirements": ["vallox-websocket-api==6.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3300,7 +3300,7 @@ uvcclient==0.12.1
 vacuum-map-parser-roborock==0.1.5
 
 # homeassistant.components.vallox
-vallox-websocket-api==6.0.0
+vallox-websocket-api==6.1.0
 
 # homeassistant.components.vegehub
 vegehub==0.1.26


### PR DESCRIPTION
## Proposed change

Bump `vallox-websocket-api` from 6.0.0 to 6.1.0.

6.1.0 adds support for the automatic profile available on Vallox units running firmware v3.1.4 or newer: a new `Profile.AUTO = 6` enum member, `MetricData.profile` returning `Profile.AUTO` when `A_CYC_STATE == 2`, and `set_profile(Profile.AUTO)` writing `A_CYC_STATE = 2` while clearing the boost/fireplace/extra timers. Nothing else changed, and no existing behaviour is affected.

This bump is split out of home-assistant/core#179212, which exposes the new profile in the integration and will be rebased on top of this once merged.

- PyPI release: https://pypi.org/project/vallox-websocket-api/6.1.0/
- Release notes: https://github.com/yozik04/vallox_websocket_api/releases/tag/6.1.0
- Diff 6.0.0 → 6.1.0: https://github.com/yozik04/vallox_websocket_api/compare/6.0.0...6.1.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
