### PR TITLE
Add static mapping functionality to Home Connect's select program entities 

### DIFF
--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -73,24 +73,28 @@ AMBIENT_LIGHT_COLOR_TEMPERATURE_ENUM = {
     },
 }
 
-STATIC_PROGRAM_KEY_MAPPINGS = [
-    {
-        PROGRAMS_TRANSLATION_KEYS_MAP[translation_key]
-        for translation_key in static_mapping_key
-    }
-    for static_mapping_key in (
+STATIC_PROGRAM_KEY_MAPPINGS = {
+    translated_program_key: translated_static_mapping_group
+    for translated_static_mapping_group in (
         {
-            ProgramKey.COOKING_OVEN_HEATING_MODE_HOT_AIR,
-            ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR,
-            ProgramKey.COOKING_OVEN_HEATING_MODE_2_D_HOT_AIR,
-        },
-        {
-            ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN,
-            # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_DRUM_CLEAN,
-            # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_70_DRUM_CLEAN_70,
-        },
+            PROGRAMS_TRANSLATION_KEYS_MAP[program_key]
+            for program_key in static_mapping_group
+        }
+        for static_mapping_group in (
+            {
+                ProgramKey.COOKING_OVEN_HEATING_MODE_HOT_AIR,
+                ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR,
+                ProgramKey.COOKING_OVEN_HEATING_MODE_2_D_HOT_AIR,
+            },
+            {
+                ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN,
+                # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_DRUM_CLEAN,
+                # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_70_DRUM_CLEAN_70,
+            },
+        )
     )
-]
+    for translated_program_key in translated_static_mapping_group
+}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -474,26 +478,24 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
 
         if not hasattr(self, "_attr_options"):
             self.set_options()
+        # If the current option is not in the options, maybe it is
+        # a key that is in one of the static mapping groups.
         if (
             self._attr_current_option is not None
             and self._attr_current_option not in self._attr_options
+            and (
+                static_mapping_group := STATIC_PROGRAM_KEY_MAPPINGS.get(
+                    self._attr_current_option
+                )
+            )
         ):
-            # If the current option is not in the options, maybe it is
-            # a key that is in one of the static mapping groups.
-            for static_mapping_group in STATIC_PROGRAM_KEY_MAPPINGS:
-                if self._attr_current_option in static_mapping_group:
-                    # If the current option is in a static mapping group,
-                    # set the current option to the one that it is also
-                    # in the entity options.
-                    self._attr_current_option = next(
-                        (
-                            key
-                            for key in static_mapping_group
-                            if key in self._attr_options
-                        ),
-                        None,
-                    )
-                    break
+            # If the current option is in a static mapping group,
+            # set the current option to the one that it is also
+            # in the entity options.
+            self._attr_current_option = next(
+                (key for key in static_mapping_group if key in self._attr_options),
+                None,
+            )
 
     @override
     async def async_select_option(self, option: str) -> None:

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -73,6 +73,25 @@ AMBIENT_LIGHT_COLOR_TEMPERATURE_ENUM = {
     },
 }
 
+STATIC_PROGRAM_KEY_MAPPINGS = [
+    {
+        PROGRAMS_TRANSLATION_KEYS_MAP[translation_key]
+        for translation_key in static_mapping_key
+    }
+    for static_mapping_key in (
+        {
+            ProgramKey.COOKING_OVEN_HEATING_MODE_HOT_AIR,
+            ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR,
+            ProgramKey.COOKING_OVEN_HEATING_MODE_2_D_HOT_AIR,
+        },
+        {
+            ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN,
+            # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_DRUM_CLEAN,
+            # ProgramKey.LAUNDRY_CARE_WASHER_DRUM_CLEAN_70_DRUM_CLEAN_70,
+        },
+    )
+]
+
 
 @dataclass(frozen=True, kw_only=True)
 class HomeConnectProgramSelectEntityDescription(
@@ -399,7 +418,6 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
             appliance_coordinator,
             desc,
         )
-        self.set_options()
 
     def set_options(self) -> None:
         """Set the options for the entity."""
@@ -453,6 +471,29 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
         self._attr_current_option = (
             PROGRAMS_TRANSLATION_KEYS_MAP.get(program_key) if program_key else None
         )
+
+        if not hasattr(self, "_attr_options"):
+            self.set_options()
+        if (
+            self._attr_current_option is not None
+            and self._attr_current_option not in self._attr_options
+        ):
+            # If the current option is not in the options, maybe it is
+            # a key that is in one of the static mapping groups.
+            for static_mapping_group in STATIC_PROGRAM_KEY_MAPPINGS:
+                if self._attr_current_option in static_mapping_group:
+                    # If the current option is in a static mapping group,
+                    # set the current option to the one that it is also
+                    # in the entity options.
+                    self._attr_current_option = next(
+                        (
+                            key
+                            for key in static_mapping_group
+                            if key in self._attr_options
+                        ),
+                        None,
+                    )
+                    break
 
     @override
     async def async_select_option(self, option: str) -> None:

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -37,7 +37,10 @@ from aiohomeconnect.model.program import (
 from aiohomeconnect.model.setting import SettingConstraints
 import pytest
 
-from homeassistant.components.home_connect.const import DOMAIN
+from homeassistant.components.home_connect.const import (
+    DOMAIN,
+    PROGRAMS_TRANSLATION_KEYS_MAP,
+)
 from homeassistant.components.select import (
     ATTR_OPTION,
     ATTR_OPTIONS,
@@ -419,6 +422,60 @@ async def test_select_program_functionality(
     )
     await hass.async_block_till_done()
     assert hass.states.is_state(entity_id, STATE_UNKNOWN)
+
+
+@pytest.mark.parametrize("appliance", ["Oven"], indirect=True)
+async def test_select_program_static_mapping(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+) -> None:
+    """Test the static mapping functionality at select program entities.
+
+    HotAir program is an option given by the API, but the API sends
+    a 3DHotAir which is not in the given options, but as stated by
+    Home Connect team, they are equivalent.
+    """
+    entity_id = "select.oven_active_program"
+    expected_program = "cooking_oven_program_heating_mode_hot_air"
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state != expected_program
+    options = state.attributes[ATTR_OPTIONS]
+    assert expected_program in options
+    assert (
+        PROGRAMS_TRANSLATION_KEYS_MAP[ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR]
+        not in options
+    )
+
+    await client.add_events(
+        [
+            EventMessage(
+                appliance.ha_id,
+                EventType.NOTIFY,
+                ArrayOfEvents(
+                    [
+                        Event(
+                            key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+                            raw_key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR,
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+    await hass.async_block_till_done()
+    assert hass.states.is_state(entity_id, expected_program)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Home Connect API sometimes sends program values that aren't on the program list, after speaking with the team, they mentioned that there are keys that are equivalent to others and that we should always use the one from the lists of available programs.

With that said, this PR, when the received program is not on the list, search if it belongs to one of the static mapping groups, and then tries to find the key that is equivalent and in the static mapping group.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175598
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
