### PR TITLE
Add Z-Wave JS WebSocket command to get network neighbors

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -221,9 +221,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZwaveJSConfigEntry) -> b
 
     entry.async_on_unload(client.disconnect)
 
+    # Local because runtime_data is not set yet if HA shuts down during setup
+    network_neighbors_lock = asyncio.Lock()
+
     async def handle_ha_shutdown(event: Event) -> None:
         """Handle HA shutdown."""
-        await client.disconnect()
+        # Wait for a running network neighbors refresh, so the client is not
+        # disconnected before it has turned the radio back on
+        async with network_neighbors_lock:
+            await client.disconnect()
 
     entry.async_on_unload(
         hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, handle_ha_shutdown)
@@ -256,6 +262,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZwaveJSConfigEntry) -> b
     entry_runtime_data = ZwaveJSData(
         client=client,
         driver_events=driver_events,
+        network_neighbors_lock=network_neighbors_lock,
     )
     entry.runtime_data = entry_runtime_data
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -1154,6 +1154,11 @@ async def client_listen(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ZwaveJSConfigEntry) -> bool:
     """Unload a config entry."""
+    # Wait for a running network neighbors refresh, so the client is not
+    # disconnected before it has turned the radio back on
+    async with entry.runtime_data.network_neighbors_lock:
+        pass
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     entry_runtime_data = entry.runtime_data

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Coroutine
 from contextlib import suppress
 import dataclasses
 from functools import partial, wraps
+import logging
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, cast
 
 from aiohttp import web, web_exceptions, web_request
@@ -104,12 +105,15 @@ if TYPE_CHECKING:
     from .models import ZwaveJSConfigEntry
 
 
+_LOGGER = logging.getLogger(__name__)
+
 DATA_UNSUBSCRIBE = "unsubs"
 
 # general API constants
 ID = "id"
 ENTRY_ID = "entry_id"
 ERR_NOT_LOADED = "not_loaded"
+ERR_RF_TOGGLE_FAILED = "rf_toggle_failed"
 NODE_ID = "node_id"
 DEVICE_ID = "device_id"
 COMMAND_CLASS_ID = "command_class_id"
@@ -645,9 +649,16 @@ async def websocket_network_neighbors(
     """
     controller = driver.controller
     neighbors: dict[int, list[int]] = {}
+    rf_restored = False
     async with entry.runtime_data.network_neighbors_lock:
         try:
-            await controller.async_toggle_rf(False)
+            if not await controller.async_toggle_rf(False):
+                # Don't read the routing table with the radio still on,
+                # that is what wedges older controllers
+                connection.send_error(
+                    msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF"
+                )
+                return
             for node in controller.nodes.values():
                 # Long range nodes are not part of the mesh
                 if node.protocol is Protocols.ZWAVE_LONG_RANGE:
@@ -661,7 +672,16 @@ async def websocket_network_neighbors(
         finally:
             # Shielded so the radio comes back on even when the connection
             # is closed while the routing table is being read
-            await asyncio.shield(controller.async_toggle_rf(True))
+            rf_restored = await asyncio.shield(controller.async_toggle_rf(True))
+            if not rf_restored:
+                _LOGGER.error(
+                    "Failed to re-enable RF after reading the neighbors of the"
+                    " nodes of config entry %s",
+                    entry.entry_id,
+                )
+    if not rf_restored:
+        connection.send_error(msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to re-enable RF")
+        return
     connection.send_result(msg[ID], neighbors)
 
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -675,7 +675,7 @@ async def websocket_network_neighbors(
             try:
                 rf_restored = await asyncio.shield(restore)
             except asyncio.CancelledError:
-                with suppress(FailedCommand):
+                with suppress(BaseZwaveJSServerError):
                     rf_restored = await asyncio.shield(restore)
                 raise
             finally:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1,5 +1,6 @@
 """Websocket API for Z-Wave JS."""
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 import dataclasses
@@ -645,8 +646,8 @@ async def websocket_network_neighbors(
     controller = driver.controller
     neighbors: dict[int, list[int]] = {}
     async with entry.runtime_data.network_neighbors_lock:
-        await controller.async_toggle_rf(False)
         try:
+            await controller.async_toggle_rf(False)
             for node in controller.nodes.values():
                 # Long range nodes are not part of the mesh
                 if node.protocol is Protocols.ZWAVE_LONG_RANGE:
@@ -658,7 +659,9 @@ async def websocket_network_neighbors(
                 except FailedCommand:
                     continue
         finally:
-            await controller.async_toggle_rf(True)
+            # Shielded so the radio comes back on even when the connection
+            # is closed while the routing table is being read
+            await asyncio.shield(controller.async_toggle_rf(True))
     connection.send_result(msg[ID], neighbors)
 
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -411,6 +411,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_network_status)
     websocket_api.async_register_command(hass, websocket_subscribe_node_status)
     websocket_api.async_register_command(hass, websocket_node_status)
+    websocket_api.async_register_command(hass, websocket_node_neighbors)
     websocket_api.async_register_command(hass, websocket_node_metadata)
     websocket_api.async_register_command(hass, websocket_node_alerts)
     websocket_api.async_register_command(hass, websocket_add_node)
@@ -615,6 +616,31 @@ async def websocket_node_status(
 ) -> None:
     """Get the status of a Z-Wave JS node."""
     connection.send_result(msg[ID], node_status(node))
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/node_neighbors",
+        vol.Required(DEVICE_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_handle_failed_command
+@async_get_node
+async def websocket_node_neighbors(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    node: Node,
+) -> None:
+    """Get the node IDs of the neighbors of a Z-Wave JS node."""
+    driver = node.client.driver
+    assert driver is not None  # The node comes from the driver instance.
+    controller = driver.controller
+
+    neighbors = await controller.async_get_node_neighbors(node)
+    connection.send_result(msg[ID], neighbors)
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -656,43 +656,41 @@ async def websocket_network_neighbors(
         except BaseZwaveJSServerError:
             return False
 
-    neighbors: dict[int, list[int]] = {}
-    rf_disabled = False
-    rf_restored = False
-    async with entry.runtime_data.network_neighbors_lock:
-        try:
-            rf_disabled = await controller.async_toggle_rf(False)
-            if rf_disabled:
-                # Snapshot the nodes, inclusion/exclusion can mutate the
-                # collection while it is being iterated
-                for node in list(controller.nodes.values()):
-                    # Long range nodes are not part of the mesh
-                    if node.protocol is Protocols.ZWAVE_LONG_RANGE:
-                        continue
-                    try:
-                        neighbors[
-                            node.node_id
-                        ] = await controller.async_get_node_neighbors(node)
-                    except FailedCommand:
-                        continue
-        finally:
-            # Shielded so the radio comes back on even when the connection is
-            # closed while the routing table is being read
-            restore = hass.async_create_task(restore_rf())
+    async def read_network_neighbors() -> tuple[bool, bool, dict[int, list[int]]]:
+        """Read the neighbors of all nodes while the radio is off."""
+        neighbors: dict[int, list[int]] = {}
+        rf_disabled = False
+        async with entry.runtime_data.network_neighbors_lock:
             try:
-                rf_restored = await asyncio.shield(restore)
-            except asyncio.CancelledError:
-                # Hold the lock until the radio is back on, so a queued
-                # refresh can't race the restore
-                rf_restored = await asyncio.shield(restore)
-                raise
+                rf_disabled = await controller.async_toggle_rf(False)
+                if rf_disabled:
+                    # Snapshot the nodes, inclusion/exclusion can mutate the
+                    # collection while it is being iterated
+                    for node in list(controller.nodes.values()):
+                        # Long range nodes are not part of the mesh
+                        if node.protocol is Protocols.ZWAVE_LONG_RANGE:
+                            continue
+                        try:
+                            neighbors[
+                                node.node_id
+                            ] = await controller.async_get_node_neighbors(node)
+                        except FailedCommand:
+                            continue
             finally:
+                rf_restored = await restore_rf()
                 if not rf_restored:
                     _LOGGER.error(
                         "Failed to re-enable RF after reading the neighbors of"
                         " the nodes of config entry %s",
                         entry.entry_id,
                     )
+        return rf_disabled, rf_restored, neighbors
+
+    # The refresh runs as its own task and is only abandoned on cancellation,
+    # so a closing connection can't interrupt it while the radio is off
+    rf_disabled, rf_restored, neighbors = await asyncio.shield(
+        hass.async_create_task(read_network_neighbors())
+    )
     if not rf_disabled:
         connection.send_error(msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF")
         return

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -670,9 +670,16 @@ async def websocket_network_neighbors(
                     except FailedCommand:
                         continue
         finally:
-            # Shielded so the radio comes back on even when the connection
-            # is closed while the routing table is being read
-            rf_restored = await asyncio.shield(controller.async_toggle_rf(True))
+            # Shielded so the radio comes back on even when the connection is
+            # closed while the routing table is being read. The lock is held
+            # until it has, so a queued refresh can't race the restore.
+            restore = asyncio.ensure_future(controller.async_toggle_rf(True))
+            try:
+                rf_restored = await asyncio.shield(restore)
+            except asyncio.CancelledError:
+                with suppress(FailedCommand):
+                    rf_restored = await asyncio.shield(restore)
+                raise
             if not rf_restored:
                 _LOGGER.error(
                     "Failed to re-enable RF after reading the neighbors of the"

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -659,7 +659,9 @@ async def websocket_network_neighbors(
                     msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF"
                 )
                 return
-            for node in controller.nodes.values():
+            # Snapshot the nodes, inclusion/exclusion can mutate the
+            # collection while it is being iterated
+            for node in list(controller.nodes.values()):
                 # Long range nodes are not part of the mesh
                 if node.protocol is Protocols.ZWAVE_LONG_RANGE:
                     continue

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -653,8 +653,6 @@ async def websocket_network_neighbors(
     rf_restored = False
     async with entry.runtime_data.network_neighbors_lock:
         try:
-            # Don't read the routing table with the radio still on,
-            # that is what wedges older controllers
             rf_disabled = await controller.async_toggle_rf(False)
             if rf_disabled:
                 # Snapshot the nodes, inclusion/exclusion can mutate the
@@ -673,19 +671,20 @@ async def websocket_network_neighbors(
             # Shielded so the radio comes back on even when the connection is
             # closed while the routing table is being read. The lock is held
             # until it has, so a queued refresh can't race the restore.
-            restore = asyncio.ensure_future(controller.async_toggle_rf(True))
+            restore = hass.async_create_task(controller.async_toggle_rf(True))
             try:
                 rf_restored = await asyncio.shield(restore)
             except asyncio.CancelledError:
                 with suppress(FailedCommand):
                     rf_restored = await asyncio.shield(restore)
                 raise
-            if not rf_restored:
-                _LOGGER.error(
-                    "Failed to re-enable RF after reading the neighbors of the"
-                    " nodes of config entry %s",
-                    entry.entry_id,
-                )
+            finally:
+                if not rf_restored:
+                    _LOGGER.error(
+                        "Failed to re-enable RF after reading the neighbors of"
+                        " the nodes of config entry %s",
+                        entry.entry_id,
+                    )
     if not rf_disabled:
         connection.send_error(msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF")
         return

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -648,6 +648,14 @@ async def websocket_network_neighbors(
     https://zwave-js.github.io/zwave-js/#/api/controller?id=getnodeneighbors
     """
     controller = driver.controller
+
+    async def restore_rf() -> bool:
+        """Turn the radio back on, returning False instead of raising."""
+        try:
+            return await controller.async_toggle_rf(True)
+        except BaseZwaveJSServerError:
+            return False
+
     neighbors: dict[int, list[int]] = {}
     rf_disabled = False
     rf_restored = False
@@ -669,14 +677,14 @@ async def websocket_network_neighbors(
                         continue
         finally:
             # Shielded so the radio comes back on even when the connection is
-            # closed while the routing table is being read. The lock is held
-            # until it has, so a queued refresh can't race the restore.
-            restore = hass.async_create_task(controller.async_toggle_rf(True))
+            # closed while the routing table is being read
+            restore = hass.async_create_task(restore_rf())
             try:
                 rf_restored = await asyncio.shield(restore)
             except asyncio.CancelledError:
-                with suppress(BaseZwaveJSServerError):
-                    rf_restored = await asyncio.shield(restore)
+                # Hold the lock until the radio is back on, so a queued
+                # refresh can't race the restore
+                rf_restored = await asyncio.shield(restore)
                 raise
             finally:
                 if not rf_restored:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -649,28 +649,26 @@ async def websocket_network_neighbors(
     """
     controller = driver.controller
     neighbors: dict[int, list[int]] = {}
+    rf_disabled = False
     rf_restored = False
     async with entry.runtime_data.network_neighbors_lock:
         try:
-            if not await controller.async_toggle_rf(False):
-                # Don't read the routing table with the radio still on,
-                # that is what wedges older controllers
-                connection.send_error(
-                    msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF"
-                )
-                return
-            # Snapshot the nodes, inclusion/exclusion can mutate the
-            # collection while it is being iterated
-            for node in list(controller.nodes.values()):
-                # Long range nodes are not part of the mesh
-                if node.protocol is Protocols.ZWAVE_LONG_RANGE:
-                    continue
-                try:
-                    neighbors[node.node_id] = await controller.async_get_node_neighbors(
-                        node
-                    )
-                except FailedCommand:
-                    continue
+            # Don't read the routing table with the radio still on,
+            # that is what wedges older controllers
+            rf_disabled = await controller.async_toggle_rf(False)
+            if rf_disabled:
+                # Snapshot the nodes, inclusion/exclusion can mutate the
+                # collection while it is being iterated
+                for node in list(controller.nodes.values()):
+                    # Long range nodes are not part of the mesh
+                    if node.protocol is Protocols.ZWAVE_LONG_RANGE:
+                        continue
+                    try:
+                        neighbors[
+                            node.node_id
+                        ] = await controller.async_get_node_neighbors(node)
+                    except FailedCommand:
+                        continue
         finally:
             # Shielded so the radio comes back on even when the connection
             # is closed while the routing table is being read
@@ -681,6 +679,9 @@ async def websocket_network_neighbors(
                     " nodes of config entry %s",
                     entry.entry_id,
                 )
+    if not rf_disabled:
+        connection.send_error(msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to disable RF")
+        return
     if not rf_restored:
         connection.send_error(msg[ID], ERR_RF_TOGGLE_FAILED, "Failed to re-enable RF")
         return

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -411,7 +411,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_network_status)
     websocket_api.async_register_command(hass, websocket_subscribe_node_status)
     websocket_api.async_register_command(hass, websocket_node_status)
-    websocket_api.async_register_command(hass, websocket_node_neighbors)
+    websocket_api.async_register_command(hass, websocket_network_neighbors)
     websocket_api.async_register_command(hass, websocket_node_metadata)
     websocket_api.async_register_command(hass, websocket_node_alerts)
     websocket_api.async_register_command(hass, websocket_add_node)
@@ -621,25 +621,44 @@ async def websocket_node_status(
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
-        vol.Required(TYPE): "zwave_js/node_neighbors",
-        vol.Required(DEVICE_ID): str,
+        vol.Required(TYPE): "zwave_js/network_neighbors",
+        vol.Required(ENTRY_ID): str,
     }
 )
 @websocket_api.async_response
 @async_handle_failed_command
-@async_get_node
-async def websocket_node_neighbors(
+@async_get_entry
+async def websocket_network_neighbors(
     hass: HomeAssistant,
     connection: ActiveConnection,
     msg: dict[str, Any],
-    node: Node,
+    entry: ZwaveJSConfigEntry,
+    client: Client,
+    driver: Driver,
 ) -> None:
-    """Get the node IDs of the neighbors of a Z-Wave JS node."""
-    driver = node.client.driver
-    assert driver is not None  # The node comes from the driver instance.
-    controller = driver.controller
+    """Get the node IDs of the neighbors of all nodes in the network.
 
-    neighbors = await controller.async_get_node_neighbors(node)
+    Reading the routing table can wedge older controllers when the radio is
+    on or reads overlap, so refreshes are serialized and done with RF off:
+    https://zwave-js.github.io/zwave-js/#/api/controller?id=getnodeneighbors
+    """
+    controller = driver.controller
+    neighbors: dict[int, list[int]] = {}
+    async with entry.runtime_data.network_neighbors_lock:
+        await controller.async_toggle_rf(False)
+        try:
+            for node in controller.nodes.values():
+                # Long range nodes are not part of the mesh
+                if node.protocol is Protocols.ZWAVE_LONG_RANGE:
+                    continue
+                try:
+                    neighbors[node.node_id] = await controller.async_get_node_neighbors(
+                        node
+                    )
+                except FailedCommand:
+                    continue
+        finally:
+            await controller.async_toggle_rf(True)
     connection.send_result(msg[ID], neighbors)
 
 

--- a/homeassistant/components/zwave_js/models.py
+++ b/homeassistant/components/zwave_js/models.py
@@ -1,5 +1,6 @@
 """Provide models for the Z-Wave integration."""
 
+import asyncio
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
@@ -32,6 +33,8 @@ class ZwaveJSData:
     client: ZwaveClient
     driver_events: DriverEvents
     old_server_log_level: LogLevel | None = None
+    # Serializes routing table reads, which require the radio to be off
+    network_neighbors_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 type ZwaveJSConfigEntry = ConfigEntry[ZwaveJSData]

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -775,6 +775,58 @@ async def test_network_neighbors_concurrent(
     ]
 
 
+async def test_network_neighbors_unload_waits(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test unloading the entry waits for the radio to be turned back on."""
+    ws_client = await hass_ws_client(hass)
+    read_started = asyncio.Event()
+    resume_read = asyncio.Event()
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["command"] == "controller.get_node_neighbors":
+            read_started.set()
+            await resume_read.wait()
+            return {"neighbors": []}
+        return {"success": True}
+
+    commands = mock_neighbors_commands(client, handler)
+
+    async def mock_disconnect() -> None:
+        commands.append({"command": "disconnect"})
+
+    client.disconnect.side_effect = mock_disconnect
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: integration.entry_id,
+        }
+    )
+    await read_started.wait()
+
+    unload_task = hass.async_create_task(
+        hass.config_entries.async_unload(integration.entry_id)
+    )
+    for _ in range(10):
+        await asyncio.sleep(0)
+    # The refresh is holding the lock, so the client must still be connected
+    assert not unload_task.done()
+
+    resume_read.set()
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert await unload_task
+    # The radio was turned back on before the client disconnected
+    assert commands[-2:] == [
+        {"command": "controller.toggle_rf", "enabled": True},
+        {"command": "disconnect"},
+    ]
+
+
 async def test_network_neighbors_invalid_entry(
     hass: HomeAssistant,
     integration: MockConfigEntry,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -601,8 +601,37 @@ async def test_network_neighbors(
         {"command": "controller.toggle_rf", "enable": True},
     ]
 
-    client.async_send_command.side_effect = original_side_effect
+    # Test a node joining the network mid-read doesn't abort the reads
+    commands.clear()
+
+    async def mock_send_command_mutating(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.get_node_neighbors":
+            client.driver.controller.nodes.setdefault(999, wallmote_central_scene)
+            return {"neighbors": []}
+        return {"success": True}
+
+    client.async_send_command.side_effect = mock_send_command_mutating
     ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {
+        "1": [],
+        str(multisensor_6.node_id): [],
+    }
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+
+    client.async_send_command.side_effect = original_side_effect
 
     # Test sending command with improper entry ID fails
     await ws_client.send_json_auto_id(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -508,10 +508,46 @@ async def test_network_neighbors(
     assert not msg["success"]
     assert msg["error"]["code"] == "zwave_error"
     assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
-    # The radio was never turned off, so it should not be turned back on
-    assert commands == [{"command": "controller.toggle_rf", "enable": False}]
+    # Turning the radio back on is attempted even if disabling it failed,
+    # since the disable command may have been effective before it errored
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enable": True},
+    ]
+
+    # Test the radio is turned back on when the command is cancelled while
+    # the radio is being turned off, e.g. because the connection closed
+    commands.clear()
+
+    async def mock_send_command_cancelled(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.toggle_rf" and not message["enable"]:
+            raise asyncio.CancelledError
+        return {"success": True}
+
+    client.async_send_command.side_effect = mock_send_command_cancelled
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    # A cancelled command sends no response, so sync on a ping instead
+    await ws_client.send_json_auto_id({TYPE: "ping"})
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "pong"
+    await hass.async_block_till_done()
+
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enable": True},
+    ]
 
     client.async_send_command.side_effect = original_side_effect
+    ws_client = await hass_ws_client(hass)
 
     # Test sending command with improper entry ID fails
     await ws_client.send_json_auto_id(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -401,6 +401,80 @@ async def test_node_status(
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
+async def test_node_neighbors(
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    client,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the node_neighbors websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+    device = get_device(hass, multisensor_6)
+
+    client.async_send_command.return_value = {"neighbors": [35, 32]}
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/node_neighbors",
+            DEVICE_ID: device.id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == [35, 32]
+    assert client.async_send_command.call_args[0][0] == {
+        "command": "controller.get_node_neighbors",
+        "nodeId": multisensor_6.node_id,
+    }
+
+    # Test FailedZWaveCommand is caught
+    with patch(
+        f"{CONTROLLER_PATCH_PREFIX}.async_get_node_neighbors",
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
+    ):
+        await ws_client.send_json_auto_id(
+            {
+                TYPE: "zwave_js/node_neighbors",
+                DEVICE_ID: device.id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == "zwave_error"
+        assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
+
+    # Test sending command with improper device ID fails
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/node_neighbors",
+            DEVICE_ID: "fake_device",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/node_neighbors",
+            DEVICE_ID: device.id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
 async def test_node_metadata(
     hass: HomeAssistant,
     wallmote_central_scene,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -460,10 +460,10 @@ async def test_network_neighbors(
     }
     # The nodes are read one at a time while the radio is off
     assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enabled": False},
         {"command": "controller.get_node_neighbors", "nodeId": 1},
         {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
-        {"command": "controller.toggle_rf", "enable": True},
+        {"command": "controller.toggle_rf", "enabled": True},
     ]
 
 
@@ -496,7 +496,7 @@ async def test_network_neighbors_node_failure(
 
     assert msg["success"]
     assert msg["result"] == {str(multisensor_6.node_id): []}
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enabled": True}
 
 
 async def test_network_neighbors_node_added_while_reading(
@@ -532,7 +532,7 @@ async def test_network_neighbors_node_added_while_reading(
         str(multisensor_6.node_id): [],
         str(wallmote_central_scene.node_id): [],
     }
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enabled": True}
 
 
 async def test_network_neighbors_rf_disable_rejected(
@@ -546,7 +546,7 @@ async def test_network_neighbors_rf_disable_rejected(
 
     async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.toggle_rf":
-            return {"success": message["enable"]}
+            return {"success": message["enabled"]}
         return {"neighbors": []}
 
     commands = mock_neighbors_commands(client, handler)
@@ -562,8 +562,8 @@ async def test_network_neighbors_rf_disable_rejected(
     assert not msg["success"]
     assert msg["error"]["code"] == "rf_toggle_failed"
     assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.toggle_rf", "enable": True},
+        {"command": "controller.toggle_rf", "enabled": False},
+        {"command": "controller.toggle_rf", "enabled": True},
     ]
 
 
@@ -579,7 +579,7 @@ async def test_network_neighbors_rf_restore_rejected(
 
     async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.toggle_rf":
-            return {"success": not message["enable"]}
+            return {"success": not message["enabled"]}
         return {"neighbors": []}
 
     commands = mock_neighbors_commands(client, handler)
@@ -594,7 +594,7 @@ async def test_network_neighbors_rf_restore_rejected(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "rf_toggle_failed"
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enabled": True}
     assert "Failed to re-enable RF" in caplog.text
 
 
@@ -608,7 +608,7 @@ async def test_network_neighbors_rf_toggle_error(
     ws_client = await hass_ws_client(hass)
 
     async def handler(message: dict[str, Any]) -> dict[str, Any]:
-        if message["enable"]:
+        if message["enabled"]:
             raise FailedZWaveCommand("failed_command", 1, "error message")
         return {"success": False}
 
@@ -641,7 +641,7 @@ async def test_network_neighbors_cancelled(
     ws_client = await hass_ws_client(hass)
 
     async def handler(message: dict[str, Any]) -> dict[str, Any]:
-        if message["command"] == "controller.toggle_rf" and not message["enable"]:
+        if message["command"] == "controller.toggle_rf" and not message["enabled"]:
             raise asyncio.CancelledError
         return {"success": True}
 
@@ -660,8 +660,8 @@ async def test_network_neighbors_cancelled(
     await hass.async_block_till_done()
 
     assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.toggle_rf", "enable": True},
+        {"command": "controller.toggle_rf", "enabled": False},
+        {"command": "controller.toggle_rf", "enabled": True},
     ]
 
 
@@ -682,7 +682,7 @@ async def test_network_neighbors_cancelled_while_restoring_rf(
             # the reads run in the handler task, the restore does not
             handler_tasks.append(asyncio.current_task())
             return {"neighbors": []}
-        if message["enable"]:
+        if message["enabled"]:
             restore_started.set()
             await resume_restore.wait()
         return {"success": True}
@@ -753,7 +753,7 @@ async def test_network_neighbors_concurrent(
     assert msg["type"] == "pong"
     # The second request must not have touched the radio yet
     assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enabled": False},
         {"command": "controller.get_node_neighbors", "nodeId": 1},
     ]
 
@@ -764,14 +764,14 @@ async def test_network_neighbors_concurrent(
     assert msg["success"]
     # The second request turns the radio off only after the first turned it on
     assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enabled": False},
         {"command": "controller.get_node_neighbors", "nodeId": 1},
         {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
-        {"command": "controller.toggle_rf", "enable": True},
-        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enabled": True},
+        {"command": "controller.toggle_rf", "enabled": False},
         {"command": "controller.get_node_neighbors", "nodeId": 1},
         {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
-        {"command": "controller.toggle_rf", "enable": True},
+        {"command": "controller.toggle_rf", "enabled": True},
     ]
 
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -667,29 +667,30 @@ async def test_network_neighbors_cancelled(
     ]
 
 
-async def test_network_neighbors_cancelled_while_restoring_rf(
+async def test_network_neighbors_handler_cancelled(
     hass: HomeAssistant,
+    multisensor_6: Node,
     integration: MockConfigEntry,
     client: MagicMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test the lock is held until the radio is back on after a cancellation."""
+    """Test an abandoned request doesn't interrupt the refresh.
+
+    The refresh must keep the lock and turn the radio back on even when the
+    websocket command handler is cancelled, e.g. by a closing connection.
+    """
     ws_client = await hass_ws_client(hass)
-    restore_started = asyncio.Event()
-    resume_restore = asyncio.Event()
-    handler_tasks: list[asyncio.Task[None]] = []
+    read_started = asyncio.Event()
+    resume_read = asyncio.Event()
 
     async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.get_node_neighbors":
-            # the reads run in the handler task, the restore does not
-            handler_tasks.append(asyncio.current_task())
+            read_started.set()
+            await resume_read.wait()
             return {"neighbors": []}
-        if message["enabled"]:
-            restore_started.set()
-            await resume_restore.wait()
         return {"success": True}
 
-    mock_neighbors_commands(client, handler)
+    commands = mock_neighbors_commands(client, handler)
     lock = integration.runtime_data.network_neighbors_lock
 
     await ws_client.send_json_auto_id(
@@ -698,20 +699,28 @@ async def test_network_neighbors_cancelled_while_restoring_rf(
             ENTRY_ID: integration.entry_id,
         }
     )
-    await restore_started.wait()
-    assert lock.locked()
+    await read_started.wait()
 
-    handler_tasks[0].cancel()
+    handler_task = next(
+        task
+        for task in asyncio.all_tasks()
+        if "_handle_async_response" in repr(task.get_coro())
+    )
+    handler_task.cancel()
     for _ in range(5):
         await asyncio.sleep(0)
-    # The radio is still being turned back on, so the lock must not be free yet
+    # The abandoned refresh keeps reading with the lock held
     assert lock.locked()
 
-    resume_restore.set()
-    for _ in range(10):
-        await asyncio.sleep(0)
+    resume_read.set()
     await hass.async_block_till_done()
     assert not lock.locked()
+    assert commands == [
+        {"command": "controller.toggle_rf", "enabled": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enabled": True},
+    ]
 
 
 async def test_network_neighbors_concurrent(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -408,6 +408,7 @@ async def test_network_neighbors(
     integration: MockConfigEntry,
     client: MagicMock,
     hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the network_neighbors websocket command."""
     entry = integration
@@ -454,6 +455,60 @@ async def test_network_neighbors(
         1,
         multisensor_6.node_id,
     ]
+
+    # Test failing to disable RF aborts before any nodes are read
+    commands.clear()
+
+    async def mock_send_command_disable_rejected(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.toggle_rf":
+            return {"success": message["enable"]}
+        return {"neighbors": []}
+
+    client.async_send_command.side_effect = mock_send_command_disable_rejected
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "rf_toggle_failed"
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.toggle_rf", "enable": True},
+    ]
+
+    # Test failing to restore RF is logged and reported as an error
+    commands.clear()
+
+    async def mock_send_command_restore_rejected(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.toggle_rf":
+            return {"success": not message["enable"]}
+        return {"neighbors": []}
+
+    client.async_send_command.side_effect = mock_send_command_restore_rejected
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "rf_toggle_failed"
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+    assert "Failed to re-enable RF" in caplog.text
 
     # Test a node that fails to report neighbors is skipped and RF is restored
     commands.clear()

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -603,6 +603,7 @@ async def test_network_neighbors_rf_toggle_error(
     integration: MockConfigEntry,
     client: MagicMock,
     hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a single response is sent when the radio can't be toggled at all."""
     ws_client = await hass_ws_client(hass)
@@ -623,7 +624,8 @@ async def test_network_neighbors_rf_toggle_error(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == "zwave_error"
+    assert msg["error"]["code"] == "rf_toggle_failed"
+    assert "Failed to re-enable RF" in caplog.text
 
     # The next frame is the pong, proving no second response was sent
     await ws_client.send_json_auto_id({TYPE: "ping"})

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -631,6 +631,91 @@ async def test_network_neighbors(
     }
     assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
 
+    # Test a failed restore after a rejected disable sends a single error
+    commands.clear()
+
+    async def mock_send_command_rejected_then_raising(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["enable"]:
+            raise FailedZWaveCommand("failed_command", 1, "error message")
+        return {"success": False}
+
+    client.async_send_command.side_effect = mock_send_command_rejected_then_raising
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "zwave_error"
+    # The next frame is the pong, proving no second response was sent
+    await ws_client.send_json_auto_id({TYPE: "ping"})
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "pong"
+
+    # Test concurrent requests are serialized behind the lock
+    commands.clear()
+    read_started = asyncio.Event()
+    resume_read = asyncio.Event()
+
+    async def mock_send_command_blocking(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.get_node_neighbors":
+            read_started.set()
+            await resume_read.wait()
+            return {"neighbors": []}
+        return {"success": True}
+
+    client.async_send_command.side_effect = mock_send_command_blocking
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    await read_started.wait()
+
+    ws_client_2 = await hass_ws_client(hass)
+    await ws_client_2.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    await ws_client_2.send_json_auto_id({TYPE: "ping"})
+    msg = await ws_client_2.receive_json()
+    assert msg["type"] == "pong"
+    # The second request must not have touched the radio yet
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+    ]
+
+    resume_read.set()
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    msg = await ws_client_2.receive_json()
+    assert msg["success"]
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enable": True},
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enable": True},
+    ]
+
     client.async_send_command.side_effect = original_side_effect
 
     # Test sending command with improper entry ID fails

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1,6 +1,7 @@
 """Test the Z-Wave JS Websocket API."""
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from http import HTTPStatus
 from io import BytesIO
@@ -401,6 +402,28 @@ async def test_node_status(
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
+def mock_neighbors_commands(
+    client: MagicMock,
+    handler: Callable[[dict[str, Any]], Coroutine[Any, Any, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Record the commands sent to the driver and answer them with handler."""
+    commands: list[dict[str, Any]] = []
+
+    async def _send_command(message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        commands.append(message)
+        return await handler(message)
+
+    client.async_send_command.side_effect = _send_command
+    return commands
+
+
+async def neighbors_ok(message: dict[str, Any]) -> dict[str, Any]:
+    """Answer both toggling RF and reading neighbors successfully."""
+    if message["command"] == "controller.get_node_neighbors":
+        return {"neighbors": []}
+    return {"success": True}
+
+
 async def test_network_neighbors(
     hass: HomeAssistant,
     multisensor_6: Node,
@@ -408,33 +431,24 @@ async def test_network_neighbors(
     integration: MockConfigEntry,
     client: MagicMock,
     hass_ws_client: WebSocketGenerator,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the network_neighbors websocket command."""
-    entry = integration
     ws_client = await hass_ws_client(hass)
-    original_side_effect = client.async_send_command.side_effect
-
     # Long range nodes are not part of the mesh and must be skipped
     wallmote_central_scene.data["protocol"] = Protocols.ZWAVE_LONG_RANGE
 
-    commands: list[dict[str, Any]] = []
-    neighbors_by_node_id = {multisensor_6.node_id: [35, 32]}
-
-    async def mock_send_command(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.get_node_neighbors":
-            return {"neighbors": neighbors_by_node_id.get(message["nodeId"], [])}
+            neighbors = [35, 32] if message["nodeId"] == multisensor_6.node_id else []
+            return {"neighbors": neighbors}
         return {"success": True}
 
-    client.async_send_command.side_effect = mock_send_command
+    commands = mock_neighbors_commands(client, handler)
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     msg = await ws_client.receive_json()
@@ -444,35 +458,103 @@ async def test_network_neighbors(
         "1": [],
         str(multisensor_6.node_id): [35, 32],
     }
-    # The radio is off while the routing table is read
-    assert commands[0] == {"command": "controller.toggle_rf", "enable": False}
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
-    assert [command["command"] for command in commands[1:-1]] == [
-        "controller.get_node_neighbors",
-        "controller.get_node_neighbors",
-    ]
-    assert [command["nodeId"] for command in commands[1:-1]] == [
-        1,
-        multisensor_6.node_id,
+    # The nodes are read one at a time while the radio is off
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enable": True},
     ]
 
-    # Test failing to disable RF aborts before any nodes are read
-    commands.clear()
 
-    async def mock_send_command_disable_rejected(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        if message["command"] == "controller.toggle_rf":
-            return {"success": message["enable"]}
+async def test_network_neighbors_node_failure(
+    hass: HomeAssistant,
+    multisensor_6: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a node that fails to report its neighbors is skipped."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["command"] != "controller.get_node_neighbors":
+            return {"success": True}
+        if message["nodeId"] == 1:
+            raise FailedZWaveCommand("failed_command", 1, "error message")
         return {"neighbors": []}
 
-    client.async_send_command.side_effect = mock_send_command_disable_rejected
+    commands = mock_neighbors_commands(client, handler)
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {str(multisensor_6.node_id): []}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+
+
+async def test_network_neighbors_node_added_while_reading(
+    hass: HomeAssistant,
+    multisensor_6: Node,
+    wallmote_central_scene: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a node joining the network while reading doesn't abort the reads."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["command"] == "controller.get_node_neighbors":
+            client.driver.controller.nodes.setdefault(999, wallmote_central_scene)
+            return {"neighbors": []}
+        return {"success": True}
+
+    commands = mock_neighbors_commands(client, handler)
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: integration.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {
+        "1": [],
+        str(multisensor_6.node_id): [],
+        str(wallmote_central_scene.node_id): [],
+    }
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+
+
+async def test_network_neighbors_rf_disable_rejected(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the nodes are not read when the radio can't be turned off."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["command"] == "controller.toggle_rf":
+            return {"success": message["enable"]}
+        return {"neighbors": []}
+
+    commands = mock_neighbors_commands(client, handler)
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: integration.entry_id,
         }
     )
     msg = await ws_client.receive_json()
@@ -484,23 +566,28 @@ async def test_network_neighbors(
         {"command": "controller.toggle_rf", "enable": True},
     ]
 
-    # Test failing to restore RF is logged and reported as an error
-    commands.clear()
 
-    async def mock_send_command_restore_rejected(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
+async def test_network_neighbors_rf_restore_rejected(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a radio that can't be turned back on is reported and logged."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.toggle_rf":
             return {"success": not message["enable"]}
         return {"neighbors": []}
 
-    client.async_send_command.side_effect = mock_send_command_restore_rejected
+    commands = mock_neighbors_commands(client, handler)
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     msg = await ws_client.receive_json()
@@ -510,84 +597,60 @@ async def test_network_neighbors(
     assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
     assert "Failed to re-enable RF" in caplog.text
 
-    # Test a node that fails to report neighbors is skipped and RF is restored
-    commands.clear()
-    failing_node_ids = {1}
 
-    async def mock_send_command_node_failure(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        if (
-            message["command"] == "controller.get_node_neighbors"
-            and message["nodeId"] in failing_node_ids
-        ):
+async def test_network_neighbors_rf_toggle_error(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a single response is sent when the radio can't be toggled at all."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["enable"]:
             raise FailedZWaveCommand("failed_command", 1, "error message")
-        if message["command"] == "controller.get_node_neighbors":
-            return {"neighbors": []}
-        return {"success": True}
+        return {"success": False}
 
-    client.async_send_command.side_effect = mock_send_command_node_failure
+    mock_neighbors_commands(client, handler)
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
-        }
-    )
-    msg = await ws_client.receive_json()
-
-    assert msg["success"]
-    assert msg["result"] == {str(multisensor_6.node_id): []}
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
-
-    # Test FailedZWaveCommand from toggling RF is caught
-    commands.clear()
-
-    async def mock_send_command_rf_failure(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        raise FailedZWaveCommand("failed_command", 1, "error message")
-
-    client.async_send_command.side_effect = mock_send_command_rf_failure
-
-    await ws_client.send_json_auto_id(
-        {
-            TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == "zwave_error"
-    assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
-    # Turning the radio back on is attempted even if disabling it failed,
-    # since the disable command may have been effective before it errored
-    assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.toggle_rf", "enable": True},
-    ]
 
-    # Test the radio is turned back on when the command is cancelled while
-    # the radio is being turned off, e.g. because the connection closed
-    commands.clear()
+    # The next frame is the pong, proving no second response was sent
+    await ws_client.send_json_auto_id({TYPE: "ping"})
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "pong"
 
-    async def mock_send_command_cancelled(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
+
+async def test_network_neighbors_cancelled(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the radio is turned back on when the command is cancelled."""
+    ws_client = await hass_ws_client(hass)
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.toggle_rf" and not message["enable"]:
             raise asyncio.CancelledError
         return {"success": True}
 
-    client.async_send_command.side_effect = mock_send_command_cancelled
+    commands = mock_neighbors_commands(client, handler)
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     # A cancelled command sends no response, so sync on a ping instead
@@ -601,132 +664,20 @@ async def test_network_neighbors(
         {"command": "controller.toggle_rf", "enable": True},
     ]
 
-    # Test a node joining the network mid-read doesn't abort the reads
-    commands.clear()
 
-    async def mock_send_command_mutating(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        if message["command"] == "controller.get_node_neighbors":
-            client.driver.controller.nodes.setdefault(999, wallmote_central_scene)
-            return {"neighbors": []}
-        return {"success": True}
-
-    client.async_send_command.side_effect = mock_send_command_mutating
+async def test_network_neighbors_cancelled_while_restoring_rf(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the lock is held until the radio is back on after a cancellation."""
     ws_client = await hass_ws_client(hass)
-
-    await ws_client.send_json_auto_id(
-        {
-            TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
-        }
-    )
-    msg = await ws_client.receive_json()
-
-    assert msg["success"]
-    assert msg["result"] == {
-        "1": [],
-        str(multisensor_6.node_id): [],
-    }
-    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
-
-    # Test a failed restore after a rejected disable sends a single error
-    commands.clear()
-
-    async def mock_send_command_rejected_then_raising(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        if message["enable"]:
-            raise FailedZWaveCommand("failed_command", 1, "error message")
-        return {"success": False}
-
-    client.async_send_command.side_effect = mock_send_command_rejected_then_raising
-
-    await ws_client.send_json_auto_id(
-        {
-            TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
-        }
-    )
-    msg = await ws_client.receive_json()
-
-    assert not msg["success"]
-    assert msg["error"]["code"] == "zwave_error"
-    # The next frame is the pong, proving no second response was sent
-    await ws_client.send_json_auto_id({TYPE: "ping"})
-    msg = await ws_client.receive_json()
-    assert msg["type"] == "pong"
-
-    # Test concurrent requests are serialized behind the lock
-    commands.clear()
-    read_started = asyncio.Event()
-    resume_read = asyncio.Event()
-
-    async def mock_send_command_blocking(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
-        if message["command"] == "controller.get_node_neighbors":
-            read_started.set()
-            await resume_read.wait()
-            return {"neighbors": []}
-        return {"success": True}
-
-    client.async_send_command.side_effect = mock_send_command_blocking
-
-    await ws_client.send_json_auto_id(
-        {
-            TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
-        }
-    )
-    await read_started.wait()
-
-    ws_client_2 = await hass_ws_client(hass)
-    await ws_client_2.send_json_auto_id(
-        {
-            TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
-        }
-    )
-    await ws_client_2.send_json_auto_id({TYPE: "ping"})
-    msg = await ws_client_2.receive_json()
-    assert msg["type"] == "pong"
-    # The second request must not have touched the radio yet
-    assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.get_node_neighbors", "nodeId": 1},
-    ]
-
-    resume_read.set()
-    msg = await ws_client.receive_json()
-    assert msg["success"]
-    msg = await ws_client_2.receive_json()
-    assert msg["success"]
-    assert commands == [
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.get_node_neighbors", "nodeId": 1},
-        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
-        {"command": "controller.toggle_rf", "enable": True},
-        {"command": "controller.toggle_rf", "enable": False},
-        {"command": "controller.get_node_neighbors", "nodeId": 1},
-        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
-        {"command": "controller.toggle_rf", "enable": True},
-    ]
-
-    # Test the lock is held until RF is restored, even when cancelled
-    commands.clear()
     restore_started = asyncio.Event()
     resume_restore = asyncio.Event()
-
     handler_tasks: list[asyncio.Task[None]] = []
 
-    async def mock_send_command_blocking_restore(
-        message: dict[str, Any], **kwargs: Any
-    ) -> dict[str, Any]:
-        commands.append(message)
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
         if message["command"] == "controller.get_node_neighbors":
             # the reads run in the handler task, the restore does not
             handler_tasks.append(asyncio.current_task())
@@ -736,14 +687,13 @@ async def test_network_neighbors(
             await resume_restore.wait()
         return {"success": True}
 
-    client.async_send_command.side_effect = mock_send_command_blocking_restore
-    lock = entry.runtime_data.network_neighbors_lock
-    ws_client_3 = await hass_ws_client(hass)
+    mock_neighbors_commands(client, handler)
+    lock = integration.runtime_data.network_neighbors_lock
 
-    await ws_client_3.send_json_auto_id(
+    await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     await restore_started.wait()
@@ -760,16 +710,81 @@ async def test_network_neighbors(
         await asyncio.sleep(0)
     await hass.async_block_till_done()
     assert not lock.locked()
+
+
+async def test_network_neighbors_concurrent(
+    hass: HomeAssistant,
+    multisensor_6: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test concurrent requests are serialized so the radio is never shared."""
+    ws_client = await hass_ws_client(hass)
+    ws_client_2 = await hass_ws_client(hass)
+    read_started = asyncio.Event()
+    resume_read = asyncio.Event()
+
+    async def handler(message: dict[str, Any]) -> dict[str, Any]:
+        if message["command"] == "controller.get_node_neighbors":
+            read_started.set()
+            await resume_read.wait()
+            return {"neighbors": []}
+        return {"success": True}
+
+    commands = mock_neighbors_commands(client, handler)
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: integration.entry_id,
+        }
+    )
+    await read_started.wait()
+
+    await ws_client_2.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: integration.entry_id,
+        }
+    )
+    await ws_client_2.send_json_auto_id({TYPE: "ping"})
+    msg = await ws_client_2.receive_json()
+    assert msg["type"] == "pong"
+    # The second request must not have touched the radio yet
     assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+    ]
+
+    resume_read.set()
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    msg = await ws_client_2.receive_json()
+    assert msg["success"]
+    # The second request turns the radio off only after the first turned it on
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enable": True},
         {"command": "controller.toggle_rf", "enable": False},
         {"command": "controller.get_node_neighbors", "nodeId": 1},
         {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
         {"command": "controller.toggle_rf", "enable": True},
     ]
 
-    client.async_send_command.side_effect = original_side_effect
 
-    # Test sending command with improper entry ID fails
+async def test_network_neighbors_invalid_entry(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the network_neighbors websocket command with an invalid entry."""
+    ws_client = await hass_ws_client(hass)
+    mock_neighbors_commands(client, neighbors_ok)
+
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
@@ -781,14 +796,13 @@ async def test_network_neighbors(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
-    # Test sending command with not loaded entry fails
-    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.config_entries.async_unload(integration.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json_auto_id(
         {
             TYPE: "zwave_js/network_neighbors",
-            ENTRY_ID: entry.entry_id,
+            ENTRY_ID: integration.entry_id,
         }
     )
     msg = await ws_client.receive_json()

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -403,9 +403,9 @@ async def test_node_status(
 
 async def test_node_neighbors(
     hass: HomeAssistant,
-    multisensor_6,
-    integration,
-    client,
+    multisensor_6: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test the node_neighbors websocket command."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -401,57 +401,123 @@ async def test_node_status(
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_node_neighbors(
+async def test_network_neighbors(
     hass: HomeAssistant,
     multisensor_6: Node,
+    wallmote_central_scene: Node,
     integration: MockConfigEntry,
     client: MagicMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test the node_neighbors websocket command."""
+    """Test the network_neighbors websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
-    device = get_device(hass, multisensor_6)
+    original_side_effect = client.async_send_command.side_effect
 
-    client.async_send_command.return_value = {"neighbors": [35, 32]}
+    # Long range nodes are not part of the mesh and must be skipped
+    wallmote_central_scene.data["protocol"] = Protocols.ZWAVE_LONG_RANGE
+
+    commands: list[dict[str, Any]] = []
+    neighbors_by_node_id = {multisensor_6.node_id: [35, 32]}
+
+    async def mock_send_command(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.get_node_neighbors":
+            return {"neighbors": neighbors_by_node_id.get(message["nodeId"], [])}
+        return {"success": True}
+
+    client.async_send_command.side_effect = mock_send_command
 
     await ws_client.send_json_auto_id(
         {
-            TYPE: "zwave_js/node_neighbors",
-            DEVICE_ID: device.id,
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
         }
     )
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    assert msg["result"] == [35, 32]
-    assert client.async_send_command.call_args[0][0] == {
-        "command": "controller.get_node_neighbors",
-        "nodeId": multisensor_6.node_id,
+    assert msg["result"] == {
+        "1": [],
+        str(multisensor_6.node_id): [35, 32],
     }
+    # The radio is off while the routing table is read
+    assert commands[0] == {"command": "controller.toggle_rf", "enable": False}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+    assert [command["command"] for command in commands[1:-1]] == [
+        "controller.get_node_neighbors",
+        "controller.get_node_neighbors",
+    ]
+    assert [command["nodeId"] for command in commands[1:-1]] == [
+        1,
+        multisensor_6.node_id,
+    ]
 
-    # Test FailedZWaveCommand is caught
-    with patch(
-        f"{CONTROLLER_PATCH_PREFIX}.async_get_node_neighbors",
-        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
-    ):
-        await ws_client.send_json_auto_id(
-            {
-                TYPE: "zwave_js/node_neighbors",
-                DEVICE_ID: device.id,
-            }
-        )
-        msg = await ws_client.receive_json()
+    # Test a node that fails to report neighbors is skipped and RF is restored
+    commands.clear()
+    failing_node_ids = {1}
 
-        assert not msg["success"]
-        assert msg["error"]["code"] == "zwave_error"
-        assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
+    async def mock_send_command_node_failure(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if (
+            message["command"] == "controller.get_node_neighbors"
+            and message["nodeId"] in failing_node_ids
+        ):
+            raise FailedZWaveCommand("failed_command", 1, "error message")
+        if message["command"] == "controller.get_node_neighbors":
+            return {"neighbors": []}
+        return {"success": True}
 
-    # Test sending command with improper device ID fails
+    client.async_send_command.side_effect = mock_send_command_node_failure
+
     await ws_client.send_json_auto_id(
         {
-            TYPE: "zwave_js/node_neighbors",
-            DEVICE_ID: "fake_device",
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {str(multisensor_6.node_id): []}
+    assert commands[-1] == {"command": "controller.toggle_rf", "enable": True}
+
+    # Test FailedZWaveCommand from toggling RF is caught
+    commands.clear()
+
+    async def mock_send_command_rf_failure(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        raise FailedZWaveCommand("failed_command", 1, "error message")
+
+    client.async_send_command.side_effect = mock_send_command_rf_failure
+
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "zwave_error"
+    assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
+    # The radio was never turned off, so it should not be turned back on
+    assert commands == [{"command": "controller.toggle_rf", "enable": False}]
+
+    client.async_send_command.side_effect = original_side_effect
+
+    # Test sending command with improper entry ID fails
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: "fake_entry_id",
         }
     )
     msg = await ws_client.receive_json()
@@ -465,8 +531,8 @@ async def test_node_neighbors(
 
     await ws_client.send_json_auto_id(
         {
-            TYPE: "zwave_js/node_neighbors",
-            DEVICE_ID: device.id,
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
         }
     )
     msg = await ws_client.receive_json()

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -716,6 +716,57 @@ async def test_network_neighbors(
         {"command": "controller.toggle_rf", "enable": True},
     ]
 
+    # Test the lock is held until RF is restored, even when cancelled
+    commands.clear()
+    restore_started = asyncio.Event()
+    resume_restore = asyncio.Event()
+
+    handler_tasks: list[asyncio.Task[None]] = []
+
+    async def mock_send_command_blocking_restore(
+        message: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        commands.append(message)
+        if message["command"] == "controller.get_node_neighbors":
+            # the reads run in the handler task, the restore does not
+            handler_tasks.append(asyncio.current_task())
+            return {"neighbors": []}
+        if message["enable"]:
+            restore_started.set()
+            await resume_restore.wait()
+        return {"success": True}
+
+    client.async_send_command.side_effect = mock_send_command_blocking_restore
+    lock = entry.runtime_data.network_neighbors_lock
+    ws_client_3 = await hass_ws_client(hass)
+
+    await ws_client_3.send_json_auto_id(
+        {
+            TYPE: "zwave_js/network_neighbors",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    await restore_started.wait()
+    assert lock.locked()
+
+    handler_tasks[0].cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    # The radio is still being turned back on, so the lock must not be free yet
+    assert lock.locked()
+
+    resume_restore.set()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    await hass.async_block_till_done()
+    assert not lock.locked()
+    assert commands == [
+        {"command": "controller.toggle_rf", "enable": False},
+        {"command": "controller.get_node_neighbors", "nodeId": 1},
+        {"command": "controller.get_node_neighbors", "nodeId": multisensor_6.node_id},
+        {"command": "controller.toggle_rf", "enable": True},
+    ]
+
     client.async_send_command.side_effect = original_side_effect
 
     # Test sending command with improper entry ID fails

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -26,7 +26,12 @@ from homeassistant.components.persistent_notification import async_dismiss
 from homeassistant.components.zwave_js import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id, get_device_id_ext
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
@@ -88,6 +93,33 @@ async def test_home_assistant_stop(
     await hass.async_stop()
 
     assert client.disconnect.call_count == 1
+
+
+async def test_home_assistant_stop_waits_for_neighbors_refresh(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    client: MagicMock,
+) -> None:
+    """Test stop disconnects only after a neighbors refresh releases the lock.
+
+    The refresh turns the radio back on before releasing, so disconnecting
+    earlier could leave the radio off.
+    """
+    disconnected = asyncio.Event()
+
+    async def mock_disconnect() -> None:
+        disconnected.set()
+
+    client.disconnect.side_effect = mock_disconnect
+
+    async with integration.runtime_data.network_neighbors_lock:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert not disconnected.is_set()
+
+    await hass.async_block_till_done()
+    assert disconnected.is_set()
 
 
 @pytest.mark.usefixtures("client", "connect_timeout")


### PR DESCRIPTION
## Proposed change

Add a `zwave_js/network_neighbors` WebSocket command that returns the neighbors of every node in the network, keyed by node ID. The network visualization only has `lwr`/`nlwr` route statistics to draw edges from, so the mesh looks much sparser than it is (see the issue's comparison with Z-Wave JS UI); neighbor data lets the frontend show the actual mesh.

Reading the routing table (`GetRoutingInfo`) can wedge older controllers when the radio is on or reads overlap, so the command follows the [Z-Wave JS guidance](https://zwave-js.github.io/zwave-js/#/api/controller?id=getnodeneighbors): refreshes are serialized behind a per-entry lock, RF is toggled off, nodes are read sequentially (skipping long range nodes, which have no mesh neighbors), and RF is restored in a `finally`, including when the client disconnects mid-read.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#161100
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request: home-assistant/frontend#53677

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




