### PR TITLE
Cancel Bluetooth scanner expire devices timer on unload

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -407,7 +407,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if mode is BluetoothScanningMode.AUTO and not details.get(ADAPTER_PASSIVE_SCAN):
         mode = BluetoothScanningMode.ACTIVE
     scanner = HaScanner(mode, adapter, address)
-    scanner.async_setup()
+    entry.async_on_unload(scanner.async_setup())
     if entry.title == address:
         hass.config_entries.async_update_entry(
             entry, title=adapter_title(adapter, details)

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -58,6 +58,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+from homeassistant.util.async_ import get_scheduled_timer_handles
 
 from . import (
     FakeRemoteScanner,
@@ -3272,6 +3273,33 @@ async def test_default_address_config_entries_removed_linux(
     await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
     assert not hass.config_entries.async_entries(bluetooth.DOMAIN)
+
+
+@pytest.mark.usefixtures("one_adapter", "mock_bleak_scanner_start")
+async def test_unload_cancels_expire_devices_timer(hass: HomeAssistant) -> None:
+    """Test unloading an adapter cancels the scanner expire devices timer."""
+
+    def _expire_devices_timers() -> list[asyncio.TimerHandle]:
+        return [
+            handle
+            for handle in get_scheduled_timer_handles(hass.loop)
+            if not handle.cancelled()
+            and "_async_expire_devices_schedule_next" in repr(handle)
+        ]
+
+    entry = MockConfigEntry(
+        domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    # The timer must exist first, otherwise the assertion below is vacuous
+    assert _expire_devices_timers()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert not _expire_devices_timers()
 
 
 @pytest.mark.usefixtures("one_adapter")


### PR DESCRIPTION
## Proposed change

`HaScanner.async_setup()` schedules a self-rescheduling 30 second expire-devices
timer and returns the `CALLBACK_TYPE` that cancels it. `async_setup_entry`
discarded that return value, while every other cleanup in the same function is
registered with `entry.async_on_unload(...)`:

```python
scanner = HaScanner(mode, adapter, address)
scanner.async_setup()                                          # return discarded
...
entry.async_on_unload(async_register_scanner(hass, scanner, connection_slots=slots))
entry.async_on_unload(entry.add_update_listener(async_update_listener))
entry.async_on_unload(scanner.async_stop)
```

In `habluetooth` (6.26.5) that returned callback is the only thing that cancels
the timer, and it has no call sites anywhere:

```python
# habluetooth/base_scanner.py
def async_setup(self) -> CALLBACK_TYPE:
    self._loop = asyncio.get_running_loop()
    self._schedule_expire_devices()
    return self._unsetup           # only canceller

def _unsetup(self) -> None:
    self._cancel_expire_devices()

def _schedule_expire_devices(self) -> None:
    ...
    self._cancel_track = loop.call_at(
        loop.time() + 30, self._async_expire_devices_schedule_next
    )

def _async_expire_devices_schedule_next(self) -> None:
    self._async_expire_devices()
    self._schedule_expire_devices()   # reschedules itself, forever
```

`scanner.async_stop` — the one scanner cleanup that *is* registered — does not
reach it either; both implementations stop the watchdog and the scan, nothing
more.

**Effect:** on unload, `async_register_scanner`'s unregister callback removes the
scanner from the manager, but the pending `loop.call_at` handle still references
`scanner._async_expire_devices_schedule_next`, so the scanner object is retained
and the timer reschedules every 30 seconds indefinitely. Each reload of the entry
adds another immortal timer and another retained scanner.

The fix registers the returned callback the same way as the surrounding
cleanups:

```diff
-    scanner.async_setup()
+    entry.async_on_unload(scanner.async_setup())
```

### Test

`test_unload_cancels_expire_devices_timer` in
`tests/components/bluetooth/test_init.py` sets up and unloads a real `HaScanner`
via the `one_adapter` fixture, and asserts no uncancelled expire-devices timer
handle survives the unload. It asserts the timer exists after setup first, so it
cannot pass vacuously if the scanner is never constructed.

Verified failing without the production change and passing with it:

```console
# without the one-line fix
FAILED tests/components/bluetooth/test_init.py::test_unload_cancels_expire_devices_timer
1 failed, 88 deselected

# with the fix
1 passed, 88 deselected
```

Note that HA's `verify_cleanup` fixture does **not** catch this today: with the
fix reverted it does observe the handle, but only logs it —

```text
WARNING tests.conftest:conftest.py:422 Lingering timer after test
<TimerHandle when=... BaseHaScanner._async_expire_devices_schedule_next()
 created at homeassistant/components/bluetooth/__init__.py:410>
```

— because `expected_lingering_timers` (`tests/conftest.py`) returns `True` for
every test under `tests/components/<domain>/` where the domain is not in
`BASE_PLATFORMS`, which exempts all of `tests/components/bluetooth/`. Hence the
explicit assertion rather than relying on the fixture.

Full suite: `pytest tests/components/bluetooth/` → **255 passed, 5 skipped**
(254 passed on `dev` before this change; the one added test is the difference).

### Open question for the maintainers

Whether this belongs in core or in `habluetooth`. The one-liner above is the
smaller edit and matches the surrounding style, but `async_setup()` returns a
`CALLBACK_TYPE` from four separate places in `habluetooth`
(`base_scanner.py` ×2, `scanner_bleak.py`, `scanner_mgmt.py`) and nothing in
either package ever calls the returned `_unsetup`. That suggests the contract
itself may be worth revisiting — e.g. having `async_stop()` call `_unsetup()`,
or making the setup/teardown pairing explicit — rather than relying on every
caller to remember to register the return value. Happy to follow up with a
`habluetooth` PR instead of or in addition to this one if that is preferred.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
