### PR TITLE
Remove deprecated Flexit fireplace switch

### DIFF
--- a/homeassistant/components/flexit_bacnet/icons.json
+++ b/homeassistant/components/flexit_bacnet/icons.json
@@ -59,12 +59,6 @@
         "state": {
           "off": "mdi:radiator-off"
         }
-      },
-      "fireplace_mode": {
-        "default": "mdi:fireplace",
-        "state": {
-          "off": "mdi:fireplace-off"
-        }
       }
     }
   }

--- a/homeassistant/components/flexit_bacnet/strings.json
+++ b/homeassistant/components/flexit_bacnet/strings.json
@@ -126,9 +126,6 @@
       },
       "electric_heater": {
         "name": "Electric heater"
-      },
-      "fireplace_mode": {
-        "name": "Fireplace mode"
       }
     }
   },
@@ -150,12 +147,6 @@
     },
     "switch_turn": {
       "message": "Failed to turn the switch {state}."
-    }
-  },
-  "issues": {
-    "deprecated_fireplace_switch": {
-      "description": "The fireplace mode switch entity `{entity_id}` is deprecated and will be removed in Home Assistant 2026.9.\n\nFireplace mode has been moved to a climate preset on the climate entity to better match the device interface.\n\nPlease update your automations to use the `climate.set_preset_mode` action with preset mode `fireplace` instead of using the switch entity.\n\nAfter updating your automations, you can safely disable this switch entity.",
-      "title": "Fireplace mode switch is deprecated"
     }
   }
 }

--- a/homeassistant/components/flexit_bacnet/switch.py
+++ b/homeassistant/components/flexit_bacnet/switch.py
@@ -13,12 +13,9 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DOMAIN
 from .coordinator import FlexitConfigEntry, FlexitCoordinator
@@ -49,13 +46,6 @@ SWITCHES: tuple[FlexitSwitchEntityDescription, ...] = (
         turn_on_fn=lambda data: data.activate_cooker_hood(),
         turn_off_fn=lambda data: data.deactivate_cooker_hood(),
     ),
-    FlexitSwitchEntityDescription(
-        key="fireplace_mode",
-        translation_key="fireplace_mode",
-        is_on_fn=lambda data: data.fireplace_ventilation_status,
-        turn_on_fn=lambda data: data.trigger_fireplace_mode(),
-        turn_off_fn=lambda data: data.trigger_fireplace_mode(),
-    ),
 )
 
 
@@ -67,43 +57,9 @@ async def async_setup_entry(
     """Set up Flexit (bacnet) switch from a config entry."""
     coordinator = config_entry.runtime_data
 
-    entities: list[FlexitSwitch] = []
-    for description in SWITCHES:
-        if description.key == "fireplace_mode":
-            # Check if deprecated fireplace switch is enabled and create repair issue
-            entity_reg = er.async_get(hass)
-            fireplace_switch_unique_id = (
-                f"{coordinator.device.serial_number}-fireplace_mode"
-            )
-            # Look up the fireplace switch entity by unique_id
-            fireplace_switch_entity_id = entity_reg.async_get_entity_id(
-                Platform.SWITCH, DOMAIN, fireplace_switch_unique_id
-            )
-            if not fireplace_switch_entity_id:
-                continue
-            entity_registry_entry = entity_reg.async_get(fireplace_switch_entity_id)
-
-            if entity_registry_entry:
-                if entity_registry_entry.disabled:
-                    entity_reg.async_remove(fireplace_switch_entity_id)
-                else:
-                    async_create_issue(
-                        hass,
-                        DOMAIN,
-                        f"deprecated_switch_{fireplace_switch_unique_id}",
-                        breaks_in_ha_version="2026.9.0",
-                        is_fixable=False,
-                        issue_domain=DOMAIN,
-                        severity=IssueSeverity.WARNING,
-                        translation_key="deprecated_fireplace_switch",
-                        translation_placeholders={
-                            "entity_id": fireplace_switch_entity_id,
-                        },
-                    )
-                    entities.append(FlexitSwitch(coordinator, description))
-        else:
-            entities.append(FlexitSwitch(coordinator, description))
-    async_add_entities(entities)
+    async_add_entities(
+        FlexitSwitch(coordinator, description) for description in SWITCHES
+    )
 
 
 PARALLEL_UPDATES = 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The deprecated Fireplace mode switch entity has been removed. Automations and scripts that use `switch.<device>_fireplace_mode` must instead use the `climate.set_preset_mode` action on the Flexit climate entity with `preset_mode: fireplace`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the scheduled Flexit BACnet Fireplace mode switch deprecation. Fireplace mode remains available as a climate preset. This also removes the obsolete repair issue, translation, and icon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47442
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating your PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests.
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr