### PR TITLE
Add support for default AWS credentials to AWS S3

### DIFF
--- a/homeassistant/components/aws_s3/__init__.py
+++ b/homeassistant/components/aws_s3/__init__.py
@@ -1,10 +1,15 @@
 """The AWS S3 integration."""
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 from aiobotocore.session import AioSession
-from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
+from botocore.exceptions import (
+    ClientError,
+    ConnectionError,
+    NoCredentialsError,
+    ParamValidationError,
+)
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -15,6 +20,7 @@ from .const import (
     CONF_BUCKET,
     CONF_ENDPOINT_URL,
     CONF_SECRET_ACCESS_KEY,
+    CONF_USE_DEFAULT_CREDENTIALS,
     DATA_BACKUP_AGENT_LISTENERS,
     DOMAIN,
 )
@@ -31,15 +37,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
     data = cast(dict, entry.data)
     try:
         session = AioSession()
+        client_kwargs: dict[str, Any] = {"endpoint_url": data.get(CONF_ENDPOINT_URL)}
+        if not data.get(CONF_USE_DEFAULT_CREDENTIALS, False):
+            # Without explicit keys, botocore resolves credentials itself
+            client_kwargs["aws_secret_access_key"] = data[CONF_SECRET_ACCESS_KEY]
+            client_kwargs["aws_access_key_id"] = data[CONF_ACCESS_KEY_ID]
         # pylint: disable-next=unnecessary-dunder-call
-        client = await session.create_client(
-            "s3",
-            endpoint_url=data.get(CONF_ENDPOINT_URL),
-            aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
-            aws_access_key_id=data[CONF_ACCESS_KEY_ID],
-        ).__aenter__()
+        client = await session.create_client("s3", **client_kwargs).__aenter__()
         await client.head_bucket(Bucket=data[CONF_BUCKET])
-    except ClientError as err:
+    except (ClientError, NoCredentialsError) as err:
         raise ConfigEntryError(
             translation_domain=DOMAIN,
             translation_key="invalid_credentials",

--- a/homeassistant/components/aws_s3/__init__.py
+++ b/homeassistant/components/aws_s3/__init__.py
@@ -38,8 +38,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
     try:
         session = AioSession()
         client_kwargs: dict[str, Any] = {"endpoint_url": data.get(CONF_ENDPOINT_URL)}
+        # Passing no keys lets botocore resolve the credentials itself
         if not data.get(CONF_USE_DEFAULT_CREDENTIALS, False):
-            # Without explicit keys, botocore resolves credentials itself
             client_kwargs["aws_secret_access_key"] = data[CONF_SECRET_ACCESS_KEY]
             client_kwargs["aws_access_key_id"] = data[CONF_ACCESS_KEY_ID]
         # pylint: disable-next=unnecessary-dunder-call

--- a/homeassistant/components/aws_s3/config_flow.py
+++ b/homeassistant/components/aws_s3/config_flow.py
@@ -4,7 +4,12 @@ from typing import Any, override
 from urllib.parse import urlparse
 
 from aiobotocore.session import AioSession
-from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
+from botocore.exceptions import (
+    ClientError,
+    ConnectionError,
+    NoCredentialsError,
+    ParamValidationError,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -22,6 +27,7 @@ from .const import (
     CONF_BUCKET,
     CONF_ENDPOINT_URL,
     CONF_SECRET_ACCESS_KEY,
+    CONF_USE_DEFAULT_CREDENTIALS,
     DEFAULT_ENDPOINT_URL,
     DESCRIPTION_AWS_S3_DOCS_URL,
     DESCRIPTION_BOTO3_DOCS_URL,
@@ -30,8 +36,9 @@ from .const import (
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ACCESS_KEY_ID): cv.string,
-        vol.Required(CONF_SECRET_ACCESS_KEY): TextSelector(
+        vol.Required(CONF_USE_DEFAULT_CREDENTIALS, default=False): cv.boolean,
+        vol.Optional(CONF_ACCESS_KEY_ID): cv.string,
+        vol.Optional(CONF_SECRET_ACCESS_KEY): TextSelector(
             config=TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
         vol.Required(CONF_BUCKET): cv.string,
@@ -54,6 +61,7 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            use_default_credentials = user_input[CONF_USE_DEFAULT_CREDENTIALS]
             normalized_prefix = user_input.get(CONF_PREFIX, "").strip("/")
             # Check for existing entries, treating missing prefix as empty
             for entry in self._async_current_entries(include_ignore=False):
@@ -69,17 +77,27 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
             hostname = urlparse(user_input[CONF_ENDPOINT_URL]).hostname
             if not hostname or not hostname.endswith(AWS_DOMAIN):
                 errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
+            elif not use_default_credentials and not (
+                user_input.get(CONF_ACCESS_KEY_ID)
+                and user_input.get(CONF_SECRET_ACCESS_KEY)
+            ):
+                errors["base"] = "credentials_required"
             else:
                 try:
                     session = AioSession()
-                    async with session.create_client(
-                        "s3",
-                        endpoint_url=user_input.get(CONF_ENDPOINT_URL),
-                        aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
-                        aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
-                    ) as client:
+                    client_kwargs: dict[str, Any] = {
+                        "endpoint_url": user_input.get(CONF_ENDPOINT_URL)
+                    }
+                    if not use_default_credentials:
+                        client_kwargs["aws_secret_access_key"] = user_input[
+                            CONF_SECRET_ACCESS_KEY
+                        ]
+                        client_kwargs["aws_access_key_id"] = user_input[
+                            CONF_ACCESS_KEY_ID
+                        ]
+                    async with session.create_client("s3", **client_kwargs) as client:
                         await client.head_bucket(Bucket=user_input[CONF_BUCKET])
-                except ClientError:
+                except ClientError, NoCredentialsError:
                     errors["base"] = "invalid_credentials"
                 except ParamValidationError as err:
                     if "Invalid bucket name" in str(err):
@@ -90,6 +108,13 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors[CONF_ENDPOINT_URL] = "cannot_connect"
                 else:
                     data = dict(user_input)
+                    if use_default_credentials:
+                        # Credentials are resolved at runtime, nothing to store
+                        data.pop(CONF_ACCESS_KEY_ID, None)
+                        data.pop(CONF_SECRET_ACCESS_KEY, None)
+                    else:
+                        # Do not persist default values
+                        data.pop(CONF_USE_DEFAULT_CREDENTIALS)
                     if not normalized_prefix:
                         # Do not persist empty optional values
                         data.pop(CONF_PREFIX, None)

--- a/homeassistant/components/aws_s3/config_flow.py
+++ b/homeassistant/components/aws_s3/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PREFIX
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -36,7 +37,7 @@ from .const import (
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USE_DEFAULT_CREDENTIALS, default=False): cv.boolean,
+        vol.Required(CONF_USE_DEFAULT_CREDENTIALS, default=False): BooleanSelector(),
         vol.Optional(CONF_ACCESS_KEY_ID): cv.string,
         vol.Optional(CONF_SECRET_ACCESS_KEY): TextSelector(
             config=TextSelectorConfig(type=TextSelectorType.PASSWORD)

--- a/homeassistant/components/aws_s3/const.py
+++ b/homeassistant/components/aws_s3/const.py
@@ -11,6 +11,7 @@ CONF_ACCESS_KEY_ID = "access_key_id"
 CONF_SECRET_ACCESS_KEY = "secret_access_key"
 CONF_ENDPOINT_URL = "endpoint_url"
 CONF_BUCKET = "bucket"
+CONF_USE_DEFAULT_CREDENTIALS = "use_default_credentials"
 
 AWS_DOMAIN = "amazonaws.com"
 DEFAULT_ENDPOINT_URL = f"https://s3.eu-central-1.{AWS_DOMAIN}/"

--- a/homeassistant/components/aws_s3/strings.json
+++ b/homeassistant/components/aws_s3/strings.json
@@ -5,6 +5,7 @@
     },
     "error": {
       "cannot_connect": "[%key:component::aws_s3::exceptions::cannot_connect::message%]",
+      "credentials_required": "Access key ID and secret access key are required when not using the default AWS credentials.",
       "invalid_bucket_name": "[%key:component::aws_s3::exceptions::invalid_bucket_name::message%]",
       "invalid_credentials": "[%key:component::aws_s3::exceptions::invalid_credentials::message%]",
       "invalid_endpoint_url": "[%key:component::aws_s3::exceptions::invalid_endpoint_url::message%]"
@@ -16,14 +17,16 @@
           "bucket": "Bucket name",
           "endpoint_url": "Endpoint URL",
           "prefix": "Prefix",
-          "secret_access_key": "Secret access key"
+          "secret_access_key": "Secret access key",
+          "use_default_credentials": "Use default AWS credentials"
         },
         "data_description": {
-          "access_key_id": "Access key ID to connect to AWS S3 API",
+          "access_key_id": "Access key ID to connect to AWS S3 API. Not needed when using the default AWS credentials.",
           "bucket": "Bucket must already exist and be writable by the provided credentials.",
           "endpoint_url": "Endpoint URL provided to [Boto3 Session]({boto3_docs_url}). Region-specific [AWS S3 endpoints]({aws_s3_docs_url}) are available in their docs.",
           "prefix": "Folder or prefix to store backups in, for example `backups`",
-          "secret_access_key": "Secret access key to connect to AWS S3 API"
+          "secret_access_key": "Secret access key to connect to AWS S3 API. Not needed when using the default AWS credentials.",
+          "use_default_credentials": "Let Boto3 resolve credentials from the environment instead of storing an access key: environment variables, a shared credentials file, an EC2 instance profile or a container role."
         },
         "title": "Add AWS S3 bucket"
       }
@@ -47,7 +50,7 @@
       "message": "Invalid bucket name"
     },
     "invalid_credentials": {
-      "message": "Bucket cannot be accessed using provided combination of access key ID and secret access key."
+      "message": "Bucket cannot be accessed using the configured credentials."
     },
     "invalid_endpoint_url": {
       "message": "Invalid endpoint URL. Please make sure it's a valid AWS S3 endpoint URL."

--- a/tests/components/aws_s3/const.py
+++ b/tests/components/aws_s3/const.py
@@ -5,6 +5,7 @@ from homeassistant.components.aws_s3.const import (
     CONF_BUCKET,
     CONF_ENDPOINT_URL,
     CONF_SECRET_ACCESS_KEY,
+    CONF_USE_DEFAULT_CREDENTIALS,
 )
 from homeassistant.const import CONF_PREFIX
 
@@ -19,5 +20,17 @@ CONFIG_ENTRY_DATA = {
 # What users submit to the flow (can include empty prefix)
 USER_INPUT = {
     **CONFIG_ENTRY_DATA,
+    CONF_PREFIX: "",
+}
+
+# Credentials are resolved by Boto3, so no keys are stored
+CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS = {
+    CONF_USE_DEFAULT_CREDENTIALS: True,
+    CONF_ENDPOINT_URL: "https://s3.eu-south-1.amazonaws.com",
+    CONF_BUCKET: "test",
+}
+
+USER_INPUT_DEFAULT_CREDENTIALS = {
+    **CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS,
     CONF_PREFIX: "",
 }

--- a/tests/components/aws_s3/test_config_flow.py
+++ b/tests/components/aws_s3/test_config_flow.py
@@ -1,28 +1,41 @@
 """Test the AWS S3 config flow."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from botocore.exceptions import (
     ClientError,
     EndpointConnectionError,
+    NoCredentialsError,
     ParamValidationError,
 )
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.aws_s3.const import CONF_BUCKET, CONF_ENDPOINT_URL, DOMAIN
+from homeassistant.components.aws_s3.const import (
+    CONF_ACCESS_KEY_ID,
+    CONF_BUCKET,
+    CONF_ENDPOINT_URL,
+    CONF_SECRET_ACCESS_KEY,
+    DOMAIN,
+)
 from homeassistant.const import CONF_PREFIX
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import CONFIG_ENTRY_DATA, USER_INPUT
+from .const import (
+    CONFIG_ENTRY_DATA,
+    CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS,
+    USER_INPUT,
+    USER_INPUT_DEFAULT_CREDENTIALS,
+)
 
 from tests.common import MockConfigEntry
 
 
 async def _async_start_flow(
     hass: HomeAssistant,
-    user_input: dict[str, str] | None = None,
+    user_input: dict[str, Any] | None = None,
 ) -> FlowResultType:
     """Initialize the config flow."""
     if user_input is None:
@@ -86,12 +99,78 @@ async def test_flow(
 
 
 @pytest.mark.parametrize(
+    ("user_input", "expected_title", "expected_data"),
+    [
+        (
+            USER_INPUT_DEFAULT_CREDENTIALS,
+            "test",
+            CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS,
+        ),
+        (
+            USER_INPUT_DEFAULT_CREDENTIALS
+            | {
+                CONF_ACCESS_KEY_ID: "TestTestTestTestTest",
+                CONF_SECRET_ACCESS_KEY: "TestTestTestTestTestTestTestTestTestTest",
+            },
+            "test",
+            CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS,
+        ),
+    ],
+    ids=["without_keys", "keys_are_discarded"],
+)
+async def test_flow_default_credentials(
+    hass: HomeAssistant,
+    user_input: dict,
+    expected_title: str,
+    expected_data: dict,
+) -> None:
+    """Test config flow letting Boto3 resolve the credentials."""
+    result = await _async_start_flow(hass, user_input)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == expected_title
+    assert result["data"] == expected_data
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        {key: value for key, value in USER_INPUT.items() if key != CONF_ACCESS_KEY_ID},
+        {
+            key: value
+            for key, value in USER_INPUT.items()
+            if key != CONF_SECRET_ACCESS_KEY
+        },
+    ],
+    ids=["without_access_key_id", "without_secret_access_key"],
+)
+async def test_flow_missing_credentials(
+    hass: HomeAssistant,
+    user_input: dict,
+) -> None:
+    """Test config flow without keys and without using the default credentials."""
+    result = await _async_start_flow(hass, user_input)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "credentials_required"}
+
+    # Fix and finish the test
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        USER_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test"
+    assert result["data"] == CONFIG_ENTRY_DATA
+
+
+@pytest.mark.parametrize(
     ("exception", "errors"),
     [
         (
             ParamValidationError(report="Invalid bucket name"),
             {CONF_BUCKET: "invalid_bucket_name"},
         ),
+        (NoCredentialsError(), {"base": "invalid_credentials"}),
         (ValueError(), {CONF_ENDPOINT_URL: "invalid_endpoint_url"}),
         (
             EndpointConnectionError(endpoint_url="http://example.com"),

--- a/tests/components/aws_s3/test_init.py
+++ b/tests/components/aws_s3/test_init.py
@@ -5,14 +5,17 @@ from unittest.mock import AsyncMock, patch
 from botocore.exceptions import (
     ClientError,
     EndpointConnectionError,
+    NoCredentialsError,
     ParamValidationError,
 )
 import pytest
 
+from homeassistant.components.aws_s3.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
+from .const import CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS
 
 from tests.common import MockConfigEntry
 
@@ -59,6 +62,29 @@ async def test_setup_entry_create_client_errors(
     ):
         await setup_integration(hass, mock_config_entry)
         assert mock_config_entry.state is state
+
+
+async def test_load_config_entry_with_default_credentials(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+) -> None:
+    """Test loading an entry that has Boto3 resolve the credentials."""
+    entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS)
+    await setup_integration(hass, entry)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_setup_entry_no_credentials_found(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+) -> None:
+    """Test setup error when Boto3 cannot resolve any credentials."""
+    entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA_DEFAULT_CREDENTIALS)
+    mock_client.head_bucket.side_effect = NoCredentialsError()
+    await setup_integration(hass, entry)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_entry_head_bucket_error(


### PR DESCRIPTION
## Proposed change

The AWS S3 integration currently requires a static access key ID and secret access key. This adds a **Use default AWS credentials** option to the config flow: when enabled, neither key is passed to the Boto3 client, so botocore resolves credentials the usual way — environment variables, a shared credentials file, an EC2 instance profile (IMDS), or a container/task role.

Nothing credential-related is stored in the config entry in that mode, which means a Home Assistant instance running on AWS can back up to S3 without long-lived keys sitting on disk; access is granted (and revoked) purely through the attached role.

Details:

- `use_default_credentials` boolean added to the user step; the two key fields become optional.
- With the option off, the flow now explicitly rejects missing keys with a `credentials_required` error rather than relying on them being required by the schema.
- `NoCredentialsError` is caught in both the config flow and `async_setup_entry` — that is what botocore raises when the option is on and nothing in the chain yields credentials — and surfaces as the existing `invalid_credentials` error/`ConfigEntryError`. Its message was reworded to no longer name the access key pair specifically, since it now covers both modes.
- Existing entries are unaffected: the option is absent from their data and defaults to off, and it is only persisted when enabled.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47427
- Link to developer documentation pull request: 

No dependency was added or updated: the integration's `aiobotocore` requirement is unchanged, so the last checklist item about library version diffs does not apply.
- Link to frontend pull request: 

Opened as a draft: I would like a maintainer's take on the naming (`use_default_credentials`) before polishing, since the documentation PR uses the same wording. AI tooling was used while preparing this change; the author reviews and stands behind the code as submitted.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

