### PR TITLE
Migrate Tessie update platform to tesla-fleet-api

### DIFF
--- a/homeassistant/components/tessie/update.py
+++ b/homeassistant/components/tessie/update.py
@@ -2,8 +2,6 @@
 
 from typing import Any, override
 
-from tessie_api import schedule_software_update
-
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -104,7 +102,7 @@ class TessieUpdateEntity(TessieEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.run(schedule_software_update, in_seconds=0)
+        await self.run(self.api.tessie_schedule_software_update(in_seconds=0))
         self.set(
             ("vehicle_state_software_update_status", TessieUpdateStatus.INSTALLING)
         )

--- a/tests/components/tessie/test_update.py
+++ b/tests/components/tessie/test_update.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import UnsupportedVehicle
 
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
@@ -11,9 +13,10 @@ from homeassistant.components.update import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import ERROR_UNKNOWN, assert_entities, setup_platform
 
 
 async def test_updates(
@@ -28,7 +31,7 @@ async def test_updates(
     entity_id = "update.test_update"
 
     with patch(
-        "homeassistant.components.tessie.update.schedule_software_update"
+        "tesla_fleet_api.tessie.Vehicle.tessie_schedule_software_update"
     ) as mock_update:
         await hass.services.async_call(
             UPDATE_DOMAIN,
@@ -41,3 +44,47 @@ async def test_updates(
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_IN_PROGRESS) == 1
+
+
+async def test_update_error(hass: HomeAssistant) -> None:
+    """Test update transport errors are translated."""
+
+    await setup_platform(hass, [Platform.UPDATE])
+
+    with (
+        patch(
+            "tesla_fleet_api.tessie.Vehicle.tessie_schedule_software_update",
+            side_effect=ERROR_UNKNOWN,
+        ) as mock_update,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: ["update.test_update"]},
+            blocking=True,
+        )
+
+    mock_update.assert_called_once()
+    assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"
+
+    with (
+        patch(
+            "tesla_fleet_api.tessie.Vehicle.tessie_schedule_software_update",
+            side_effect=UnsupportedVehicle,
+        ) as mock_update,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: ["update.test_update"]},
+            blocking=True,
+        )
+
+    mock_update.assert_called_once()
+    assert isinstance(error.value.__cause__, UnsupportedVehicle)
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "command_failed"

--- a/tests/components/tessie/test_update.py
+++ b/tests/components/tessie/test_update.py
@@ -73,7 +73,7 @@ async def test_update_error(hass: HomeAssistant) -> None:
     with (
         patch(
             "tesla_fleet_api.tessie.Vehicle.tessie_schedule_software_update",
-            side_effect=UnsupportedVehicle,
+            side_effect=UnsupportedVehicle(),
         ) as mock_update,
         pytest.raises(HomeAssistantError) as error,
     ):


### PR DESCRIPTION
## Proposed change

First step of moving the Tessie integration onto `tesla-fleet-api`, one platform at a time. `update` is the smallest platform still calling the legacy `tessie-api` library, so it goes first to settle the migration pattern before the larger platforms follow.

The install action now calls `TessieVehicle.tessie_schedule_software_update` via the awaitable branch of `TessieEntity.run`, so failures surface as translated `HomeAssistantError`s through `handle_command` (`cannot_connect` for transport errors, `command_failed` carrying the library's message) — matching the other platforms already on `tesla-fleet-api`. The legacy `tessie-api` pin and `handle_legacy_command` stay until no platform imports `tessie_api`.

Tests move with the platform and cover both error paths.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
