### PR TITLE
Add Roomba dock and mission diagnostic sensors

### DIFF
--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -24,10 +25,49 @@ async def async_setup_entry(
     roomba = domain_data.roomba
     blid = domain_data.blid
     entities: list[BinarySensorEntity] = [RoombaCharging(roomba, blid)]
-    status = roomba_reported_state(roomba).get("bin", {})
+    reported = roomba_reported_state(roomba)
+    status = reported.get("bin", {})
     if "full" in status:
         entities.append(RoombaBinStatus(roomba, blid))
+    entities.extend(
+        RoombaDockCapability(roomba, blid, api_key, translation_key)
+        for api_key, translation_key in (
+            ("evacAllowed", "bin_empty_allowed"),
+            ("padWashAllowed", "pad_wash_allowed"),
+            ("padDryAllowed", "pad_dry_allowed"),
+        )
+        if api_key in reported
+    )
     async_add_entities(entities)
+
+
+class RoombaDockCapability(IRobotEntity, BinarySensorEntity):
+    """Reports whether the dock currently permits an action."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, roomba, blid: str, api_key: str, translation_key: str) -> None:
+        """Initialize the capability binary sensor."""
+        super().__init__(roomba, blid)
+        self._api_key = api_key
+        self._attr_translation_key = translation_key
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        """Return the ID of this sensor."""
+        return f"{self._attr_translation_key}_{self._blid}"
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return whether the dock currently permits this action."""
+        return roomba_reported_state(self.vacuum).get(self._api_key) in (True, 1)
+
+    @override
+    def new_state_filter(self, new_state):
+        """Filter the new state."""
+        return self._api_key in new_state
 
 
 class RoombaBinStatus(IRobotEntity, BinarySensorEntity):

--- a/homeassistant/components/roomba/entity.py
+++ b/homeassistant/components/roomba/entity.py
@@ -1,6 +1,6 @@
 """Base class for iRobot devices."""
 
-from typing import override
+from typing import Any, override
 
 from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.helpers import device_registry as dr
@@ -55,6 +55,11 @@ class IRobotEntity(Entity):
     def unique_id(self):
         """Return the uniqueid of the vacuum cleaner."""
         return self.robot_unique_id
+
+    @property
+    def clean_mission_status(self) -> dict[str, Any]:
+        """Return the current clean mission status."""
+        return self.vacuum_state.get("cleanMissionStatus", {})
 
     @property
     def run_stats(self):

--- a/homeassistant/components/roomba/icons.json
+++ b/homeassistant/components/roomba/icons.json
@@ -1,8 +1,17 @@
 {
   "entity": {
     "binary_sensor": {
+      "bin_empty_allowed": {
+        "default": "mdi:delete-empty"
+      },
       "bin_full": {
         "default": "mdi:delete-variant"
+      },
+      "pad_dry_allowed": {
+        "default": "mdi:tumble-dryer"
+      },
+      "pad_wash_allowed": {
+        "default": "mdi:washing-machine"
       }
     },
     "sensor": {
@@ -15,6 +24,12 @@
       "canceled_missions": {
         "default": "mdi:counter"
       },
+      "detected_pad": {
+        "default": "mdi:rectangle-outline"
+      },
+      "dock_state": {
+        "default": "mdi:home-import-outline"
+      },
       "dock_tank_level": {
         "default": "mdi:water"
       },
@@ -23,6 +38,15 @@
       },
       "last_mission": {
         "default": "mdi:calendar-clock"
+      },
+      "mission_cycle": {
+        "default": "mdi:sync"
+      },
+      "mission_phase": {
+        "default": "mdi:state-machine"
+      },
+      "not_ready_code": {
+        "default": "mdi:alert-circle-outline"
       },
       "scrubs_count": {
         "default": "mdi:counter"

--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -36,6 +36,18 @@ DOCK_SENSORS: list[RoombaSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda self: self.dock_tank_level,
     ),
+    # The dock reports its activity as an undocumented numeric code. Observed
+    # on a Roomba Combo: 300 while the robot is away or the dock idle, 301 at
+    # rest on the dock, 302 and 303 during a bin evacuation, and 300/301
+    # alternating through a pad wash. The full mapping is not published, so the
+    # raw value is surfaced rather than a guessed enum that would be wrong for
+    # other models or firmware.
+    RoombaSensorEntityDescription(
+        key="dock_state",
+        translation_key="dock_state",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda self: self.vacuum_state.get("dock", {}).get("state"),
+    ),
 ]
 
 SENSORS: list[RoombaSensorEntityDescription] = [
@@ -135,6 +147,31 @@ SENSORS: list[RoombaSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda self: self.last_mission,
         entity_registry_enabled_default=False,
+    ),
+    RoombaSensorEntityDescription(
+        key="mission_phase",
+        translation_key="mission_phase",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda self: self.clean_mission_status.get("phase"),
+    ),
+    RoombaSensorEntityDescription(
+        key="mission_cycle",
+        translation_key="mission_cycle",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda self: self.clean_mission_status.get("cycle"),
+    ),
+    RoombaSensorEntityDescription(
+        key="not_ready_code",
+        translation_key="not_ready_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda self: self.clean_mission_status.get("notReady"),
+        entity_registry_enabled_default=False,
+    ),
+    RoombaSensorEntityDescription(
+        key="detected_pad",
+        translation_key="detected_pad",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda self: self.vacuum_state.get("detectedPad"),
     ),
 ]
 

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -46,8 +46,17 @@
   },
   "entity": {
     "binary_sensor": {
+      "bin_empty_allowed": {
+        "name": "Bin empty allowed"
+      },
       "bin_full": {
         "name": "Bin full"
+      },
+      "pad_dry_allowed": {
+        "name": "Pad dry allowed"
+      },
+      "pad_wash_allowed": {
+        "name": "Pad wash allowed"
       }
     },
     "sensor": {
@@ -60,6 +69,12 @@
       "canceled_missions": {
         "name": "Canceled missions"
       },
+      "detected_pad": {
+        "name": "Detected pad"
+      },
+      "dock_state": {
+        "name": "Dock state"
+      },
       "dock_tank_level": {
         "name": "Dock tank level"
       },
@@ -68,6 +83,15 @@
       },
       "last_mission": {
         "name": "Last mission start time"
+      },
+      "mission_cycle": {
+        "name": "Mission cycle"
+      },
+      "mission_phase": {
+        "name": "Mission phase"
+      },
+      "not_ready_code": {
+        "name": "Not ready code"
       },
       "scrubs_count": {
         "name": "Scrubs"

--- a/tests/components/roomba/conftest.py
+++ b/tests/components/roomba/conftest.py
@@ -40,7 +40,10 @@ def mock_roomba() -> Generator[AsyncMock]:
                 "cap": {"pose": 1},
                 "cleanMissionStatus": {"cycle": "none", "phase": "charge"},
                 "pose": {"point": {"x": 1, "y": 2}, "theta": 90},
-                "dock": {"tankLvl": 99},
+                "dock": {"tankLvl": 99, "state": 301},
+                "evacAllowed": True,
+                "padWashAllowed": 1,
+                "padDryAllowed": 1,
                 "hwPartsRev": {
                     "navSerialNo": "12345",
                     "wlan0HwAddr": "AA:BB:CC:DD:EE:FF",

--- a/tests/components/roomba/snapshots/test_binary_sensor.ambr
+++ b/tests/components/roomba/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,54 @@
 # serializer version: 1
+# name: test_entities[binary_sensor.test_roomba_bin_empty_allowed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_roomba_bin_empty_allowed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bin empty allowed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bin empty allowed',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bin_empty_allowed',
+    'unique_id': 'bin_empty_allowed_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_bin_empty_allowed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Bin empty allowed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_roomba_bin_empty_allowed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_entities[binary_sensor.test_roomba_bin_full-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -94,6 +144,106 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.test_roomba_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_pad_dry_allowed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_roomba_pad_dry_allowed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Pad dry allowed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pad dry allowed',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pad_dry_allowed',
+    'unique_id': 'pad_dry_allowed_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_pad_dry_allowed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Pad dry allowed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_roomba_pad_dry_allowed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_pad_wash_allowed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_roomba_pad_wash_allowed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Pad wash allowed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pad wash allowed',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pad_wash_allowed',
+    'unique_id': 'pad_wash_allowed_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_pad_wash_allowed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Pad wash allowed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_roomba_pad_wash_allowed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/roomba/snapshots/test_sensor.ambr
+++ b/tests/components/roomba/snapshots/test_sensor.ambr
@@ -209,6 +209,106 @@
     'state': 'unknown',
   })
 # ---
+# name: test_entities[sensor.test_roomba_detected_pad-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_detected_pad',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Detected pad',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Detected pad',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'detected_pad',
+    'unique_id': 'detected_pad_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.test_roomba_detected_pad-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Detected pad',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_detected_pad',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.test_roomba_dock_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_dock_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Dock state',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Dock state',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dock_state',
+    'unique_id': 'dock_state_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.test_roomba_dock_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Dock state',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_dock_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '301',
+  })
+# ---
 # name: test_entities[sensor.test_roomba_dock_tank_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -359,6 +459,156 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.test_roomba_last_mission_start_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.test_roomba_mission_cycle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_mission_cycle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mission cycle',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mission cycle',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mission_cycle',
+    'unique_id': 'mission_cycle_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.test_roomba_mission_cycle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Mission cycle',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_mission_cycle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_entities[sensor.test_roomba_mission_phase-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_mission_phase',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mission phase',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mission phase',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mission_phase',
+    'unique_id': 'mission_phase_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.test_roomba_mission_phase-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Mission phase',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_mission_phase',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charge',
+  })
+# ---
+# name: test_entities[sensor.test_roomba_not_ready_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_not_ready_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Not ready code',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Not ready code',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'not_ready_code',
+    'unique_id': 'not_ready_code_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.test_roomba_not_ready_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Not ready code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_not_ready_code',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change

A Roomba Combo reports its dock's activity, but none of it reaches Home Assistant, so the device's state cannot be evaluated. Pad washing, basin rinsing and tank refilling all happen while the robot sits on the dock, and today the only observable difference is `vacuum` reporting `docked` throughout.

The values below were read off a Roomba Combo (sku `x085020`, sw `topaz+1.12.11`) over the local MQTT interface, by triggering each dock command and recording what changed:

| Entity | Field | Observed |
|---|---|---|
| Dock state | `dock.state` | `300`–`303`; changes through bin empty and pad wash |
| Mission phase | `cleanMissionStatus.phase` | `run`, `charge`, `evac`, `padWash`, `refill`, `hmPostMsn`, `hmUsrDock`, `stop` |
| Mission cycle | `cleanMissionStatus.cycle` | `clean`, `evac`, `none` |
| Not ready code | `cleanMissionStatus.notReady` | `0`, `39` (saving map), `68` |
| Detected pad | `detectedPad` | `reusableWet` on a mop run |
| Bin empty / pad wash / pad dry allowed | `evacAllowed`, `padWashAllowed`, `padDryAllowed` | the flags the app uses to decide which dock actions to offer |

`phase` and `cycle` are the fields the vacuum activity is derived from, so exposing them makes that mapping observable rather than something to be inferred. All are diagnostic; `not_ready` is disabled by default.

The capability binary sensors are only created when the robot reports the corresponding key, so models without a dock are unaffected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- Link to documentation pull request: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

The test fixture gains `dock.state` and the three capability flags so the new entities are constructed and snapshotted. `detectedPad` is deliberately not added to the fixture: its presence selects the `BraavaJet` class, which would change the vacuum entity under test.
