### PR TITLE
Migrate WOL switch to template switch

### DIFF
--- a/homeassistant/components/ping/config_flow.py
+++ b/homeassistant/components/ping/config_flow.py
@@ -37,6 +37,12 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    async def async_step_import(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the import step."""
+        return await self.async_step_user(user_input)
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/ping/config_flow.py
+++ b/homeassistant/components/ping/config_flow.py
@@ -41,6 +41,7 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the import step."""
+        # Can be removed when Wake on LAN import is removed in 2027.2
         return await self.async_step_user(user_input)
 
     @override

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -660,6 +660,10 @@ CONFIG_FLOW = {
         validate_user_input=validate_user_input(Platform.WEATHER),
         description_placeholders=_get_forecast_description_place_holders,
     ),
+    "import": SchemaFlowFormStep(
+        config_schema(Platform.SWITCH),
+        validate_user_input=validate_user_input(Platform.SWITCH),
+    ),
 }
 
 

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -542,13 +542,18 @@ def validate_user_input(
     """
 
     async def _validate_user_input(
-        _: SchemaCommonFlowHandler,
+        handler: SchemaCommonFlowHandler,
         user_input: dict[str, Any],
     ) -> dict[str, Any]:
         """Add template type to user input."""
         if template_type == Platform.SENSOR:
             _validate_unit(user_input)
             _validate_state_class(user_input)
+        if template_type == Platform.SWITCH:
+            # Can be removed when Wake on LAN import is removed in 2027.2
+            handler.parent_handler._async_abort_entries_match(  # noqa: SLF001
+                {CONF_ON_ACTION: user_input.get(CONF_ON_ACTION)}
+            )
         return {"template_type": template_type} | user_input
 
     return _validate_user_input
@@ -661,6 +666,7 @@ CONFIG_FLOW = {
         description_placeholders=_get_forecast_description_place_holders,
     ),
     "import": SchemaFlowFormStep(
+        # Can be removed when Wake on LAN import is removed in 2027.2
         config_schema(Platform.SWITCH),
         validate_user_input=validate_user_input(Platform.SWITCH),
     ),

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -551,8 +551,13 @@ def validate_user_input(
             _validate_state_class(user_input)
         if template_type == Platform.SWITCH:
             # Can be removed when Wake on LAN import is removed in 2027.2
+            match = {CONF_ON_ACTION: user_input.get(CONF_ON_ACTION)}
+            if turn_off := user_input.get(CONF_OFF_ACTION):
+                match[CONF_OFF_ACTION] = turn_off
+            if value_template := user_input.get(CONF_VALUE_TEMPLATE):
+                match[CONF_VALUE_TEMPLATE] = value_template
             handler.parent_handler._async_abort_entries_match(  # noqa: SLF001
-                {CONF_ON_ACTION: user_input.get(CONF_ON_ACTION)}
+                match
             )
         return {"template_type": template_type} | user_input
 

--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SECUREON_PASSWORD, DOMAIN, PLATFORMS
@@ -35,6 +36,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def send_magic_packet(call: ServiceCall) -> None:
         """Send magic packet to wake up a device."""
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "wol_service_deprecated",
+            breaks_in_ha_version="2027.2.0",
+            is_fixable=False,
+            is_persistent=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="wol_service_deprecated",
+        )
+
         mac_address: str = call.data[CONF_MAC]
         secureon_password = call.data.get(CONF_SECUREON_PASSWORD)
         broadcast_address = call.data.get(CONF_BROADCAST_ADDRESS)

--- a/homeassistant/components/wake_on_lan/config_flow.py
+++ b/homeassistant/components/wake_on_lan/config_flow.py
@@ -60,7 +60,11 @@ CONFIG_FLOW = {
     "user": SchemaFlowFormStep(
         schema=vol.Schema(DATA_SCHEMA).extend(OPTIONS_SCHEMA),
         validate_user_input=validate,
-    )
+    ),
+    "import": SchemaFlowFormStep(
+        schema=vol.Schema(DATA_SCHEMA).extend(OPTIONS_SCHEMA),
+        validate_user_input=validate,
+    ),
 }
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(

--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -5,6 +5,7 @@ from homeassistant.const import Platform
 DOMAIN = "wake_on_lan"
 PLATFORMS = [Platform.BUTTON]
 
+CONF_ON_ACTION = "turn_on"
 CONF_OFF_ACTION = "turn_off"
 CONF_SECUREON_PASSWORD = "secureon_password"
 

--- a/homeassistant/components/wake_on_lan/repairs.py
+++ b/homeassistant/components/wake_on_lan/repairs.py
@@ -17,12 +17,11 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
     CONF_NAME,
-    CONF_OPTIMISTIC,
-    CONF_STATE,
+    CONF_VALUE_TEMPLATE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CONF_OFF_ACTION, CONF_ON_ACTION, DOMAIN
 
@@ -102,31 +101,39 @@ class MigrateSwitchFlow(RepairsFlow):
                 return self.async_abort(reason="could_not_get_ping_entity")
 
             # Import Wake on LAN config to get a config entry with a button entity
-            config = {
-                CONF_MAC: mac,
-                CONF_BROADCAST_ADDRESS: broadcast_address,
-                CONF_BROADCAST_PORT: broadcast_port,
-            }
-            import_result = await self.hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=config,
-            )
-            if not (
-                import_result["type"] is FlowResultType.CREATE_ENTRY
-                or (
-                    import_result["type"] is FlowResultType.ABORT
-                    and import_result["reason"] == "already_configured"
+            wol_entry_id = None
+            wol_entries = self.hass.config_entries.async_entries(DOMAIN)
+            for entry in wol_entries:
+                if entry.options.get(CONF_MAC) == dr.format_mac(mac):
+                    wol_entry_id = entry.entry_id
+                    break
+            if not wol_entry_id:
+                wol_config: dict[str, Any] = {CONF_MAC: mac}
+                if broadcast_address is not None:
+                    wol_config[CONF_BROADCAST_ADDRESS] = broadcast_address
+                if broadcast_port is not None:
+                    wol_config[CONF_BROADCAST_PORT] = broadcast_port
+                import_result = await self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data=wol_config,
                 )
-            ):
-                return self.async_abort(reason="could_not_import_wol")
+                if not (
+                    import_result["type"] is FlowResultType.CREATE_ENTRY
+                    or (
+                        import_result["type"] is FlowResultType.ABORT
+                        and import_result["reason"] == "already_configured"
+                    )
+                ):
+                    return self.async_abort(reason="could_not_import_wol")
+                wol_entry_id = import_result["result"].entry_id
 
             wol_entity_id = None
             for _ in range(10):
                 # Wait for wol config entry entity to be created
                 if entities := er.async_entries_for_config_entry(
                     entity_reg,
-                    import_result["result"].entry_id,
+                    wol_entry_id,
                 ):
                     wol_entity_id = entities[0].entity_id
                     break
@@ -136,16 +143,17 @@ class MigrateSwitchFlow(RepairsFlow):
 
             template_config = {
                 CONF_NAME: name,
-                CONF_OPTIMISTIC: bool(ping_host),
-                CONF_ON_ACTION: {
-                    "action": "button.press",
-                    "target": {
-                        "entity_id": wol_entity_id,
-                    },
-                },
+                CONF_ON_ACTION: [
+                    {
+                        "action": "button.press",
+                        "target": {
+                            "entity_id": wol_entity_id,
+                        },
+                    }
+                ],
             }
             if ping_entity_id:
-                template_config[CONF_STATE] = (
+                template_config[CONF_VALUE_TEMPLATE] = (
                     "{{ is_state('" + ping_entity_id + "', 'on') }}"
                 )
             if turn_off_action:
@@ -165,12 +173,16 @@ class MigrateSwitchFlow(RepairsFlow):
             ):
                 return self.async_abort(reason="could_not_import_template")
 
-            return self.async_create_entry(data={})
+            return self.async_create_entry(
+                data={},
+                description="with_ping" if ping_host else "no_ping",
+                description_placeholders={"mac": mac, "host": ping_host or ""},
+            )
 
         return self.async_show_form(
             step_id="migrate",
             data_schema=vol.Schema({}),
-            description_placeholders={"title": name},
+            description_placeholders={"mac": mac},
         )
 
 

--- a/homeassistant/components/wake_on_lan/repairs.py
+++ b/homeassistant/components/wake_on_lan/repairs.py
@@ -1,0 +1,186 @@
+"""Repairs platform for the Wake on LAN integration."""
+
+import asyncio
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_STATE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_OFF_ACTION, CONF_ON_ACTION, DOMAIN
+
+
+class MigrateSwitchFlow(RepairsFlow):
+    """Repair flow to migrate switch to a template switch."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        """Create flow."""
+        self._data = data
+        super().__init__()
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_migrate()
+
+    async def async_step_migrate(
+        self, user_input: dict[str, Any] | None = None
+    ) -> RepairsFlowResult:
+        """Handle the migration step of a fix flow."""
+        ping_host: str | None = self._data.get(CONF_HOST)
+        mac: str = self._data[CONF_MAC]
+        broadcast_address: str | None = self._data.get(CONF_BROADCAST_ADDRESS)
+        broadcast_port: int | None = self._data.get(CONF_BROADCAST_PORT)
+        turn_off_action: list[dict[str, Any]] | None = self._data.get(CONF_OFF_ACTION)
+        name: str = self._data[CONF_NAME]
+
+        if user_input is not None:
+            entity_reg = er.async_get(self.hass)
+            ping_entry_id: str | None = None
+
+            # Setup ping sensor if host is provided
+            if ping_host:
+                ping_entry_id = None
+                ping_entries = self.hass.config_entries.async_entries("ping")
+                for entry in ping_entries:
+                    if entry.options.get(CONF_HOST) == ping_host:
+                        ping_entry_id = entry.entry_id
+                        break
+                if not ping_entry_id:
+                    ping_config = {
+                        CONF_HOST: ping_host,
+                    }
+                    import_result = await self.hass.config_entries.flow.async_init(
+                        "ping",
+                        context={"source": SOURCE_IMPORT},
+                        data=ping_config,
+                    )
+                    if not (
+                        import_result["type"] is FlowResultType.CREATE_ENTRY
+                        or (
+                            import_result["type"] is FlowResultType.ABORT
+                            and import_result["reason"] == "already_configured"
+                        )
+                    ):
+                        return self.async_abort(reason="could_not_import_host")
+                    ping_entry_id = import_result["result"].entry_id
+
+            ping_entity_id = None
+            for _ in range(10):
+                # Wait for ping config entry entity to be created
+                if ping_entry_id and (
+                    entities := er.async_entries_for_config_entry(
+                        entity_reg,
+                        ping_entry_id,
+                    )
+                ):
+                    for entity in entities:
+                        if entity.domain == "binary_sensor":
+                            ping_entity_id = entity.entity_id
+                            break
+                    break
+                await asyncio.sleep(1)
+            if not ping_entity_id:
+                return self.async_abort(reason="could_not_get_ping_entity")
+
+            # Import Wake on LAN config to get a config entry with a button entity
+            config = {
+                CONF_MAC: mac,
+                CONF_BROADCAST_ADDRESS: broadcast_address,
+                CONF_BROADCAST_PORT: broadcast_port,
+            }
+            import_result = await self.hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=config,
+            )
+            if not (
+                import_result["type"] is FlowResultType.CREATE_ENTRY
+                or (
+                    import_result["type"] is FlowResultType.ABORT
+                    and import_result["reason"] == "already_configured"
+                )
+            ):
+                return self.async_abort(reason="could_not_import_wol")
+
+            wol_entity_id = None
+            for _ in range(10):
+                # Wait for wol config entry entity to be created
+                if entities := er.async_entries_for_config_entry(
+                    entity_reg,
+                    import_result["result"].entry_id,
+                ):
+                    wol_entity_id = entities[0].entity_id
+                    break
+                await asyncio.sleep(1)
+            if not wol_entity_id:
+                return self.async_abort(reason="could_not_get_wol_entity")
+
+            template_config = {
+                CONF_NAME: name,
+                CONF_OPTIMISTIC: bool(ping_host),
+                CONF_ON_ACTION: {
+                    "action": "button.press",
+                    "target": {
+                        "entity_id": wol_entity_id,
+                    },
+                },
+            }
+            if ping_entity_id:
+                template_config[CONF_STATE] = (
+                    "{{ is_state('" + ping_entity_id + "', 'on') }}"
+                )
+            if turn_off_action:
+                template_config[CONF_OFF_ACTION] = turn_off_action
+
+            import_result = await self.hass.config_entries.flow.async_init(
+                "template",
+                context={"source": SOURCE_IMPORT},
+                data=template_config,
+            )
+            if not (
+                import_result["type"] is FlowResultType.CREATE_ENTRY
+                or (
+                    import_result["type"] is FlowResultType.ABORT
+                    and import_result["reason"] == "already_configured"
+                )
+            ):
+                return self.async_abort(reason="could_not_import_template")
+
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="migrate",
+            data_schema=vol.Schema({}),
+            description_placeholders={"title": name},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if data:
+        return MigrateSwitchFlow(data)
+
+    return ConfirmRepairFlow()

--- a/homeassistant/components/wake_on_lan/repairs.py
+++ b/homeassistant/components/wake_on_lan/repairs.py
@@ -5,13 +5,11 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.ping import DOMAIN as PING_DOMAIN
 from homeassistant.components.repairs import (
     ConfirmRepairFlow,
     RepairsFlow,
     RepairsFlowResult,
 )
-from homeassistant.components.template import DOMAIN as TEMPLATE_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_BROADCAST_ADDRESS,
@@ -57,8 +55,8 @@ class MigrateSwitchFlow(RepairsFlow):
             entity_reg = er.async_get(self.hass)
             ping_entry_id: str | None = None
 
-            # Setup ping sensor if host is provided
             if ping_host:
+                # If a hosts was provided, setup a Ping config entry
                 ping_entry_id = None
                 ping_entries = self.hass.config_entries.async_entries("ping")
                 for entry in ping_entries:
@@ -70,7 +68,7 @@ class MigrateSwitchFlow(RepairsFlow):
                         CONF_HOST: ping_host,
                     }
                     import_result = await self.hass.config_entries.flow.async_init(
-                        PING_DOMAIN,
+                        "ping",
                         context={"source": SOURCE_IMPORT},
                         data=ping_config,
                     )
@@ -86,7 +84,7 @@ class MigrateSwitchFlow(RepairsFlow):
 
             ping_entity_id = None
             for _ in range(10):
-                # Wait for ping config entry entity to be created
+                # Wait for Ping binary sensor to be created
                 if ping_entry_id and (
                     entities := er.async_entries_for_config_entry(
                         entity_reg,
@@ -132,7 +130,7 @@ class MigrateSwitchFlow(RepairsFlow):
 
             wol_entity_id = None
             for _ in range(10):
-                # Wait for wol config entry entity to be created
+                # Wait for WOL button to be created
                 if entities := er.async_entries_for_config_entry(
                     entity_reg,
                     wol_entry_id,
@@ -143,6 +141,7 @@ class MigrateSwitchFlow(RepairsFlow):
             if not wol_entity_id:
                 return self.async_abort(reason="could_not_get_wol_entity")
 
+            # Create the Template switch based on the above entities created
             template_config = {
                 CONF_NAME: name,
                 CONF_ON_ACTION: [
@@ -162,7 +161,7 @@ class MigrateSwitchFlow(RepairsFlow):
                 template_config[CONF_OFF_ACTION] = turn_off_action
 
             import_result = await self.hass.config_entries.flow.async_init(
-                TEMPLATE_DOMAIN,
+                "template",
                 context={"source": SOURCE_IMPORT},
                 data=template_config,
             )

--- a/homeassistant/components/wake_on_lan/repairs.py
+++ b/homeassistant/components/wake_on_lan/repairs.py
@@ -51,38 +51,44 @@ class MigrateSwitchFlow(RepairsFlow):
         turn_off_action: list[dict[str, Any]] | None = self._data.get(CONF_OFF_ACTION)
         name: str = self._data[CONF_NAME]
 
-        if user_input is not None:
-            entity_reg = er.async_get(self.hass)
-            ping_entry_id: str | None = None
+        if user_input is None:
+            return self.async_show_form(
+                step_id="migrate",
+                data_schema=vol.Schema({}),
+                description_placeholders={"mac": mac},
+            )
 
-            if ping_host:
-                # If a hosts was provided, setup a Ping config entry
-                ping_entry_id = None
-                ping_entries = self.hass.config_entries.async_entries("ping")
-                for entry in ping_entries:
-                    if entry.options.get(CONF_HOST) == ping_host:
-                        ping_entry_id = entry.entry_id
-                        break
-                if not ping_entry_id:
-                    ping_config = {
-                        CONF_HOST: ping_host,
-                    }
-                    import_result = await self.hass.config_entries.flow.async_init(
-                        "ping",
-                        context={"source": SOURCE_IMPORT},
-                        data=ping_config,
+        entity_reg = er.async_get(self.hass)
+        ping_entry_id: str | None = None
+
+        ping_entity_id = None
+        if ping_host:
+            # If a hosts was provided, setup a Ping config entry
+            ping_entry_id = None
+            ping_entries = self.hass.config_entries.async_entries("ping")
+            for entry in ping_entries:
+                if entry.options.get(CONF_HOST) == ping_host:
+                    ping_entry_id = entry.entry_id
+                    break
+            if not ping_entry_id:
+                ping_config = {
+                    CONF_HOST: ping_host,
+                }
+                import_result = await self.hass.config_entries.flow.async_init(
+                    "ping",
+                    context={"source": SOURCE_IMPORT},
+                    data=ping_config,
+                )
+                if not (
+                    import_result["type"] is FlowResultType.CREATE_ENTRY
+                    or (
+                        import_result["type"] is FlowResultType.ABORT
+                        and import_result["reason"] == "already_configured"
                     )
-                    if not (
-                        import_result["type"] is FlowResultType.CREATE_ENTRY
-                        or (
-                            import_result["type"] is FlowResultType.ABORT
-                            and import_result["reason"] == "already_configured"
-                        )
-                    ):
-                        return self.async_abort(reason="could_not_import_host")
-                    ping_entry_id = import_result["result"].entry_id
+                ):
+                    return self.async_abort(reason="could_not_import_host")
+                ping_entry_id = import_result["result"].entry_id
 
-            ping_entity_id = None
             for _ in range(10):
                 # Wait for Ping binary sensor to be created
                 if ping_entry_id and (
@@ -100,70 +106,23 @@ class MigrateSwitchFlow(RepairsFlow):
             if not ping_entity_id:
                 return self.async_abort(reason="could_not_get_ping_entity")
 
-            # Import Wake on LAN config to get a config entry with a button entity
-            wol_entry_id = None
-            wol_entries = self.hass.config_entries.async_entries(DOMAIN)
-            for entry in wol_entries:
-                if entry.options.get(CONF_MAC) == dr.format_mac(mac):
-                    wol_entry_id = entry.entry_id
-                    break
-            if not wol_entry_id:
-                wol_config: dict[str, Any] = {CONF_MAC: mac}
-                if broadcast_address is not None:
-                    wol_config[CONF_BROADCAST_ADDRESS] = broadcast_address
-                if broadcast_port is not None:
-                    wol_config[CONF_BROADCAST_PORT] = broadcast_port
-                import_result = await self.hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": SOURCE_IMPORT},
-                    data=wol_config,
-                )
-                if not (
-                    import_result["type"] is FlowResultType.CREATE_ENTRY
-                    or (
-                        import_result["type"] is FlowResultType.ABORT
-                        and import_result["reason"] == "already_configured"
-                    )
-                ):
-                    return self.async_abort(reason="could_not_import_wol")
-                wol_entry_id = import_result["result"].entry_id
-
-            wol_entity_id = None
-            for _ in range(10):
-                # Wait for WOL button to be created
-                if entities := er.async_entries_for_config_entry(
-                    entity_reg,
-                    wol_entry_id,
-                ):
-                    wol_entity_id = entities[0].entity_id
-                    break
-                await asyncio.sleep(1)
-            if not wol_entity_id:
-                return self.async_abort(reason="could_not_get_wol_entity")
-
-            # Create the Template switch based on the above entities created
-            template_config = {
-                CONF_NAME: name,
-                CONF_ON_ACTION: [
-                    {
-                        "action": "button.press",
-                        "target": {
-                            "entity_id": wol_entity_id,
-                        },
-                    }
-                ],
-            }
-            if ping_entity_id:
-                template_config[CONF_VALUE_TEMPLATE] = (
-                    "{{ is_state('" + ping_entity_id + "', 'on') }}"
-                )
-            if turn_off_action:
-                template_config[CONF_OFF_ACTION] = turn_off_action
-
+        # Import Wake on LAN config to get a config entry with a button entity
+        wol_entry_id = None
+        wol_entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in wol_entries:
+            if entry.options.get(CONF_MAC) == dr.format_mac(mac):
+                wol_entry_id = entry.entry_id
+                break
+        if not wol_entry_id:
+            wol_config: dict[str, Any] = {CONF_MAC: mac}
+            if broadcast_address is not None:
+                wol_config[CONF_BROADCAST_ADDRESS] = broadcast_address
+            if broadcast_port is not None:
+                wol_config[CONF_BROADCAST_PORT] = broadcast_port
             import_result = await self.hass.config_entries.flow.async_init(
-                "template",
+                DOMAIN,
                 context={"source": SOURCE_IMPORT},
-                data=template_config,
+                data=wol_config,
             )
             if not (
                 import_result["type"] is FlowResultType.CREATE_ENTRY
@@ -172,18 +131,59 @@ class MigrateSwitchFlow(RepairsFlow):
                     and import_result["reason"] == "already_configured"
                 )
             ):
-                return self.async_abort(reason="could_not_import_template")
+                return self.async_abort(reason="could_not_import_wol")
+            wol_entry_id = import_result["result"].entry_id
 
-            return self.async_create_entry(
-                data={},
-                description="with_ping" if ping_host else "no_ping",
-                description_placeholders={"mac": mac, "host": ping_host or ""},
+        wol_entity_id = None
+        for _ in range(10):
+            # Wait for WOL button to be created
+            if entities := er.async_entries_for_config_entry(
+                entity_reg,
+                wol_entry_id,
+            ):
+                wol_entity_id = entities[0].entity_id
+                break
+            await asyncio.sleep(1)
+        if not wol_entity_id:
+            return self.async_abort(reason="could_not_get_wol_entity")
+
+        # Create the Template switch based on the above entities created
+        template_config = {
+            CONF_NAME: name,
+            CONF_ON_ACTION: [
+                {
+                    "action": "button.press",
+                    "target": {
+                        "entity_id": wol_entity_id,
+                    },
+                }
+            ],
+        }
+        if ping_entity_id:
+            template_config[CONF_VALUE_TEMPLATE] = (
+                "{{ is_state('" + ping_entity_id + "', 'on') }}"
             )
+        if turn_off_action:
+            template_config[CONF_OFF_ACTION] = turn_off_action
 
-        return self.async_show_form(
-            step_id="migrate",
-            data_schema=vol.Schema({}),
-            description_placeholders={"mac": mac},
+        import_result = await self.hass.config_entries.flow.async_init(
+            "template",
+            context={"source": SOURCE_IMPORT},
+            data=template_config,
+        )
+        if not (
+            import_result["type"] is FlowResultType.CREATE_ENTRY
+            or (
+                import_result["type"] is FlowResultType.ABORT
+                and import_result["reason"] == "already_configured"
+            )
+        ):
+            return self.async_abort(reason="could_not_import_template")
+
+        return self.async_create_entry(
+            data={},
+            description="with_ping" if ping_host else "no_ping",
+            description_placeholders={"mac": mac, "host": ping_host or ""},
         )
 
 

--- a/homeassistant/components/wake_on_lan/repairs.py
+++ b/homeassistant/components/wake_on_lan/repairs.py
@@ -5,11 +5,13 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.ping import DOMAIN as PING_DOMAIN
 from homeassistant.components.repairs import (
     ConfirmRepairFlow,
     RepairsFlow,
     RepairsFlowResult,
 )
+from homeassistant.components.template import DOMAIN as TEMPLATE_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_BROADCAST_ADDRESS,
@@ -68,7 +70,7 @@ class MigrateSwitchFlow(RepairsFlow):
                         CONF_HOST: ping_host,
                     }
                     import_result = await self.hass.config_entries.flow.async_init(
-                        "ping",
+                        PING_DOMAIN,
                         context={"source": SOURCE_IMPORT},
                         data=ping_config,
                     )
@@ -160,7 +162,7 @@ class MigrateSwitchFlow(RepairsFlow):
                 template_config[CONF_OFF_ACTION] = turn_off_action
 
             import_result = await self.hass.config_entries.flow.async_init(
-                "template",
+                TEMPLATE_DOMAIN,
                 context={"source": SOURCE_IMPORT},
                 data=template_config,
             )

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -20,6 +20,23 @@
       }
     }
   },
+  "issues": {
+    "migrate_to_template": {
+      "fix_flow": {
+        "abort": {
+          "could_not_import": "Failed to import the config entry for the Group helper\n**Error:** {error}\n\nPlease manually remove the Min/Max helper and create your new Group helper.",
+          "entity_not_found": "Entity could not be found as it has been removed, aborting the repair."
+        },
+        "step": {
+          "migrate": {
+            "description": "Bla bla bla.",
+            "title": "[%key:component::wake_on_lan::issues::migrate_to_template::title%]"
+          }
+        }
+      },
+      "title": "WOL switch has been deprecated"
+    }
+  },
   "options": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -24,17 +24,29 @@
     "migrate_to_template": {
       "fix_flow": {
         "abort": {
-          "could_not_import": "Failed to import the config entry for the Group helper\n**Error:** {error}\n\nPlease manually remove the Min/Max helper and create your new Group helper.",
-          "entity_not_found": "Entity could not be found as it has been removed, aborting the repair."
+          "could_not_get_ping_entity": "Ping entity could not be retrieved after the import",
+          "could_not_get_wol_entity": "Wake on LAN button could not be retrieved after the import",
+          "could_not_import_host": "Failed to import the configuration into a Ping sensor",
+          "could_not_import_template": "Failed to import the configuration into a Template switch",
+          "could_not_import_wol": "Failed to import the configuration into a Wake on LAN button"
+        },
+        "create_entry": {
+          "default": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Ping binary sensor has been created for the host {host}.\n- A Template switch has been created that will use the newly created Wake on LAN button and Ping binary sensor.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue.",
+          "no_ping": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Template switch has been created that will use the newly created Wake on LAN button.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue.",
+          "with_ping": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Ping binary sensor has been created for the host {host}.\n- A Template switch has been created that will use the newly created Wake on LAN button and Ping binary sensor.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue."
         },
         "step": {
           "migrate": {
-            "description": "Bla bla bla.",
+            "description": "Using the Wake on LAN integration to create a switch entity for mac `{mac}` has been deprecated and will be removed in Home Assistant 2027.2.0.\n\nBy clicking submit, your configuration will be migrated. Depending on your configuration, it will can:\n\n- Create a Wake on LAN button entity to send magic packets\n- Create a Ping binary sensor for your host\n- Create a Template switch to control on/off actions",
             "title": "[%key:component::wake_on_lan::issues::migrate_to_template::title%]"
           }
         }
       },
-      "title": "WOL switch has been deprecated"
+      "title": "Wake on LAN switch has been deprecated"
+    },
+    "wol_service_deprecated": {
+      "description": "The Wake on LAN magic packet action has been deprecated and will be removed in Home Assistant 2027.2.0.\n\nPlease create a new Wake on LAN config entry for the device you want to send magic packets to and update any automation or script that reference this action to use a Wake on LAN button entity.",
+      "title": "Wake on LAN magic packet action has been deprecated"
     }
   },
   "options": {

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -31,13 +31,12 @@
           "could_not_import_wol": "Failed to import the configuration into a Wake on LAN button"
         },
         "create_entry": {
-          "default": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Ping binary sensor has been created for the host {host}.\n- A Template switch has been created that will use the newly created Wake on LAN button and Ping binary sensor.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue.",
           "no_ping": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Template switch has been created that will use the newly created Wake on LAN button.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue.",
           "with_ping": "Your configuration has been migrated to a new Wake on LAN config entry.\n\n-A Wake on LAN config entry has been created with a button for sending magic packets to {mac}.\n- A Ping binary sensor has been created for the host {host}.\n- A Template switch has been created that will use the newly created Wake on LAN button and Ping binary sensor.\n\nYou can now remove the old Wake on LAN switch from your YAML configuration and restart Home Assistant to fix this issue."
         },
         "step": {
           "migrate": {
-            "description": "Using the Wake on LAN integration to create a switch entity for mac `{mac}` has been deprecated and will be removed in Home Assistant 2027.2.0.\n\nBy clicking submit, your configuration will be migrated. Depending on your configuration, it will can:\n\n- Create a Wake on LAN button entity to send magic packets\n- Create a Ping binary sensor for your host\n- Create a Template switch to control on/off actions",
+            "description": "Using the Wake on LAN integration to create a switch entity for mac `{mac}` has been deprecated and will be removed in Home Assistant 2027.2.0.\n\nBy clicking submit, your configuration will be migrated. Depending on your configuration, it can:\n\n- Create a Wake on LAN button entity to send magic packets\n- Create a Ping binary sensor for your host\n- Create a Template switch to control on/off actions",
             "title": "[%key:component::wake_on_lan::issues::migrate_to_template::title%]"
           }
         }

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -47,6 +48,18 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up a wake on lan switch."""
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "migrate_to_template",
+        breaks_in_ha_version="2026.12.0",
+        is_fixable=True,
+        is_persistent=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="migrate_to_template",
+        data=config,
+    )
+
     broadcast_address: str | None = config.get(CONF_BROADCAST_ADDRESS)
     broadcast_port: int | None = config.get(CONF_BROADCAST_PORT)
     host: str | None = config.get(CONF_HOST)

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -1,5 +1,7 @@
 """Support for wake on lan."""
 
+import hashlib
+import json
 import logging
 import subprocess as sp
 from typing import Any, override
@@ -48,10 +50,15 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up a wake on lan switch."""
+
+    def make_hash(config: dict[str, Any]) -> str:
+        d = hashlib.sha1(json.dumps(config, sort_keys=True).encode())
+        return d.hexdigest()
+
     async_create_issue(
         hass,
         DOMAIN,
-        "migrate_to_template",
+        f"migrate_to_template-{make_hash(config)}",
         breaks_in_ha_version="2026.12.0",
         is_fixable=True,
         is_persistent=False,

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
@@ -101,3 +102,35 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
         assert len(mocked_wakeonlan.mock_calls) == 1
         assert mocked_wakeonlan.mock_calls[0][1][0] == mac
         assert not mocked_wakeonlan.mock_calls[0][2]
+
+
+async def test_send_magic_packet_raise_repair(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test of send magic packet service call raises a repair."""
+    assert await async_setup_component(hass, "repairs", {})
+    mac = "aa:bb:cc:dd:ee:ff"
+    with patch("homeassistant.components.wake_on_lan.wakeonlan"):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_MAGIC_PACKET,
+            {"mac": mac},
+            blocking=True,
+        )
+
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "wol_service_deprecated":
+            issue = i
+    assert issue is not None
+    assert issue["issue_id"] == "wol_service_deprecated"
+    assert issue["translation_key"] == "wol_service_deprecated"

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -1,0 +1,89 @@
+"""Test repairs for Wake on LAN."""
+
+from unittest.mock import patch
+
+from icmplib import Host
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.wake_on_lan.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
+
+from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+FULL_CONFIG = {
+    "platform": "wake_on_lan",
+    "name": "Test",
+    "mac": "00-01-02-03-04-05",
+    "host": "somehostname.local",
+    "turn_off": [
+        {
+            "action": "input_number.increment",
+            "target": {"entity_id": "input_number.number"},
+        }
+    ],
+    "broadcast_address": "255.255.255.255",
+    "broadcast_port": "1",
+}
+
+
+async def test_full_config(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test fixing bad country."""
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: FULL_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test")
+    assert state
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "migrate_to_template":
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, "migrate_to_template")
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "migrate_to_template":
+            issue = i
+    assert not issue

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -28,6 +28,29 @@ FULL_CONFIG = {
     "broadcast_address": "255.255.255.255",
     "broadcast_port": "1",
 }
+MINIMAL_CONFIG = {
+    "platform": "wake_on_lan",
+    "mac": "00-01-02-03-04-05",
+}
+NO_HOST_CONFIG = {
+    "platform": "wake_on_lan",
+    "name": "Test",
+    "mac": "00-01-02-03-04-05",
+    "turn_off": [
+        {
+            "action": "input_number.increment",
+            "target": {"entity_id": "input_number.number"},
+        }
+    ],
+}
+NO_TURN_OFF_CONFIG = {
+    "platform": "wake_on_lan",
+    "name": "Test",
+    "mac": "00-01-02-03-04-05",
+    "host": "somehostname.local",
+    "broadcast_address": "255.255.255.255",
+    "broadcast_port": "1",
+}
 
 
 async def test_full_config(
@@ -36,7 +59,7 @@ async def test_full_config(
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test fixing bad country."""
+    """Test fixing with a full config."""
     assert await async_setup_component(hass, "repairs", {})
     assert await async_setup_component(
         hass,
@@ -149,4 +172,320 @@ async def test_full_config(
                 "target": {"entity_id": ["input_number.number"]},
             }
         ],
+    }
+
+
+async def test_minimal_config(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test fixing with minimal configuration."""
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: MINIMAL_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.wake_on_lan")
+    assert state
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # Repair does not remove the WOL switch
+    state = hass.states.get("switch.wake_on_lan")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert not issue
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+    wol_entity = wol_entities[0].entity_id
+
+    wol_config_entry = wol_config_entries[0]
+    assert wol_config_entry.title == "Wake on LAN 00:01:02:03:04:05"
+    assert wol_config_entry.options == {
+        "mac": "00:01:02:03:04:05",
+    }
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+    assert template_entities[0].original_name == "Wake on LAN"
+
+    template_config_entry = template_config_entries[0]
+    assert template_config_entry.title == "Wake on LAN"
+    assert template_config_entry.options == {
+        "template_type": "switch",
+        "name": "Wake on LAN",
+        "turn_on": [
+            {
+                "action": "button.press",
+                "target": {"entity_id": wol_entity},
+            }
+        ],
+    }
+
+
+async def test_no_host_config(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test fixing with a no host configured."""
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: NO_HOST_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test")
+    assert state
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # Repair does not remove the WOL switch
+    state = hass.states.get("switch.test")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert not issue
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+    wol_entity = wol_entities[0].entity_id
+
+    wol_config_entry = wol_config_entries[0]
+    assert wol_config_entry.title == "Wake on LAN 00:01:02:03:04:05"
+    assert wol_config_entry.options == {
+        "mac": "00:01:02:03:04:05",
+    }
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+    assert template_entities[0].original_name == "Test"
+
+    template_config_entry = template_config_entries[0]
+    assert template_config_entry.title == "Test"
+    assert template_config_entry.options == {
+        "template_type": "switch",
+        "name": "Test",
+        "turn_on": [
+            {
+                "action": "button.press",
+                "target": {"entity_id": wol_entity},
+            }
+        ],
+        "turn_off": [
+            {
+                "action": "input_number.increment",
+                "target": {"entity_id": ["input_number.number"]},
+            }
+        ],
+    }
+
+
+async def test_no_turn_off_config(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test fixing with no turn off action in config."""
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: NO_TURN_OFF_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test")
+    assert state
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # Repair does not remove the WOL switch
+    state = hass.states.get("switch.test")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert not issue
+
+    ping_config_entries = hass.config_entries.async_entries("ping")
+    assert ping_config_entries
+    ping_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        ping_config_entries[0].entry_id
+    )
+    assert ping_entities
+    ping_entity = ping_entities[0].entity_id
+
+    ping_config_entry = ping_config_entries[0]
+    assert ping_config_entry.title == "somehostname.local"
+    assert ping_config_entry.options == {
+        "host": "somehostname.local",
+        "count": 5,
+        "consider_home": 180,
+    }
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+    wol_entity = wol_entities[0].entity_id
+
+    wol_config_entry = wol_config_entries[0]
+    assert wol_config_entry.title == "Wake on LAN 00:01:02:03:04:05"
+    assert wol_config_entry.options == {
+        "mac": "00:01:02:03:04:05",
+        "broadcast_address": "255.255.255.255",
+        "broadcast_port": 1,
+    }
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+    assert template_entities[0].original_name == "Test"
+
+    template_config_entry = template_config_entries[0]
+    assert template_config_entry.title == "Test"
+    assert template_config_entry.options == {
+        "template_type": "switch",
+        "name": "Test",
+        "turn_on": [
+            {
+                "action": "button.press",
+                "target": {"entity_id": wol_entity},
+            }
+        ],
+        "value_template": "{{ is_state('" + ping_entity + "', 'on') }}",
     }

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -8,6 +8,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.wake_on_lan.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
@@ -33,6 +34,7 @@ async def test_full_config(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test fixing bad country."""
     assert await async_setup_component(hass, "repairs", {})
@@ -88,3 +90,63 @@ async def test_full_config(
         if i["issue_id"].startswith("migrate_to_template"):
             issue = i
     assert not issue
+
+    ping_config_entries = hass.config_entries.async_entries("ping")
+    assert ping_config_entries
+    ping_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        ping_config_entries[0].entry_id
+    )
+    assert ping_entities
+    ping_entity = ping_entities[0].entity_id
+
+    ping_config_entry = ping_config_entries[0]
+    assert ping_config_entry.title == "somehostname.local"
+    assert ping_config_entry.options == {
+        "host": "somehostname.local",
+        "count": 5,
+        "consider_home": 180,
+    }
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+    wol_entity = wol_entities[0].entity_id
+
+    wol_config_entry = wol_config_entries[0]
+    assert wol_config_entry.title == "Wake on LAN 00:01:02:03:04:05"
+    assert wol_config_entry.options == {
+        "mac": "00:01:02:03:04:05",
+        "broadcast_address": "255.255.255.255",
+        "broadcast_port": 1,
+    }
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+    assert template_entities[0].original_name == "Test"
+
+    template_config_entry = template_config_entries[0]
+    assert template_config_entry.title == "Test"
+    assert template_config_entry.options == {
+        "template_type": "switch",
+        "name": "Test",
+        "turn_on": [
+            {
+                "action": "button.press",
+                "target": {"entity_id": wol_entity},
+            }
+        ],
+        "value_template": "{{ is_state('" + ping_entity + "', 'on') }}",
+        "turn_off": [
+            {
+                "action": "input_number.increment",
+                "target": {"entity_id": ["input_number.number"]},
+            }
+        ],
+    }

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -56,11 +56,11 @@ async def test_full_config(
     assert len(msg["result"]["issues"]) > 0
     issue = None
     for i in msg["result"]["issues"]:
-        if i["issue_id"] == "migrate_to_template":
+        if i["issue_id"].startswith("migrate_to_template"):
             issue = i
     assert issue is not None
 
-    data = await start_repair_fix_flow(client, DOMAIN, "migrate_to_template")
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
 
     flow_id = data["flow_id"]
     assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
@@ -75,6 +75,7 @@ async def test_full_config(
     assert data["type"] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
+    # Repair does not remove the WOL switch
     state = hass.states.get("switch.test")
     assert state
 
@@ -84,6 +85,6 @@ async def test_full_config(
     assert msg["success"]
     issue = None
     for i in msg["result"]["issues"]:
-        if i["issue_id"] == "migrate_to_template":
+        if i["issue_id"].startswith("migrate_to_template"):
             issue = i
     assert not issue

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -668,6 +668,12 @@ async def test_template_switch_already_exist(
                     "target": {"entity_id": "button.wake_on_lan_00_01_02_03_04_05"},
                 }
             ],
+            "turn_off": [
+                {
+                    "action": "input_number.increment",
+                    "target": {"entity_id": ["input_number.number"]},
+                }
+            ],
             "value_template": "{{ is_state('binary_sensor.somehostname_local', 'on') }}",
         },
     )

--- a/tests/components/wake_on_lan/test_repairs.py
+++ b/tests/components/wake_on_lan/test_repairs.py
@@ -11,6 +11,7 @@ from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -489,3 +490,269 @@ async def test_no_turn_off_config(
         ],
         "value_template": "{{ is_state('" + ping_entity + "', 'on') }}",
     }
+
+
+async def test_input_entities_already_exist(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test fixing when matching ping and WOL entity already exist.
+
+    Only the Template switch should be created.
+    """
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: FULL_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    ping_entry = MockConfigEntry(
+        title="somehostname.local",
+        domain="ping",
+        data={},
+        options={
+            "host": "somehostname.local",
+            "count": 5,
+            "consider_home": 180,
+        },
+        minor_version=2,
+    )
+    ping_entry.add_to_hass(hass)
+    wol_entry = MockConfigEntry(
+        title="Wake on LAN 00:01:02:03:04:05",
+        domain="wake_on_lan",
+        data={},
+        options={
+            "mac": "00:01:02:03:04:05",
+            "broadcast_address": "255.255.255.255",
+            "broadcast_port": 1,
+        },
+    )
+    wol_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        await hass.config_entries.async_setup(ping_entry.entry_id)
+    await hass.config_entries.async_setup(wol_entry.entry_id)
+    await hass.async_block_till_done(True)
+
+    states = hass.states.async_all()
+    # switch.test - WOL YAML switch
+    # binary_sensor.somehostname_local - Ping config entry
+    # zone.home
+    # button.wake_on_lan_00_01_02_03_04_05 - WOL config entry
+    assert len(states) == 4
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # Repair does not remove the WOL switch
+    state = hass.states.get("switch.test")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert not issue
+
+    ping_config_entries = hass.config_entries.async_entries("ping")
+    assert ping_config_entries
+    ping_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        ping_config_entries[0].entry_id
+    )
+    assert ping_entities
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+
+    states = hass.states.async_all()
+    # switch.test - WOL YAML switch
+    # binary_sensor.somehostname_local - Ping config entry
+    # zone.home
+    # button.wake_on_lan_00_01_02_03_04_05 - WOL config entry
+    # switch.test_2 - Template switch
+    assert len(states) == 5
+
+
+async def test_template_switch_already_exist(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test fixing when also template switch already exist."""
+    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {SWITCH_DOMAIN: FULL_CONFIG},
+    )
+    await hass.async_block_till_done()
+
+    ping_entry = MockConfigEntry(
+        title="somehostname.local",
+        domain="ping",
+        data={},
+        options={
+            "host": "somehostname.local",
+            "count": 5,
+            "consider_home": 180,
+        },
+        minor_version=2,
+    )
+    ping_entry.add_to_hass(hass)
+    wol_entry = MockConfigEntry(
+        title="Wake on LAN 00:01:02:03:04:05",
+        domain="wake_on_lan",
+        data={},
+        options={
+            "mac": "00:01:02:03:04:05",
+            "broadcast_address": "255.255.255.255",
+            "broadcast_port": 1,
+        },
+    )
+    wol_entry.add_to_hass(hass)
+    template_entry = MockConfigEntry(
+        title="Test",
+        domain="template",
+        data={},
+        options={
+            "template_type": "switch",
+            "name": "Test",
+            "turn_on": [
+                {
+                    "action": "button.press",
+                    "target": {"entity_id": "button.wake_on_lan_00_01_02_03_04_05"},
+                }
+            ],
+            "value_template": "{{ is_state('binary_sensor.somehostname_local', 'on') }}",
+        },
+    )
+    template_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.ping.helpers.async_ping",
+        return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
+    ):
+        await hass.config_entries.async_setup(ping_entry.entry_id)
+    await hass.config_entries.async_setup(wol_entry.entry_id)
+    await hass.config_entries.async_setup(template_entry.entry_id)
+    await hass.async_block_till_done(True)
+
+    states = hass.states.async_all()
+    # switch.test - WOL YAML switch
+    # binary_sensor.somehostname_local - Ping config entry
+    # zone.home
+    # button.wake_on_lan_00_01_02_03_04_05 - WOL config entry
+    # switch.test_2 - Template switch
+    assert len(states) == 5
+
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert issue is not None
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue["issue_id"])
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {"mac": "00-01-02-03-04-05"}
+    assert data["step_id"] == "migrate"
+
+    data = await process_repair_fix_flow(client, flow_id, json={})
+
+    assert data["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # Repair does not remove the WOL switch
+    state = hass.states.get("switch.test")
+    assert state
+
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"].startswith("migrate_to_template"):
+            issue = i
+    assert not issue
+
+    ping_config_entries = hass.config_entries.async_entries("ping")
+    assert ping_config_entries
+    ping_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        ping_config_entries[0].entry_id
+    )
+    assert ping_entities
+
+    wol_config_entries = hass.config_entries.async_entries("wake_on_lan")
+    assert wol_config_entries
+    wol_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        wol_config_entries[0].entry_id
+    )
+    assert wol_entities
+
+    template_config_entries = hass.config_entries.async_entries("template")
+    assert template_config_entries
+    template_entities = entity_registry.entities.get_entries_for_config_entry_id(
+        template_config_entries[0].entry_id
+    )
+    assert template_entities
+
+    states = hass.states.async_all()
+    # switch.test - WOL YAML switch
+    # binary_sensor.somehostname_local - Ping config entry
+    # zone.home
+    # button.wake_on_lan_00_01_02_03_04_05 - WOL config entry
+    # switch.test_2 - Template switch
+    assert len(states) == 5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Your Wake on LAN switch has been imported and created
- A Ping binary sensor if a host was configured
- A Wake on LAN button for sending magic packets
- A Template switch that uses the above entities to control the device

In addition the `send_magic_packet` action has been deprecated and will be removed with the above.

The existing YAML configuration can be removed

## Proposed change
See breaking
Background: https://github.com/home-assistant/core/pull/121605#discussion_r1670983249

<img width="457" height="365" alt="image" src="https://github.com/user-attachments/assets/93394ecc-3df0-4899-9683-5f42e37a22d1" />
<img width="457" height="283" alt="image" src="https://github.com/user-attachments/assets/a1c5cf9f-9665-48d3-9ff5-d91038b5d654" />



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47466
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53671

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 