### PR TITLE
Add Hydro-Quebec Peak Events integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -833,6 +833,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/hvv_departures/ @vigonotion
 /homeassistant/components/hydrawise/ @dknowles2 @thomaskistler @ptcryan
 /tests/components/hydrawise/ @dknowles2 @thomaskistler @ptcryan
+/homeassistant/components/hydroquebec_peak/ @Beat-YT
+/tests/components/hydroquebec_peak/ @Beat-YT
 /homeassistant/components/hyperion/ @dermotduffy
 /tests/components/hyperion/ @dermotduffy
 /homeassistant/components/hypontech/ @jcisio

--- a/homeassistant/components/hydroquebec_peak/__init__.py
+++ b/homeassistant/components/hydroquebec_peak/__init__.py
@@ -1,0 +1,25 @@
+"""The Hydro-Québec Peak Events integration."""
+
+from homeassistant.core import HomeAssistant
+
+from .const import PLATFORMS
+from .coordinator import HydroQuebecPeakConfigEntry, HydroQuebecPeakCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: HydroQuebecPeakConfigEntry
+) -> bool:
+    """Set up Hydro-Québec Peak Events from a config entry."""
+    coordinator = HydroQuebecPeakCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: HydroQuebecPeakConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/hydroquebec_peak/config_flow.py
+++ b/homeassistant/components/hydroquebec_peak/config_flow.py
@@ -1,0 +1,59 @@
+"""Config flow for the Hydro-Québec Peak Events integration."""
+
+from typing import Any, override
+
+from hydropeak_opendata import OpenDataClient, OpenDataError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import CONF_OFFER, DOMAIN, LOGGER
+
+
+class HydroQuebecPeakConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Hydro-Québec Peak Events."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step: pick an offer from the live feed."""
+        if user_input is not None:
+            offer = user_input[CONF_OFFER]
+            await self.async_set_unique_id(offer)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=offer, data={CONF_OFFER: offer})
+
+        client = OpenDataClient(async_get_clientsession(self.hass))
+        try:
+            labels = await client.get_offer_labels()
+        except OpenDataError as err:
+            LOGGER.debug("Error fetching available offers: %s", err)
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_OFFER): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(value=offer, label=label)
+                                for offer, label in labels.items()
+                            ],
+                            mode=SelectSelectorMode.DROPDOWN,
+                            sort=True,
+                        )
+                    )
+                }
+            ),
+        )

--- a/homeassistant/components/hydroquebec_peak/const.py
+++ b/homeassistant/components/hydroquebec_peak/const.py
@@ -1,0 +1,23 @@
+"""Constants for the Hydro-Québec Peak Events integration."""
+
+from datetime import timedelta
+import logging
+from typing import Final
+
+from homeassistant.const import Platform
+
+DOMAIN: Final = "hydroquebec_peak"
+LOGGER = logging.getLogger(__package__)
+
+CONF_OFFER: Final = "offer"
+
+# The feed is a small static file behind a CDN and events are published
+# hours in advance; conditional requests make polling cheap.
+SCAN_INTERVAL: Final = timedelta(minutes=15)
+
+PLATFORMS: Final = [Platform.SENSOR]
+
+EVENTS_TABLE_URL: Final = (
+    "https://donnees.hydroquebec.com/explore/dataset/evenements-pointe/table/"
+    "?sort=datedebut"
+)

--- a/homeassistant/components/hydroquebec_peak/coordinator.py
+++ b/homeassistant/components/hydroquebec_peak/coordinator.py
@@ -1,0 +1,96 @@
+"""DataUpdateCoordinator for the Hydro-Québec Peak Events integration."""
+
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import override
+
+from hydropeak_opendata import OpenDataClient, OpenDataError, PeakEvent
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_OFFER, DOMAIN, LOGGER, SCAN_INTERVAL
+
+type HydroQuebecPeakConfigEntry = ConfigEntry[HydroQuebecPeakCoordinator]
+
+
+class HydroQuebecPeakCoordinator(DataUpdateCoordinator[tuple[PeakEvent, ...]]):
+    """Coordinator fetching peak events for one offer.
+
+    Each config entry (one per offer) has its own coordinator. The library
+    client sends conditional requests, so refreshes are answered with a
+    cheap 304 unless Hydro-Québec published new data.
+    """
+
+    config_entry: HydroQuebecPeakConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, config_entry: HydroQuebecPeakConfigEntry
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.offer: str = config_entry.data[CONF_OFFER]
+        self.client = OpenDataClient(async_get_clientsession(hass))
+        self._boundary_unsub: Callable[[], None] | None = None
+
+    @override
+    async def _async_update_data(self) -> tuple[PeakEvent, ...]:
+        """Fetch the events for this entry's offer."""
+        try:
+            events = await self.client.get_events(self.offer)
+        except OpenDataError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        self._schedule_boundary_refresh(events)
+        return events
+
+    def _schedule_boundary_refresh(self, events: tuple[PeakEvent, ...]) -> None:
+        """Notify entities at the next moment a state can flip.
+
+        Entity states depend on the current time (event in progress,
+        today/tomorrow flags), not only on the fetched data. Schedule a
+        listener update at the next event start/end or local midnight so
+        states flip on time instead of waiting for the next poll.
+        """
+        now = dt_util.utcnow()
+        boundaries = [
+            boundary
+            for event in events
+            for boundary in (event.start, event.end)
+            if boundary > now
+        ]
+        boundaries.append(dt_util.start_of_local_day() + timedelta(days=1))
+
+        if self._boundary_unsub is not None:
+            self._boundary_unsub()
+        self._boundary_unsub = async_track_point_in_utc_time(
+            self.hass, self._handle_boundary, min(boundaries)
+        )
+
+    @callback
+    def _handle_boundary(self, now: datetime) -> None:
+        """Handle a state boundary: refresh listeners and rearm."""
+        self._boundary_unsub = None
+        self._schedule_boundary_refresh(self.data or ())
+        self.async_update_listeners()
+
+    @override
+    async def async_shutdown(self) -> None:
+        """Cancel the boundary timer on shutdown."""
+        await super().async_shutdown()
+        if self._boundary_unsub is not None:
+            self._boundary_unsub()
+            self._boundary_unsub = None

--- a/homeassistant/components/hydroquebec_peak/entity.py
+++ b/homeassistant/components/hydroquebec_peak/entity.py
@@ -1,0 +1,35 @@
+"""Base entity for the Hydro-Québec Peak Events integration."""
+
+from urllib.parse import quote
+
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, EVENTS_TABLE_URL
+from .coordinator import HydroQuebecPeakCoordinator
+
+
+class HydroQuebecPeakEntity(CoordinatorEntity[HydroQuebecPeakCoordinator]):
+    """Base entity: one device per configured offer."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HydroQuebecPeakCoordinator,
+        entity_description: EntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{coordinator.offer}_{entity_description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.offer)},
+            name=coordinator.offer,
+            manufacturer="Hydro-Québec",
+            entry_type=DeviceEntryType.SERVICE,
+            configuration_url=(
+                f"{EVENTS_TABLE_URL}&refine.offre={quote(coordinator.offer)}"
+            ),
+        )

--- a/homeassistant/components/hydroquebec_peak/manifest.json
+++ b/homeassistant/components/hydroquebec_peak/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "hydroquebec_peak",
+  "name": "Hydro-Québec Peak Events",
+  "codeowners": ["@Beat-YT"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/hydroquebec_peak",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "loggers": ["hydropeak_opendata"],
+  "quality_scale": "bronze",
+  "requirements": ["hydropeak-opendata==0.2.0"]
+}

--- a/homeassistant/components/hydroquebec_peak/quality_scale.yaml
+++ b/homeassistant/components/hydroquebec_peak/quality_scale.yaml
@@ -1,0 +1,86 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not provide any actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not provide any actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
+  entity-event-setup:
+    status: exempt
+    comment: Entities do not subscribe to external events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not provide any actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration has no options flow.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: The open data feed requires no authentication.
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: This is a cloud service that cannot be discovered.
+  discovery:
+    status: exempt
+    comment: This is a cloud service that cannot be discovered.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: Each config entry represents exactly one offer with a fixed set of entities.
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: Each config entry has exactly one device that is removed with the entry.
+  strict-typing: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done

--- a/homeassistant/components/hydroquebec_peak/sensor.py
+++ b/homeassistant/components/hydroquebec_peak/sensor.py
@@ -1,0 +1,82 @@
+"""Sensors for the Hydro-Québec Peak Events integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+
+from hydropeak_opendata import PeakEvent
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .coordinator import HydroQuebecPeakConfigEntry
+from .entity import HydroQuebecPeakEntity
+
+# The coordinator handles all I/O; entities only read its data
+PARALLEL_UPDATES = 0
+
+
+def _current_or_next_event(events: tuple[PeakEvent, ...]) -> PeakEvent | None:
+    """Return the event in progress, or the next upcoming one."""
+    now = dt_util.utcnow()
+    return next(
+        (event for event in events if event.is_active(now)),
+        next((event for event in events if event.start > now), None),
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class HydroQuebecPeakSensorDescription(SensorEntityDescription):
+    """Describes a Hydro-Québec peak event sensor."""
+
+    value_fn: Callable[[PeakEvent], datetime]
+
+
+SENSORS: tuple[HydroQuebecPeakSensorDescription, ...] = (
+    HydroQuebecPeakSensorDescription(
+        key="event_begin",
+        translation_key="event_begin",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda event: event.start,
+    ),
+    HydroQuebecPeakSensorDescription(
+        key="event_end",
+        translation_key="event_end",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda event: event.end,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HydroQuebecPeakConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the sensor platform."""
+    async_add_entities(
+        HydroQuebecPeakSensor(entry.runtime_data, description)
+        for description in SENSORS
+    )
+
+
+class HydroQuebecPeakSensor(HydroQuebecPeakEntity, SensorEntity):
+    """Timestamp of the current or next peak event."""
+
+    entity_description: HydroQuebecPeakSensorDescription
+
+    @property
+    @override
+    def native_value(self) -> datetime | None:
+        """Return the timestamp for the current or next event, if any."""
+        event = _current_or_next_event(self.coordinator.data)
+        if event is None:
+            return None
+        return self.entity_description.value_fn(event)

--- a/homeassistant/components/hydroquebec_peak/strings.json
+++ b/homeassistant/components/hydroquebec_peak/strings.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "offer": "Offer"
+        },
+        "data_description": {
+          "offer": "The Hydro-Québec peak savings offer you are enrolled in. The list comes from Hydro-Québec's open data for the current season."
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "event_begin": {
+        "name": "Event begins"
+      },
+      "event_end": {
+        "name": "Event ends"
+      }
+    }
+  },
+  "exceptions": {
+    "update_failed": {
+      "message": "Error fetching peak events: {error}"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -350,6 +350,7 @@ FLOWS = {
         "huum",
         "hvv_departures",
         "hydrawise",
+        "hydroquebec_peak",
         "hyperion",
         "hypontech",
         "ialarm",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3159,6 +3159,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "hydroquebec_peak": {
+      "name": "Hydro-Qu\u00e9bec Peak Events",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "hyperion": {
       "name": "Hyperion",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1313,6 +1313,9 @@ huawei-lte-api==1.11.0
 # homeassistant.components.huum
 huum==0.8.2
 
+# homeassistant.components.hydroquebec_peak
+hydropeak-opendata==0.2.0
+
 # homeassistant.components.hyperion
 hyperion-py==0.7.6
 

--- a/tests/components/hydroquebec_peak/__init__.py
+++ b/tests/components/hydroquebec_peak/__init__.py
@@ -1,0 +1,13 @@
+"""Tests for the Hydro-Québec Peak Events integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the integration for testing."""
+    await hass.config.async_set_time_zone("America/Toronto")
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/hydroquebec_peak/conftest.py
+++ b/tests/components/hydroquebec_peak/conftest.py
@@ -1,0 +1,83 @@
+"""Common fixtures for the Hydro-Québec Peak Events tests."""
+
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hydropeak_opendata import PeakEvent
+import pytest
+
+from homeassistant.components.hydroquebec_peak.const import CONF_OFFER, DOMAIN
+
+from tests.common import MockConfigEntry
+
+TEST_OFFER = "Credit hivernal Residentiel (CPC-D)"
+OTHER_OFFER = "Flex Residentiel (TPC-DPC)"
+
+EST = timezone(timedelta(hours=-5))
+
+TEST_EVENTS = (
+    PeakEvent(
+        offer=TEST_OFFER,
+        start=datetime(2026, 1, 9, 6, 0, tzinfo=EST),
+        end=datetime(2026, 1, 9, 9, 0, tzinfo=EST),
+        period="AM",
+        sector="Residentiel",
+    ),
+    PeakEvent(
+        offer=TEST_OFFER,
+        start=datetime(2026, 1, 9, 16, 0, tzinfo=EST),
+        end=datetime(2026, 1, 9, 20, 0, tzinfo=EST),
+        period="PM",
+        sector="Residentiel",
+    ),
+    PeakEvent(
+        offer=TEST_OFFER,
+        start=datetime(2026, 1, 10, 6, 0, tzinfo=EST),
+        end=datetime(2026, 1, 10, 9, 0, tzinfo=EST),
+        period="AM",
+        sector="Residentiel",
+    ),
+)
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.hydroquebec_peak.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title=TEST_OFFER,
+        domain=DOMAIN,
+        data={CONF_OFFER: TEST_OFFER},
+        unique_id=TEST_OFFER,
+    )
+
+
+@pytest.fixture
+def mock_client() -> Generator[MagicMock]:
+    """Return a mocked OpenDataClient."""
+    with (
+        patch(
+            "homeassistant.components.hydroquebec_peak.coordinator.OpenDataClient",
+            autospec=True,
+        ) as client_mock,
+        patch(
+            "homeassistant.components.hydroquebec_peak.config_flow.OpenDataClient",
+            new=client_mock,
+        ),
+    ):
+        client = client_mock.return_value
+        client.get_offer_labels = AsyncMock(
+            return_value={TEST_OFFER: TEST_OFFER, OTHER_OFFER: OTHER_OFFER}
+        )
+        client.get_events = AsyncMock(return_value=TEST_EVENTS)
+        yield client

--- a/tests/components/hydroquebec_peak/test_config_flow.py
+++ b/tests/components/hydroquebec_peak/test_config_flow.py
@@ -1,0 +1,66 @@
+"""Tests for the Hydro-Québec Peak Events config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from hydropeak_opendata import OpenDataConnectionError
+
+from homeassistant.components.hydroquebec_peak.const import CONF_OFFER, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import TEST_OFFER
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_flow(
+    hass: HomeAssistant, mock_client: MagicMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the full happy path."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_OFFER: TEST_OFFER}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_OFFER
+    assert result["data"] == {CONF_OFFER: TEST_OFFER}
+    assert result["result"].unique_id == TEST_OFFER
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test configuring the same offer twice aborts."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_OFFER: TEST_OFFER}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_cannot_connect(hass: HomeAssistant, mock_client: MagicMock) -> None:
+    """Test the flow aborts when the offer list cannot be fetched."""
+    mock_client.get_offer_labels.side_effect = OpenDataConnectionError("boom")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/hydroquebec_peak/test_init.py
+++ b/tests/components/hydroquebec_peak/test_init.py
@@ -1,0 +1,38 @@
+"""Tests for the Hydro-Québec Peak Events integration setup."""
+
+from unittest.mock import MagicMock
+
+from hydropeak_opendata import OpenDataConnectionError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful setup and unload."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_retry_on_error(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the entry goes to setup retry when the feed is unavailable."""
+    mock_client.get_events.side_effect = OpenDataConnectionError("boom")
+
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/hydroquebec_peak/test_sensor.py
+++ b/tests/components/hydroquebec_peak/test_sensor.py
@@ -1,0 +1,89 @@
+"""Tests for the Hydro-Québec Peak Events sensors."""
+
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_sensors_next_event(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Sensors expose the upcoming event when none is active."""
+    # 12:00 EST: morning event over, evening event (16:00-20:00 EST) upcoming
+    freezer.move_to("2026-01-09T17:00:00+00:00")
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_begins")
+    assert state is not None
+    assert state.state == "2026-01-09T21:00:00+00:00"
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_ends")
+    assert state is not None
+    assert state.state == "2026-01-10T01:00:00+00:00"
+
+
+async def test_sensors_active_event(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Sensors expose the event in progress over the next one."""
+    # 17:00 EST: the evening event is in progress
+    freezer.move_to("2026-01-09T22:00:00+00:00")
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_begins")
+    assert state is not None
+    assert state.state == "2026-01-09T21:00:00+00:00"
+
+
+async def test_sensors_roll_over_at_boundary(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Sensors roll to the next event at the boundary, not the next poll."""
+    # 19:59 EST, one minute before the 16:00-20:00 EST event ends
+    freezer.move_to("2026-01-10T00:59:00+00:00")
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_begins")
+    assert state is not None
+    assert state.state == "2026-01-09T21:00:00+00:00"
+
+    # Cross the event end; the coordinator's boundary timer must fire
+    freezer.move_to("2026-01-10T01:00:01+00:00")
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_begins")
+    assert state is not None
+    assert state.state == "2026-01-10T11:00:00+00:00"
+
+
+async def test_sensors_no_events(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Sensors are unknown when no event is scheduled."""
+    freezer.move_to("2026-01-09T17:00:00+00:00")
+    mock_client.get_events.return_value = ()
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.credit_hivernal_residentiel_cpc_d_event_begins")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change

Add the Hydro-Québec Peak Events integration (`hydroquebec_peak`).

Hydro-Québec is the electricity utility of Québec, Canada. During winters, they announce peak demand events when electricity usage is high due to cold weather. Customers enrolled in a peak savings offer (Winter Credit Option, Rate Flex D, business offers, etc.) reduce their consumption during these events and receive bill credits or lower rates.

This integration exposes peak event timestamps from Hydro-Québec's public open data feed so automations can react — for example, preheating a home before an event starts. It requires no Hydro-Québec account or credentials.

Communication with the data source is handled by the [hydropeak-opendata](https://github.com/Beat-YT/hydropeak-opendata) library on PyPI. The feed is a static JSON file behind a CDN; the library uses conditional requests (ETag/If-None-Match) to keep polling lightweight.

This PR adds the sensor platform only. A follow-up PR will add the binary sensor platform.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47447
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is adde

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr