### PR TITLE
Refactor MELCloud Home test asserts

### DIFF
--- a/tests/components/melcloud_home/test_climate.py
+++ b/tests/components/melcloud_home/test_climate.py
@@ -127,8 +127,7 @@ async def test_ata_hvac_modes(
 
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get(ATA_ENTITY_ID)
-    assert state is not None
+    assert (state := hass.states.get(ATA_ENTITY_ID))
     assert state.attributes["hvac_modes"] == expected_hvac_modes
 
 
@@ -469,8 +468,7 @@ async def test_ata_temperature_range_by_mode(
 
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get(ATA_ENTITY_ID)
-    assert state is not None
+    assert (state := hass.states.get(ATA_ENTITY_ID))
     assert state.attributes["min_temp"] == expected_min
     assert state.attributes["max_temp"] == expected_max
 
@@ -489,8 +487,7 @@ async def test_ata_no_capabilities_temperature_range(
 
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get(ATA_ENTITY_ID)
-    assert state is not None
+    assert (state := hass.states.get(ATA_ENTITY_ID))
     assert state.attributes["min_temp"] == 7
     assert state.attributes["max_temp"] == 35
     assert HVACMode.FAN_ONLY in state.attributes["hvac_modes"]
@@ -517,12 +514,10 @@ async def test_atw_zone_temperature_range(
 
     await setup_integration(hass, mock_config_entry)
 
-    state1 = hass.states.get(ATW_ZONE1_ENTITY_ID)
-    assert state1 is not None
+    assert (state1 := hass.states.get(ATW_ZONE1_ENTITY_ID))
     assert state1.attributes["min_temp"] == 10.0
     assert state1.attributes["max_temp"] == 30.0
 
-    state2 = hass.states.get(ATW_ZONE2_ENTITY_ID)
-    assert state2 is not None
+    assert (state2 := hass.states.get(ATW_ZONE2_ENTITY_ID))
     assert state2.attributes["min_temp"] == 12.0
     assert state2.attributes["max_temp"] == 28.0

--- a/tests/components/melcloud_home/test_init.py
+++ b/tests/components/melcloud_home/test_init.py
@@ -295,10 +295,16 @@ async def test_energy_coordinator_context_fetch_failure(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    energy_sensor = hass.states.get("sensor.living_room_ac_energy_consumed_monthly")
-    assert energy_sensor is not None
+    assert (
+        energy_sensor := hass.states.get(
+            "sensor.living_room_ac_energy_consumed_monthly"
+        )
+    )
     assert energy_sensor.state == STATE_UNAVAILABLE
 
-    room_temperature_sensor = hass.states.get("sensor.living_room_ac_room_temperature")
-    assert room_temperature_sensor is not None
+    assert (
+        room_temperature_sensor := hass.states.get(
+            "sensor.living_room_ac_room_temperature"
+        )
+    )
     assert room_temperature_sensor.state != STATE_UNAVAILABLE


### PR DESCRIPTION
Match the assert (state := hass.states.get(...)) style used elsewhere for the hass.states.get() lookups in test_climate.py and test_init.py.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
