### PR TITLE
Fix Roomba vacuum state during dock maintenance

### DIFF
--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -32,11 +32,13 @@ SUPPORT_IROBOT = (
 STATE_MAP = {
     "": VacuumActivity.IDLE,
     "charge": VacuumActivity.DOCKED,
-    "evac": VacuumActivity.RETURNING,  # Emptying at cleanbase
+    "evac": VacuumActivity.DOCKED,  # Emptying at cleanbase; the robot does not move
     "hmMidMsn": VacuumActivity.CLEANING,  # Recharging at the middle of a cycle
     "hmPostMsn": VacuumActivity.RETURNING,  # Cycle finished
     "hmUsrDock": VacuumActivity.RETURNING,
+    "padWash": VacuumActivity.DOCKED,  # Dock washing the mop pad
     "pause": VacuumActivity.PAUSED,
+    "refill": VacuumActivity.DOCKED,  # Dock refilling the robot's tank
     "run": VacuumActivity.CLEANING,
     "stop": VacuumActivity.IDLE,
     "stuck": VacuumActivity.ERROR,
@@ -131,6 +133,9 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
             state = STATE_MAP[phase]
         except KeyError:
             return VacuumActivity.ERROR
+        # Dock servicing reports `run` with no mission cycle.
+        if cycle == "none" and state is VacuumActivity.CLEANING:
+            state = VacuumActivity.DOCKED
         # A robot stopped in the middle of a mission is paused, but one that is
         # docked to recharge mid-mission stays docked (the charging binary
         # sensor distinguishes it from a user-initiated pause on the floor).

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -134,7 +134,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         except KeyError:
             return VacuumActivity.ERROR
         # Dock servicing reports `run` with no mission cycle.
-        if cycle == "none" and state is VacuumActivity.CLEANING:
+        if phase == "run" and cycle == "none":
             state = VacuumActivity.DOCKED
         # A robot stopped in the middle of a mission is paused, but one that is
         # docked to recharge mid-mission stays docked (the charging binary

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -28,6 +28,13 @@ ENTITY_ID = "vacuum.test_roomba"
         ("stop", "clean", VacuumActivity.PAUSED),
         ("stop", "none", VacuumActivity.IDLE),
         ("stuck", "clean", VacuumActivity.ERROR),
+        # Dock maintenance: the robot is stationary on the dock throughout.
+        ("evac", "evac", VacuumActivity.DOCKED),
+        ("evac", "clean", VacuumActivity.DOCKED),
+        ("padWash", "none", VacuumActivity.DOCKED),
+        ("refill", "none", VacuumActivity.DOCKED),
+        # Dock servicing reports `run` with no mission cycle.
+        ("run", "none", VacuumActivity.DOCKED),
     ],
 )
 async def test_vacuum_activity(


### PR DESCRIPTION
## Proposed change

On robots with a self-emptying or pad-washing dock, four dock activities report the wrong state:

| Dock activity | Robot reports | Current | Correct |
|---|---|---|---|
| Bin empty | phase `evac` | `returning` | `docked` |
| Tank refill | phase `refill` | `error` | `docked` |
| Pad wash | phase `padWash` | `error` | `docked` |
| Basin rinse | phase `run`, cycle `none` | `cleaning` | `docked` |

`refill` and `padWash` are missing from `STATE_MAP` and hit the `KeyError` fallback. `evac` is mapped to `RETURNING`, but emptying happens on the dock and the robot does not move; homing is `hmPostMsn`/`hmUsrDock`, which are mapped separately. Dock servicing reports `run` with `cycle: none`, and `run` maps to `CLEANING` without consulting `cycle`.

Observed on a Roomba Combo (sku `x085020`, sw `topaz+1.12.11`) by triggering each dock command and reading `cleanMissionStatus`.

That the robot is in the dock for the whole of an `evac` is supported by `dock.state`, a separate key in the reported shadow that owes nothing to `cleanMissionStatus.phase`. Tabulating every value it took against the mission phase in force, over 30 days on this robot:

```
dock.state  intervals  total     mission phases it occurred with
300         32          ~10600s  run, padWash, hmUsrDock, charge
301         38         ~147000s  charge, evac, padWash, hmUsrDock, stop, hmMidMsn, hmPostMsn
302          5              61s  evac only
303          5              28s  evac only
```

302 and 303 occur only while the phase is `evac`, never during `charge`, `run`, `padWash` or either homing phase, and `dock.tankLvl` changed across one of those intervals. I have no iRobot documentation for what 300-303 mean, so reading 302/303 as active evacuation is inference from the correlation and the durations rather than a documented meaning; what it does establish is that the dock reports its own servicing states, and a dock cannot run an evacuation on a robot that is not in it.

(An earlier version of this description argued from the `charging` binary sensor dropping during the evacuation. That was wrong of me and I have removed it: `RoombaCharging.is_on` is `cleanMissionStatus.phase == "charge"`, so it necessarily goes off when the phase becomes `evac` and shows nothing about power or motion.)

Verified on the device after the change: each dock command holds `docked`, and a normal mission still reports `cleaning`, `paused`, `returning`, `docked`. Existing parametrized cases are unaffected; five rows added for the new behaviour.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
