### PR TITLE
Retry a stalled Twinkly request

### DIFF
--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DEVICE_TIMEOUT, DOMAIN
 from .coordinator import TwinklyConfigEntry, TwinklyCoordinator
 
 PLATFORMS = [Platform.LIGHT, Platform.SELECT]
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> b
     # we will be able to properly share the connection.
     host = entry.data[CONF_HOST]
 
-    client = Twinkly(host, async_get_clientsession(hass))
+    client = Twinkly(host, async_get_clientsession(hass), timeout=DEVICE_TIMEOUT)
 
     coordinator = TwinklyCoordinator(hass, entry, client)
 
@@ -47,7 +47,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> bool:
     """Migrate old entry."""
     if entry.minor_version == 1:
-        client = Twinkly(entry.data[CONF_HOST], async_get_clientsession(hass))
+        client = Twinkly(
+            entry.data[CONF_HOST],
+            async_get_clientsession(hass),
+            timeout=DEVICE_TIMEOUT,
+        )
         try:
             device_info = await client.get_details()
         except (TimeoutError, ClientError) as exception:

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_ID, CONF_MODEL, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DEV_ID, DEV_MODEL, DEV_NAME, DOMAIN
+from .const import DEV_ID, DEV_MODEL, DEV_NAME, DEVICE_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
         if host is not None:
             try:
                 device_info = await Twinkly(
-                    host, async_get_clientsession(self.hass)
+                    host, async_get_clientsession(self.hass), timeout=DEVICE_TIMEOUT
                 ).get_details()
             except TimeoutError, ClientError:
                 errors[CONF_HOST] = "cannot_connect"
@@ -64,7 +64,9 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: discovery_info.ip})
         try:
             device_info = await Twinkly(
-                discovery_info.ip, async_get_clientsession(self.hass)
+                discovery_info.ip,
+                async_get_clientsession(self.hass),
+                timeout=DEVICE_TIMEOUT,
             ).get_details()
         except TimeoutError, ClientError:
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -18,6 +18,6 @@ DEV_PROFILE_RGBW = "RGBW"
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
 
-# Kept short on purpose: a stalled request is retried rather than waited out,
-# and the tail of a stall is long enough that no timeout would cover it.
-DEVICE_TIMEOUT = 3
+# Matches the library default, set explicitly so the integration does not
+# inherit it. A device waking its radio can take several seconds to answer.
+DEVICE_TIMEOUT = 10

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -17,3 +17,7 @@ DEV_PROFILE_RGBW = "RGBW"
 
 # Minimum version required to support effects
 MIN_EFFECT_VERSION = "2.7.1"
+
+# Kept short on purpose: a stalled request is retried rather than waited out,
+# and the tail of a stall is long enough that no timeout would cover it.
+DEVICE_TIMEOUT = 3

--- a/homeassistant/components/twinkly/coordinator.py
+++ b/homeassistant/components/twinkly/coordinator.py
@@ -98,7 +98,7 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
             raise UpdateFailed from exception
         if self.supports_effects:
             try:
-                current_movie = await self.client.get_current_movie()
+                current_movie = await self._request(self.client.get_current_movie)
             except (TwinklyError, TimeoutError, ClientError) as exception:
                 _LOGGER.debug("Error fetching current movie: %s", exception)
         brightness = (

--- a/homeassistant/components/twinkly/coordinator.py
+++ b/homeassistant/components/twinkly/coordinator.py
@@ -68,7 +68,6 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
             MIN_EFFECT_VERSION
         )
 
-    @override
     async def _request[_T](self, request: Callable[[], Awaitable[_T]]) -> _T:
         """Make a request, retrying it once if it times out.
 
@@ -82,6 +81,7 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
         except TimeoutError:
             return await request()
 
+    @override
     async def _async_update_data(self) -> TwinklyData:
         """Fetch data from Twinkly."""
         movies: list[dict[str, Any]] = []

--- a/homeassistant/components/twinkly/coordinator.py
+++ b/homeassistant/components/twinkly/coordinator.py
@@ -1,5 +1,6 @@
 """Coordinator for Twinkly."""
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -58,8 +59,8 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
     async def _async_setup(self) -> None:
         """Set up the Twinkly data."""
         try:
-            software_version = await self.client.get_firmware_version()
-            self.device_name = (await self.client.get_details())[DEV_NAME]
+            software_version = await self._request(self.client.get_firmware_version)
+            self.device_name = (await self._request(self.client.get_details))[DEV_NAME]
         except (TimeoutError, ClientError) as exception:
             raise UpdateFailed from exception
         self.software_version = software_version["version"]
@@ -68,18 +69,31 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
         )
 
     @override
+    async def _request[_T](self, request: Callable[[], Awaitable[_T]]) -> _T:
+        """Make a request, retrying it once if it times out.
+
+        A device that stalls one request keeps answering others: it replies on
+        a new connection within milliseconds while the first is still hanging.
+        aiohttp closes a timed-out connection instead of returning it to the
+        pool, so the retry gets a fresh one.
+        """
+        try:
+            return await request()
+        except TimeoutError:
+            return await request()
+
     async def _async_update_data(self) -> TwinklyData:
         """Fetch data from Twinkly."""
         movies: list[dict[str, Any]] = []
         current_movie: dict[str, Any] = {}
         try:
-            device_info = await self.client.get_details()
-            brightness = await self.client.get_brightness()
-            is_on = await self.client.is_on()
-            mode_data = await self.client.get_mode()
+            device_info = await self._request(self.client.get_details)
+            brightness = await self._request(self.client.get_brightness)
+            is_on = await self._request(self.client.is_on)
+            mode_data = await self._request(self.client.get_mode)
             current_mode = mode_data.get("mode")
             if self.supports_effects:
-                movies = (await self.client.get_saved_movies())["movies"]
+                movies = (await self._request(self.client.get_saved_movies))["movies"]
         except (TimeoutError, ClientError) as exception:
             raise UpdateFailed from exception
         if self.supports_effects:

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from . import setup_integration
 from .const import TEST_MAC, TEST_MODEL
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.mark.usefixtures("mock_twinkly_client")
@@ -84,3 +84,33 @@ async def test_mac_migration(
         (DOMAIN, config_entry.unique_id), config_entry.entry_id
     ).identifiers == {(DOMAIN, TEST_MAC)}
     assert config_entry.unique_id == TEST_MAC
+
+
+@pytest.mark.usefixtures("mock_twinkly_client")
+async def test_request_retried_once_on_timeout(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_twinkly_client: AsyncMock,
+) -> None:
+    """A request that times out once is retried, so setup still succeeds."""
+    details = load_json_object_fixture("get_details.json", DOMAIN)
+    # Only the first call times out; without the retry setup would fail here.
+    mock_twinkly_client.get_details.side_effect = [TimeoutError, details, details]
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_request_gives_up_after_the_retry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_twinkly_client: AsyncMock,
+) -> None:
+    """A request that keeps timing out still fails, after exactly one retry."""
+    mock_twinkly_client.get_details.side_effect = TimeoutError
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_twinkly_client.get_details.call_count == 2

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from . import setup_integration
 from .const import TEST_MAC, TEST_MODEL
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.mark.usefixtures("mock_twinkly_client")
@@ -93,7 +93,7 @@ async def test_request_retried_once_on_timeout(
     mock_twinkly_client: AsyncMock,
 ) -> None:
     """A request that times out once is retried, so setup still succeeds."""
-    details = load_json_object_fixture("get_details.json", DOMAIN)
+    details = await async_load_json_object_fixture(hass, "get_details.json", DOMAIN)
     # Only the first call times out; without the retry setup would fail here.
     mock_twinkly_client.get_details.side_effect = [TimeoutError, details, details]
 


### PR DESCRIPTION
## Proposed change

Twinkly devices intermittently stall a single request while continuing to answer everything else. The coordinator treats that as a dead device and marks all its entities unavailable until the next poll.

The coordinator now retries a timed-out request once. A device that stalls one request answers a new connection within milliseconds, and aiohttp closes a timed-out connection instead of returning it to the pool, so the retry gets a fresh one. Locally this turned every stall into a few seconds of delay instead of an outage.

Raising the timeout is not enough on its own: 10 seconds does avoid most of these, but some stalls run well past 30 seconds. Raising the default in `ttls` was still worth doing for its other consumers, but the retry belongs here, where the coordinator decides what counts as an unavailable device.

`DEVICE_TIMEOUT` is carried over from the now-closed #179140, set to the library's current default so the integration states its own timeout rather than inheriting one.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179140
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
