### PR TITLE
Fix OneDrive OAuth token refresh reauthentication

### DIFF
--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -13,9 +13,15 @@ from onedrive_personal_sdk.exceptions import (
     OneDriveException,
 )
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -176,7 +182,21 @@ async def _get_onedrive_client(
     session = OAuth2Session(hass, entry, implementation)
 
     async def get_access_token() -> str:
-        await session.async_ensure_token_valid()
+        setup_in_progress = entry.state is ConfigEntryState.SETUP_IN_PROGRESS
+        try:
+            await session.async_ensure_token_valid()
+        except OAuth2TokenRequestReauthError as err:
+            if setup_in_progress:
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="authentication_failed",
+                ) from err
+            entry.async_start_reauth(hass)
+            raise
+        except OAuth2TokenRequestError as err:
+            if setup_in_progress:
+                raise ConfigEntryNotReady from err
+            raise
         return cast(str, session.token[CONF_ACCESS_TOKEN])
 
     return (

--- a/tests/components/onedrive/test_init.py
+++ b/tests/components/onedrive/test_init.py
@@ -3,7 +3,7 @@
 from copy import copy
 from html import escape
 from json import dumps
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from onedrive_personal_sdk.const import DriveState
 from onedrive_personal_sdk.exceptions import (
@@ -20,8 +20,13 @@ from homeassistant.components.onedrive.const import (
     CONF_FOLDER_NAME,
     DOMAIN,
 )
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -56,6 +61,110 @@ async def test_load_unload_config_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_oauth_token_request_reauth_error_starts_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_approot: AppRoot,
+    mock_onedrive_client: MagicMock,
+    mock_onedrive_client_init: MagicMock,
+) -> None:
+    """Test a token refresh reauth error starts a reauth flow."""
+
+    async def get_approot() -> AppRoot:
+        token_callback = mock_onedrive_client_init.call_args[0][0]
+        await token_callback()
+        return mock_approot
+
+    mock_onedrive_client.get_approot.side_effect = get_approot
+
+    with patch(
+        "homeassistant.components.onedrive.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestReauthError(
+            request_info=Mock(),
+            domain=DOMAIN,
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow["handler"] == DOMAIN
+    assert flow.get("step_id") == "reauth_confirm"
+    assert flow.get("context", {}).get("source") == SOURCE_REAUTH
+
+
+async def test_oauth_token_request_reauth_error_during_update_starts_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_onedrive_client_init: MagicMock,
+) -> None:
+    """Test a token refresh reauth error during an update starts reauth."""
+    await setup_integration(hass, mock_config_entry)
+    token_callback = mock_onedrive_client_init.call_args[0][0]
+
+    with (
+        patch(
+            "homeassistant.components.onedrive.OAuth2Session.async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestReauthError(
+                request_info=Mock(),
+                domain=DOMAIN,
+            ),
+        ),
+        pytest.raises(OAuth2TokenRequestReauthError),
+    ):
+        await token_callback()
+
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["handler"] == DOMAIN
+    assert flows[0].get("step_id") == "reauth_confirm"
+    assert flows[0].get("context", {}).get("source") == SOURCE_REAUTH
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(
+            OAuth2TokenRequestError(request_info=Mock(), domain=DOMAIN),
+            id="generic",
+        ),
+        pytest.param(
+            OAuth2TokenRequestTransientError(request_info=Mock(), domain=DOMAIN),
+            id="transient",
+        ),
+    ],
+)
+async def test_oauth_token_request_error_retries_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_approot: AppRoot,
+    mock_onedrive_client: MagicMock,
+    mock_onedrive_client_init: MagicMock,
+    error: OAuth2TokenRequestError,
+) -> None:
+    """Test a token refresh error retries setup."""
+
+    async def get_approot() -> AppRoot:
+        token_callback = mock_onedrive_client_init.call_args[0][0]
+        await token_callback()
+        return mock_approot
+
+    mock_onedrive_client.get_approot.side_effect = get_approot
+
+    with patch(
+        "homeassistant.components.onedrive.OAuth2Session.async_ensure_token_valid",
+        side_effect=error,
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.config_entries.flow.async_progress()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle OAuth token refresh failures in the OneDrive integration so Home Assistant starts reauthentication when the refresh token is no longer accepted. During setup, reauthentication failures are mapped to `ConfigEntryAuthFailed` and generic or transient refresh failures are retried through `ConfigEntryNotReady`. After setup, a reauthentication failure starts the normal reauth flow and is re-raised for the existing caller.

Add regression coverage for setup-time reauth, runtime reauth, and generic/transient setup-retry behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- No issue is being opened for this focused bugfix.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

