### PR TITLE
Add reauthentication flow to Karakeep

### DIFF
--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Karakeep."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any, override
 
@@ -28,6 +29,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
     }
 )
+STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
 
 
 class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -89,6 +91,38 @@ class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication with a new API token."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            token = user_input[CONF_TOKEN].strip()
+
+            errors = await self._async_validate_input(
+                reauth_entry.data[CONF_URL],
+                token,
+                reauth_entry.data[CONF_VERIFY_SSL],
+            )
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates={CONF_TOKEN: token}
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )
 

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -14,6 +14,7 @@ from aiokarakeep import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, UPDATE_INTERVAL
@@ -60,7 +61,10 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
         try:
             return await self.client.async_get_stats()
         except KarakeepAuthError as err:
-            raise UpdateFailed("Invalid Karakeep API token") from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_auth",
+            ) from err
         except KarakeepConnectionError as err:
             raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
         except (KarakeepApiError, KarakeepInvalidResponseError) as err:

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -44,7 +44,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold
@@ -68,9 +68,7 @@ rules:
   entity-device-class: todo
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations:
-    status: exempt
-    comment: This integration does not raise translatable Home Assistant exceptions.
+  exception-translations: todo
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "api_error": "The Karakeep API returned an unexpected response.",
@@ -11,6 +12,15 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "token": "[%key:component::karakeep::config::step::user::data::token%]"
+        },
+        "data_description": {
+          "token": "[%key:component::karakeep::config::step::user::data_description::token%]"
+        },
+        "description": "The API token for your Karakeep instance is no longer valid. Enter a new one to reconnect."
+      },
       "user": {
         "data": {
           "token": "API token",
@@ -52,6 +62,11 @@
         "name": "Tags",
         "unit_of_measurement": "tags"
       }
+    }
+  },
+  "exceptions": {
+    "invalid_auth": {
+      "message": "[%key:common::config_flow::error::invalid_auth%]"
     }
   }
 }

--- a/tests/components/karakeep/const.py
+++ b/tests/components/karakeep/const.py
@@ -13,4 +13,5 @@ TEST_STATS = KarakeepStats(
 
 TEST_VERSION = "0.32.0"
 TEST_TOKEN = "test-token"
+NEW_TOKEN = "new-test-token"
 TEST_URL = "https://karakeep.example.com"

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import TEST_TOKEN, TEST_URL
+from .const import NEW_TOKEN, TEST_TOKEN, TEST_URL
 
 from tests.common import MockConfigEntry
 
@@ -161,3 +161,74 @@ async def test_duplicate(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     mock_karakeep_client.async_get_stats.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_karakeep_client")
+async def test_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reauthentication flow updates the token."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_TOKEN: f" {NEW_TOKEN} "},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {
+        CONF_URL: TEST_URL,
+        CONF_TOKEN: NEW_TOKEN,
+        CONF_VERIFY_SSL: True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (KarakeepAuthError("Invalid token", 401), "invalid_auth"),
+        (KarakeepConnectionError("Cannot connect"), "cannot_connect"),
+        (KarakeepApiError("API error", 500), "api_error"),
+        (Exception("Boom"), "unknown"),
+    ],
+)
+async def test_reauth_errors(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    error: str,
+) -> None:
+    """Test the reauthentication flow shows errors and recovers."""
+    mock_config_entry.add_to_hass(hass)
+    mock_karakeep_client.async_get_stats.side_effect = side_effect
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_TOKEN: NEW_TOKEN},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_karakeep_client.async_get_stats.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_TOKEN: NEW_TOKEN},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_TOKEN] == NEW_TOKEN

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -11,7 +11,7 @@ from aiokarakeep import (
 import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -40,7 +40,6 @@ async def test_setup_entry(
 @pytest.mark.parametrize(
     "side_effect",
     [
-        KarakeepAuthError("Invalid token", 401),
         KarakeepConnectionError("Cannot connect"),
         KarakeepApiError("API error", 500),
         KarakeepInvalidResponseError("Invalid response"),
@@ -58,6 +57,23 @@ async def test_setup_entry_update_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_auth_failure_starts_reauth(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an invalid token puts the entry in error and starts a reauth flow."""
+    mock_karakeep_client.async_get_stats.side_effect = KarakeepAuthError(
+        "Invalid token", 401
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 async def test_setup_entry_version_failure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the reauthentication flow to the Karakeep integration

`exception-translations` moves from `exempt` to `todo`. The existing exempt comment was already inaccurate. The coordinator raised untranslated `UpdateFailed` and this PR adds a translated `ConfigEntryAuthFailed`. A follow-up PR completes the rule.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
