### PR TITLE
Make URLs in GeoSphere Austria Warnings more specific

### DIFF
--- a/homeassistant/components/geosphere_austria_warnings/coordinator.py
+++ b/homeassistant/components/geosphere_austria_warnings/coordinator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import override
 
+from propcache.api import cached_property
 from pygeosphere_warnings import (
     GeoSphereApiError,
     GeoSphereConnectionError,
@@ -21,7 +22,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, WARNINGS_URL
 
 # Warnings are event driven and updated by GeoSphere Austria as needed.
 # The cheap HEAD precheck keeps the cost of a poll low, so a relatively
@@ -55,6 +56,17 @@ class GeoSphereUpdateCoordinator(DataUpdateCoordinator[GeoSphereData]):
         )
         self.client = GeoSphereWarningsClient(async_get_clientsession(hass))
         self._last_modified: datetime | None = None
+
+    @cached_property
+    def warnings_portal_url(self) -> str:
+        """Returns the URL to the configured municipality's details page on the warnings portal."""
+        longitude = self.config_entry.data[CONF_LONGITUDE]
+        latitude = self.config_entry.data[CONF_LATITUDE]
+        return (
+            WARNINGS_URL
+            # codespell:ignore-next-line alle
+            + f"wsapp/de/alle/gesamterzeitraum/0/{longitude:.5f},{latitude:.5f}"
+        )
 
     @override
     async def _async_update_data(self) -> GeoSphereData:

--- a/homeassistant/components/geosphere_austria_warnings/entity.py
+++ b/homeassistant/components/geosphere_austria_warnings/entity.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN, MANUFACTURER, WARNINGS_URL
+from .const import ATTRIBUTION, DOMAIN, MANUFACTURER
 from .coordinator import GeoSphereUpdateCoordinator
 
 
@@ -29,5 +29,5 @@ class GeoSphereEntity(CoordinatorEntity[GeoSphereUpdateCoordinator]):
             name=municipality.name,
             manufacturer=MANUFACTURER,
             entry_type=DeviceEntryType.SERVICE,
-            configuration_url=WARNINGS_URL,
+            configuration_url=coordinator.warnings_portal_url,
         )

--- a/tests/components/geosphere_austria_warnings/snapshots/test_sensor.ambr
+++ b/tests/components/geosphere_austria_warnings/snapshots/test_sensor.ambr
@@ -1,4 +1,34 @@
 # serializer version: 1
+# name: test_sensors.4
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': 'https://warnungen.zamg.at/wsapp/de/alle/gesamterzeitraum/0/16.35640,48.24860',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'geosphere_austria_warnings',
+        '30740',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'GeoSphere Austria',
+    'model': None,
+    'model_id': None,
+    'name': 'Schwechat',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_sensors[sensor.schwechat_active_warnings-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/geosphere_austria_warnings/test_sensor.py
+++ b/tests/components/geosphere_austria_warnings/test_sensor.py
@@ -7,12 +7,13 @@ from pygeosphere_warnings import GeoSphereConnectionError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.geosphere_austria_warnings.const import DOMAIN
 from homeassistant.components.geosphere_austria_warnings.coordinator import (
     UPDATE_INTERVAL,
 )
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
 
@@ -28,12 +29,19 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the state of the sensors while a warning is active."""
     await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "30740"), mock_config_entry.entry_id
+    )
+    assert device_entry
+    assert device_entry == snapshot
 
 
 @pytest.mark.freeze_time("2023-03-27 20:00:00+00:00")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The "Visit" link in GeoSphere Austria Warnings devices just pointed to the generic warnings page rather than to the specific geographic area the device was configured for.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [N/A] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [N/A] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [N/A] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [N/A] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [N/A] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
