### PR TITLE
Warn when a Lovelace YAML resource points to a missing local file

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import logging
 import os
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 import voluptuous as vol
 
@@ -13,7 +14,7 @@ from homeassistant.config import (
     async_hass_config_yaml,
     async_process_component_and_handle_errors,
 )
-from homeassistant.const import CONF_FILENAME, CONF_MODE, CONF_RESOURCES
+from homeassistant.const import CONF_FILENAME, CONF_MODE, CONF_RESOURCES, CONF_URL
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -334,7 +335,50 @@ async def create_yaml_resource_col(
                 )
                 yaml_resources = ll_conf[CONF_RESOURCES]
 
+    if yaml_resources:
+        await _async_warn_missing_local_resources(hass, yaml_resources)
+
     return resources.ResourceYAMLCollection(yaml_resources or [])
+
+
+def _missing_resource_files(candidates: dict[str, str]) -> list[tuple[str, str]]:
+    """Return (url, path) pairs for resource files that do not exist."""
+    return [(url, path) for url, path in candidates.items() if not os.path.isfile(path)]
+
+
+async def _async_warn_missing_local_resources(
+    hass: HomeAssistant, yaml_resources: list[ConfigType]
+) -> None:
+    """Warn for /local resource URLs that have no backing file in www."""
+    candidates: dict[str, str] = {}
+    for resource in yaml_resources:
+        url: str | None = resource.get(CONF_URL)
+        if not url:
+            continue
+        parts = urlsplit(url)
+        # Only URLs served from <config>/www can be checked, skip external URLs
+        # and custom static paths such as /hacsfiles/
+        if parts.scheme or parts.netloc:
+            continue
+        path = unquote(parts.path)
+        if not path.startswith("/local/"):
+            continue
+        candidates[url] = hass.config.path(
+            "www", path.removeprefix("/local/").lstrip("/")
+        )
+
+    if not candidates:
+        return
+
+    for url, file_path in await hass.async_add_executor_job(
+        _missing_resource_files, candidates
+    ):
+        _LOGGER.warning(
+            "Lovelace resource %s was not found at %s"
+            " (file and folder names are case sensitive)",
+            url,
+            file_path,
+        )
 
 
 @callback

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 import logging
 import os
+import posixpath
 from typing import Any
 from urllib.parse import unquote, urlsplit
 
@@ -355,12 +356,17 @@ async def _async_warn_missing_local_resources(
         url: str | None = resource.get(CONF_URL)
         if not url:
             continue
-        parts = urlsplit(url)
+        try:
+            parts = urlsplit(url)
+        except ValueError:
+            # Any string is accepted as URL, an unparsable one is not a local file
+            continue
         # Only URLs served from <config>/www can be checked, skip external URLs
         # and custom static paths such as /hacsfiles/
         if parts.scheme or parts.netloc:
             continue
-        path = unquote(parts.path)
+        # Normalize the way a browser would, so traversal cannot escape www
+        path = posixpath.normpath(unquote(parts.path))
         if not path.startswith("/local/"):
             continue
         candidates[url] = hass.config.path(

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -87,6 +87,10 @@ async def test_yaml_resources_missing_local_file_warning(
                     {"type": "module", "url": "https://example.com/local/remote.js"},
                     {"type": "module", "url": "//example.com/local/scheme.js"},
                     {"type": "module", "url": "/hacsfiles/plugin/plugin.js"},
+                    # normalizing this leaves www, so it is not a local file
+                    {"type": "module", "url": "/local/../configuration.yaml"},
+                    # any string is accepted as URL, this one cannot be parsed
+                    {"type": "module", "url": "//["},
                     # url is optional in the resource schema
                     {"type": "module"},
                 ],
@@ -100,6 +104,7 @@ async def test_yaml_resources_missing_local_file_warning(
     assert "remote.js" not in caplog.text
     assert "scheme.js" not in caplog.text
     assert "plugin.js" not in caplog.text
+    assert "configuration.yaml" not in caplog.text
 
 
 async def test_yaml_resources_without_local_files_never_warns(

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -1,6 +1,7 @@
 """Test Lovelace resources."""
 
 import copy
+from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, patch
 import uuid
@@ -56,6 +57,71 @@ async def test_yaml_resources_backwards(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == RESOURCE_EXAMPLES
+
+
+async def test_yaml_resources_missing_local_file_warning(
+    hass: HomeAssistant,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a warning is logged for /local resources without a backing file."""
+    hass.config.config_dir = str(tmp_path)
+
+    def _create_www_file() -> None:
+        (tmp_path / "www").mkdir()
+        (tmp_path / "www" / "exists.js").write_text("")
+
+    await hass.async_add_executor_job(_create_www_file)
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "lovelace": {
+                "resource_mode": "yaml",
+                "resources": [
+                    {"type": "module", "url": "/local/exists.js?v=1.2"},
+                    {"type": "module", "url": "/local/missing.js"},
+                    # remote URLs are not backed by a file in www, even when
+                    # their path looks like one
+                    {"type": "module", "url": "https://example.com/local/remote.js"},
+                    {"type": "module", "url": "//example.com/local/scheme.js"},
+                    {"type": "module", "url": "/hacsfiles/plugin/plugin.js"},
+                    # url is optional in the resource schema
+                    {"type": "module"},
+                ],
+            }
+        },
+    )
+
+    assert "/local/missing.js" in caplog.text
+    assert str(tmp_path / "www" / "missing.js") in caplog.text
+    assert "exists.js" not in caplog.text
+    assert "remote.js" not in caplog.text
+    assert "scheme.js" not in caplog.text
+    assert "plugin.js" not in caplog.text
+
+
+async def test_yaml_resources_without_local_files_never_warns(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test resources that cannot be resolved to a file are not checked."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "lovelace": {
+                "resource_mode": "yaml",
+                "resources": [
+                    {"type": "module", "url": "https://example.com/local/remote.js"},
+                    {"type": "module", "url": "/hacsfiles/plugin/plugin.js"},
+                ],
+            }
+        },
+    )
+
+    assert "was not found" not in caplog.text
 
 
 @pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])


### PR DESCRIPTION
## Proposed change

Lovelace resources configured in YAML that point to a non-existent file under `/local/` fail silently, with no error logged anywhere. This logs a warning during setup and on `lovelace.reload_resources`, naming both the configured URL and the resolved filesystem path, and mentioning that names are case sensitive. Remote URLs and paths outside `/local/` are skipped, since they cannot be resolved against `<config>/www`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179316
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: home-assistant/frontend#53675

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

