### PR TITLE
Reauthenticate Netatmo when granted token scopes are incomplete

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetatmoConfigEntry) -> b
     required_scopes = set(api.get_api_scopes(entry.data["auth_implementation"]))
     raw_token_scopes = session.token["scope"]
     token_scopes = (
-        set(raw_token_scopes.split(" "))
+        set(raw_token_scopes.split())
         if isinstance(raw_token_scopes, str)
         else set(raw_token_scopes)
     )

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -70,13 +70,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetatmoConfigEntry) -> b
     except (OAuth2TokenRequestError, ClientError) as ex:
         raise ConfigEntryNotReady from ex
 
-    required_scopes = api.get_api_scopes(entry.data["auth_implementation"])
-    if not (set(session.token["scope"]) & set(required_scopes)):
-        _LOGGER.warning(
-            "Session is missing scopes: %s",
-            set(required_scopes) - set(session.token["scope"]),
-        )
+    required_scopes = set(api.get_api_scopes(entry.data["auth_implementation"]))
+    raw_token_scopes = session.token["scope"]
+    token_scopes = (
+        set(raw_token_scopes.split(" "))
+        if isinstance(raw_token_scopes, str)
+        else set(raw_token_scopes)
+    )
+    if not (token_scopes & required_scopes):
+        _LOGGER.warning("Session is missing scopes: %s", required_scopes - token_scopes)
         raise ConfigEntryAuthFailed("Token scope not valid, trigger renewal")
+
+    # Some, but not all, required scopes are granted: the token still works,
+    # so let setup succeed and only prompt for reauth to fill the gap.
+    # async_start_reauth is a no-op while a reauth/reconfigure flow is
+    # already in progress for this entry, so this does not spam duplicate
+    # flows across reloads within one run. It intentionally does not persist
+    # a "already prompted" marker either: a config flow does not survive a
+    # restart, and neither should our record of having started one, or a
+    # dismissed prompt would silently never come back.
+    if missing_scopes := required_scopes - token_scopes:
+        _LOGGER.warning(
+            "Session is missing scopes: %s; requesting reauthentication to grant them",
+            missing_scopes,
+        )
+        entry.async_start_reauth(hass)
 
     auth = api.AsyncConfigEntryNetatmoAuth(
         aiohttp_client.async_get_clientsession(hass), session

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -78,7 +78,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetatmoConfigEntry) -> b
         else set(raw_token_scopes)
     )
     if not (token_scopes & required_scopes):
-        _LOGGER.warning("Session is missing scopes: %s", required_scopes - token_scopes)
+        _LOGGER.warning(
+            "Session is missing scopes: %s", sorted(required_scopes - token_scopes)
+        )
         raise ConfigEntryAuthFailed("Token scope not valid, trigger renewal")
 
     # Some, but not all, required scopes are granted: the token still works,
@@ -92,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetatmoConfigEntry) -> b
     if missing_scopes := required_scopes - token_scopes:
         _LOGGER.warning(
             "Session is missing scopes: %s; requesting reauthentication to grant them",
-            missing_scopes,
+            sorted(missing_scopes),
         )
         entry.async_start_reauth(hass)
 

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -500,7 +500,7 @@ async def test_setup_component_string_token_scope_missing_some(
     setup succeeds and a reauth flow is started to fill the gap.
     """
     config_entry = MockConfigEntry(
-        domain="netatmo",
+        domain=DOMAIN,
         data={
             "auth_implementation": "cloud",
             "token": {
@@ -543,7 +543,7 @@ async def test_setup_component_string_token_scope_missing_some(
     # Test a reauth flow is initiated to fill the scope gap
     assert len(list(config_entry.async_get_active_flows(hass, {"reauth"}))) == 1
 
-    for config_entry in hass.config_entries.async_entries("netatmo"):
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
         await hass.config_entries.async_remove(config_entry.entry_id)
 
 
@@ -557,7 +557,7 @@ async def test_setup_component_string_token_scope_no_overlap(
     for the string form.
     """
     config_entry = MockConfigEntry(
-        domain="netatmo",
+        domain=DOMAIN,
         data={
             "auth_implementation": "cloud",
             "token": {
@@ -588,7 +588,7 @@ async def test_setup_component_string_token_scope_no_overlap(
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
-    for config_entry in hass.config_entries.async_entries("netatmo"):
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
         await hass.config_entries.async_remove(config_entry.entry_id)
 
 

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -488,8 +488,17 @@ async def test_setup_component_with_delay(
         mock_dropwebhook.assert_called_once()
 
 
-async def test_setup_component_invalid_token_scope(hass: HomeAssistant) -> None:
-    """Test handling of invalid token scope."""
+async def test_setup_component_string_token_scope_missing_some(
+    hass: HomeAssistant,
+) -> None:
+    """Test a space-separated string token scope with too few scopes.
+
+    The OAuth2 standard represents `scope` as a single space-separated
+    string rather than a list; Netatmo's real API sends a list, but the
+    string form must still be parsed correctly rather than iterated
+    character by character. This grant overlaps the required scopes, so
+    setup succeeds and a reauth flow is started to fill the gap.
+    """
     config_entry = MockConfigEntry(
         domain="netatmo",
         data={
@@ -514,9 +523,7 @@ async def test_setup_component_invalid_token_scope(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.netatmo.async_get_config_entry_implementation",
         ) as mock_impl,
-        patch(
-            "homeassistant.components.netatmo.webhook.webhook_generate_url"
-        ) as mock_webhook,
+        patch("homeassistant.components.netatmo.webhook.webhook_generate_url"),
     ):
         mock_auth.return_value.async_post_api_request.side_effect = partial(
             fake_post_request, hass
@@ -527,18 +534,149 @@ async def test_setup_component_invalid_token_scope(hass: HomeAssistant) -> None:
 
     await hass.async_block_till_done()
 
-    mock_auth.assert_not_called()
+    mock_auth.assert_called_once()
     mock_impl.assert_called_once()
-    mock_webhook.assert_not_called()
 
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.LOADED
     assert hass.config_entries.async_entries(DOMAIN)
 
-    # Test a reauth flow is initiated
+    # Test a reauth flow is initiated to fill the scope gap
     assert len(list(config_entry.async_get_active_flows(hass, {"reauth"}))) == 1
 
     for config_entry in hass.config_entries.async_entries("netatmo"):
         await hass.config_entries.async_remove(config_entry.entry_id)
+
+
+async def test_setup_component_string_token_scope_no_overlap(
+    hass: HomeAssistant,
+) -> None:
+    """Test a space-separated string token scope sharing no required scope.
+
+    Parsed character by character, any string would overlap the required
+    scopes and reach the partial-grant path, so this pins the hard failure
+    for the string form.
+    """
+    config_entry = MockConfigEntry(
+        domain="netatmo",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+                "expires_at": time() + 1000,
+                "scope": "read_nothing write_nothing",
+            },
+        },
+        options={},
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
+        ),
+        patch(
+            "homeassistant.components.netatmo.async_get_config_entry_implementation",
+        ),
+        patch("homeassistant.components.netatmo.webhook.webhook_generate_url"),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    for config_entry in hass.config_entries.async_entries("netatmo"):
+        await hass.config_entries.async_remove(config_entry.entry_id)
+
+
+async def test_setup_component_missing_optional_scopes(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test setup succeeds and starts a reauth flow for missing scopes.
+
+    A partial scope grant (some but not all requested scopes approved) must
+    not block setup - some Netatmo apps never get every requested scope
+    approved, so a strict full-coverage check would put a legitimately
+    reduced grant into a permanent reauth loop. Instead, setup succeeds
+    with the reduced grant and a reauth flow is started automatically so
+    the account can be re-linked to pick up the missing scopes.
+    """
+    token_scopes = sorted(set(ALL_SCOPES) - {"read_station"})
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            "token": {**config_entry.data["token"], "scope": token_scopes},
+        },
+    )
+
+    with selected_platforms([Platform.COVER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    active_flows = list(config_entry.async_get_active_flows(hass, {"reauth"}))
+    assert len(active_flows) == 1
+
+    # Dismiss the flow, as if the user closed it without completing it.
+    hass.config_entries.flow.async_abort(active_flows[0]["flow_id"])
+
+    # Re-linking with the full scope grant does not start another reauth flow.
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            "token": {**config_entry.data["token"], "scope": ALL_SCOPES},
+        },
+    )
+    with selected_platforms([Platform.COVER]):
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert not list(config_entry.async_get_active_flows(hass, {"reauth"}))
+
+
+async def test_setup_component_missing_optional_scopes_reauth_not_duplicated(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+) -> None:
+    """Test that an unresolved scope gap does not duplicate the reauth flow.
+
+    entry.async_start_reauth is a no-op while a matching reauth flow is
+    already in progress for the entry. A reload with the same reduced grant,
+    while that first flow is still open, must not spawn a second one
+    alongside it.
+    """
+    token_scopes = sorted(set(ALL_SCOPES) - {"read_station"})
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            "token": {**config_entry.data["token"], "scope": token_scopes},
+        },
+    )
+
+    with selected_platforms([Platform.COVER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert len(list(config_entry.async_get_active_flows(hass, {"reauth"}))) == 1
+
+    # Reload with the same reduced grant and the first flow still open.
+    with selected_platforms([Platform.COVER]):
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert len(list(config_entry.async_get_active_flows(hass, {"reauth"}))) == 1
 
 
 async def test_setup_component_invalid_token(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Netatmo config entry setup checks the granted OAuth token scopes against
the scopes the integration requests, but only ever checked for *some*
overlap. A token granted before a scope was added to the integration stayed
silently degraded forever: setup succeeded, but the account was never
re-linked to pick up the new scope.

This adds a proper comparison: if none of the required scopes are granted,
setup fails with `ConfigEntryAuthFailed` as before. If some are granted but
others are missing, setup still succeeds with the reduced grant, and a
reauth flow is started so the user can re-link the account.
`entry.async_start_reauth` is a no-op while a matching flow is already in
progress for the entry, so this does not spawn duplicate flows across
reloads within one run. No "already prompted" marker is persisted beyond
that: a config flow does not survive a restart, and neither does our
record of having started one, or a dismissed prompt would silently never
come back.

This also fixes a latent bug in the same scope comparison: the granted
scopes returned by the token can be a space-separated string, and the old
code built a set from it directly, which iterates the string character by
character instead of splitting on scope names.

Covered by new unit tests for the no-overlap, partial-overlap and
not-duplicated-while-in-progress cases. Also verified end-to-end against my
own Netatmo cloud-linked account on a live instance: removing a granted
scope from the stored token and restarting starts a reauth flow, and
restarting again without completing it starts the flow again rather than
staying silent. Completing the reauth flow itself was not exercised live.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: none
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
