### PR TITLE
Migrate roomba config - use connection mode option in latest roombapy

### DIFF
--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_BLID, CONF_CONTINUOUS, PLATFORMS, ROOMBA_SESSION
+from .const import CONF_BLID, CONF_CONN_MODE, CONF_CONTINUOUS, PLATFORMS, ROOMBA_SESSION
 from .models import RoombaConfigEntry, RoombaData
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ async def async_setup_entry(
         hass.config_entries.async_update_entry(
             config_entry,
             options={
-                CONF_CONTINUOUS: config_entry.data[CONF_CONTINUOUS],
+                CONF_CONN_MODE: config_entry.data[CONF_CONN_MODE],
                 CONF_DELAY: config_entry.data[CONF_DELAY],
             },
         )
@@ -45,7 +45,7 @@ async def async_setup_entry(
             address=config_entry.data[CONF_HOST],
             blid=config_entry.data[CONF_BLID],
             password=config_entry.data[CONF_PASSWORD],
-            continuous=config_entry.options[CONF_CONTINUOUS],
+            mode=config_entry.options[CONF_CONN_MODE],
             delay=config_entry.options[CONF_DELAY],
         )
     )
@@ -126,6 +126,37 @@ async def async_unload_entry(
         await async_disconnect_or_timeout(hass, roomba=config_entry.runtime_data.roomba)
 
     return unload_ok
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: RoombaConfigEntry
+) -> bool:
+    """Migrate Roomba config entry."""
+    _LOGGER.debug(
+        "Roomba configuration migration from version %s.",
+        config_entry.version,
+    )
+
+    if config_entry.version < 2:
+        new_conn_mode = (
+            "continuous"
+            if config_entry.options[CONF_CONTINUOUS] is True
+            else "periodic"
+        )
+        new_options = {
+            CONF_CONN_MODE: new_conn_mode,
+            CONF_DELAY: config_entry.options[CONF_DELAY],
+        }
+
+        hass.config_entries.async_update_entry(
+            config_entry, options=new_options, version=2
+        )
+
+        _LOGGER.debug(
+            "Roomba configuration was migrated to version %s successfully.", 2
+        )
+
+    return True
 
 
 def roomba_reported_state(roomba: Roomba) -> dict[str, Any]:

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -133,28 +133,25 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate Roomba config entry."""
     _LOGGER.debug(
-        "Roomba configuration migration from version %s.",
+        "Roomba configuration migration from version %s",
         config_entry.version,
     )
 
     if config_entry.version < 2:
+        old_options = config_entry.options or config_entry.data
         new_conn_mode = (
-            "continuous"
-            if config_entry.options[CONF_CONTINUOUS] is True
-            else "periodic"
+            "continuous" if old_options[CONF_CONTINUOUS] is True else "periodic"
         )
         new_options = {
             CONF_CONN_MODE: new_conn_mode,
-            CONF_DELAY: config_entry.options[CONF_DELAY],
+            CONF_DELAY: old_options[CONF_DELAY],
         }
 
         hass.config_entries.async_update_entry(
             config_entry, options=new_options, version=2
         )
 
-        _LOGGER.debug(
-            "Roomba configuration was migrated to version %s successfully.", 2
-        )
+        _LOGGER.debug("Roomba configuration was migrated to version %s successfully", 2)
 
     return True
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -12,15 +12,22 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import CannotConnect, async_connect_or_timeout, async_disconnect_or_timeout
 from .const import (
     CONF_BLID,
+    CONF_CONN_MODE,
     CONF_CONTINUOUS,
-    DEFAULT_CONTINUOUS,
+    CONNECTION_MODES,
     DEFAULT_DELAY,
+    DEFAULT_MODE,
     DOMAIN,
     ROOMBA_SESSION,
 )
@@ -31,7 +38,7 @@ ALL_ATTEMPTS = 2
 HOST_ATTEMPTS = 6
 ROOMBA_WAKE_TIME = 6
 
-DEFAULT_OPTIONS = {CONF_CONTINUOUS: DEFAULT_CONTINUOUS, CONF_DELAY: DEFAULT_DELAY}
+DEFAULT_OPTIONS = {CONF_CONN_MODE: DEFAULT_MODE, CONF_DELAY: DEFAULT_DELAY}
 
 MAX_NUM_DEVICES_TO_DISCOVER = 25
 
@@ -52,7 +59,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             address=data[CONF_HOST],
             blid=data[CONF_BLID],
             password=data[CONF_PASSWORD],
-            continuous=True,
+            mode=CONF_CONTINUOUS,
             delay=data[CONF_DELAY],
         )
     )
@@ -71,7 +78,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class RoombaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Roomba configuration flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     name: str | None = None
     blid: str
@@ -324,10 +331,15 @@ class RoombaOptionsFlowHandler(OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(
-                        CONF_CONTINUOUS,
-                        default=options.get(CONF_CONTINUOUS, DEFAULT_CONTINUOUS),
-                    ): bool,
+                    vol.Required(
+                        CONF_CONN_MODE,
+                        default=options.get(CONF_CONN_MODE, DEFAULT_MODE),
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=CONNECTION_MODES,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
                     vol.Optional(
                         CONF_DELAY,
                         default=options.get(CONF_DELAY, DEFAULT_DELAY),

--- a/homeassistant/components/roomba/const.py
+++ b/homeassistant/components/roomba/const.py
@@ -5,9 +5,13 @@ from homeassistant.const import Platform
 DOMAIN = "roomba"
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.VACUUM]
 CONF_CERT = "certificate"
+CONF_CONN_MODE = "connection_mode"
 CONF_CONTINUOUS = "continuous"
+CONF_PERIODIC = "periodic"
+CONF_ADHOC = "adhoc"
+CONNECTION_MODES = [CONF_CONTINUOUS, CONF_PERIODIC, CONF_ADHOC]
 CONF_BLID = "blid"
 DEFAULT_CERT = "/etc/ssl/certs/ca-certificates.crt"
-DEFAULT_CONTINUOUS = True
+DEFAULT_MODE = CONF_CONTINUOUS
 DEFAULT_DELAY = 30
 ROOMBA_SESSION = "roomba_session"

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -93,6 +93,7 @@
     "step": {
       "init": {
         "data": {
+          "connection_mode": "Connection mode",
           "continuous": "Continuous",
           "delay": "Delay"
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This migrates the roomba integration to use the latest version of roombapy library which introduces the `connection_mode` option instead of the `continuous` boolean flag. This change requires new config entity structure thus a migration of already configured integration is necessary.

This PR depends on https://github.com/pschmitt/roombapy/pull/571 and releasing a new version of `roombapy` which should be referenced in `homeassistant/components/roomba/manifest.json`.

The change was verified in combination with https://github.com/pschmitt/roombapy/pull/571 and works locally with Roomba 696  vacuum.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
