### PR TITLE
Fix Google Health sleep sensors

### DIFF
--- a/homeassistant/components/google_health/coordinator.py
+++ b/homeassistant/components/google_health/coordinator.py
@@ -42,6 +42,7 @@ POLLING_INTERVAL = timedelta(minutes=15)
 BODY_POLLING_INTERVAL = timedelta(hours=1)
 DEVICE_POLLING_INTERVAL = timedelta(hours=1)
 DEFAULT_PAGE_SIZE = 1
+SLEEP_PAGE_SIZE = 10
 
 
 @dataclass
@@ -254,6 +255,7 @@ class GoogleHealthDeviceCoordinator(
 class GoogleHealthSleepData:
     """Class to hold sleep data."""
 
+    # The most recent sleep session with summary data
     sleep: Sleep | None = None
 
 
@@ -281,9 +283,15 @@ class GoogleHealthSleepCoordinator(
     @override
     async def _async_fetch_data(self) -> GoogleHealthSleepData:
         """Fetch latest sleep session."""
-        sleep_result = await self.api.sleep.list(page_size=DEFAULT_PAGE_SIZE)
-        sleep = sleep_result.data_points[0].data if sleep_result.data_points else None
-        return GoogleHealthSleepData(sleep=sleep)
+        sleep_result = await self.api.sleep.list(page_size=SLEEP_PAGE_SIZE)
+
+        # Find the first session with a sleep summary
+        for data_point in sleep_result.data_points or ():
+            if data_point.data and data_point.data.summary:
+                return GoogleHealthSleepData(sleep=data_point.data)
+
+        # No sessions or current session still in progress
+        return GoogleHealthSleepData()
 
 
 @dataclass

--- a/tests/components/google_health/fixtures/sleep_in_progress.json
+++ b/tests/components/google_health/fixtures/sleep_in_progress.json
@@ -1,0 +1,31 @@
+{
+  "dataPoints": [
+    {
+      "name": "users/me/dataTypes/sleep/dataPoints/session-active-12345",
+      "sleep": {
+        "interval": {
+          "startTime": "2026-08-16T22:00:00Z",
+          "startUtcOffset": "-07:00"
+        }
+      }
+    },
+    {
+      "name": "users/me/dataTypes/sleep/dataPoints/session-12345",
+      "sleep": {
+        "interval": {
+          "startTime": "2026-08-15T22:00:00Z",
+          "endTime": "2026-08-16T06:00:00Z",
+          "startUtcOffset": "-07:00",
+          "endUtcOffset": "-07:00"
+        },
+        "summary": {
+          "minutesToFallAsleep": 15,
+          "minutesAfterWakeUp": 10,
+          "minutesAsleep": 420,
+          "minutesInSleepPeriod": 480,
+          "minutesAwake": 60
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/test_config_flow.py
+++ b/tests/components/google_health/test_config_flow.py
@@ -201,7 +201,7 @@ async def test_config_flow_get_identity_error(
     mock_google_health_client: AsyncMock,
 ) -> None:
     """Test config flow aborts if get_identity raises an API error."""
-    mock_google_health_client.get_identity.side_effect = GoogleHealthApiError
+    mock_google_health_client.get_identity.side_effect = GoogleHealthApiError("Error")
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -243,7 +243,9 @@ async def test_config_flow_api_not_enabled(
     mock_google_health_client: AsyncMock,
 ) -> None:
     """Test config flow aborts if the Google Health API is not enabled."""
-    mock_google_health_client.get_identity.side_effect = HealthApiForbiddenException
+    mock_google_health_client.get_identity.side_effect = HealthApiForbiddenException(
+        "Forbidden"
+    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/google_health/test_init.py
+++ b/tests/components/google_health/test_init.py
@@ -54,7 +54,9 @@ async def test_setup_api_error(
     integration_setup: Callable[[], Awaitable[bool]],
 ) -> None:
     """Test setup error retry handling when API fails."""
-    mock_google_health_client.steps.today.side_effect = GoogleHealthApiError
+    mock_google_health_client.steps.today.side_effect = GoogleHealthApiError(
+        "API error"
+    )
 
     assert not await integration_setup()
     assert config_entry.state is config_entries.ConfigEntryState.SETUP_RETRY
@@ -67,7 +69,9 @@ async def test_setup_auth_error(
     integration_setup: Callable[[], Awaitable[bool]],
 ) -> None:
     """Test setup error when API returns auth or forbidden errors."""
-    mock_google_health_client.steps.today.side_effect = HealthApiForbiddenException
+    mock_google_health_client.steps.today.side_effect = HealthApiForbiddenException(
+        "Forbidden"
+    )
 
     assert not await integration_setup()
     assert config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from google_health_api.const import HealthApiScope
-from google_health_api.model import ListPairedDevicesResult, _ListPairedDevicesModel
+from google_health_api.model import (
+    SLEEP,
+    ListPairedDevicesResult,
+    _ListPairedDevicesModel,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -21,7 +25,7 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 
-from .conftest import paired_devices_fixture
+from .conftest import _list_fixture, paired_devices_fixture
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -93,6 +97,61 @@ async def test_sensor_empty_sleep(
 ) -> None:
     """Test sleep sensors when the sleep endpoint returns no data."""
     mock_google_health_client.sleep.list.return_value = MagicMock(data_points=[])
+
+    assert await integration_setup()
+
+    time_asleep_state = hass.states.get("sensor.google_health_time_asleep")
+    assert time_asleep_state is not None
+    assert time_asleep_state.state == "unknown"
+
+
+async def test_sensor_in_progress_sleep(
+    hass: HomeAssistant,
+    mock_google_health_client: AsyncMock,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test sleep sensors return latest completed session when an active session is in progress."""
+    mock_google_health_client.sleep.list.return_value = _list_fixture(
+        "sleep_in_progress.json", SLEEP
+    )
+
+    assert await integration_setup()
+
+    time_asleep_state = hass.states.get("sensor.google_health_time_asleep")
+    assert time_asleep_state is not None
+    assert time_asleep_state.state == "420"
+
+    time_awake_state = hass.states.get("sensor.google_health_time_awake")
+    assert time_awake_state is not None
+    assert time_awake_state.state == "60"
+
+    time_in_bed_state = hass.states.get("sensor.google_health_time_in_bed")
+    assert time_in_bed_state is not None
+    assert time_in_bed_state.state == "480"
+
+    time_to_fall_asleep_state = hass.states.get(
+        "sensor.google_health_time_to_fall_asleep"
+    )
+    assert time_to_fall_asleep_state is not None
+    assert time_to_fall_asleep_state.state == "15"
+
+    time_after_wakeup_state = hass.states.get(
+        "sensor.google_health_time_after_waking_up"
+    )
+    assert time_after_wakeup_state is not None
+    assert time_after_wakeup_state.state == "10"
+
+
+async def test_sensor_only_in_progress_sleep(
+    hass: HomeAssistant,
+    mock_google_health_client: AsyncMock,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test sleep sensors when only an in-progress session with no summary exists."""
+    full_fixture = _list_fixture("sleep_in_progress.json", SLEEP)
+    mock_google_health_client.sleep.list.return_value = MagicMock(
+        data_points=full_fixture.data_points[:1]
+    )
 
     assert await integration_setup()
 


### PR DESCRIPTION
## Proposed change
Fix Google health sleep sensors

In Google Health, when a user is currently asleep / in an active sleep session, the API returns the active session as the most recent session with `summary=None`. Previously, `GoogleHealthSleepCoordinator` requested `page_size=1`, causing `GoogleHealthSleepCoordinator` to only receive the in-progress session without summary metrics, which caused all sleep duration sensors to go `unknown`.

This change updates `GoogleHealthSleepCoordinator` to fetch recent sleep sessions (`page_size=10`) and select the first session that has a computed `summary`. If a session is currently in progress, duration sensors continue reporting the metrics from the latest completed sleep session rather than going `unknown`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178375
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
