### PR TITLE
Add Advanced Price Forecast attributes to Amber Electric forecast sensor

### DIFF
--- a/homeassistant/components/amberelectric/sensor.py
+++ b/homeassistant/components/amberelectric/sensor.py
@@ -155,6 +155,19 @@ class AmberForecastSensor(AmberSensor):
                 datum["range_min"] = format_cents_to_dollars(interval.range.min)
                 datum["range_max"] = format_cents_to_dollars(interval.range.max)
 
+            if interval.advanced_price is not None:
+                multiplier = -1 if interval.channel_type == ChannelType.FEEDIN else 1
+                datum["advanced_price_low"] = multiplier * format_cents_to_dollars(
+                    interval.advanced_price.low
+                )
+                datum["advanced_price_predicted"] = (
+                    multiplier
+                    * format_cents_to_dollars(interval.advanced_price.predicted)
+                )
+                datum["advanced_price_high"] = multiplier * format_cents_to_dollars(
+                    interval.advanced_price.high
+                )
+
             data["forecasts"].append(datum)
 
         return data

--- a/tests/components/amberelectric/test_sensor.py
+++ b/tests/components/amberelectric/test_sensor.py
@@ -144,6 +144,21 @@ async def test_general_forecast_sensor_with_range(
     assert first_forecast.get("range_max") == 0.09
 
 
+@pytest.mark.usefixtures("mock_amber_client_general_forecasts")
+async def test_general_forecast_sensor_with_advanced_price(
+    hass: HomeAssistant, general_channel_config_entry: MockConfigEntry
+) -> None:
+    """Test the General Forecast sensor with an advanced price."""
+    await setup_integration(hass, general_channel_config_entry)
+    price = hass.states.get("sensor.mock_title_general_forecast")
+    assert price
+    attributes = price.attributes
+    first_forecast = attributes["forecasts"][0]
+    assert first_forecast.get("advanced_price_low") == 0.07
+    assert first_forecast.get("advanced_price_predicted") == 0.09
+    assert first_forecast.get("advanced_price_high") == 0.1
+
+
 @pytest.mark.usefixtures("mock_amber_client_general_and_controlled_load")
 async def test_controlled_load_forecast_sensor(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Amber Electric's Python client library (`amberelectric==2.0.12`, already the pinned version in this integration's `manifest.json`) exposes an `advanced_price` field (`low`/`predicted`/`high`, in c/kWh) on forecast interval objects. This is Amber's [Advanced Price Forecast](https://help.amber.com.au/hc/en-us/articles/28605992738445-How-Amber-s-Advanced-Price-Forecasts-work) feature.

The `amberelectric.get_forecasts` service action (`services.py`) already exposed these fields in its response, but the `AmberForecastSensor` entity's `extra_state_attributes` did not. This change adds the same `advanced_price_low`, `advanced_price_predicted`, and `advanced_price_high` attributes (per forecast interval, inside the `forecasts` list attribute) to the sensor entity, mirroring the exact pattern already used in `services.py` `get_forecasts()`, including the feed-in sign-flip via `multiplier`.

A test was added (`test_general_forecast_sensor_with_advanced_price`) using the existing `mock_amber_client_general_forecasts` fixture, which already had `advanced_price=True` test data prepared but previously unused by any sensor test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
