### PR TITLE
Keep Z-Wave JS node statistics flowing when a route can't be resolved

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -51,6 +51,7 @@ from zwave_js_server.model.node.firmware import (
     NodeFirmwareUpdateProgress,
     NodeFirmwareUpdateResult,
 )
+from zwave_js_server.model.statistics import RouteStatistics
 from zwave_js_server.model.utils import (
     async_parse_qr_code_string,
     async_try_parse_dsk_from_qr_code_string,
@@ -2835,10 +2836,28 @@ def _get_node_statistics_dict(
         device = dev_reg.async_get_device_by_identifier(
             get_device_id(driver, node), entry.entry_id
         )
-        assert device
+        if device is None:
+            raise ValueError(f"Device for node {node.node_id} not found")
         return device.id
 
-    data: dict = {
+    def _get_route_statistics_dict(
+        route_statistics: RouteStatistics | None,
+    ) -> dict[str, Any] | None:
+        """Get dictionary of route statistics."""
+        if route_statistics is None:
+            return None
+        try:
+            data: dict[str, Any] = dict(route_statistics.as_dict())
+            for key in ("repeaters", "route_failed_between"):
+                if data[key]:
+                    data[key] = [_convert_node_to_device_id(node) for node in data[key]]
+        except KeyError, StopIteration, ValueError:
+            # The route may reference nodes that have been removed from the
+            # network or that don't have a device entry
+            return None
+        return data
+
+    return {
         "commands_tx": statistics.commands_tx,
         "commands_rx": statistics.commands_rx,
         "commands_dropped_tx": statistics.commands_dropped_tx,
@@ -2846,20 +2865,9 @@ def _get_node_statistics_dict(
         "timeout_response": statistics.timeout_response,
         "rtt": statistics.rtt,
         "rssi": statistics.rssi,
-        "lwr": statistics.lwr.as_dict() if statistics.lwr else None,
-        "nlwr": statistics.nlwr.as_dict() if statistics.nlwr else None,
+        "lwr": _get_route_statistics_dict(statistics.lwr),
+        "nlwr": _get_route_statistics_dict(statistics.nlwr),
     }
-    for key in ("lwr", "nlwr"):
-        if not data[key]:
-            continue
-        for key_2 in ("repeaters", "route_failed_between"):
-            if not data[key][key_2]:
-                continue
-            data[key][key_2] = [
-                _convert_node_to_device_id(node) for node in data[key][key_2]
-            ]
-
-    return data
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2853,7 +2853,9 @@ def _get_node_statistics_dict(
                     data[key] = [_convert_node_to_device_id(node) for node in data[key]]
         except KeyError, StopIteration, ValueError:
             # The route may reference nodes that have been removed from the
-            # network or that don't have a device entry
+            # network (KeyError) or that don't have a device entry (ValueError),
+            # and async_get_config_entry_from_node raises StopIteration when
+            # the config entry is no longer loaded
             return None
         return data
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -5119,6 +5119,7 @@ async def test_subscribe_controller_statistics(
 
 async def test_subscribe_node_statistics(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     multisensor_6,
     wallmote_central_scene,
     zen_31,
@@ -5233,6 +5234,56 @@ async def test_subscribe_node_statistics(
             ],
         },
     }
+
+    # Fire statistics updated with a route that references a node
+    # that has been removed from the network
+    event = Event(
+        "statistics updated",
+        {
+            "source": "node",
+            "event": "statistics updated",
+            "nodeId": multisensor_6.node_id,
+            "statistics": {
+                "commandsTX": 1,
+                "commandsRX": 2,
+                "commandsDroppedTX": 3,
+                "commandsDroppedRX": 4,
+                "timeoutResponse": 5,
+                "lwr": {
+                    "protocolDataRate": 1,
+                    "rssi": 1,
+                    "repeaters": [999],
+                    "repeaterRSSI": [1],
+                },
+                "nlwr": {
+                    "protocolDataRate": 2,
+                    "rssi": 2,
+                    "repeaters": [wallmote_central_scene.node_id],
+                    "repeaterRSSI": [2],
+                },
+            },
+        },
+    )
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+    assert msg["event"]["lwr"] is None
+    assert msg["event"]["nlwr"] == {
+        "protocol_data_rate": 2,
+        "rssi": 2,
+        "repeaters": [wallmote_central_scene_device.id],
+        "repeater_rssi": [2],
+        "route_failed_between": None,
+    }
+
+    # Fire statistics updated with a route that references a node
+    # whose device has been removed from the registry
+    device_registry.async_remove_device(wallmote_central_scene_device.id)
+    await hass.async_block_till_done()
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+    assert msg["event"]["lwr"] is None
+    assert msg["event"]["nlwr"] is None
+    assert msg["event"]["commands_tx"] == 1
 
     # Test sending command with improper entry ID fails
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -101,7 +101,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry, MockUser
-from tests.typing import ClientSessionGenerator, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 CONTROLLER_PATCH_PREFIX = "zwave_js_server.model.controller.Controller"
 
@@ -5119,7 +5123,6 @@ async def test_subscribe_controller_statistics(
 
 async def test_subscribe_node_statistics(
     hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
     multisensor_6,
     wallmote_central_scene,
     zen_31,
@@ -5235,56 +5238,6 @@ async def test_subscribe_node_statistics(
         },
     }
 
-    # Fire statistics updated with a route that references a node
-    # that has been removed from the network
-    event = Event(
-        "statistics updated",
-        {
-            "source": "node",
-            "event": "statistics updated",
-            "nodeId": multisensor_6.node_id,
-            "statistics": {
-                "commandsTX": 1,
-                "commandsRX": 2,
-                "commandsDroppedTX": 3,
-                "commandsDroppedRX": 4,
-                "timeoutResponse": 5,
-                "lwr": {
-                    "protocolDataRate": 1,
-                    "rssi": 1,
-                    "repeaters": [999],
-                    "repeaterRSSI": [1],
-                },
-                "nlwr": {
-                    "protocolDataRate": 2,
-                    "rssi": 2,
-                    "repeaters": [wallmote_central_scene.node_id],
-                    "repeaterRSSI": [2],
-                },
-            },
-        },
-    )
-    client.driver.controller.receive_event(event)
-    msg = await ws_client.receive_json()
-    assert msg["event"]["lwr"] is None
-    assert msg["event"]["nlwr"] == {
-        "protocol_data_rate": 2,
-        "rssi": 2,
-        "repeaters": [wallmote_central_scene_device.id],
-        "repeater_rssi": [2],
-        "route_failed_between": None,
-    }
-
-    # Fire statistics updated with a route that references a node
-    # whose device has been removed from the registry
-    device_registry.async_remove_device(wallmote_central_scene_device.id)
-    await hass.async_block_till_done()
-    client.driver.controller.receive_event(event)
-    msg = await ws_client.receive_json()
-    assert msg["event"]["lwr"] is None
-    assert msg["event"]["nlwr"] is None
-    assert msg["event"]["commands_tx"] == 1
-
     # Test sending command with improper entry ID fails
     await ws_client.send_json(
         {
@@ -5313,6 +5266,148 @@ async def test_subscribe_node_statistics(
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+def _stats_updated_event(node_id: int, repeater_node_id: int) -> Event:
+    """Return a statistics updated event with a route through the repeater."""
+    return Event(
+        "statistics updated",
+        {
+            "source": "node",
+            "event": "statistics updated",
+            "nodeId": node_id,
+            "statistics": {
+                "commandsTX": 1,
+                "commandsRX": 2,
+                "commandsDroppedTX": 3,
+                "commandsDroppedRX": 4,
+                "timeoutResponse": 5,
+                "lwr": {
+                    "protocolDataRate": 1,
+                    "rssi": 1,
+                    "repeaters": [repeater_node_id],
+                    "repeaterRSSI": [1],
+                },
+            },
+        },
+    )
+
+
+async def _subscribe_node_statistics(
+    ws_client: MockHAClientWebSocket, device_id: str
+) -> None:
+    """Subscribe to node statistics and consume the initial state event."""
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/subscribe_node_statistics",
+            DEVICE_ID: device_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "statistics updated"
+
+
+async def test_node_statistics_route_with_removed_node(
+    hass: HomeAssistant,
+    multisensor_6: Node,
+    wallmote_central_scene: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a route referencing a node that was removed from the network.
+
+    Resolving the repeater in the controller's node collection raises
+    KeyError, which must null the route instead of breaking the subscription.
+    """
+    ws_client = await hass_ws_client(hass)
+    device = get_device(hass, multisensor_6)
+    wallmote_device = get_device(hass, wallmote_central_scene)
+    await _subscribe_node_statistics(ws_client, device.id)
+
+    event = _stats_updated_event(multisensor_6.node_id, 999)
+    event.data["statistics"]["nlwr"] = {
+        "protocolDataRate": 2,
+        "rssi": 2,
+        "repeaters": [wallmote_central_scene.node_id],
+        "repeaterRSSI": [2],
+    }
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+
+    assert msg["event"]["commands_tx"] == 1
+    assert msg["event"]["lwr"] is None
+    # only the unresolvable route is dropped
+    assert msg["event"]["nlwr"] == {
+        "protocol_data_rate": 2,
+        "rssi": 2,
+        "repeaters": [wallmote_device.id],
+        "repeater_rssi": [2],
+        "route_failed_between": None,
+    }
+
+
+async def test_node_statistics_route_with_removed_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    multisensor_6: Node,
+    wallmote_central_scene: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a route referencing a node without a device registry entry.
+
+    Converting the repeater to a device ID raises ValueError, which must null
+    the route instead of breaking the subscription.
+    """
+    ws_client = await hass_ws_client(hass)
+    device = get_device(hass, multisensor_6)
+    wallmote_device = get_device(hass, wallmote_central_scene)
+    await _subscribe_node_statistics(ws_client, device.id)
+
+    device_registry.async_remove_device(wallmote_device.id)
+    await hass.async_block_till_done()
+
+    client.driver.controller.receive_event(
+        _stats_updated_event(multisensor_6.node_id, wallmote_central_scene.node_id)
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["event"]["commands_tx"] == 1
+    assert msg["event"]["lwr"] is None
+
+
+async def test_node_statistics_route_with_unloaded_entry(
+    hass: HomeAssistant,
+    multisensor_6: Node,
+    wallmote_central_scene: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a route received after the config entry was unloaded.
+
+    async_get_config_entry_from_node raises StopIteration when no loaded
+    config entry owns the node, which must null the route instead of
+    breaking the subscription.
+    """
+    ws_client = await hass_ws_client(hass)
+    device = get_device(hass, multisensor_6)
+    await _subscribe_node_statistics(ws_client, device.id)
+
+    await hass.config_entries.async_unload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    client.driver.controller.receive_event(
+        _stats_updated_event(multisensor_6.node_id, wallmote_central_scene.node_id)
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["event"]["commands_tx"] == 1
+    assert msg["event"]["lwr"] is None
 
 
 async def test_hard_reset_controller(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -5339,7 +5339,6 @@ async def test_node_statistics_route_with_removed_node(
 
     assert msg["event"]["commands_tx"] == 1
     assert msg["event"]["lwr"] is None
-    # only the unresolvable route is dropped
     assert msg["event"]["nlwr"] == {
         "protocol_data_rate": 2,
         "rssi": 2,


### PR DESCRIPTION
## Proposed change

Serializing node statistics raised (`assert device`, or a `KeyError` from `RouteStatistics.as_dict()`) when an `lwr`/`nlwr` route referenced a node that was removed from the network or has no device registry entry, killing the `zwave_js/subscribe_node_statistics` subscription — the client silently stops receiving statistics. Serialize each route independently and send `None` for a route that can't be resolved, keeping the counters and the other route flowing.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#161100
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
