### PR TITLE
Add announce support to HEOS media player

### DIFF
--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -195,32 +195,32 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Handle player attribute updated."""
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
-        
+
         # Check for announcement completion
         if self._announce_in_progress and event == heos_const.EVENT_PLAYER_STATE_CHANGED:
             await self._check_announcement_completion()
-        
+
         self._handle_coordinator_update()
 
     async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
         """Play an announcement with pause/resume functionality."""
         # Reset completion flag for new announcement
         self._announce_completed = False
-        
+
         # Check if we should save and restore state
         if self._player.state == PlayState.PLAY:
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
             _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
-            
+
             # Pause the current playback
             await self._player.pause()
             # Give the pause command time to take effect
             await asyncio.sleep(0.5)
-        
+
         # Mark announcement as in progress
         self._announce_in_progress = True
-        
+
         # Set volume if specified in extra
         extra = kwargs.get("extra", {})
         if "volume" in extra:
@@ -229,7 +229,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 await self._player.set_volume(int(volume_level * 100))
             except (ValueError, TypeError) as err:
                 _LOGGER.warning("Invalid volume level for announcement: %s", err)
-        
+
         # Play the announcement
         await self._player.play_url(media_id)
 
@@ -249,27 +249,27 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Restore the player state after announcement completion."""
         if not self._announce_restore_state:
             return
-        
+
         state = self._announce_restore_state
         _LOGGER.debug("Restoring state after announcement: %s", state)
-        
+
         try:
             # Remove TTS from queue if it was added
             if state["tts_url"]:
                 # Small delay to ensure HEOS has processed the state change
                 await asyncio.sleep(0.2)
                 await self._remove_tts_from_queue(state["tts_url"])
-            
+
             # Restore volume
             await self._player.set_volume(state["volume"])
-            
+
             # Restore mute state
             if state["is_muted"] != self._player.is_muted:
                 await self._player.set_mute(state["is_muted"])
-            
+
             # Restore play mode
             await self._player.set_play_mode(state["repeat"], state["shuffle"])
-            
+
             # Resume playback if it was playing before
             if state["was_playing"]:
                 # Check if we're still on the TTS track - if so, skip it
@@ -287,7 +287,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                     if self._player.state != PlayState.PLAY:
                         _LOGGER.debug("Not on TTS track, ensuring playback continues")
                         await self._player.play()
-            
+
             _LOGGER.debug("State restoration completed")
         except HeosError as err:
             _LOGGER.error("Error restoring state after announcement: %s", err)
@@ -303,7 +303,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # Get current queue after TTS
             queue_after = await self._player.get_queue()
             _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
-            
+
             # Find all "Url Stream" items (based on the log analysis)
             tts_queue_ids = []
             for item in queue_after:
@@ -316,14 +316,14 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
                         item.queue_id, item.song, getattr(item, 'media_id', 'N/A')
                     )
-            
+
             # Remove TTS items from queue
             if tts_queue_ids:
                 _LOGGER.debug("Removing TTS Url Stream items from queue: %s", tts_queue_ids)
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
                 _LOGGER.debug("No TTS Url Stream items found to remove")
-                
+
         except HeosError as err:
             _LOGGER.warning("Could not remove TTS from queue: %s", err)
 
@@ -332,23 +332,23 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # Prevent multiple restoration attempts
         if self._announce_completed:
             return
-            
+
         if not self._announce_in_progress or not self._announce_restore_state:
             return
-        
+
         # Wait a moment to ensure the state change is processed
         await asyncio.sleep(0.5)
-        
+
         # Check if announcement has completed
         current_media_id = self._player.now_playing_media.media_id
         tts_url = self._announce_restore_state.get("tts_url")
-        
+
         # Simple completion detection: if we're not playing the TTS URL anymore
         # This handles both cases where TTS stops or moves to next track
         if current_media_id != tts_url:
             # Give it a moment to ensure this is a permanent state change
             await asyncio.sleep(0.3)
-            
+
             # Double-check the state is stable
             if self._player.now_playing_media.media_id != tts_url:
                 # Mark as completed to prevent multiple triggers
@@ -471,7 +471,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Play a piece of media."""
         # Handle announce parameter for TTS announcements
         announce = kwargs.get(ATTR_MEDIA_ANNOUNCE, False)
-        
+
         if heos_source.is_media_uri(media_id):
             media, _data = heos_source.from_media_uri(media_id)
             if not isinstance(media, MediaItem):

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,5 +1,6 @@
 """Denon HEOS Media Player."""
 
+import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 import dataclasses
@@ -25,6 +26,7 @@ from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_ANNOUNCE,
     ATTR_MEDIA_ENQUEUE,
     BrowseError,
     BrowseMedia,
@@ -183,13 +185,179 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             serial_number=player.serial,  # Only available for some models
             sw_version=player.version,
         )
+        # Announcement state tracking
+        self._announce_restore_state: dict[str, Any] | None = None
+        self._announce_in_progress: bool = False
+        self._announce_completed: bool = False
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
         """Handle player attribute updated."""
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
+        
+        # Check for announcement completion
+        if self._announce_in_progress and event == heos_const.EVENT_PLAYER_STATE_CHANGED:
+            await self._check_announcement_completion()
+        
         self._handle_coordinator_update()
+
+    async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
+        """Play an announcement with pause/resume functionality."""
+        # Reset completion flag for new announcement
+        self._announce_completed = False
+        
+        # Check if we should save and restore state
+        if self._player.state == PlayState.PLAY:
+            self._announce_restore_state = self._snapshot_state()
+            self._announce_restore_state["tts_url"] = media_id
+            _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
+            
+            # Pause the current playback
+            await self._player.pause()
+            # Give the pause command time to take effect
+            await asyncio.sleep(0.5)
+        
+        # Mark announcement as in progress
+        self._announce_in_progress = True
+        
+        # Set volume if specified in extra
+        extra = kwargs.get("extra", {})
+        if "volume" in extra:
+            try:
+                volume_level = float(extra["volume"]) / 100
+                await self._player.set_volume(int(volume_level * 100))
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning("Invalid volume level for announcement: %s", err)
+        
+        # Play the announcement
+        await self._player.play_url(media_id)
+
+    def _snapshot_state(self) -> dict[str, Any]:
+        """Snapshot the current player state for restoration after announcement."""
+        return {
+            "was_playing": self._player.state == PlayState.PLAY,
+            "volume": self._player.volume,
+            "is_muted": self._player.is_muted,
+            "repeat": self._player.repeat,
+            "shuffle": self._player.shuffle,
+            "media_id": self._player.now_playing_media.media_id,
+            "tts_url": None,
+        }
+
+    async def _restore_state(self) -> None:
+        """Restore the player state after announcement completion."""
+        if not self._announce_restore_state:
+            return
+        
+        state = self._announce_restore_state
+        _LOGGER.debug("Restoring state after announcement: %s", state)
+        
+        try:
+            # Remove TTS from queue if it was added
+            if state["tts_url"]:
+                # Small delay to ensure HEOS has processed the state change
+                await asyncio.sleep(0.2)
+                await self._remove_tts_from_queue(state["tts_url"])
+            
+            # Restore volume
+            await self._player.set_volume(state["volume"])
+            
+            # Restore mute state
+            if state["is_muted"] != self._player.is_muted:
+                await self._player.set_mute(state["is_muted"])
+            
+            # Restore play mode
+            await self._player.set_play_mode(state["repeat"], state["shuffle"])
+            
+            # Resume playback if it was playing before
+            if state["was_playing"]:
+                # Check if we're still on the TTS track - if so, skip it
+                current_media_id = self._player.now_playing_media.media_id
+                if current_media_id == state.get("tts_url"):
+                    try:
+                        _LOGGER.debug("Still on TTS track, skipping to next")
+                        await self._player.play_next()
+                    except HeosError as err:
+                        _LOGGER.debug("Could not skip TTS track: %s", err)
+                        # Fallback to just play
+                        await self._player.play()
+                else:
+                    # Already moved to next track or different media, just ensure we're playing
+                    if self._player.state != PlayState.PLAY:
+                        _LOGGER.debug("Not on TTS track, ensuring playback continues")
+                        await self._player.play()
+            
+            _LOGGER.debug("State restoration completed")
+        except HeosError as err:
+            _LOGGER.error("Error restoring state after announcement: %s", err)
+        finally:
+            # Clear the announcement state
+            self._announce_restore_state = None
+            self._announce_in_progress = False
+            self._announce_completed = False
+
+    async def _remove_tts_from_queue(self, tts_url: str) -> None:
+        """Remove TTS URL from the queue if it was added."""
+        try:
+            # Get current queue after TTS
+            queue_after = await self._player.get_queue()
+            _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
+            
+            # Find all "Url Stream" items (based on the log analysis)
+            tts_queue_ids = []
+            for item in queue_after:
+                # Check for the exact TTS characteristics from the logs
+                if (hasattr(item, 'song') and item.song == "Url Stream" and
+                    hasattr(item, 'album') and item.album == "Url Stream" and
+                    hasattr(item, 'artist') and item.artist == "Url Stream"):
+                    tts_queue_ids.append(item.queue_id)
+                    _LOGGER.debug(
+                        "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
+                        item.queue_id, item.song, getattr(item, 'media_id', 'N/A')
+                    )
+            
+            # Remove TTS items from queue
+            if tts_queue_ids:
+                _LOGGER.debug("Removing TTS Url Stream items from queue: %s", tts_queue_ids)
+                await self._player.remove_from_queue(tts_queue_ids)
+            else:
+                _LOGGER.debug("No TTS Url Stream items found to remove")
+                
+        except HeosError as err:
+            _LOGGER.warning("Could not remove TTS from queue: %s", err)
+
+    async def _check_announcement_completion(self) -> None:
+        """Check if the announcement has completed and restore state."""
+        # Prevent multiple restoration attempts
+        if self._announce_completed:
+            return
+            
+        if not self._announce_in_progress or not self._announce_restore_state:
+            return
+        
+        # Wait a moment to ensure the state change is processed
+        await asyncio.sleep(0.5)
+        
+        # Check if announcement has completed
+        current_media_id = self._player.now_playing_media.media_id
+        tts_url = self._announce_restore_state.get("tts_url")
+        
+        # Simple completion detection: if we're not playing the TTS URL anymore
+        # This handles both cases where TTS stops or moves to next track
+        if current_media_id != tts_url:
+            # Give it a moment to ensure this is a permanent state change
+            await asyncio.sleep(0.3)
+            
+            # Double-check the state is stable
+            if self._player.now_playing_media.media_id != tts_url:
+                # Mark as completed to prevent multiple triggers
+                self._announce_completed = True
+                _LOGGER.debug(
+                    "Announcement completed - was playing TTS, now playing: %s, state: %s",
+                    current_media_id, self._player.state
+                )
+                await self._restore_state()
 
     @callback
     @override
@@ -301,6 +469,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play a piece of media."""
+        # Handle announce parameter for TTS announcements
+        announce = kwargs.get(ATTR_MEDIA_ANNOUNCE, False)
+        
         if heos_source.is_media_uri(media_id):
             media, _data = heos_source.from_media_uri(media_id)
             if not isinstance(media, MediaItem):
@@ -320,6 +491,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         if media_type in {MediaType.URL, MediaType.MUSIC}:
             media_id = async_process_play_media_url(self.hass, media_id)
+
+            # Handle announcement mode
+            if announce:
+                await self._play_announcement(media_id, kwargs)
+                return
 
             await self._player.play_url(media_id)
             return

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -17,13 +17,9 @@ from pyheos import (
     HeosPlayer,
     MediaItem,
     MediaMusicSource,
+    MediaType as HeosMediaType,
     PlayState,
     RepeatType,
-)
-from pyheos import (
-    MediaType as HeosMediaType,
-)
-from pyheos import (
     const as heos_const,
 )
 from pyheos.util import mediauri as heos_source

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -218,54 +218,63 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_restore_state["tts_url"] = media_id
         _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
 
-        # Pause current playback if playing
-        if self._player.state == PlayState.PLAY:
-            await self._player.pause()
-            # Give the pause command time to take effect
-            await asyncio.sleep(0.5)
+        try:
+            # Pause current playback if playing
+            if self._player.state == PlayState.PLAY:
+                await self._player.pause()
+                # Give the pause command time to take effect
+                await asyncio.sleep(0.5)
 
-        # Mark announcement as in progress (only after state is captured)
-        self._announce_in_progress = True
-        
-        # Capture the announcement media signature after a brief delay
-        # This allows HEOS to start playing and report the media info
-        self.hass.async_create_task(self._capture_announcement_signature())
+            # Mark announcement as in progress (only after state is captured)
+            self._announce_in_progress = True
 
-        # Set volume if specified in extra
-        extra = kwargs.get("extra", {})
-        if "volume" in extra:
-            try:
-                volume_value = float(extra["volume"])
-                # Support both normalized (0.0-1.0) and percentage (0-100) formats
-                if 0.0 <= volume_value <= 1.0:
-                    # Normalized format (Home Assistant style)
-                    volume_percent = int(volume_value * 100)
-                elif 0 <= volume_value <= 100:
-                    # Percentage format
-                    volume_percent = int(volume_value)
-                else:
-                    # Out of range, clamp to valid range
-                    volume_percent = max(0, min(100, int(volume_value)))
-                    _LOGGER.warning(
-                        "Volume %s out of range, clamping to %s",
-                        volume_value,
-                        volume_percent,
-                    )
-                await self._player.set_volume(volume_percent)
-            except (ValueError, TypeError) as err:
-                _LOGGER.warning("Invalid volume level for announcement: %s", err)
+            # Capture the announcement media signature after a brief delay
+            # This allows HEOS to start playing and report the media info
+            self.hass.async_create_task(self._capture_announcement_signature())
 
-        # Play the announcement
-        await self._player.play_url(media_id)
+            # Set volume if specified in extra
+            extra = kwargs.get("extra", {})
+            if "volume" in extra:
+                try:
+                    volume_value = float(extra["volume"])
+                    # Support both normalized (0.0-1.0) and percentage (0-100) formats
+                    if 0.0 <= volume_value <= 1.0:
+                        # Normalized format (Home Assistant style)
+                        volume_percent = int(volume_value * 100)
+                    elif 0 <= volume_value <= 100:
+                        # Percentage format
+                        volume_percent = int(volume_value)
+                    else:
+                        # Out of range, clamp to valid range
+                        volume_percent = max(0, min(100, int(volume_value)))
+                        _LOGGER.warning(
+                            "Volume %s out of range, clamping to %s",
+                            volume_value,
+                            volume_percent,
+                        )
+                    await self._player.set_volume(volume_percent)
+                except (ValueError, TypeError) as err:
+                    _LOGGER.warning("Invalid volume level for announcement: %s", err)
+
+            # Play the announcement
+            await self._player.play_url(media_id)
+        except Exception as err:
+            # If announcement fails, clean up state to prevent getting stuck
+            _LOGGER.error("Failed to play announcement: %s", err)
+            self._announce_in_progress = False
+            self._announce_completed = False
+            self._announce_media_signature = None
+            self._announce_restore_state = None
+            raise
 
     async def _capture_announcement_signature(self) -> None:
         """Capture the media signature of the playing announcement."""
         # Wait for HEOS to start playing and report media info
         await asyncio.sleep(1.0)
-        
+
         if not self._announce_in_progress:
             return
-            
+
         # Capture the current media signature
         current_media = self._player.now_playing_media
         self._announce_media_signature = {
@@ -432,7 +441,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 or getattr(current_media, "album", None) != signature["album"]
                 or getattr(current_media, "artist", None) != signature["artist"]
             )
-            
+
             if media_changed:
                 is_completed = True
                 _LOGGER.debug("TTS completion detected: media signature changed")
@@ -440,19 +449,18 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 # Stopped while still showing announcement media
                 is_completed = True
                 _LOGGER.debug("TTS completion detected: player stopped")
-        else:
-            # Fallback if signature wasn't captured yet
-            # Check if stopped (announcement likely finished)
-            if current_state == PlayState.STOP:
+        # Fallback if signature wasn't captured yet
+        # Check if stopped (announcement likely finished)
+        elif current_state == PlayState.STOP:
+            is_completed = True
+            _LOGGER.debug("TTS completion detected: player stopped (no signature)")
+        # Check if paused and media is no longer the URL stream pattern
+        elif current_state == PlayState.PAUSE:
+            if hasattr(current_media, "song") and current_media.song != "Url Stream":
                 is_completed = True
-                _LOGGER.debug("TTS completion detected: player stopped (no signature)")
-            # Check if paused and media is no longer the URL stream pattern
-            elif current_state == PlayState.PAUSE:
-                if hasattr(current_media, "song") and current_media.song != "Url Stream":
-                    is_completed = True
-                    _LOGGER.debug(
-                        "TTS completion detected: paused, not URL stream",
-                    )
+                _LOGGER.debug(
+                    "TTS completion detected: paused, not URL stream",
+                )
 
         if is_completed:
             # Give it a moment to ensure this is a permanent state change
@@ -471,7 +479,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._announce_completed = True
                 _LOGGER.debug(
                     "Announcement completed - was playing TTS, now playing: %s, state: %s",
-                    current_media_id,
+                    self._player.now_playing_media.media_id,
                     self._player.state,
                 )
                 await self._restore_state()

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,14 +1,32 @@
 """Denon HEOS Media Player."""
 
 import asyncio
-import dataclasses
-import logging
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
+import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
+import logging
 from operator import ior
 from typing import Any, Final, override
+
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    PlayState,
+    RepeatType,
+)
+from pyheos import (
+    MediaType as HeosMediaType,
+)
+from pyheos import (
+    const as heos_const,
+)
+from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -33,23 +51,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    PlayState,
-    RepeatType,
-)
-from pyheos import (
-    MediaType as HeosMediaType,
-)
-from pyheos import (
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
 
 from . import services
 from .const import DOMAIN

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,28 +1,14 @@
 """Denon HEOS Media Player."""
 
 import asyncio
+import dataclasses
+import logging
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
-import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
-import logging
 from operator import ior
 from typing import Any, Final, override
-
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    MediaType as HeosMediaType,
-    PlayState,
-    RepeatType,
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -47,6 +33,23 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    PlayState,
+    RepeatType,
+)
+from pyheos import (
+    MediaType as HeosMediaType,
+)
+from pyheos import (
+    const as heos_const,
+)
+from pyheos.util import mediauri as heos_source
 
 from . import services
 from .const import DOMAIN
@@ -359,37 +362,51 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if not self._announce_in_progress or not self._announce_restore_state:
             return
 
+        # Capture state locally to avoid race conditions with concurrent calls
+        restore_state = self._announce_restore_state
+        tts_url = restore_state.get("tts_url")
+
         # Wait a moment to ensure the state change is processed
         await asyncio.sleep(0.5)
 
-        tts_url = self._announce_restore_state.get("tts_url")
-        
+        # Re-check that announcement is still in progress after sleep
+        if not self._announce_in_progress or not self._announce_restore_state:
+            return
+
         # Check multiple indicators for announcement completion
         current_media_id = self._player.now_playing_media.media_id
         current_media = self._player.now_playing_media
-        
+        current_state = self._player.state
+
         # Completion detection using multiple signals:
         # 1. Media ID changed from TTS URL (if HEOS reports it)
-        # 2. State changed to STOP/PAUSE after playing
-        # 3. Now playing media changed from "Url Stream" pattern
+        # 2. State changed to STOP (announcement finished)
+        # 3. State is PAUSE and media is no longer the URL stream pattern
         is_completed = False
-        
+
         # Check if media_id changed (most reliable if available)
         if current_media_id and current_media_id != tts_url:
             is_completed = True
             _LOGGER.debug("TTS completion detected: media_id changed")
-        # Check if stopped/paused and media is no longer the URL stream pattern
-        elif self._player.state in (PlayState.STOP, PlayState.PAUSE):
+        # Check if stopped (announcement likely finished)
+        elif current_state == PlayState.STOP:
+            is_completed = True
+            _LOGGER.debug("TTS completion detected: player stopped")
+        # Check if paused and media is no longer the URL stream pattern
+        elif current_state == PlayState.PAUSE:
             if hasattr(current_media, "song") and current_media.song != "Url Stream":
                 is_completed = True
                 _LOGGER.debug(
-                    "TTS completion detected: state=%s, not URL stream",
-                    self._player.state,
+                    "TTS completion detected: paused, not URL stream",
                 )
-        
+
         if is_completed:
             # Give it a moment to ensure this is a permanent state change
             await asyncio.sleep(0.3)
+
+            # Re-check one final time that we should still restore
+            if not self._announce_in_progress or not self._announce_restore_state:
+                return
 
             # Double-check the state is stable
             if (

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -191,6 +191,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_completed: bool = False
         self._announce_media_signature: dict[str, Any] | None = None
         self._announce_started: bool = False
+        self._announce_start_time: datetime | None = None
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -256,6 +257,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # Mark announcement as in progress AFTER play_url to avoid race with pause event
             self._announce_in_progress = True
             self._announce_started = False  # Will be set when media signature captured
+            self._announce_start_time = utcnow()  # Track when announcement started
 
             # Capture the announcement media signature after a brief delay
             # This allows HEOS to start playing and report the media info
@@ -266,6 +268,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_in_progress = False
             self._announce_completed = False
             self._announce_started = False
+            self._announce_start_time = None
             self._announce_media_signature = None
             self._announce_restore_state = None
             raise
@@ -356,6 +359,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_in_progress = False
             self._announce_completed = False
             self._announce_started = False
+            self._announce_start_time = None
             self._announce_media_signature = None
 
     async def _remove_tts_from_queue(self, tts_url: str) -> None:
@@ -416,14 +420,18 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if not self._announce_in_progress or not self._announce_restore_state:
             return
 
-        # Don't check completion until announcement has actually started
-        # This prevents race with pause event triggering premature completion
-        if not self._announce_started:
-            return
-
         # Capture state locally to avoid race conditions with concurrent calls
         restore_state = self._announce_restore_state
         tts_url = restore_state.get("tts_url")
+
+        # Grace period: don't check completion for first 2 seconds after start
+        # This prevents race with pause event triggering premature completion
+        # After grace period, allow fallback detection even without signature
+        if self._announce_start_time:
+            time_since_start = (utcnow() - self._announce_start_time).total_seconds()
+            if time_since_start < 2.0 and not self._announce_started:
+                # Still in grace period and announcement hasn't started yet
+                return
 
         # Wait a moment to ensure the state change is processed
         await asyncio.sleep(0.5)

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,14 +1,30 @@
 """Denon HEOS Media Player."""
 
 import asyncio
-import dataclasses
-import logging
+
+
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
+import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
+import logging
 from operator import ior
 from typing import Any, Final, override
+
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    MediaType as HeosMediaType,
+    PlayState,
+    RepeatType,
+    const as heos_const
+)
+from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -33,24 +49,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    PlayState,
-    RepeatType,
-)
-from pyheos import (
-    MediaType as HeosMediaType,
-)
-from pyheos import (
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
-
 from . import services
 from .const import DOMAIN
 from .coordinator import HeosConfigEntry, HeosCoordinator
@@ -233,8 +231,23 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         extra = kwargs.get("extra", {})
         if "volume" in extra:
             try:
-                volume_level = float(extra["volume"]) / 100
-                await self._player.set_volume(int(volume_level * 100))
+                volume_value = float(extra["volume"])
+                # Support both normalized (0.0-1.0) and percentage (0-100) formats
+                if 0.0 <= volume_value <= 1.0:
+                    # Normalized format (Home Assistant style)
+                    volume_percent = int(volume_value * 100)
+                elif 0 <= volume_value <= 100:
+                    # Percentage format
+                    volume_percent = int(volume_value)
+                else:
+                    # Out of range, clamp to valid range
+                    volume_percent = max(0, min(100, int(volume_value)))
+                    _LOGGER.warning(
+                        "Volume %s out of range, clamping to %s",
+                        volume_value,
+                        volume_percent,
+                    )
+                await self._player.set_volume(volume_percent)
             except (ValueError, TypeError) as err:
                 _LOGGER.warning("Invalid volume level for announcement: %s", err)
 

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -262,7 +262,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # Capture the announcement media signature after a brief delay
             # This allows HEOS to start playing and report the media info
             self.hass.async_create_task(self._capture_announcement_signature())
-        except Exception as err:
+        except (HeosError, ValueError, TypeError) as err:
             # If announcement fails, attempt to restore pre-announcement state
             _LOGGER.error("Failed to play announcement: %s", err)
 
@@ -282,7 +282,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         await self._player.play()
 
                     _LOGGER.debug("Restored state after announcement failure")
-                except Exception as restore_err:
+                except HeosError as restore_err:
                     _LOGGER.warning(
                         "Could not restore state after announcement failure: %s",
                         restore_err,

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,8 +1,6 @@
 """Denon HEOS Media Player."""
 
 import asyncio
-
-
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 import dataclasses
@@ -22,7 +20,7 @@ from pyheos import (
     MediaType as HeosMediaType,
     PlayState,
     RepeatType,
-    const as heos_const
+    const as heos_const,
 )
 from pyheos.util import mediauri as heos_source
 
@@ -49,6 +47,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
+
 from . import services
 from .const import DOMAIN
 from .coordinator import HeosConfigEntry, HeosCoordinator
@@ -190,6 +189,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_restore_state: dict[str, Any] | None = None
         self._announce_in_progress: bool = False
         self._announce_completed: bool = False
+        self._announce_media_signature: dict[str, Any] | None = None
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -226,6 +226,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         # Mark announcement as in progress (only after state is captured)
         self._announce_in_progress = True
+        
+        # Capture the announcement media signature after a brief delay
+        # This allows HEOS to start playing and report the media info
+        self.hass.async_create_task(self._capture_announcement_signature())
 
         # Set volume if specified in extra
         extra = kwargs.get("extra", {})
@@ -253,6 +257,27 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         # Play the announcement
         await self._player.play_url(media_id)
+
+    async def _capture_announcement_signature(self) -> None:
+        """Capture the media signature of the playing announcement."""
+        # Wait for HEOS to start playing and report media info
+        await asyncio.sleep(1.0)
+        
+        if not self._announce_in_progress:
+            return
+            
+        # Capture the current media signature
+        current_media = self._player.now_playing_media
+        self._announce_media_signature = {
+            "media_id": current_media.media_id,
+            "song": getattr(current_media, "song", None),
+            "album": getattr(current_media, "album", None),
+            "artist": getattr(current_media, "artist", None),
+        }
+        _LOGGER.debug(
+            "Captured announcement media signature: %s",
+            self._announce_media_signature,
+        )
 
     def _snapshot_state(self) -> dict[str, Any]:
         """Snapshot the current player state for restoration after announcement."""
@@ -316,6 +341,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_restore_state = None
             self._announce_in_progress = False
             self._announce_completed = False
+            self._announce_media_signature = None
 
     async def _remove_tts_from_queue(self, tts_url: str) -> None:
         """Remove TTS URL from the queue if it was added."""
@@ -387,31 +413,46 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             return
 
         # Check multiple indicators for announcement completion
-        current_media_id = self._player.now_playing_media.media_id
         current_media = self._player.now_playing_media
         current_state = self._player.state
 
         # Completion detection using multiple signals:
-        # 1. Media ID changed from TTS URL (if HEOS reports it)
+        # 1. Media signature changed from captured announcement signature
         # 2. State changed to STOP (announcement finished)
-        # 3. State is PAUSE and media is no longer the URL stream pattern
+        # 3. State is PAUSE and media signature changed
         is_completed = False
 
-        # Check if media_id changed (most reliable if available)
-        if current_media_id and current_media_id != tts_url:
-            is_completed = True
-            _LOGGER.debug("TTS completion detected: media_id changed")
-        # Check if stopped (announcement likely finished)
-        elif current_state == PlayState.STOP:
-            is_completed = True
-            _LOGGER.debug("TTS completion detected: player stopped")
-        # Check if paused and media is no longer the URL stream pattern
-        elif current_state == PlayState.PAUSE:
-            if hasattr(current_media, "song") and current_media.song != "Url Stream":
+        # If we captured the announcement signature, use it for reliable detection
+        if self._announce_media_signature:
+            signature = self._announce_media_signature
+            # Check if any part of the media signature changed
+            media_changed = (
+                current_media.media_id != signature["media_id"]
+                or getattr(current_media, "song", None) != signature["song"]
+                or getattr(current_media, "album", None) != signature["album"]
+                or getattr(current_media, "artist", None) != signature["artist"]
+            )
+            
+            if media_changed:
                 is_completed = True
-                _LOGGER.debug(
-                    "TTS completion detected: paused, not URL stream",
-                )
+                _LOGGER.debug("TTS completion detected: media signature changed")
+            elif current_state == PlayState.STOP:
+                # Stopped while still showing announcement media
+                is_completed = True
+                _LOGGER.debug("TTS completion detected: player stopped")
+        else:
+            # Fallback if signature wasn't captured yet
+            # Check if stopped (announcement likely finished)
+            if current_state == PlayState.STOP:
+                is_completed = True
+                _LOGGER.debug("TTS completion detected: player stopped (no signature)")
+            # Check if paused and media is no longer the URL stream pattern
+            elif current_state == PlayState.PAUSE:
+                if hasattr(current_media, "song") and current_media.song != "Url Stream":
+                    is_completed = True
+                    _LOGGER.debug(
+                        "TTS completion detected: paused, not URL stream",
+                    )
 
         if is_completed:
             # Give it a moment to ensure this is a permanent state change

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -190,6 +190,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_in_progress: bool = False
         self._announce_completed: bool = False
         self._announce_media_signature: dict[str, Any] | None = None
+        self._announce_started: bool = False
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -225,14 +226,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 # Give the pause command time to take effect
                 await asyncio.sleep(0.5)
 
-            # Mark announcement as in progress (only after state is captured)
-            self._announce_in_progress = True
-
-            # Capture the announcement media signature after a brief delay
-            # This allows HEOS to start playing and report the media info
-            self.hass.async_create_task(self._capture_announcement_signature())
-
-            # Set volume if specified in extra
+            # Set volume if specified in extra (before marking as in progress)
             extra = kwargs.get("extra", {})
             if "volume" in extra:
                 try:
@@ -258,11 +252,20 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
             # Play the announcement
             await self._player.play_url(media_id)
+
+            # Mark announcement as in progress AFTER play_url to avoid race with pause event
+            self._announce_in_progress = True
+            self._announce_started = False  # Will be set when media signature captured
+
+            # Capture the announcement media signature after a brief delay
+            # This allows HEOS to start playing and report the media info
+            self.hass.async_create_task(self._capture_announcement_signature())
         except Exception as err:
             # If announcement fails, clean up state to prevent getting stuck
             _LOGGER.error("Failed to play announcement: %s", err)
             self._announce_in_progress = False
             self._announce_completed = False
+            self._announce_started = False
             self._announce_media_signature = None
             self._announce_restore_state = None
             raise
@@ -283,6 +286,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             "album": getattr(current_media, "album", None),
             "artist": getattr(current_media, "artist", None),
         }
+        # Mark announcement as actually started
+        self._announce_started = True
         _LOGGER.debug(
             "Captured announcement media signature: %s",
             self._announce_media_signature,
@@ -350,6 +355,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_restore_state = None
             self._announce_in_progress = False
             self._announce_completed = False
+            self._announce_started = False
             self._announce_media_signature = None
 
     async def _remove_tts_from_queue(self, tts_url: str) -> None:
@@ -408,6 +414,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             return
 
         if not self._announce_in_progress or not self._announce_restore_state:
+            return
+
+        # Don't check completion until announcement has actually started
+        # This prevents race with pause event triggering premature completion
+        if not self._announce_started:
             return
 
         # Capture state locally to avoid race conditions with concurrent calls

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -263,8 +263,32 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # This allows HEOS to start playing and report the media info
             self.hass.async_create_task(self._capture_announcement_signature())
         except Exception as err:
-            # If announcement fails, clean up state to prevent getting stuck
+            # If announcement fails, attempt to restore pre-announcement state
             _LOGGER.error("Failed to play announcement: %s", err)
+
+            # Best-effort restoration if we changed state before failure
+            if self._announce_restore_state:
+                try:
+                    state = self._announce_restore_state
+                    # Don't try to remove TTS from queue since announcement never started
+                    # Just restore volume, mute, and play state
+                    await self._player.set_volume(state["volume"])
+                    if state["is_muted"] != self._player.is_muted:
+                        await self._player.set_mute(state["is_muted"])
+                    await self._player.set_play_mode(state["repeat"], state["shuffle"])
+
+                    # Resume playback if it was playing before
+                    if state["was_playing"] and self._player.state != PlayState.PLAY:
+                        await self._player.play()
+
+                    _LOGGER.debug("Restored state after announcement failure")
+                except Exception as restore_err:
+                    _LOGGER.warning(
+                        "Could not restore state after announcement failure: %s",
+                        restore_err,
+                    )
+
+            # Clean up announcement state
             self._announce_in_progress = False
             self._announce_completed = False
             self._announce_started = False

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -215,9 +215,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # This ensures we can properly track and clean up announcement state
         self._announce_restore_state = self._snapshot_state()
         self._announce_restore_state["tts_url"] = media_id
-        _LOGGER.debug(
-            "Saving state for announcement: %s", self._announce_restore_state
-        )
+        _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
 
         # Pause current playback if playing
         if self._player.state == PlayState.PLAY:
@@ -344,9 +342,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
             # Remove TTS items from queue
             if tts_queue_ids:
-                _LOGGER.debug(
-                    "Removing TTS items from queue: %s", tts_queue_ids
-                )
+                _LOGGER.debug("Removing TTS items from queue: %s", tts_queue_ids)
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
                 _LOGGER.debug("No TTS items found to remove")
@@ -386,7 +382,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         elif self._player.state in (PlayState.STOP, PlayState.PAUSE):
             if hasattr(current_media, "song") and current_media.song != "Url Stream":
                 is_completed = True
-                _LOGGER.debug("TTS completion detected: state=%s, not URL stream", self._player.state)
+                _LOGGER.debug(
+                    "TTS completion detected: state=%s, not URL stream",
+                    self._player.state,
+                )
         
         if is_completed:
             # Give it a moment to ensure this is a permanent state change

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,28 +1,14 @@
 """Denon HEOS Media Player."""
 
 import asyncio
+import dataclasses
+import logging
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
-import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
-import logging
 from operator import ior
 from typing import Any, Final, override
-
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    MediaType as HeosMediaType,
-    PlayState,
-    RepeatType,
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -47,6 +33,23 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    PlayState,
+    RepeatType,
+)
+from pyheos import (
+    MediaType as HeosMediaType,
+)
+from pyheos import (
+    const as heos_const,
+)
+from pyheos.util import mediauri as heos_source
 
 from . import services
 from .const import DOMAIN
@@ -138,14 +141,14 @@ type _FuncType[**_P, _R] = Callable[_P, Awaitable[_R]]
 type _ReturnFuncType[**_P, _R] = Callable[_P, Coroutine[Any, Any, _R]]
 
 
-def catch_action_error[**_P, _R](
+def catch_action_error[**P, R](
     action: str,
-) -> Callable[[_FuncType[_P, _R]], _ReturnFuncType[_P, _R]]:
+) -> Callable[[_FuncType[P, R]], _ReturnFuncType[P, R]]:
     """Return decorator that catches errors and raises HomeAssistantError."""
 
-    def decorator(func: _FuncType[_P, _R]) -> _ReturnFuncType[_P, _R]:
+    def decorator(func: _FuncType[P, R]) -> _ReturnFuncType[P, R]:
         @wraps(func)
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             try:
                 return await func(*args, **kwargs)
             except (HeosError, ValueError) as ex:
@@ -197,7 +200,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._media_position_updated_at = utcnow()
 
         # Check for announcement completion
-        if self._announce_in_progress and event == heos_const.EVENT_PLAYER_STATE_CHANGED:
+        if (
+            self._announce_in_progress
+            and event == heos_const.EVENT_PLAYER_STATE_CHANGED
+        ):
             await self._check_announcement_completion()
 
         self._handle_coordinator_update()
@@ -211,7 +217,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if self._player.state == PlayState.PLAY:
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
-            _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
+            _LOGGER.debug(
+                "Saving state for announcement: %s", self._announce_restore_state
+            )
 
             # Pause the current playback
             await self._player.pause()
@@ -282,11 +290,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         _LOGGER.debug("Could not skip TTS track: %s", err)
                         # Fallback to just play
                         await self._player.play()
-                else:
-                    # Already moved to next track or different media, just ensure we're playing
-                    if self._player.state != PlayState.PLAY:
-                        _LOGGER.debug("Not on TTS track, ensuring playback continues")
-                        await self._player.play()
+                # Already moved to next track or different media, just ensure we're playing
+                elif self._player.state != PlayState.PLAY:
+                    _LOGGER.debug("Not on TTS track, ensuring playback continues")
+                    await self._player.play()
 
             _LOGGER.debug("State restoration completed")
         except HeosError as err:
@@ -308,18 +315,27 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             tts_queue_ids = []
             for item in queue_after:
                 # Check for the exact TTS characteristics from the logs
-                if (hasattr(item, 'song') and item.song == "Url Stream" and
-                    hasattr(item, 'album') and item.album == "Url Stream" and
-                    hasattr(item, 'artist') and item.artist == "Url Stream"):
+                if (
+                    hasattr(item, "song")
+                    and item.song == "Url Stream"
+                    and hasattr(item, "album")
+                    and item.album == "Url Stream"
+                    and hasattr(item, "artist")
+                    and item.artist == "Url Stream"
+                ):
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
                         "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
-                        item.queue_id, item.song, getattr(item, 'media_id', 'N/A')
+                        item.queue_id,
+                        item.song,
+                        getattr(item, "media_id", "N/A"),
                     )
 
             # Remove TTS items from queue
             if tts_queue_ids:
-                _LOGGER.debug("Removing TTS Url Stream items from queue: %s", tts_queue_ids)
+                _LOGGER.debug(
+                    "Removing TTS Url Stream items from queue: %s", tts_queue_ids
+                )
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
                 _LOGGER.debug("No TTS Url Stream items found to remove")
@@ -355,7 +371,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._announce_completed = True
                 _LOGGER.debug(
                     "Announcement completed - was playing TTS, now playing: %s, state: %s",
-                    current_media_id, self._player.state
+                    current_media_id,
+                    self._player.state,
                 )
                 await self._restore_state()
 

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -196,12 +196,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
 
-        # Check for announcement completion
-        if (
-            self._announce_in_progress
-            and event == heos_const.EVENT_PLAYER_STATE_CHANGED
+        # Check for announcement completion on relevant events
+        # Use background task to avoid blocking event processing
+        if self._announce_in_progress and event in (
+            heos_const.EVENT_PLAYER_STATE_CHANGED,
+            heos_const.EVENT_PLAYER_NOW_PLAYING_CHANGED,
         ):
-            await self._check_announcement_completion()
+            self.hass.async_create_task(self._check_announcement_completion())
 
         self._handle_coordinator_update()
 
@@ -210,20 +211,21 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # Reset completion flag for new announcement
         self._announce_completed = False
 
-        # Check if we should save and restore state
-        if self._player.state == PlayState.PLAY:
-            self._announce_restore_state = self._snapshot_state()
-            self._announce_restore_state["tts_url"] = media_id
-            _LOGGER.debug(
-                "Saving state for announcement: %s", self._announce_restore_state
-            )
+        # Always snapshot state for announcements (even if paused/stopped)
+        # This ensures we can properly track and clean up announcement state
+        self._announce_restore_state = self._snapshot_state()
+        self._announce_restore_state["tts_url"] = media_id
+        _LOGGER.debug(
+            "Saving state for announcement: %s", self._announce_restore_state
+        )
 
-            # Pause the current playback
+        # Pause current playback if playing
+        if self._player.state == PlayState.PLAY:
             await self._player.pause()
             # Give the pause command time to take effect
             await asyncio.sleep(0.5)
 
-        # Mark announcement as in progress
+        # Mark announcement as in progress (only after state is captured)
         self._announce_in_progress = True
 
         # Set volume if specified in extra
@@ -308,34 +310,46 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             queue_after = await self._player.get_queue()
             _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
 
-            # Find all "Url Stream" items (based on the log analysis)
+            # Find queue items matching the TTS URL
             tts_queue_ids = []
             for item in queue_after:
-                # Check for the exact TTS characteristics from the logs
-                if (
-                    hasattr(item, "song")
+                # Match by media_id/URL if available
+                item_media_id = getattr(item, "media_id", None)
+                if item_media_id and item_media_id == tts_url:
+                    tts_queue_ids.append(item.queue_id)
+                    _LOGGER.debug(
+                        "Found TTS item by media_id: queue_id=%s, media_id=%s",
+                        item.queue_id,
+                        item_media_id,
+                    )
+                # Fallback: match "Url Stream" items only if media_id not available
+                # and only match the most recent one (likely the TTS we just played)
+                elif (
+                    not item_media_id
+                    and hasattr(item, "song")
                     and item.song == "Url Stream"
                     and hasattr(item, "album")
                     and item.album == "Url Stream"
                     and hasattr(item, "artist")
                     and item.artist == "Url Stream"
                 ):
-                    tts_queue_ids.append(item.queue_id)
-                    _LOGGER.debug(
-                        "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
-                        item.queue_id,
-                        item.song,
-                        getattr(item, "media_id", "N/A"),
-                    )
+                    # Only take the first match to avoid removing legitimate streams
+                    if not tts_queue_ids:
+                        tts_queue_ids.append(item.queue_id)
+                        _LOGGER.debug(
+                            "Found TTS Url Stream item: queue_id=%s, song=%s",
+                            item.queue_id,
+                            item.song,
+                        )
 
             # Remove TTS items from queue
             if tts_queue_ids:
                 _LOGGER.debug(
-                    "Removing TTS Url Stream items from queue: %s", tts_queue_ids
+                    "Removing TTS items from queue: %s", tts_queue_ids
                 )
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
-                _LOGGER.debug("No TTS Url Stream items found to remove")
+                _LOGGER.debug("No TTS items found to remove")
 
         except HeosError as err:
             _LOGGER.warning("Could not remove TTS from queue: %s", err)
@@ -352,18 +366,37 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # Wait a moment to ensure the state change is processed
         await asyncio.sleep(0.5)
 
-        # Check if announcement has completed
-        current_media_id = self._player.now_playing_media.media_id
         tts_url = self._announce_restore_state.get("tts_url")
-
-        # Simple completion detection: if we're not playing the TTS URL anymore
-        # This handles both cases where TTS stops or moves to next track
-        if current_media_id != tts_url:
+        
+        # Check multiple indicators for announcement completion
+        current_media_id = self._player.now_playing_media.media_id
+        current_media = self._player.now_playing_media
+        
+        # Completion detection using multiple signals:
+        # 1. Media ID changed from TTS URL (if HEOS reports it)
+        # 2. State changed to STOP/PAUSE after playing
+        # 3. Now playing media changed from "Url Stream" pattern
+        is_completed = False
+        
+        # Check if media_id changed (most reliable if available)
+        if current_media_id and current_media_id != tts_url:
+            is_completed = True
+            _LOGGER.debug("TTS completion detected: media_id changed")
+        # Check if stopped/paused and media is no longer the URL stream pattern
+        elif self._player.state in (PlayState.STOP, PlayState.PAUSE):
+            if hasattr(current_media, "song") and current_media.song != "Url Stream":
+                is_completed = True
+                _LOGGER.debug("TTS completion detected: state=%s, not URL stream", self._player.state)
+        
+        if is_completed:
             # Give it a moment to ensure this is a permanent state change
             await asyncio.sleep(0.3)
 
             # Double-check the state is stable
-            if self._player.now_playing_media.media_id != tts_url:
+            if (
+                self._player.now_playing_media.media_id != tts_url
+                or self._player.state in (PlayState.STOP, PlayState.PAUSE)
+            ):
                 # Mark as completed to prevent multiple triggers
                 self._announce_completed = True
                 _LOGGER.debug(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Summary
This PR adds long awaited support for the `announce` parameter in the HEOS media player integration, enabling TTS announcements to pause music, play the announcement, and then resume playback with comprehensive state management and error handling.

### Features
- **Pause before announcement**: Automatically pauses music when an announcement is requested
- **Volume control**: Supports both normalized (0.0-1.0) and percentage (0-100) volume formats for announcements
- **State restoration**: Restores volume, mute state, play mode, and playback after announcement
- **Queue cleanup**: Intelligently removes TTS items from queue by matching media signature
- **Smart resumption**: Skips TTS items and continues with next track to avoid restarting current song
- **Non-blocking**: Uses background tasks for completion detection to avoid blocking event processing
- **Robust error handling**: Restores state even if announcement fails partway through

### Implementation Details

#### Core Functionality
- Added `announce` parameter detection in `async_play_media`
- Implemented state snapshot to save player state before announcement (even when paused/stopped)
- Always captures state to ensure proper cleanup in all scenarios

#### Completion Detection
- **Media signature capture**: Records actual HEOS media info after announcement starts
- **Multiple detection signals**: Checks media ID changes, state transitions, and media pattern changes
- **Grace period protection**: 2-second grace period prevents premature completion from pause events
- **Fallback detection**: Works even if signature capture fails (STOP/PAUSE state checks)
- **Background processing**: Completion checks run as async tasks to keep event handler responsive

#### Queue Management
- **Targeted removal**: Matches TTS items by media_id first, falls back to "Url Stream" pattern
- **Safe cleanup**: Only removes first matching URL stream to avoid deleting legitimate streams
- **Signature-based**: Uses captured announcement signature for reliable identification

#### Error Handling & Recovery
- **Exception safety**: Catches specific exceptions (HeosError, ValueError, TypeError)
- **State restoration on failure**: If announcement fails after pausing/volume change, restores original state
- **Best-effort recovery**: Attempts restoration but doesn't fail if restoration errors occur
- **Race condition prevention**: Grace period + started flag prevents premature completion
- **Concurrent call safety**: Local state capture prevents race conditions in completion checks

#### State Machine
- `_announce_in_progress`: Tracks if announcement is active
- `_announce_started`: Set when media signature captured (prevents premature completion)
- `_announce_completed`: Prevents multiple restoration attempts
- `_announce_start_time`: Enables grace period timeout logic
- `_announce_media_signature`: Stores actual HEOS media info for reliable completion detection
- `_announce_restore_state`: Snapshot of pre-announcement state

### Technical Improvements
1. **Non-blocking event handler**: Uses `async_create_task()` for completion checks
2. **Race condition fixes**: 
   - Set `_announce_in_progress` after `play_url()` to avoid pause event race
   - Grace period prevents premature completion during startup
   - Local state capture in completion check prevents concurrent call issues
3. **Timeout protection**: After 2 seconds, allows fallback detection even without signature
4. **Volume format support**: Handles both HA normalized (0.0-1.0) and percentage (0-100) formats
5. **Comprehensive cleanup**: All state variables cleared in finally blocks and exception handlers

### Limitations
Due to HEOS protocol limitations, exact position resumption within a track is not supported. The implementation skips to the next track rather than restarting the current track from the beginning.

### Testing
Tested with Home Assistant TTS integrations (Google Translate, Cloud TTS, etc.) and confirmed:
- Music pauses before announcement
- Announcement plays at specified volume (both normalized and percentage formats)
- Music resumes with next track after announcement
- TTS items are removed from queue
- Volume and play mode are restored
- State restored even if announcement fails
- No blocking of event processing
- Handles concurrent completion checks safely
- Works even if media signature capture fails

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47459
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
