### PR TITLE
Name the panel owner when a url path collides

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -382,7 +382,7 @@ def async_register_built_in_panel(
 
     panels = hass.data.setdefault(DATA_PANELS, {})
 
-    if not update and (existing := panels.get(panel.frontend_url_path)):
+    if not update and (existing := panels.get(panel.frontend_url_path)) is not None:
         raise ValueError(
             f"Overwriting panel {panel.frontend_url_path} owned by"
             f" {existing.component_name}"

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -382,8 +382,11 @@ def async_register_built_in_panel(
 
     panels = hass.data.setdefault(DATA_PANELS, {})
 
-    if not update and panel.frontend_url_path in panels:
-        raise ValueError(f"Overwriting panel {panel.frontend_url_path}")
+    if not update and (existing := panels.get(panel.frontend_url_path)):
+        raise ValueError(
+            f"Overwriting panel {panel.frontend_url_path} owned by"
+            f" {existing.component_name}"
+        )
 
     panels[panel.frontend_url_path] = panel
 

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -20,6 +20,7 @@ from homeassistant.components.frontend import (
     CONF_GITHUB_TOKEN,
     CONF_THEMES,
     CONFIG_SCHEMA,
+    DATA_PANELS,
     DEFAULT_THEME_COLOR,
     DOMAIN,
     EVENT_PANELS_UPDATED,
@@ -756,6 +757,23 @@ async def test_async_panel_exists(hass: HomeAssistant) -> None:
 
     async_remove_panel(hass, "test_panel")
     assert async_panel_exists(hass, "test_panel") is False
+
+
+async def test_register_panel_collision_names_the_owner(hass: HomeAssistant) -> None:
+    """Test the collision error says which component holds the url path.
+
+    The path is often claimed by a dashboard or a custom panel rather than by
+    the integration that fails, and the failure takes that integration down,
+    so the message has to point at the holder.
+    """
+    async_register_built_in_panel(hass, "lovelace", frontend_url_path="todo")
+
+    with pytest.raises(ValueError, match="Overwriting panel todo owned by lovelace"):
+        async_register_built_in_panel(hass, "todo", frontend_url_path="todo")
+
+    # Registering with update=True stays allowed.
+    async_register_built_in_panel(hass, "todo", frontend_url_path="todo", update=True)
+    assert hass.data[DATA_PANELS]["todo"].component_name == "todo"
 
 
 async def test_get_panels_non_admin(

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -760,7 +760,7 @@ async def test_async_panel_exists(hass: HomeAssistant) -> None:
 
 
 async def test_register_panel_collision_names_the_owner(hass: HomeAssistant) -> None:
-    """Test the collision error says which component holds the url path.
+    """Test that the collision error says which component holds the URL path.
 
     The path is often claimed by a dashboard or a custom panel rather than by
     the integration that fails, and the failure takes that integration down,


### PR DESCRIPTION
## Proposed change

A url path collision raises `Overwriting panel <path>`, which names the path but not who already holds it. That is the one piece needed to act on it, and it is available at the point of the raise.

It matters because the component that fails is usually not the one at fault. A dashboard or a `panel_custom` entry can claim any path — both take a plain `cv.string` with nothing excluding built-in panel paths — and whichever integration sets up afterwards is the one that raises. The failure is not confined to the panel either: registration happens partway through `async_setup`, so the rest of that integration never runs and it reports as an invalid config.

Seen in #172702, where the reported symptom was the `todo` integration failing to set up.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #172702
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

