### PR TITLE
Bump python technove to 2.1.3

### DIFF
--- a/homeassistant/components/technove/manifest.json
+++ b/homeassistant/components/technove/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/technove",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["python-technove==2.1.2"],
+  "requirements": ["python-technove==2.1.3"],
   "zeroconf": ["_technove-stations._tcp.local."]
 }

--- a/homeassistant/components/technove/number.py
+++ b/homeassistant/components/technove/number.py
@@ -44,6 +44,7 @@ async def _set_max_current(
             translation_domain=DOMAIN, translation_key="max_current_in_sharing_mode"
         )
     await coordinator.technove.set_max_current(int(value))
+    await coordinator.async_request_refresh()
 
 
 NUMBERS = [

--- a/homeassistant/components/technove/number.py
+++ b/homeassistant/components/technove/number.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any, override
 
-from technove import MIN_CURRENT, TechnoVE
+from technove import MIN_CURRENT, Station as TechnoVEStation
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -29,8 +29,8 @@ PARALLEL_UPDATES = 1
 class TechnoVENumberDescription(NumberEntityDescription):
     """Describes TechnoVE number entity."""
 
-    native_max_value_fn: Callable[[TechnoVE], float]
-    native_value_fn: Callable[[TechnoVE], float]
+    native_max_value_fn: Callable[[TechnoVEStation], float]
+    native_value_fn: Callable[[TechnoVEStation], float]
     set_value_fn: Callable[
         [TechnoVEDataUpdateCoordinator, float], Coroutine[Any, Any, None]
     ]
@@ -43,7 +43,7 @@ async def _set_max_current(
         raise ServiceValidationError(
             translation_domain=DOMAIN, translation_key="max_current_in_sharing_mode"
         )
-    await coordinator.technove.set_max_current(value)
+    await coordinator.technove.set_max_current(int(value))
 
 
 NUMBERS = [

--- a/homeassistant/components/technove/number.py
+++ b/homeassistant/components/technove/number.py
@@ -44,7 +44,6 @@ async def _set_max_current(
             translation_domain=DOMAIN, translation_key="max_current_in_sharing_mode"
         )
     await coordinator.technove.set_max_current(int(value))
-    await coordinator.async_request_refresh()
 
 
 NUMBERS = [

--- a/homeassistant/components/technove/sensor.py
+++ b/homeassistant/components/technove/sensor.py
@@ -28,7 +28,7 @@ from .entity import TechnoVEEntity
 
 PARALLEL_UPDATES = 0
 
-STATUS_TYPE = [s.value for s in Status if s != Status.UNKNOWN]
+STATUS_TYPE = [s.value for s in Status if s is not Status.UNKNOWN]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/technove/switch.py
+++ b/homeassistant/components/technove/switch.py
@@ -1,7 +1,7 @@
 """Support for TechnoVE switches."""
 
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, override
 
 from technove import Station as TechnoVEStation
@@ -29,8 +29,7 @@ async def _set_charging_enabled(
             translation_key="set_charging_enabled_on_auto_charge",
         )
     await coordinator.technove.set_charging_enabled(enabled=enabled)
-    coordinator.data.info = replace(coordinator.data.info, is_session_active=enabled)
-    coordinator.async_set_updated_data(coordinator.data)
+    await coordinator.async_request_refresh()
 
 
 async def _enable_charging(coordinator: TechnoVEDataUpdateCoordinator) -> None:

--- a/homeassistant/components/technove/switch.py
+++ b/homeassistant/components/technove/switch.py
@@ -1,7 +1,7 @@
 """Support for TechnoVE switches."""
 
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, override
 
 from technove import Station as TechnoVEStation
@@ -29,7 +29,7 @@ async def _set_charging_enabled(
             translation_key="set_charging_enabled_on_auto_charge",
         )
     await coordinator.technove.set_charging_enabled(enabled=enabled)
-    coordinator.data.info.is_session_active = enabled
+    coordinator.data.info = replace(coordinator.data.info, is_session_active=enabled)
     coordinator.async_set_updated_data(coordinator.data)
 
 

--- a/homeassistant/components/technove/switch.py
+++ b/homeassistant/components/technove/switch.py
@@ -44,6 +44,7 @@ async def _set_auto_charge(
     coordinator: TechnoVEDataUpdateCoordinator, enabled: bool
 ) -> None:
     await coordinator.technove.set_auto_charge(enabled=enabled)
+    await coordinator.async_request_refresh()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/technove/switch.py
+++ b/homeassistant/components/technove/switch.py
@@ -1,7 +1,7 @@
 """Support for TechnoVE switches."""
 
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, override
 
 from technove import Station as TechnoVEStation
@@ -29,7 +29,8 @@ async def _set_charging_enabled(
             translation_key="set_charging_enabled_on_auto_charge",
         )
     await coordinator.technove.set_charging_enabled(enabled=enabled)
-    await coordinator.async_request_refresh()
+    coordinator.data.info = replace(coordinator.data.info, is_session_active=enabled)
+    coordinator.async_set_updated_data(coordinator.data)
 
 
 async def _enable_charging(coordinator: TechnoVEDataUpdateCoordinator) -> None:
@@ -44,7 +45,6 @@ async def _set_auto_charge(
     coordinator: TechnoVEDataUpdateCoordinator, enabled: bool
 ) -> None:
     await coordinator.technove.set_auto_charge(enabled=enabled)
-    await coordinator.async_request_refresh()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2786,7 +2786,7 @@ python-swisscom-internet-box==0.2.0
 python-tado==0.18.16
 
 # homeassistant.components.technove
-python-technove==2.1.2
+python-technove==2.1.3
 
 # homeassistant.components.telegram_bot
 python-telegram-bot[socks]==22.7

--- a/tests/components/technove/test_config_flow.py
+++ b/tests/components/technove/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the TechnoVE config flow."""
 
+from dataclasses import replace
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 
@@ -317,7 +318,7 @@ async def test_full_reconfigure_flow_unique_id_mismatch(
 
     # Change mac address to simulate a different device
     device = mock_technove.update.return_value
-    device.info.mac_address = "AA:AA:AA:AA:AA:CC"
+    device.info = replace(device.info, mac_address="AA:AA:AA:AA:AA:CC")
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
 

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -65,6 +65,7 @@ async def test_number_expected_value(
 
     assert method_mock.call_count == 1
     method_mock.assert_called_with(**called_with_value)
+    assert mock_technove.update.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -1,5 +1,6 @@
 """Tests for the TechnoVE number platform."""
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -111,7 +112,7 @@ async def test_set_max_current_sharing_mode(
 
     # Enable power sharing mode
     device = mock_technove.update.return_value
-    device.info.in_sharing_mode = True
+    device.info = replace(device.info, in_sharing_mode=True)
 
     with pytest.raises(
         ServiceValidationError,

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -65,7 +65,6 @@ async def test_number_expected_value(
 
     assert method_mock.call_count == 1
     method_mock.assert_called_with(**called_with_value)
-    assert mock_technove.update.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/components/technove/test_sensor.py
+++ b/tests/components/technove/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the TechnoVE sensor platform."""
 
+from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import MagicMock
 
@@ -71,7 +72,7 @@ async def test_no_wifi_support(
     """Test missing Wi-Fi information from TechnoVE device."""
     # Remove Wi-Fi info
     device = mock_technove.update.return_value
-    device.info.network_ssid = None
+    device.info = replace(device.info, network_ssid=None)
 
     # Setup
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/technove/test_switch.py
+++ b/tests/components/technove/test_switch.py
@@ -46,54 +46,57 @@ async def test_switches(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "method", "called_with_on", "called_with_off"),
+    ("entity_id", "service", "method", "called_with"),
     [
         (
             "switch.technove_station_auto_charge",
+            SERVICE_TURN_ON,
             "set_auto_charge",
             {"enabled": True},
+        ),
+        (
+            "switch.technove_station_auto_charge",
+            SERVICE_TURN_OFF,
+            "set_auto_charge",
             {"enabled": False},
         ),
         (
             "switch.technove_station_charging_enabled",
+            SERVICE_TURN_ON,
             "set_charging_enabled",
             {"enabled": True},
+        ),
+        (
+            "switch.technove_station_charging_enabled",
+            SERVICE_TURN_OFF,
+            "set_charging_enabled",
             {"enabled": False},
         ),
     ],
 )
 @pytest.mark.usefixtures("init_integration")
-async def test_switch_on_off(
+async def test_switch_services(
     hass: HomeAssistant,
     mock_technove: MagicMock,
     entity_id: str,
+    service: str,
     method: str,
-    called_with_on: dict[str, bool | int],
-    called_with_off: dict[str, bool | int],
+    called_with: dict[str, bool | int],
 ) -> None:
-    """Test on/off services."""
+    """Test switch services."""
     state = hass.states.get(entity_id)
     method_mock = getattr(mock_technove, method)
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
+        service,
         {ATTR_ENTITY_ID: state.entity_id},
         blocking=True,
     )
 
     assert method_mock.call_count == 1
-    method_mock.assert_called_with(**called_with_on)
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: state.entity_id},
-        blocking=True,
-    )
-
-    assert method_mock.call_count == 2
-    method_mock.assert_called_with(**called_with_off)
+    method_mock.assert_called_with(**called_with)
+    assert mock_technove.update.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/components/technove/test_switch.py
+++ b/tests/components/technove/test_switch.py
@@ -1,5 +1,6 @@
 """Tests for the TechnoVE switch platform."""
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -184,7 +185,7 @@ async def test_disable_charging_auto_charge(
 
     # Enable auto-charge mode
     device = mock_technove.update.return_value
-    device.info.auto_charge = True
+    device.info = replace(device.info, auto_charge=True)
 
     with pytest.raises(
         ServiceValidationError,

--- a/tests/components/technove/test_switch.py
+++ b/tests/components/technove/test_switch.py
@@ -46,57 +46,54 @@ async def test_switches(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "service", "method", "called_with"),
+    ("entity_id", "method", "called_with_on", "called_with_off"),
     [
         (
             "switch.technove_station_auto_charge",
-            SERVICE_TURN_ON,
             "set_auto_charge",
             {"enabled": True},
-        ),
-        (
-            "switch.technove_station_auto_charge",
-            SERVICE_TURN_OFF,
-            "set_auto_charge",
             {"enabled": False},
         ),
         (
             "switch.technove_station_charging_enabled",
-            SERVICE_TURN_ON,
             "set_charging_enabled",
             {"enabled": True},
-        ),
-        (
-            "switch.technove_station_charging_enabled",
-            SERVICE_TURN_OFF,
-            "set_charging_enabled",
             {"enabled": False},
         ),
     ],
 )
 @pytest.mark.usefixtures("init_integration")
-async def test_switch_services(
+async def test_switch_on_off(
     hass: HomeAssistant,
     mock_technove: MagicMock,
     entity_id: str,
-    service: str,
     method: str,
-    called_with: dict[str, bool | int],
+    called_with_on: dict[str, bool | int],
+    called_with_off: dict[str, bool | int],
 ) -> None:
-    """Test switch services."""
+    """Test on/off services."""
     state = hass.states.get(entity_id)
     method_mock = getattr(mock_technove, method)
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
-        service,
+        SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: state.entity_id},
         blocking=True,
     )
 
     assert method_mock.call_count == 1
-    method_mock.assert_called_with(**called_with)
-    assert mock_technove.update.call_count == 2
+    method_mock.assert_called_with(**called_with_on)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: state.entity_id},
+        blocking=True,
+    )
+
+    assert method_mock.call_count == 2
+    method_mock.assert_called_with(**called_with_off)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update PyTechnoVE library from 2.1.2 to 2.1.2. It adds PEP 561 py.typed marker and classifier and does a few other tweaks.

https://github.com/Moustachauve/pytechnove/releases/tag/v2.1.3

https://github.com/Moustachauve/pytechnove/compare/v2.1.2...v2.1.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
