### PR TITLE
Only offer Braava mop behavior where the robot reports it

### DIFF
--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -344,6 +344,14 @@ class BraavaJet(IRobotVacuum):
             for spray in BRAAVA_SPRAY_AMOUNT
         ]
 
+        # Mopping behavior is derived from `rankOverlap`. Combo models report a
+        # mop pad but not `rankOverlap`, so the behavior half of the fan speed
+        # can never be resolved and the entity would report a value outside its
+        # own fan speed list. Only offer the feature where it can be produced.
+        if self.vacuum_state.get("rankOverlap") is None:
+            self._attr_supported_features &= ~VacuumEntityFeature.FAN_SPEED
+            self._attr_fan_speed_list = []
+
     @property
     @override
     def fan_speed(self) -> str:

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -344,10 +344,8 @@ class BraavaJet(IRobotVacuum):
             for spray in BRAAVA_SPRAY_AMOUNT
         ]
 
-        # Mopping behavior is derived from `rankOverlap`. Combo models report a
-        # mop pad but not `rankOverlap`, so the behavior half of the fan speed
-        # can never be resolved and the entity would report a value outside its
-        # own fan speed list. Only offer the feature where it can be produced.
+        # Combo models report a mop pad but not `rankOverlap`, which the mop
+        # behavior is derived from.
         if self.vacuum_state.get("rankOverlap") is None:
             self._attr_supported_features &= ~VacuumEntityFeature.FAN_SPEED
             self._attr_fan_speed_list = []

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.components.vacuum import VacuumActivity, VacuumEntityFeature
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
@@ -52,3 +52,40 @@ async def test_vacuum_activity(
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    ("rank_overlap", "expect_fan_speed"),
+    [
+        # A Braava Jet reports rankOverlap and gets the mop behavior control.
+        (67, True),
+        # A Combo reports a mop pad but no rankOverlap, so the behavior cannot
+        # be resolved and the feature is not offered.
+        (None, False),
+    ],
+)
+async def test_braava_fan_speed_requires_rank_overlap(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    rank_overlap: int | None,
+    expect_fan_speed: bool,
+) -> None:
+    """Test that fan speed is only offered when it can be produced."""
+    reported = mock_roomba.master_state["state"]["reported"]
+    reported["detectedPad"] = "reusableWet"
+    reported["padWetness"] = {"reusable": 1}
+    if rank_overlap is None:
+        reported.pop("rankOverlap", None)
+    else:
+        reported["rankOverlap"] = rank_overlap
+
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.VACUUM]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    supported = VacuumEntityFeature(state.attributes["supported_features"])
+    assert bool(supported & VacuumEntityFeature.FAN_SPEED) is expect_fan_speed

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -58,13 +58,9 @@ async def test_vacuum_activity(
 @pytest.mark.parametrize(
     ("extra_state", "expect_fan_speed_support", "expected_fan_speed"),
     [
-        # A Braava Jet reports rankOverlap and gets the mop behavior control.
-        # rankOverlap 67 is OVERLAP_STANDARD, and fan_speed reads the
-        # "disposable" pad wetness, so the value resolves to a real member of
-        # the entity's own fan speed list.
+        # 67 is OVERLAP_STANDARD.
         ({"rankOverlap": 67}, True, "Standard-1"),
-        # A Combo reports a mop pad but no rankOverlap, so the behavior cannot
-        # be resolved and the feature is not offered at all.
+        # Combo models report a mop pad but no rankOverlap.
         ({}, False, None),
     ],
 )
@@ -79,8 +75,7 @@ async def test_braava_fan_speed_requires_rank_overlap(
     """Test that fan speed is only offered when it can be produced."""
     reported = mock_roomba.master_state["state"]["reported"]
     reported["detectedPad"] = "reusableWet"
-    # A Braava Jet reports both keys with the same value, and fan_speed reads
-    # the disposable one.
+    # fan_speed reads the "disposable" key.
     reported["padWetness"] = {"disposable": 1, "reusable": 1}
     reported.pop("rankOverlap", None)
     reported.update(extra_state)
@@ -94,6 +89,4 @@ async def test_braava_fan_speed_requires_rank_overlap(
     assert state is not None
     supported = VacuumEntityFeature(state.attributes["supported_features"])
     assert bool(supported & VacuumEntityFeature.FAN_SPEED) is expect_fan_speed_support
-    # The reported value must be a real member of the list the entity offers,
-    # which is the whole point of withholding the feature.
     assert state.attributes.get("fan_speed") == expected_fan_speed

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -1,5 +1,6 @@
 """Tests for the Roomba vacuum platform."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -55,30 +56,28 @@ async def test_vacuum_activity(
 
 
 @pytest.mark.parametrize(
-    ("rank_overlap", "expect_fan_speed"),
+    ("extra_state", "expect_fan_speed"),
     [
         # A Braava Jet reports rankOverlap and gets the mop behavior control.
-        (67, True),
+        ({"rankOverlap": 67}, True),
         # A Combo reports a mop pad but no rankOverlap, so the behavior cannot
         # be resolved and the feature is not offered.
-        (None, False),
+        ({}, False),
     ],
 )
 async def test_braava_fan_speed_requires_rank_overlap(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_roomba: AsyncMock,
-    rank_overlap: int | None,
+    extra_state: dict[str, Any],
     expect_fan_speed: bool,
 ) -> None:
     """Test that fan speed is only offered when it can be produced."""
     reported = mock_roomba.master_state["state"]["reported"]
     reported["detectedPad"] = "reusableWet"
     reported["padWetness"] = {"reusable": 1}
-    if rank_overlap is None:
-        reported.pop("rankOverlap", None)
-    else:
-        reported["rankOverlap"] = rank_overlap
+    reported.pop("rankOverlap", None)
+    reported.update(extra_state)
 
     with patch("homeassistant.components.roomba.PLATFORMS", [Platform.VACUUM]):
         mock_config_entry.add_to_hass(hass)

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -56,13 +56,16 @@ async def test_vacuum_activity(
 
 
 @pytest.mark.parametrize(
-    ("extra_state", "expect_fan_speed"),
+    ("extra_state", "expect_fan_speed_support", "expected_fan_speed"),
     [
         # A Braava Jet reports rankOverlap and gets the mop behavior control.
-        ({"rankOverlap": 67}, True),
+        # rankOverlap 67 is OVERLAP_STANDARD, and fan_speed reads the
+        # "disposable" pad wetness, so the value resolves to a real member of
+        # the entity's own fan speed list.
+        ({"rankOverlap": 67}, True, "Standard-1"),
         # A Combo reports a mop pad but no rankOverlap, so the behavior cannot
-        # be resolved and the feature is not offered.
-        ({}, False),
+        # be resolved and the feature is not offered at all.
+        ({}, False, None),
     ],
 )
 async def test_braava_fan_speed_requires_rank_overlap(
@@ -70,12 +73,15 @@ async def test_braava_fan_speed_requires_rank_overlap(
     mock_config_entry: MockConfigEntry,
     mock_roomba: AsyncMock,
     extra_state: dict[str, Any],
-    expect_fan_speed: bool,
+    expect_fan_speed_support: bool,
+    expected_fan_speed: str | None,
 ) -> None:
     """Test that fan speed is only offered when it can be produced."""
     reported = mock_roomba.master_state["state"]["reported"]
     reported["detectedPad"] = "reusableWet"
-    reported["padWetness"] = {"reusable": 1}
+    # A Braava Jet reports both keys with the same value, and fan_speed reads
+    # the disposable one.
+    reported["padWetness"] = {"disposable": 1, "reusable": 1}
     reported.pop("rankOverlap", None)
     reported.update(extra_state)
 
@@ -87,4 +93,7 @@ async def test_braava_fan_speed_requires_rank_overlap(
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     supported = VacuumEntityFeature(state.attributes["supported_features"])
-    assert bool(supported & VacuumEntityFeature.FAN_SPEED) is expect_fan_speed
+    assert bool(supported & VacuumEntityFeature.FAN_SPEED) is expect_fan_speed_support
+    # The reported value must be a real member of the list the entity offers,
+    # which is the whole point of withholding the feature.
+    assert state.attributes.get("fan_speed") == expected_fan_speed


### PR DESCRIPTION
## Proposed change

`BraavaJet` is selected whenever the robot reports `detectedPad`, which includes Roomba Combo models. It builds `fan_speed` as `"{behavior}-{spray}"`, where the behavior comes from `rankOverlap` (67/85/25) and the spray from `padWetness`.

A Roomba Combo 10 Max reports no `rankOverlap`, so the behavior half never resolves and the entity reports the literal string `"None-None"` â€” a value that is not in its own `fan_speed_list`, and one the robot will not accept back.

Observed on a Combo 10 Max (sku `x085020`, sw `topaz+1.12.11`), both mid-mission and idle:

```
detectedPad   "reusableWet"
padWetness    {"reusable": 1}
rankOverlap   null
fan_speed     "None-None"
```

The pad type is not the issue: with a disposable pad the spray half would resolve and the value would be `"None-1"`, still outside the list. `rankOverlap` is the missing input, so the capability is keyed on it â€” the integration already gates `RoombaVacuumCarpetBoost` on `cap.carpetBoost` the same way.

Braava Jets, which do report `rankOverlap`, are unaffected and keep the control.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
