### PR TITLE
Split user flow init and data submission in wolflink config flow tests

### DIFF
--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -26,6 +26,15 @@ DEVICE = Device(1234, 5678, "test-device")
 SECOND_DEVICE = Device(5678, 9999, "second-device")
 
 
+async def _start_user_flow(hass: HomeAssistant) -> dict:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    return result
+
+
 async def test_show_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -37,11 +46,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
 
 async def test_create_entry(hass: HomeAssistant) -> None:
     """Test entry creation only stores credentials, not the device list."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    result = await _start_user_flow(hass)
 
     with (
         patch(
@@ -72,11 +77,7 @@ async def test_user_flow_errors(
     hass: HomeAssistant, side_effect: Exception, expected_error: str
 ) -> None:
     """Test error handling in the user step keeps the form open with errors."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    result = await _start_user_flow(hass)
 
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -92,11 +93,7 @@ async def test_user_flow_errors(
 
 async def test_no_devices_abort(hass: HomeAssistant) -> None:
     """Test we abort if the account has no devices."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    result = await _start_user_flow(hass)
 
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -116,11 +113,7 @@ async def test_already_configured_aborts(
     """Test entries with the same username can't be configured twice."""
     mock_config_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    result = await _start_user_flow(hass)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=INPUT_CONFIG

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -37,6 +37,12 @@ async def test_show_form(hass: HomeAssistant) -> None:
 
 async def test_create_entry(hass: HomeAssistant) -> None:
     """Test entry creation only stores credentials, not the device list."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
     with (
         patch(
             "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -44,8 +50,8 @@ async def test_create_entry(hass: HomeAssistant) -> None:
         ),
         patch("homeassistant.components.wolflink.async_setup_entry", return_value=True),
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=INPUT_CONFIG
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=INPUT_CONFIG
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -66,12 +72,18 @@ async def test_user_flow_errors(
     hass: HomeAssistant, side_effect: Exception, expected_error: str
 ) -> None:
     """Test error handling in the user step keeps the form open with errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
         side_effect=side_effect,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=INPUT_CONFIG
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=INPUT_CONFIG
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -80,12 +92,18 @@ async def test_user_flow_errors(
 
 async def test_no_devices_abort(hass: HomeAssistant) -> None:
     """Test we abort if the account has no devices."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
         return_value=[],
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=INPUT_CONFIG
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=INPUT_CONFIG
         )
 
     assert result["type"] is FlowResultType.ABORT
@@ -99,7 +117,13 @@ async def test_already_configured_aborts(
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=INPUT_CONFIG
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=INPUT_CONFIG
     )
 
     assert result["type"] is FlowResultType.ABORT


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `wolflink` config flow tests were passing `data=` directly to `async_init`, which doesn't reflect real user interaction. A user first opens the flow (seeing the form), then submits it. Each affected test is updated to:

1. Call `async_init` without `data=` and assert the form is shown
2. Submit input via a follow-up `async_configure` call

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178989
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr