### PR TITLE
Remove the concept of device info types from device registry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -168,42 +168,6 @@ class ChildDeviceInfo(TypedDict, total=False):
     translation_placeholders: Mapping[str, str] | None
 
 
-DEVICE_INFO_TYPES = {
-    # Device info is categorized by finding the first device info type which has all
-    # the keys of the device info. The link device info type must be kept first
-    # to make it preferred over primary.
-    "link": {
-        "connections",
-        "identifiers",
-    },
-    "primary": {
-        "configuration_url",
-        "connections",
-        "entry_type",
-        "hw_version",
-        "identifiers",
-        "manufacturer",
-        "model",
-        "model_id",
-        "name",
-        "serial_number",
-        "suggested_area",
-        "sw_version",
-        "via_device",
-        "via_device_id",
-    },
-    "secondary": {
-        "connections",
-        "default_manufacturer",
-        "default_model",
-        "default_name",
-        # Used by Fritz
-        "via_device",
-        "via_device_id",
-    },
-}
-
-
 class _EventDeviceRegistryUpdatedData_Create(TypedDict):
     """EventDeviceRegistryUpdated data for action type 'create'."""
 
@@ -281,40 +245,17 @@ class DeviceConnectionCollisionError(DeviceCollisionError):
         )
 
 
-def _determine_device_info_type(
+def _validate_device_info(
     config_entry: ConfigEntry,
     device_info: DeviceInfo,
-) -> str:
-    """Determine the type of a device info."""
-    keys = set(device_info)
-
-    # If no keys or not enough info to match up, abort
+) -> None:
+    """Validate that a device info has enough information to match up a device."""
     if not device_info.get("connections") and not device_info.get("identifiers"):
         raise DeviceInfoError(
             config_entry.domain,
             device_info,
             "device info must include at least one of identifiers or connections",
         )
-
-    device_info_type: str | None = None
-
-    # Find the first device info type which has all keys in the device info
-    for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
-        if keys <= allowed_keys:
-            device_info_type = possible_type
-            break
-
-    if device_info_type is None:
-        raise DeviceInfoError(
-            config_entry.domain,
-            device_info,
-            (
-                "device info needs to either describe a device, "
-                "link to existing device or provide extra information."
-            ),
-        )
-
-    return device_info_type
 
 
 class _ValidatedDeviceInfoFields(TypedDict):
@@ -2252,7 +2193,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             if val is not UNDEFINED
         }
 
-        device_info_type = _determine_device_info_type(config_entry, device_info)
+        _validate_device_info(config_entry, device_info)
 
         if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()
@@ -2372,7 +2313,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
             self.devices[device.id] = device
             # If creating a new device, default to the config entry name
-            if device_info_type == "primary" and (not name or name is UNDEFINED):
+            if not name or name is UNDEFINED:
                 name = config_entry.title
 
         elif (

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -256,6 +256,13 @@ def _validate_device_info(
             device_info,
             "device info must include at least one of identifiers or connections",
         )
+    for field in ("manufacturer", "model", "name"):
+        if field in device_info and f"default_{field}" in device_info:
+            raise DeviceInfoError(
+                config_entry.domain,
+                device_info,
+                f"passing both `{field}` and `default_{field}` is not allowed",
+            )
 
 
 class _ValidatedDeviceInfoFields(TypedDict):

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -101,7 +101,9 @@ async def test_get_actions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id,
+            "attributes",
+            {"supported_features": features_state},
         )
     expected_actions = [
         {
@@ -184,7 +186,7 @@ async def test_get_actions_arm_night_only(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     hass.states.async_set(
-        "alarm_control_panel.test_5678", "attributes", {"supported_features": 4}
+        entity_entry.entity_id, "attributes", {"supported_features": 4}
     )
     expected_actions = [
         {

--- a/tests/components/alarm_control_panel/test_device_condition.py
+++ b/tests/components/alarm_control_panel/test_device_condition.py
@@ -80,7 +80,7 @@ async def test_get_conditions(
     )
     if set_state:
         hass.states.async_set(
-            "alarm_control_panel.test_5678",
+            entity_entry.entity_id,
             "attributes",
             {"supported_features": features_state},
         )

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -169,11 +169,11 @@ async def test_get_trigger_capabilities(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     hass.states.async_set(
-        "alarm_control_panel.test_5678", "attributes", {"supported_features": 15}
+        entity_entry.entity_id, "attributes", {"supported_features": 15}
     )
 
     triggers = await async_get_device_automations(
@@ -208,11 +208,11 @@ async def test_get_trigger_capabilities_legacy(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     hass.states.async_set(
-        "alarm_control_panel.test_5678", "attributes", {"supported_features": 15}
+        entity_entry.entity_id, "attributes", {"supported_features": 15}
     )
 
     triggers = await async_get_device_automations(

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -1991,7 +1991,7 @@ async def test_acknowledge(
         device_registry.async_update_device(light_device.id, area_id=area_2.id)
 
         _reset()
-        await _run("turn on light 2")
+        await _run("turn on Mock Title light 2")
 
         # Acknowledgment sound should be not played (different device area)
         text_to_speech.assert_called_once()

--- a/tests/components/assist_pipeline/test_select.py
+++ b/tests/components/assist_pipeline/test_select.py
@@ -16,7 +16,7 @@ from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -126,6 +126,7 @@ async def test_select_entity_registering_device(
 
 async def test_select_entity_changing_pipelines(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_select: MockConfigEntry,
     pipeline_1: Pipeline,
     pipeline_2: Pipeline,
@@ -135,7 +136,12 @@ async def test_select_entity_changing_pipelines(
     config_entry = init_select  # nicer naming
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
 
-    state = hass.states.get("select.assist_pipeline_test_prefix_pipeline")
+    pipeline_entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, "test-prefix-pipeline"
+    )
+    assert pipeline_entity_id is not None
+
+    state = hass.states.get(pipeline_entity_id)
     assert state is not None
     assert state.state == "preferred"
     assert state.attributes["options"] == [
@@ -150,13 +156,13 @@ async def test_select_entity_changing_pipelines(
         "select",
         "select_option",
         {
-            "entity_id": "select.assist_pipeline_test_prefix_pipeline",
+            "entity_id": pipeline_entity_id,
             "option": pipeline_2.name,
         },
         blocking=True,
     )
 
-    state = hass.states.get("select.assist_pipeline_test_prefix_pipeline")
+    state = hass.states.get(pipeline_entity_id)
     assert state is not None
     assert state.state == pipeline_2.name
 
@@ -168,14 +174,14 @@ async def test_select_entity_changing_pipelines(
         config_entry, [Platform.SELECT]
     )
 
-    state = hass.states.get("select.assist_pipeline_test_prefix_pipeline")
+    state = hass.states.get(pipeline_entity_id)
     assert state is not None
     assert state.state == pipeline_2.name
 
     # Remove selected pipeline
     await pipeline_storage.async_delete_item(pipeline_2.id)
 
-    state = hass.states.get("select.assist_pipeline_test_prefix_pipeline")
+    state = hass.states.get(pipeline_entity_id)
     assert state is not None
     assert state.state == "preferred"
     assert state.attributes["options"] == [
@@ -187,13 +193,19 @@ async def test_select_entity_changing_pipelines(
 
 async def test_select_entity_changing_vad_sensitivity(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     init_select: MockConfigEntry,
 ) -> None:
     """Test entity tracking vad sensitivity changes."""
     config_entry = init_select  # nicer naming
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
 
-    state = hass.states.get("select.assist_pipeline_test_vad_sensitivity")
+    vad_entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, "test-vad_sensitivity"
+    )
+    assert vad_entity_id is not None
+
+    state = hass.states.get(vad_entity_id)
     assert state is not None
     assert state.state == VadSensitivity.DEFAULT.value
 
@@ -202,13 +214,13 @@ async def test_select_entity_changing_vad_sensitivity(
         "select",
         "select_option",
         {
-            "entity_id": "select.assist_pipeline_test_vad_sensitivity",
+            "entity_id": vad_entity_id,
             "option": VadSensitivity.AGGRESSIVE.value,
         },
         blocking=True,
     )
 
-    state = hass.states.get("select.assist_pipeline_test_vad_sensitivity")
+    state = hass.states.get(vad_entity_id)
     assert state is not None
     assert state.state == VadSensitivity.AGGRESSIVE.value
 
@@ -220,6 +232,6 @@ async def test_select_entity_changing_vad_sensitivity(
         config_entry, [Platform.SELECT]
     )
 
-    state = hass.states.get("select.assist_pipeline_test_vad_sensitivity")
+    state = hass.states.get(vad_entity_id)
     assert state is not None
     assert state.state == VadSensitivity.AGGRESSIVE.value

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -68,7 +68,9 @@ async def test_get_actions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id,
+            "attributes",
+            {"supported_features": features_state},
         )
 
     expected_actions = []
@@ -380,7 +382,7 @@ async def test_capabilities(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678",
+            entity_entry.entity_id,
             HVACMode.COOL,
             capabilities_state,
         )
@@ -498,7 +500,7 @@ async def test_capabilities_legacy(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678",
+            entity_entry.entity_id,
             HVACMode.COOL,
             capabilities_state,
         )

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -64,7 +64,9 @@ async def test_get_conditions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id,
+            "attributes",
+            {"supported_features": features_state},
         )
     expected_conditions = []
     expected_conditions += [

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -82,7 +82,7 @@ async def test_get_conditions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id, "attributes", {"supported_features": features_state}
         )
     await hass.async_block_till_done()
 

--- a/tests/components/derivative/test_diagnostics.py
+++ b/tests/components/derivative/test_diagnostics.py
@@ -21,4 +21,4 @@ async def test_diagnostics(
     assert isinstance(result, dict)
     assert result["config_entry"]["domain"] == "derivative"
     assert result["config_entry"]["options"]["name"] == "My derivative"
-    assert result["entity"][0]["entity_id"] == "sensor.my_derivative"
+    assert result["entity"][0]["entity_id"] == "sensor.mock_title_my_derivative"

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -97,7 +97,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -116,7 +118,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id is None
 
     # Check that the device is removed
@@ -141,7 +145,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -160,7 +166,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id is None
 
     # Check that the source device is not removed
@@ -187,7 +195,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -207,7 +217,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id is None
 
     # Check that the derivative config entry is not in the device
@@ -239,7 +251,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -261,7 +275,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_device_2.id
 
     # Check that the derivative config entry is not in any of the devices
@@ -289,7 +305,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -375,7 +393,7 @@ async def test_migration_1_2(
         options={
             "name": "My derivative",
             "round": 1.0,
-            "source": "sensor.test_unique",
+            "source": sensor_entity_entry.entity_id,
             "time_window": {"seconds": 0.0},
             "unit_prefix": "k",
             "unit_time": "min",
@@ -395,7 +413,9 @@ async def test_migration_1_2(
     # derivative entity is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert derivative_config_entry.entry_id not in sensor_device.config_entries
-    derivative_entity_entry = entity_registry.async_get("sensor.my_derivative")
+    derivative_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_derivative"
+    )
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert derivative_config_entry.version == 1

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -915,7 +915,7 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     derivative_config_entry = MockConfigEntry(
         data={},
@@ -923,7 +923,7 @@ async def test_device_id(
         options={
             "name": "Derivative",
             "round": 1.0,
-            "source": "sensor.test_source",
+            "source": source_entity.entity_id,
             "time_window": {"seconds": 0.0},
             "unit_prefix": "k",
             "unit_time": "min",
@@ -936,7 +936,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    derivative_entity = entity_registry.async_get("sensor.derivative")
+    derivative_entity = entity_registry.async_get("sensor.mock_title_derivative")
     assert derivative_entity is not None
     assert derivative_entity.device_id == source_entity.device_id
 

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -1359,12 +1359,13 @@ async def test_unavailable_device(
             blocking=True,
         )
 
-    # Check hass device information has not been filled in yet
+    # The device is named after the config entry until it can be connected to;
+    # detailed information such as manufacturer is filled in once connected.
     device = device_registry.async_get_device_by_connection(
         (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
-    assert device.name is None
+    assert device.name == MOCK_DEVICE_NAME
     assert device.manufacturer is None
 
     # Unload config entry to clean up

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -1856,7 +1856,7 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("switch.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     helper_config_entry = MockConfigEntry(
         data={},
@@ -1864,7 +1864,7 @@ async def test_device_id(
         options={
             "device_class": "humidifier",
             "dry_tolerance": 2.0,
-            "humidifier": "switch.test_source",
+            "humidifier": source_entity.entity_id,
             "name": "Test",
             "target_sensor": ENT_SENSOR,
             "wet_tolerance": 4.0,
@@ -1876,7 +1876,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(helper_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    helper_entity = entity_registry.async_get("humidifier.test")
+    helper_entity = entity_registry.async_get("humidifier.mock_title_test")
     assert helper_entity is not None
     assert helper_entity.device_id == source_entity.device_id
 
@@ -1895,7 +1895,7 @@ async def test_device_id_yaml(
         identifiers={("switch", "identifier_test")},
         connections={("mac", "30:31:32:33:34:35")},
     )
-    entity_registry.async_get_or_create(
+    source_entity = entity_registry.async_get_or_create(
         "switch",
         "test",
         "source",
@@ -1911,7 +1911,7 @@ async def test_device_id_yaml(
             "humidifier": {
                 "platform": "generic_hygrostat",
                 "name": "test",
-                "humidifier": "switch.test_source",
+                "humidifier": source_entity.entity_id,
                 "target_sensor": ENT_SENSOR,
                 "unique_id": "generic_hygrostat_yaml",
             }

--- a/tests/components/generic_hygrostat/test_init.py
+++ b/tests/components/generic_hygrostat/test_init.py
@@ -148,8 +148,8 @@ def track_entity_registry_actions(hass: HomeAssistant, entity_id: str) -> list[s
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("switch.test_unique", None, ["update"]),
-        ("sensor.test_unique", "switch_device_id", []),
+        ("switch.mock_title", None, ["update"]),
+        ("sensor.mock_title", "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -172,7 +172,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     await hass.async_block_till_done()
 
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -195,7 +195,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     # Check that the helper entity is linked to the expected source device
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
 
@@ -221,8 +221,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("switch.test_unique", None, ["update"]),
-        ("sensor.test_unique", "switch_device_id", []),
+        ("switch.mock_title", None, ["update"]),
+        ("sensor.mock_title", "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -245,7 +245,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     await hass.async_block_till_done()
 
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -268,7 +268,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the helper entity is linked to the expected source device
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
 
@@ -302,8 +302,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
         "expected_events",
     ),
     [
-        ("switch.test_unique", 1, None, ["update"]),
-        ("sensor.test_unique", 0, "switch_device_id", []),
+        ("switch.mock_title", 1, None, ["update"]),
+        ("sensor.mock_title", 0, "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -327,7 +327,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     await hass.async_block_till_done()
 
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -351,7 +351,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the helper entity is linked to the expected source device
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
 
@@ -377,7 +377,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 )
 @pytest.mark.parametrize(
     ("source_entity_id", "unload_entry_calls", "expected_events"),
-    [("switch.test_unique", 1, ["update"]), ("sensor.test_unique", 0, [])],
+    [("switch.mock_title", 1, ["update"]), ("sensor.mock_title", 0, [])],
 )
 async def test_async_handle_source_entity_changes_source_entity_moved_other_device(
     hass: HomeAssistant,
@@ -403,7 +403,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     await hass.async_block_till_done()
 
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -430,7 +430,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     # Check that the helper entity is linked to the expected source device
     switch_entity_entry = entity_registry.async_get(switch_entity_entry.entity_id)
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -459,8 +459,8 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 @pytest.mark.parametrize(
     ("source_entity_id", "new_entity_id", "config_key"),
     [
-        ("switch.test_unique", "switch.new_entity_id", "humidifier"),
-        ("sensor.test_unique", "sensor.new_entity_id", "target_sensor"),
+        ("switch.mock_title", "switch.new_entity_id", "humidifier"),
+        ("sensor.mock_title", "sensor.new_entity_id", "target_sensor"),
     ],
 )
 async def test_async_handle_source_entity_new_entity_id(
@@ -482,7 +482,7 @@ async def test_async_handle_source_entity_new_entity_id(
     await hass.async_block_till_done()
 
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -558,7 +558,7 @@ async def test_migration_1_1(
     switch_device = device_registry.async_get(switch_device.id)
     assert generic_hygrostat_config_entry.entry_id not in switch_device.config_entries
     generic_hygrostat_entity_entry = entity_registry.async_get(
-        "humidifier.my_generic_hygrostat"
+        "humidifier.mock_title_my_generic_hygrostat"
     )
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -1848,14 +1848,14 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("switch.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     helper_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
             "name": "Test",
-            "heater": "switch.test_source",
+            "heater": source_entity.entity_id,
             "target_sensor": ENT_SENSOR,
             "ac_mode": False,
             "cold_tolerance": 0.3,
@@ -1868,7 +1868,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(helper_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    helper_entity = entity_registry.async_get("climate.test")
+    helper_entity = entity_registry.async_get("climate.mock_title_test")
     assert helper_entity is not None
     assert helper_entity.device_id == source_entity.device_id
 

--- a/tests/components/generic_thermostat/test_init.py
+++ b/tests/components/generic_thermostat/test_init.py
@@ -152,8 +152,8 @@ def track_entity_registry_actions(hass: HomeAssistant, entity_id: str) -> list[s
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("switch.test_unique", None, ["update"]),
-        ("sensor.test_unique", "switch_device_id", []),
+        ("switch.mock_title", None, ["update"]),
+        ("sensor.mock_title", "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -176,7 +176,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     await hass.async_block_till_done()
 
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -199,7 +199,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 
     # Check that the helper entity is linked to the expected source device
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == expected_helper_device_id
 
@@ -226,8 +226,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("switch.test_unique", None, ["update"]),
-        ("sensor.test_unique", "switch_device_id", []),
+        ("switch.mock_title", None, ["update"]),
+        ("sensor.mock_title", "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -250,7 +250,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     await hass.async_block_till_done()
 
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -273,7 +273,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the helper entity is linked to the expected source device
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == expected_helper_device_id
 
@@ -308,8 +308,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
         "expected_events",
     ),
     [
-        ("switch.test_unique", 1, None, ["update"]),
-        ("sensor.test_unique", 0, "switch_device_id", []),
+        ("switch.mock_title", 1, None, ["update"]),
+        ("sensor.mock_title", 0, "switch_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -333,7 +333,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     await hass.async_block_till_done()
 
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -357,7 +357,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the helper entity is linked to the expected source device
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == expected_helper_device_id
 
@@ -384,7 +384,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 )
 @pytest.mark.parametrize(
     ("source_entity_id", "unload_entry_calls", "expected_events"),
-    [("switch.test_unique", 1, ["update"]), ("sensor.test_unique", 0, [])],
+    [("switch.mock_title", 1, ["update"]), ("sensor.mock_title", 0, [])],
 )
 async def test_async_handle_source_entity_changes_source_entity_moved_other_device(
     hass: HomeAssistant,
@@ -410,7 +410,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     await hass.async_block_till_done()
 
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -439,7 +439,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     # Check that the helper entity is linked to the expected source device
     switch_entity_entry = entity_registry.async_get(switch_entity_entry.entity_id)
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -471,8 +471,8 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 @pytest.mark.parametrize(
     ("source_entity_id", "new_entity_id", "config_key"),
     [
-        ("switch.test_unique", "switch.new_entity_id", "heater"),
-        ("sensor.test_unique", "sensor.new_entity_id", "target_sensor"),
+        ("switch.mock_title", "switch.new_entity_id", "heater"),
+        ("sensor.mock_title", "sensor.new_entity_id", "target_sensor"),
     ],
 )
 async def test_async_handle_source_entity_new_entity_id(
@@ -494,7 +494,7 @@ async def test_async_handle_source_entity_new_entity_id(
     await hass.async_block_till_done()
 
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
@@ -571,7 +571,7 @@ async def test_migration_1_1(
     switch_device = device_registry.async_get(switch_device.id)
     assert generic_thermostat_config_entry.entry_id not in switch_device.config_entries
     generic_thermostat_entity_entry = entity_registry.async_get(
-        "climate.my_generic_thermostat"
+        "climate.mock_title_my_generic_thermostat"
     )
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 

--- a/tests/components/history_stats/test_init.py
+++ b/tests/components/history_stats/test_init.py
@@ -127,7 +127,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -146,7 +148,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("sensor.my_history_stats")
+    assert not entity_registry.async_get(history_stats_entity_entry.entity_id)
 
     # Check that the device is removed
     assert not device_registry.async_get(sensor_device.id)
@@ -177,7 +179,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -196,7 +200,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("sensor.my_history_stats")
+    assert not entity_registry.async_get(history_stats_entity_entry.entity_id)
 
     # Check that the source device is not removed
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -225,7 +229,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -245,7 +251,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        history_stats_entity_entry.entity_id
+    )
     assert history_stats_entity_entry.device_id is None
 
     # Check that the history_stats config entry is not in the device
@@ -278,7 +286,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -300,7 +310,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        history_stats_entity_entry.entity_id
+    )
     assert history_stats_entity_entry.device_id == sensor_device_2.id
 
     # Check that the history_stats config entry is not in any of the devices
@@ -329,7 +341,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -398,7 +412,9 @@ async def test_migration_1_1(
     # entity is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert history_stats_config_entry.entry_id not in sensor_device.config_entries
-    history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
+    history_stats_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_history_stats"
+    )
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert history_stats_config_entry.version == 2
@@ -449,9 +465,11 @@ async def test_migration_1_2(
         == HistoryStatsConfigFlowHandler.MINOR_VERSION
     )
 
-    assert hass.states.get("sensor.my_history_stats") is not None
+    assert hass.states.get("sensor.mock_title_my_history_stats") is not None
     assert (
-        hass.states.get("sensor.my_history_stats").attributes.get(CONF_STATE_CLASS)
+        hass.states.get("sensor.mock_title_my_history_stats").attributes.get(
+            CONF_STATE_CLASS
+        )
         == SensorStateClass.MEASUREMENT
     )
 

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -2162,14 +2162,14 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("binary_sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     history_stats_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
             CONF_NAME: DEFAULT_NAME,
-            CONF_ENTITY_ID: "binary_sensor.test_source",
+            CONF_ENTITY_ID: source_entity.entity_id,
             CONF_STATE: ["on"],
             CONF_TYPE: "count",
             CONF_START: "{{ as_timestamp(utcnow()) - 3600 }}",
@@ -2182,7 +2182,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    history_stats_entity = entity_registry.async_get("sensor.history_stats")
+    history_stats_entity = entity_registry.async_get("sensor.mock_title_history_stats")
     assert history_stats_entity is not None
     assert history_stats_entity.device_id == source_entity.device_id
 

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -58,7 +58,9 @@ async def test_get_actions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id,
+            "attributes",
+            {"supported_features": features_state},
         )
     expected_actions = []
     basic_action_types = ["set_humidity", "turn_on", "turn_off", "toggle"]
@@ -471,7 +473,7 @@ async def test_capabilities(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678",
+            entity_entry.entity_id,
             STATE_ON,
             capabilities_state,
         )
@@ -615,7 +617,7 @@ async def test_capabilities_legacy(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678",
+            entity_entry.entity_id,
             STATE_ON,
             capabilities_state,
         )

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -54,7 +54,9 @@ async def test_get_conditions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id,
+            "attributes",
+            {"supported_features": features_state},
         )
     expected_conditions = []
     basic_condition_types = ["is_on", "is_off"]

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -395,8 +395,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 8
     assert {service_calls[6].data["some"], service_calls[7].data["some"]} == {
-        "turn_off device - humidifier.test_5678 - on - off - None",
-        "turn_on_or_off device - humidifier.test_5678 - on - off - None",
+        f"turn_off device - {entry.entity_id} - on - off - None",
+        f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
     # Fake turn on
@@ -408,8 +408,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 10
     assert {service_calls[8].data["some"], service_calls[9].data["some"]} == {
-        "turn_on device - humidifier.test_5678 - off - on - None",
-        "turn_on_or_off device - humidifier.test_5678 - off - on - None",
+        f"turn_on device - {entry.entity_id} - off - on - None",
+        f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
 
 

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -197,7 +197,7 @@ async def test_entry_changed(hass: HomeAssistant, platform) -> None:
 
     assert config_entry.entry_id not in _get_device_config_entries(input_entry)
     assert config_entry.entry_id not in _get_device_config_entries(valid_entry)
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get("sensor.input_my_integration")
     assert integration_entity_entry.device_id == input_entry.device_id
 
     hass.config_entries.async_update_entry(
@@ -209,7 +209,7 @@ async def test_entry_changed(hass: HomeAssistant, platform) -> None:
     # Check that the device association has updated
     assert config_entry.entry_id not in _get_device_config_entries(input_entry)
     assert config_entry.entry_id not in _get_device_config_entries(valid_entry)
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get("sensor.input_my_integration")
     assert integration_entity_entry.device_id == valid_entry.device_id
 
 
@@ -226,7 +226,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -245,7 +247,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id is None
 
     # Check that the device is removed
@@ -270,7 +274,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -289,7 +295,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id is None
 
     # Check that the source device is not removed
@@ -318,7 +326,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -338,7 +348,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id is None
 
     # Check that the integration config entry is not in the device
@@ -370,7 +382,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -392,7 +406,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_device_2.id
 
     # Check that the derivative config entry is not in any of the devices
@@ -420,7 +436,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -489,7 +507,9 @@ async def test_migration_1_1(
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert integration_config_entry.entry_id not in sensor_device.config_entries
-    integration_entity_entry = entity_registry.async_get("sensor.my_integration")
+    integration_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_integration"
+    )
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert integration_config_entry.version == 1

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -892,7 +892,7 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get("sensor.mock_title") is not None
 
     integration_config_entry = MockConfigEntry(
         data={},
@@ -901,7 +901,7 @@ async def test_device_id(
             "method": "trapezoidal",
             "name": "integration",
             "round": 1.0,
-            "source": "sensor.test_source",
+            "source": "sensor.mock_title",
             "unit_prefix": "k",
             "unit_time": "min",
         },
@@ -913,7 +913,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    integration_entity = entity_registry.async_get("sensor.integration")
+    integration_entity = entity_registry.async_get("sensor.mock_title_integration")
     assert integration_entity is not None
     assert integration_entity.device_id == source_entity.device_id
 

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -238,6 +238,6 @@ async def test_switch_ui_load(knx: KNXTestKit) -> None:
     # unrelated light in config store
     await knx.assert_read("1/0/21", response=True, ignore_order=True)
     knx.assert_state(
-        "switch.test",  # has_entity_name with unregistered device
+        "switch.knx_test",  # has_entity_name with device named after config entry
         STATE_ON,
     )

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -53,7 +53,7 @@ async def test_get_actions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id, "attributes", {"supported_features": features_state}
         )
     expected_actions = []
     basic_action_types = ["lock", "unlock"]

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -265,8 +265,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
-        "turned_on - device - media_player.test_5678 - off - on - None",
-        "changed_states - device - media_player.test_5678 - off - on - None",
+        f"turned_on - device - {entry.entity_id} - off - on - None",
+        f"changed_states - device - {entry.entity_id} - off - on - None",
     }
 
     # Fake that the entity is turning off.
@@ -274,8 +274,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 4
     assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
-        "turned_off - device - media_player.test_5678 - on - off - None",
-        "changed_states - device - media_player.test_5678 - on - off - None",
+        f"turned_off - device - {entry.entity_id} - on - off - None",
+        f"changed_states - device - {entry.entity_id} - on - off - None",
     }
 
     # Fake that the entity becomes idle.
@@ -283,8 +283,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 6
     assert {service_calls[4].data["some"], service_calls[5].data["some"]} == {
-        "idle - device - media_player.test_5678 - off - idle - None",
-        "changed_states - device - media_player.test_5678 - off - idle - None",
+        f"idle - device - {entry.entity_id} - off - idle - None",
+        f"changed_states - device - {entry.entity_id} - off - idle - None",
     }
 
     # Fake that the entity starts playing.
@@ -292,8 +292,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 8
     assert {service_calls[6].data["some"], service_calls[7].data["some"]} == {
-        "playing - device - media_player.test_5678 - idle - playing - None",
-        "changed_states - device - media_player.test_5678 - idle - playing - None",
+        f"playing - device - {entry.entity_id} - idle - playing - None",
+        f"changed_states - device - {entry.entity_id} - idle - playing - None",
     }
 
     # Fake that the entity is paused.
@@ -301,8 +301,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 10
     assert {service_calls[8].data["some"], service_calls[9].data["some"]} == {
-        "paused - device - media_player.test_5678 - playing - paused - None",
-        "changed_states - device - media_player.test_5678 - playing - paused - None",
+        f"paused - device - {entry.entity_id} - playing - paused - None",
+        f"changed_states - device - {entry.entity_id} - playing - paused - None",
     }
 
     # Fake that the entity is buffering.
@@ -310,8 +310,8 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(service_calls) == 12
     assert {service_calls[10].data["some"], service_calls[11].data["some"]} == {
-        "buffering - device - media_player.test_5678 - paused - buffering - None",
-        "changed_states - device - media_player.test_5678 - paused - buffering - None",
+        f"buffering - device - {entry.entity_id} - paused - buffering - None",
+        f"changed_states - device - {entry.entity_id} - paused - buffering - None",
     }
 
 
@@ -370,7 +370,7 @@ async def test_if_fires_on_state_change_legacy(
     assert len(service_calls) == 1
     assert (
         service_calls[0].data["some"]
-        == "turned_on - device - media_player.test_5678 - off - on - None"
+        == f"turned_on - device - {entry.entity_id} - off - on - None"
     )
 
 

--- a/tests/components/miele/snapshots/test_sensor.ambr
+++ b/tests/components/miele/snapshots/test_sensor.ambr
@@ -520,7 +520,7 @@
     'state': 'own_program',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.powerdisk_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -534,7 +534,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -557,21 +557,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.powerdisk_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '80.5',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.rinse_aid_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -585,7 +585,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -608,21 +608,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.rinse_aid_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.salt_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -636,7 +636,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -659,21 +659,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.salt_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -687,7 +687,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -710,21 +710,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level_2-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -738,7 +738,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -761,21 +761,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_1_level_2-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -789,7 +789,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -812,21 +812,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level_2-entry]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -840,7 +840,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -863,21 +863,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.twindos_2_level_2-state]
+# name: test_coffee_system_sensor_states[platforms0-coffee_system.json][sensor.miele_test_twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.degreasing_cycles-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -893,7 +893,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -916,21 +916,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.degreasing_cycles-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.descaling_cycles-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -946,7 +946,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -969,14 +969,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.descaling_cycles-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2168,7 +2168,7 @@
     'state': 'off',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2184,7 +2184,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2207,21 +2207,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.powerdisk_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2235,7 +2235,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2258,21 +2258,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.powerdisk_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '80.5',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.rinse_aid_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2286,7 +2286,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2309,21 +2309,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.rinse_aid_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.salt_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2337,7 +2337,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2360,21 +2360,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.salt_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2388,7 +2388,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2411,21 +2411,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level_2-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2439,7 +2439,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2462,21 +2462,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_1_level_2-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2490,7 +2490,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2513,21 +2513,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level_2-entry]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2541,7 +2541,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2564,21 +2564,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.twindos_2_level_2-state]
+# name: test_fan_hob_sensor_states[platforms0-fan_devices.json][sensor.miele_test_twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.degreasing_cycles-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2594,7 +2594,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2617,21 +2617,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.degreasing_cycles-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.descaling_cycles-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2647,7 +2647,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2670,14 +2670,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.descaling_cycles-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3048,7 +3048,7 @@
     'state': '-18.0',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3064,7 +3064,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3087,21 +3087,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.powerdisk_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3115,7 +3115,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3138,21 +3138,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.powerdisk_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '80.5',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.rinse_aid_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3166,7 +3166,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3189,21 +3189,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.rinse_aid_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.salt_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3217,7 +3217,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3240,21 +3240,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.salt_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3268,7 +3268,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3291,21 +3291,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level_2-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3319,7 +3319,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3342,21 +3342,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_1_level_2-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3370,7 +3370,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3393,21 +3393,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level_2-entry]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3421,7 +3421,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3444,21 +3444,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.twindos_2_level_2-state]
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.miele_test_twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.degreasing_cycles-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3474,7 +3474,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3497,21 +3497,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.degreasing_cycles-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.descaling_cycles-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -3527,7 +3527,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3550,14 +3550,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.descaling_cycles-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4159,7 +4159,7 @@
     'state': 'plate_step_boost',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4175,7 +4175,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4198,21 +4198,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.powerdisk_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4226,7 +4226,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4249,21 +4249,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.powerdisk_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '80.5',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.rinse_aid_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4277,7 +4277,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4300,21 +4300,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.rinse_aid_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.salt_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4328,7 +4328,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4351,21 +4351,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.salt_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4379,7 +4379,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4402,21 +4402,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level_2-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4430,7 +4430,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4453,21 +4453,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_1_level_2-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4481,7 +4481,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4504,21 +4504,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level_2-entry]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4532,7 +4532,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4555,21 +4555,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_hob_sensor_states[platforms0-hob.json][sensor.twindos_2_level_2-state]
+# name: test_hob_sensor_states[platforms0-hob.json][sensor.miele_test_twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.degreasing_cycles-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4585,7 +4585,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4608,21 +4608,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.degreasing_cycles-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.descaling_cycles-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4638,7 +4638,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4661,14 +4661,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.descaling_cycles-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4923,7 +4923,7 @@
     'state': 'off',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -4939,7 +4939,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4962,14 +4962,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6863,7 +6863,7 @@
     'state': '19.54',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.powerdisk_level-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -6877,7 +6877,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6900,14 +6900,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.powerdisk_level-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7067,7 +7067,7 @@
     'state': '4.0',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.rinse_aid_level-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -7081,7 +7081,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -7104,21 +7104,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.rinse_aid_level-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.salt_level-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -7132,7 +7132,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -7155,21 +7155,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.salt_level-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.twindos_1_level-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -7183,7 +7183,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -7206,21 +7206,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.twindos_1_level-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.twindos_2_level-entry]
+# name: test_sensor_states[platforms0][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -7234,7 +7234,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -7257,14 +7257,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[platforms0][sensor.twindos_2_level-state]
+# name: test_sensor_states[platforms0][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -8383,7 +8383,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.degreasing_cycles-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -8399,7 +8399,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -8422,21 +8422,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.degreasing_cycles-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.descaling_cycles-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -8452,7 +8452,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -8475,14 +8475,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.descaling_cycles-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -8737,7 +8737,7 @@
     'state': 'off',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -8753,7 +8753,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -8776,14 +8776,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10677,7 +10677,7 @@
     'state': '19.54',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.powerdisk_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10691,7 +10691,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10714,14 +10714,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.powerdisk_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10881,7 +10881,7 @@
     'state': '4.0',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.rinse_aid_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10895,7 +10895,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10918,21 +10918,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.rinse_aid_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.salt_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10946,7 +10946,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10969,21 +10969,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.salt_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.twindos_1_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10997,7 +10997,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -11020,21 +11020,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.twindos_1_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.twindos_2_level-entry]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -11048,7 +11048,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -11071,14 +11071,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push[platforms0][sensor.twindos_2_level-state]
+# name: test_sensor_states_api_push[platforms0][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12197,7 +12197,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.degreasing_cycles-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -12213,7 +12213,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -12236,21 +12236,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.degreasing_cycles-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.descaling_cycles-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -12266,7 +12266,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -12289,14 +12289,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.descaling_cycles-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12551,7 +12551,7 @@
     'state': 'off',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -12567,7 +12567,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -12590,14 +12590,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -14491,7 +14491,7 @@
     'state': '19.54',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.powerdisk_level-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -14505,7 +14505,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -14528,14 +14528,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.powerdisk_level-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -14695,7 +14695,7 @@
     'state': '4.0',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.rinse_aid_level-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -14709,7 +14709,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -14732,21 +14732,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.rinse_aid_level-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '25',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.salt_level-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -14760,7 +14760,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -14783,21 +14783,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.salt_level-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.twindos_1_level-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -14811,7 +14811,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -14834,21 +14834,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.twindos_1_level-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.twindos_2_level-entry]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -14862,7 +14862,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -14885,14 +14885,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states_api_push_one_device[platforms0][sensor.twindos_2_level-state]
+# name: test_sensor_states_api_push_one_device[platforms0][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -16011,7 +16011,7 @@
     'state': '0.0',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.degreasing_cycles-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_degreasing_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16027,7 +16027,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16050,21 +16050,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.degreasing_cycles-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_degreasing_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Degreasing cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Degreasing cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.degreasing_cycles',
+    'entity_id': 'sensor.miele_test_degreasing_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.descaling_cycles-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_descaling_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16080,7 +16080,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16103,21 +16103,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.descaling_cycles-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_descaling_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Descaling cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Descaling cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.descaling_cycles',
+    'entity_id': 'sensor.miele_test_descaling_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.milk_pipework_cleaning_cycles-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_milk_pipework_cleaning_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16133,7 +16133,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16156,21 +16156,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.milk_pipework_cleaning_cycles-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_milk_pipework_cleaning_cycles-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Milk pipework cleaning cycles',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Milk pipework cleaning cycles',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.milk_pipework_cleaning_cycles',
+    'entity_id': 'sensor.miele_test_milk_pipework_cleaning_cycles',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.powerdisk_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_powerdisk_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16184,7 +16184,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16207,21 +16207,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.powerdisk_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_powerdisk_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PowerDisk level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test PowerDisk level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.powerdisk_level',
+    'entity_id': 'sensor.miele_test_powerdisk_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '80.5',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.rinse_aid_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_rinse_aid_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16235,7 +16235,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16258,14 +16258,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.rinse_aid_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_rinse_aid_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rinse aid level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Rinse aid level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rinse_aid_level',
+    'entity_id': 'sensor.miele_test_rinse_aid_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -16761,7 +16761,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.salt_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_salt_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16775,7 +16775,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16798,21 +16798,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.salt_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_salt_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Salt level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test Salt level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.salt_level',
+    'entity_id': 'sensor.miele_test_salt_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '75',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_1_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16826,7 +16826,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16849,21 +16849,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_1_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level',
+    'entity_id': 'sensor.miele_test_twindos_1_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level_2-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_1_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16877,7 +16877,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16900,21 +16900,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_1_level_2-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_1_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 1 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 1 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_1_level_2',
+    'entity_id': 'sensor.miele_test_twindos_1_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '63',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_2_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16928,7 +16928,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -16951,21 +16951,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_2_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level',
+    'entity_id': 'sensor.miele_test_twindos_2_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level_2-entry]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_2_level_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -16979,7 +16979,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -17002,14 +17002,14 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.twindos_2_level_2-state]
+# name: test_vacuum_sensor_states[platforms0-vacuum_device.json][sensor.miele_test_twindos_2_level_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'TwinDos 2 level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Miele test TwinDos 2 level',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.twindos_2_level_2',
+    'entity_id': 'sensor.miele_test_twindos_2_level_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/mold_indicator/test_init.py
+++ b/tests/components/mold_indicator/test_init.py
@@ -196,9 +196,9 @@ async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("sensor.test_unique_indoor_humidity", None, ["update"]),
-        ("sensor.test_unique_indoor_temperature", "humidity_device_id", []),
-        ("sensor.test_unique_outdoor_temperature", "humidity_device_id", []),
+        ("sensor.mock_title", None, ["update"]),
+        ("sensor.mock_title_2", "humidity_device_id", []),
+        ("sensor.mock_title_3", "humidity_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -218,7 +218,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -239,7 +241,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_not_called()
 
     # Check that the helper entity is linked to the expected source device
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert mold_indicator_entity_entry.device_id == expected_helper_device_id
 
     # Check that the device is removed
@@ -255,9 +259,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 @pytest.mark.parametrize(
     ("source_entity_id", "expected_helper_device_id", "expected_events"),
     [
-        ("sensor.test_unique_indoor_humidity", None, ["update"]),
-        ("sensor.test_unique_indoor_temperature", "humidity_device_id", []),
-        ("sensor.test_unique_outdoor_temperature", "humidity_device_id", []),
+        ("sensor.mock_title", None, ["update"]),
+        ("sensor.mock_title_2", "humidity_device_id", []),
+        ("sensor.mock_title_3", "humidity_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -277,7 +281,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -298,7 +304,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_not_called()
 
     # Check that the helper entity is linked to the expected source device
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert mold_indicator_entity_entry.device_id == expected_helper_device_id
 
     # Check that the source device is not removed
@@ -323,9 +331,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
         "expected_events",
     ),
     [
-        ("sensor.test_unique_indoor_humidity", 1, None, ["update"]),
-        ("sensor.test_unique_indoor_temperature", 0, "humidity_device_id", []),
-        ("sensor.test_unique_outdoor_temperature", 0, "humidity_device_id", []),
+        ("sensor.mock_title", 1, None, ["update"]),
+        ("sensor.mock_title_2", 0, "humidity_device_id", []),
+        ("sensor.mock_title_3", 0, "humidity_device_id", []),
     ],
     indirect=["expected_helper_device_id"],
 )
@@ -346,7 +354,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -368,7 +378,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert len(mock_unload_entry.mock_calls) == unload_entry_calls
 
     # Check that the helper entity is linked to the expected source device
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert mold_indicator_entity_entry.device_id == expected_helper_device_id
 
     # Check that the mold_indicator config entry is not in the device
@@ -385,9 +397,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 @pytest.mark.parametrize(
     ("source_entity_id", "unload_entry_calls", "expected_events"),
     [
-        ("sensor.test_unique_indoor_humidity", 1, ["update"]),
-        ("sensor.test_unique_indoor_temperature", 0, []),
-        ("sensor.test_unique_outdoor_temperature", 0, []),
+        ("sensor.mock_title", 1, ["update"]),
+        ("sensor.mock_title_2", 0, []),
+        ("sensor.mock_title_3", 0, []),
     ],
 )
 async def test_async_handle_source_entity_changes_source_entity_moved_other_device(
@@ -411,7 +423,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -438,7 +452,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     indoor_humidity_entity_entry = entity_registry.async_get(
         indoor_humidity_entity_entry.entity_id
     )
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -459,9 +475,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 @pytest.mark.parametrize(
     ("source_entity_id", "config_key"),
     [
-        ("sensor.test_unique_indoor_humidity", CONF_INDOOR_HUMIDITY),
-        ("sensor.test_unique_indoor_temperature", CONF_INDOOR_TEMP),
-        ("sensor.test_unique_outdoor_temperature", CONF_OUTDOOR_TEMP),
+        ("sensor.mock_title", CONF_INDOOR_HUMIDITY),
+        ("sensor.mock_title_2", CONF_INDOOR_TEMP),
+        ("sensor.mock_title_3", CONF_OUTDOOR_TEMP),
     ],
 )
 async def test_async_handle_source_entity_new_entity_id(
@@ -479,7 +495,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )
@@ -550,7 +568,9 @@ async def test_migration_1_1(
     # is linked to the source device
     source_device = device_registry.async_get(indoor_humidity_device.id)
     assert mold_indicator_config_entry.entry_id not in source_device.config_entries
-    mold_indicator_entity_entry = entity_registry.async_get("sensor.my_mold_indicator")
+    mold_indicator_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_mold_indicator"
+    )
     assert (
         mold_indicator_entity_entry.device_id == indoor_humidity_entity_entry.device_id
     )

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -272,10 +272,10 @@ async def test_cleanup_device_tracker(
         ("mqtt", "0AFFD2"), mqtt_config_entry.entry_id
     )
     assert device_entry is not None
-    entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
+    entity_entry = entity_registry.async_get("device_tracker.mqtt")
     assert entity_entry is not None
 
-    state = hass.states.get("device_tracker.mqtt_unique")
+    state = hass.states.get("device_tracker.mqtt")
     assert state is not None
 
     # Remove MQTT from the device
@@ -289,11 +289,11 @@ async def test_cleanup_device_tracker(
         ("mqtt", "0AFFD2"), mqtt_config_entry.entry_id
     )
     assert device_entry is None
-    entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
+    entity_entry = entity_registry.async_get("device_tracker.mqtt")
     assert entity_entry is None
 
     # Verify state is removed
-    state = hass.states.get("device_tracker.mqtt_unique")
+    state = hass.states.get("device_tracker.mqtt")
     assert state is None
     await hass.async_block_till_done()
 

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -72,7 +72,7 @@ async def test_entry_diagnostics(
     expected_debug_info = {
         "entities": [
             {
-                "entity_id": "sensor.mqtt_sensor",
+                "entity_id": "sensor.mqtt_mqtt_sensor",
                 "subscriptions": [{"topic": "foobar/sensor", "messages": []}],
                 "discovery_data": {
                     "payload": config_sensor,
@@ -101,13 +101,13 @@ async def test_entry_diagnostics(
                 "disabled": False,
                 "disabled_by": None,
                 "entity_category": None,
-                "entity_id": "sensor.mqtt_sensor",
+                "entity_id": "sensor.mqtt_mqtt_sensor",
                 "icon": None,
                 "original_device_class": None,
                 "original_icon": None,
                 "state": {
-                    "attributes": {"friendly_name": "MQTT Sensor"},
-                    "entity_id": "sensor.mqtt_sensor",
+                    "attributes": {"friendly_name": "MQTT MQTT Sensor"},
+                    "entity_id": "sensor.mqtt_mqtt_sensor",
                     "last_changed": ANY,
                     "last_reported": ANY,
                     "last_updated": ANY,
@@ -117,7 +117,7 @@ async def test_entry_diagnostics(
             }
         ],
         "id": device_entry.id,
-        "name": None,
+        "name": "MQTT",
         "name_by_user": None,
     }
 
@@ -199,7 +199,7 @@ async def test_redact_diagnostics(
     expected_debug_info = {
         "entities": [
             {
-                "entity_id": "device_tracker.mqtt_unique",
+                "entity_id": "device_tracker.mqtt",
                 "subscriptions": [
                     {
                         "topic": "attributes-topic",
@@ -234,12 +234,13 @@ async def test_redact_diagnostics(
                 "disabled": False,
                 "disabled_by": None,
                 "entity_category": None,
-                "entity_id": "device_tracker.mqtt_unique",
+                "entity_id": "device_tracker.mqtt",
                 "icon": None,
                 "original_device_class": None,
                 "original_icon": None,
                 "state": {
                     "attributes": {
+                        "friendly_name": "MQTT",
                         "gps_accuracy": 1.5,
                         "in_zones": ["zone.home"],
                         "latitude": "**REDACTED**",
@@ -247,7 +248,7 @@ async def test_redact_diagnostics(
                         "source_type": "gps",
                         "tracking_type": "position",
                     },
-                    "entity_id": "device_tracker.mqtt_unique",
+                    "entity_id": "device_tracker.mqtt",
                     "last_changed": ANY,
                     "last_reported": ANY,
                     "last_updated": ANY,
@@ -257,7 +258,7 @@ async def test_redact_diagnostics(
             }
         ],
         "id": device_entry.id,
-        "name": None,
+        "name": "MQTT",
         "name_by_user": None,
     }
 
@@ -294,7 +295,7 @@ async def test_redact_diagnostics(
         "connected": True,
         "device": {
             "id": device_entry.id,
-            "name": None,
+            "name": "MQTT",
             "name_by_user": None,
             "disabled": False,
             "disabled_by": None,

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1198,9 +1198,9 @@ async def test_discovery_component_availability_overridden(
         payload,
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.beer")
+    state = hass.states.get("binary_sensor.mqtt_beer")
     assert state is not None
-    assert state.name == "Beer"
+    assert state.name == "MQTT Beer"
     assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(
@@ -1209,7 +1209,7 @@ async def test_discovery_component_availability_overridden(
         "online",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.beer")
+    state = hass.states.get("binary_sensor.mqtt_beer")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -1219,7 +1219,7 @@ async def test_discovery_component_availability_overridden(
         "online",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.beer")
+    state = hass.states.get("binary_sensor.mqtt_beer")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -1229,7 +1229,7 @@ async def test_discovery_component_availability_overridden(
         "ON",
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.beer")
+    state = hass.states.get("binary_sensor.mqtt_beer")
     assert state is not None
     assert state.state == STATE_ON
 
@@ -1741,7 +1741,7 @@ async def test_duplicate_removal(
                 '"name": "sensor2"'
                 "}",
             },
-            ["sensor.sensor1", "sensor.sensor2"],
+            ["sensor.mqtt_sensor1", "sensor.mqtt_sensor2"],
         ),
         (
             {
@@ -1760,7 +1760,7 @@ async def test_duplicate_removal(
                 '"unique_id": "unique2"'
                 "}}}"
             },
-            ["sensor.sensor1", "sensor.sensor2"],
+            ["sensor.mqtt_sensor1", "sensor.mqtt_sensor2"],
         ),
     ],
 )
@@ -1836,7 +1836,7 @@ async def test_cleanup_device_manual(
             '{ "device":{"identifiers":["0AFFD2"]},'
             '  "state_topic": "foobar/sensor",'
             '  "unique_id": "unique" }',
-            ["sensor.mqtt_sensor"],
+            ["sensor.mqtt_mqtt_sensor"],
         ),
         (
             "homeassistant/device/bla/config",
@@ -1853,7 +1853,7 @@ async def test_cleanup_device_manual(
             '  "state_topic": "foobar/sensor2",'
             '  "unique_id": "unique2"'
             "}}}",
-            ["sensor.sensor1", "sensor.sensor2"],
+            ["sensor.mqtt_sensor1", "sensor.mqtt_sensor2"],
         ),
     ],
 )
@@ -1877,7 +1877,7 @@ async def test_cleanup_device_mqtt(
         '  "unique_id": "unique_base" }'
     )
     base_discovery_topic = "homeassistant/sensor/bla_base/config"
-    base_entity_id = "sensor.sensor_base"
+    base_entity_id = "sensor.mqtt_sensor_base"
     async_fire_mqtt_message(hass, base_discovery_topic, data)
     await hass.async_block_till_done()
 
@@ -1965,7 +1965,7 @@ async def test_cleanup_device_mqtt_device_discovery(
         '  "unique_id": "unique2"'
         "}}}"
     )
-    entity_ids = ["sensor.sensor1", "sensor.sensor2"]
+    entity_ids = ["sensor.mqtt_sensor1", "sensor.mqtt_sensor2"]
     async_fire_mqtt_message(hass, discovery_topic, discovery_payload)
     await hass.async_block_till_done()
 
@@ -2116,10 +2116,10 @@ async def test_cleanup_device_multiple_config_entries(
         )
         is not None
     )
-    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
     assert entity_entry is not None
 
-    state = hass.states.get("sensor.mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_mqtt_sensor")
     assert state is not None
 
     # Remove MQTT from the device
@@ -2135,12 +2135,12 @@ async def test_cleanup_device_multiple_config_entries(
         ("mac", "12:34:56:AB:CD:EF"), config_entry.entry_id
     )
     assert device_entry is not None
-    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
     assert device_entry.config_entries == {config_entry.entry_id}
     assert entity_entry is None
 
     # Verify state is removed
-    state = hass.states.get("sensor.mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_mqtt_sensor")
     assert state is None
     await hass.async_block_till_done()
 
@@ -2241,10 +2241,10 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
         )
         is not None
     )
-    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
     assert entity_entry is not None
 
-    state = hass.states.get("sensor.mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_mqtt_sensor")
     assert state is not None
 
     # Send MQTT messages to remove
@@ -2260,12 +2260,12 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
         ("mac", "12:34:56:AB:CD:EF"), config_entry.entry_id
     )
     assert device_entry is not None
-    entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
+    entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
     assert device_entry.config_entries == {config_entry.entry_id}
     assert entity_entry is None
 
     # Verify state is removed
-    state = hass.states.get("sensor.mqtt_sensor")
+    state = hass.states.get("sensor.mqtt_mqtt_sensor")
     assert state is None
     await hass.async_block_till_done()
 
@@ -3194,7 +3194,7 @@ async def test_discovery_dispatcher_signal_type_messages(
             '  "state_topic": "foobar/sensor3",'
             '  "unique_id": "unique3"'
             "}}}",
-            ["sensor.sensor1", "sensor.sensor2", "sensor.sensor3"],
+            ["sensor.mqtt_sensor1", "sensor.mqtt_sensor2", "sensor.mqtt_sensor3"],
         ),
     ],
 )
@@ -3281,7 +3281,7 @@ async def test_discovery_with_late_via_device_discovery(
             hass.config_entries.async_entries("mqtt")[0].entry_id,
         )
         assert via_device_entry is not None
-        assert via_device_entry.name is None
+        assert via_device_entry.name == "MQTT"
 
     await hass.async_block_till_done()
 
@@ -3376,7 +3376,7 @@ async def test_discovery_with_late_via_device_update(
             hass.config_entries.async_entries("mqtt")[0].entry_id,
         )
         assert via_device_entry is not None
-        assert via_device_entry.name is None
+        assert via_device_entry.name == "MQTT"
 
     await hass.async_block_till_done()
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1200,7 +1200,7 @@ async def test_mqtt_ws_get_device_debug_info(
     expected_result = {
         "entities": [
             {
-                "entity_id": "sensor.mqtt_sensor",
+                "entity_id": "sensor.mqtt_mqtt_sensor",
                 "subscriptions": [{"topic": "foobar/sensor", "messages": []}],
                 "discovery_data": {
                     "payload": config_sensor,
@@ -1263,7 +1263,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     expected_result = {
         "entities": [
             {
-                "entity_id": "camera.mqtt_camera",
+                "entity_id": "camera.mqtt_mqtt_camera",
                 "subscriptions": [
                     {
                         "topic": "foobar/image",

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -113,9 +113,9 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.mqtt_sensor",
-            DEFAULT_SENSOR_NAME,
-            None,
+            "sensor.mock_title_mqtt_sensor",
+            f"Mock Title {DEFAULT_SENSOR_NAME}",
+            "Mock Title",
             True,
         ),
         (  # default_entity_name_with_device_name
@@ -160,9 +160,9 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.humidity",
-            "Humidity",
-            None,
+            "sensor.mock_title_humidity",
+            "Mock Title Humidity",
+            "Mock Title",
             True,
         ),
         (  # name_overrides_device_class
@@ -194,9 +194,9 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.mysensor",
-            "MySensor",
-            None,
+            "sensor.mock_title_mysensor",
+            "Mock Title MySensor",
+            "Mock Title",
             True,
         ),
         (  # none_entity_name_with_device_name
@@ -228,9 +228,9 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.mqtt_veryunique",
-            "mqtt veryunique",
-            None,
+            "sensor.mock_title",
+            "Mock Title",
+            "Mock Title",
             True,
         ),
         (  # entity_name_and_device_name_the_same

--- a/tests/components/overkiz/snapshots/test_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.living_room_temperature_temperature-entry]
+# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.somfy_tahoma_switch_living_room_temperature_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.living_room_temperature_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_living_room_temperature_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -41,16 +41,16 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.living_room_temperature_temperature-state]
+# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.somfy_tahoma_switch_living_room_temperature_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living room temperature Temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Somfy TaHoma Switch Living room temperature Temperature',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.living_room_temperature_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_living_room_temperature_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -9296,7 +9296,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_discrete_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_discrete_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9317,7 +9317,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temp_probe_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_discrete_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9340,7 +9340,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_discrete_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_discrete_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -9354,14 +9354,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temp_probe_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_discrete_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'normal',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9377,7 +9377,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temp_probe_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9400,7 +9400,7 @@
     'unit_of_measurement': 'dB',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
@@ -9409,14 +9409,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dB',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temp_probe_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '54',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_sensor_defect-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_sensor_defect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9437,7 +9437,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temp_probe_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_sensor_defect',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9460,7 +9460,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_sensor_defect-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_sensor_defect-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -9473,14 +9473,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temp_probe_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_sensor_defect',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_temperature-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9496,7 +9496,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.garden_temp_probe_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9522,7 +9522,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temp_probe_temperature-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temp_probe_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
@@ -9531,14 +9531,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temp_probe_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temp_probe_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '24.2',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_discrete_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_discrete_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9559,7 +9559,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temperature_sensor_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_discrete_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9582,7 +9582,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_discrete_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_discrete_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -9596,14 +9596,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temperature_sensor_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_discrete_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'good',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9619,7 +9619,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temperature_sensor_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9642,7 +9642,7 @@
     'unit_of_measurement': 'dB',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
@@ -9651,14 +9651,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dB',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temperature_sensor_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '98',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_sensor_defect-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_sensor_defect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9679,7 +9679,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.garden_temperature_sensor_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_sensor_defect',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9702,7 +9702,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_sensor_defect-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_sensor_defect-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -9715,14 +9715,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temperature_sensor_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_sensor_defect',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_temperature-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -9738,7 +9738,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.garden_temperature_sensor_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -9764,7 +9764,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.garden_temperature_sensor_temperature-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_garden_temperature_sensor_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
@@ -9773,7 +9773,7 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.garden_temperature_sensor_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_garden_temperature_sensor_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10501,7 +10501,7 @@
     'state': '96',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_discrete_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_discrete_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10522,7 +10522,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.kitchen_temp_probe_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_discrete_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10545,7 +10545,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_discrete_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_discrete_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -10559,14 +10559,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kitchen_temp_probe_discrete_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_discrete_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'good',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_rssi_level-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_rssi_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10582,7 +10582,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.kitchen_temp_probe_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_rssi_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10605,7 +10605,7 @@
     'unit_of_measurement': 'dB',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_rssi_level-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_rssi_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
@@ -10614,14 +10614,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dB',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kitchen_temp_probe_rssi_level',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_rssi_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '82',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_sensor_defect-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_sensor_defect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10642,7 +10642,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.kitchen_temp_probe_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_sensor_defect',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10665,7 +10665,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_sensor_defect-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_sensor_defect-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -10678,14 +10678,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kitchen_temp_probe_sensor_defect',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_sensor_defect',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_temperature-entry]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -10701,7 +10701,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.kitchen_temp_probe_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -10727,7 +10727,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.kitchen_temp_probe_temperature-state]
+# name: test_sensor_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][sensor.somfy_tahoma_switch_kitchen_temp_probe_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
@@ -10736,7 +10736,7 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kitchen_temp_probe_temperature',
+    'entity_id': 'sensor.somfy_tahoma_switch_kitchen_temp_probe_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/overkiz/snapshots/test_switch.ambr
+++ b/tests/components/overkiz/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank-entry]
+# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.somfy_tahoma_switch_hot_water_tank-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.hot_water_tank',
+    'entity_id': 'switch.somfy_tahoma_switch_hot_water_tank',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,14 +36,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank-state]
+# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.somfy_tahoma_switch_hot_water_tank-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hot Water Tank',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Somfy TaHoma Switch Hot Water Tank',
       <EntityStateAttribute.ICON: 'icon'>: 'mdi:water-boiler',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.hot_water_tank',
+    'entity_id': 'switch.somfy_tahoma_switch_hot_water_tank',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/overkiz/snapshots/test_water_heater.ambr
+++ b/tests/components/overkiz/snapshots/test_water_heater.ambr
@@ -147,7 +147,7 @@
     'state': 'auto',
   })
 # ---
-# name: test_water_heater_entities_snapshot[cloud_atlantic_cozytouch.json][water_heater.yutaki_dhw-entry]
+# name: test_water_heater_entities_snapshot[cloud_atlantic_cozytouch.json][water_heater.somfy_tahoma_switch_yutaki_dhw-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -169,7 +169,7 @@
     'disabled_by': None,
     'domain': 'water_heater',
     'entity_category': None,
-    'entity_id': 'water_heater.yutaki_dhw',
+    'entity_id': 'water_heater.somfy_tahoma_switch_yutaki_dhw',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -192,11 +192,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_water_heater_entities_snapshot[cloud_atlantic_cozytouch.json][water_heater.yutaki_dhw-state]
+# name: test_water_heater_entities_snapshot[cloud_atlantic_cozytouch.json][water_heater.somfy_tahoma_switch_yutaki_dhw-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <WaterHeaterStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 46,
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Yutaki DHW',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Somfy TaHoma Switch Yutaki DHW',
       <WaterHeaterCapabilityAttribute.MAX_TEMP: 'max_temp'>: 70,
       <WaterHeaterCapabilityAttribute.MIN_TEMP: 'min_temp'>: 30,
       <WaterHeaterCapabilityAttribute.OPERATION_LIST: 'operation_list'>: list([
@@ -211,7 +211,7 @@
       <WaterHeaterStateAttribute.TEMPERATURE: 'temperature'>: 54,
     }),
     'context': <ANY>,
-    'entity_id': 'water_heater.yutaki_dhw',
+    'entity_id': 'water_heater.somfy_tahoma_switch_yutaki_dhw',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/overkiz/test_switch.py
+++ b/tests/components/overkiz/test_switch.py
@@ -52,12 +52,12 @@ MYFOX_CAMERA = FixtureDevice(
     "myfox://SOMFY_PROTECT-1234567890ABCDEF/jQ5ul40RVLnipT6JB8b3JK96tUsf14mR",
     "switch.outdoor_camera_camera_shutter",
 )
-# Sub-device (#7 suffix) whose DomesticHotWaterTank description has no name set,
-# so the entity name falls back to the device label alone.
+# Sub-device (#7 suffix) whose device has no name set, so it takes the config
+# entry title, and the entity id becomes device name + entity name.
 DOMESTIC_HOT_WATER_TANK = FixtureDevice(
     "setup/cloud_somfy_myfox_europe.json",
     "io://1234-5678-1202/6019143#7",
-    "switch.hot_water_tank",
+    "switch.somfy_tahoma_switch_hot_water_tank",
 )
 
 

--- a/tests/components/overkiz/test_water_heater.py
+++ b/tests/components/overkiz/test_water_heater.py
@@ -42,7 +42,7 @@ DHW_CE_FLAT_C2 = FixtureDevice(
 DHW_HITACHI_YUTAKI = FixtureDevice(
     "setup/cloud_atlantic_cozytouch.json",
     "modbus://1234-5678-5643/6381497/1#4",
-    "water_heater.yutaki_dhw",
+    "water_heater.somfy_tahoma_switch_yutaki_dhw",
 )
 
 # Thermor Aéromax 4 (io:AtlanticDomesticHotWaterProductionIOComponent)

--- a/tests/components/snooz/snapshots/test_init.ambr
+++ b/tests/components/snooz/snapshots/test_init.ambr
@@ -26,7 +26,7 @@
     'manufacturer': None,
     'model': None,
     'model_id': None,
-    'name': None,
+    'name': 'Mock Title',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,

--- a/tests/components/squeezebox/snapshots/test_switch.ambr
+++ b/tests/components/squeezebox/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entity_registry[switch.alarm_1-entry]
+# name: test_entity_registry[switch.mock_title_alarm_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.alarm_1',
+    'entity_id': 'switch.mock_title_alarm_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,21 +36,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity_registry[switch.alarm_1-state]
+# name: test_entity_registry[switch.mock_title_alarm_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'alarm_id': '1',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Alarm (1)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Alarm (1)',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.alarm_1',
+    'entity_id': 'switch.mock_title_alarm_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_entity_registry[switch.alarms_enabled-entry]
+# name: test_entity_registry[switch.mock_title_alarms_enabled-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.alarms_enabled',
+    'entity_id': 'switch.mock_title_alarms_enabled',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -87,13 +87,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entity_registry[switch.alarms_enabled-state]
+# name: test_entity_registry[switch.mock_title_alarms_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Alarms enabled',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Alarms enabled',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.alarms_enabled',
+    'entity_id': 'switch.mock_title_alarms_enabled',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/squeezebox/test_binary_sensor.py
+++ b/tests/components/squeezebox/test_binary_sensor.py
@@ -8,11 +8,18 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.components.squeezebox.const import PLAYER_UPDATE_INTERVAL
+from homeassistant.components.squeezebox.const import (
+    DOMAIN,
+    PLAYER_SENSOR_ALARM_ACTIVE,
+    PLAYER_SENSOR_ALARM_SNOOZE,
+    PLAYER_SENSOR_ALARM_UPCOMING,
+    PLAYER_UPDATE_INTERVAL,
+)
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import FAKE_QUERY_RESPONSE
+from .conftest import FAKE_QUERY_RESPONSE, TEST_MAC
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -67,24 +74,35 @@ async def mock_player(
 
 async def test_player_alarm_sensors_device_class(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_player: MagicMock,
 ) -> None:
     """Test player alarm binary sensors have correct device class."""
 
+    upcoming_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_UPCOMING}"
+    )
+    active_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_ACTIVE}"
+    )
+    snooze_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_SNOOZE}"
+    )
+
     # Test alarm upcoming sensor device class
-    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
+    upcoming_state = hass.states.get(upcoming_id)
     assert upcoming_state is not None
     assert upcoming_state.attributes.get("device_class") is None
 
     # Test alarm active sensor device class
-    active_state = hass.states.get("binary_sensor.alarm_active")
+    active_state = hass.states.get(active_id)
     assert active_state is not None
     assert (
         active_state.attributes.get("device_class") == BinarySensorDeviceClass.RUNNING
     )
 
     # Test alarm snooze sensor device class
-    snooze_state = hass.states.get("binary_sensor.alarm_snoozed")
+    snooze_state = hass.states.get(snooze_id)
     assert snooze_state is not None
     assert (
         snooze_state.attributes.get("device_class") == BinarySensorDeviceClass.RUNNING
@@ -93,6 +111,7 @@ async def test_player_alarm_sensors_device_class(
 
 async def test_player_alarm_sensors_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_player: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -100,18 +119,28 @@ async def test_player_alarm_sensors_state(
 
     player = mock_player
 
+    upcoming_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_UPCOMING}"
+    )
+    active_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_ACTIVE}"
+    )
+    snooze_id = entity_registry.async_get_entity_id(
+        Platform.BINARY_SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_ALARM_SNOOZE}"
+    )
+
     # Test alarm upcoming sensor
-    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
+    upcoming_state = hass.states.get(upcoming_id)
     assert upcoming_state is not None
     assert upcoming_state.state == STATE_ON
 
     # Test alarm active sensor
-    active_state = hass.states.get("binary_sensor.alarm_active")
+    active_state = hass.states.get(active_id)
     assert active_state is not None
     assert active_state.state == STATE_OFF
 
     # Test alarm snooze sensor
-    snooze_state = hass.states.get("binary_sensor.alarm_snoozed")
+    snooze_state = hass.states.get(snooze_id)
     assert snooze_state is not None
     assert snooze_state.state == STATE_OFF
 
@@ -123,10 +152,10 @@ async def test_player_alarm_sensors_state(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    upcoming_state = hass.states.get("binary_sensor.alarm_upcoming")
+    upcoming_state = hass.states.get(upcoming_id)
     assert upcoming_state is not None
     assert upcoming_state.state == STATE_OFF
 
-    active_state = hass.states.get("binary_sensor.alarm_active")
+    active_state = hass.states.get(active_id)
     assert active_state is not None
     assert active_state.state == STATE_ON

--- a/tests/components/squeezebox/test_button.py
+++ b/tests/components/squeezebox/test_button.py
@@ -5,8 +5,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.squeezebox.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import TEST_MAC
 
 
 @pytest.fixture(autouse=True)
@@ -17,13 +21,18 @@ def squeezebox_button_platform():
 
 
 async def test_squeezebox_press(
-    hass: HomeAssistant, configured_player: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    configured_player: MagicMock,
 ) -> None:
     """Test press service call."""
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.BUTTON, DOMAIN, f"{TEST_MAC[0]}_preset_1"
+    )
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.preset_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
 

--- a/tests/components/squeezebox/test_sensor.py
+++ b/tests/components/squeezebox/test_sensor.py
@@ -7,11 +7,16 @@ from unittest.mock import MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.squeezebox.const import PLAYER_UPDATE_INTERVAL
+from homeassistant.components.squeezebox.const import (
+    DOMAIN,
+    PLAYER_SENSOR_NEXT_ALARM,
+    PLAYER_UPDATE_INTERVAL,
+)
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import FAKE_QUERY_RESPONSE, TEST_ALARM_NEXT_TIME
+from .conftest import FAKE_QUERY_RESPONSE, TEST_ALARM_NEXT_TIME, TEST_MAC
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -44,6 +49,7 @@ async def test_server_sensor(
 
 async def test_player_sensor_next_alarm(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     config_entry: MockConfigEntry,
     lms: MagicMock,
     freezer: FrozenDateTimeFactory,
@@ -59,8 +65,12 @@ async def test_player_sensor_next_alarm(
         await hass.async_block_till_done(wait_background_tasks=True)
     player = (await lms.async_get_players())[0]
 
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{TEST_MAC[0]}_{PLAYER_SENSOR_NEXT_ALARM}"
+    )
+
     # test alarm time is set from player
-    state = hass.states.get("sensor.next_alarm")
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == TEST_ALARM_NEXT_TIME.isoformat()
 
@@ -70,6 +80,6 @@ async def test_player_sensor_next_alarm(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.next_alarm")
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/squeezebox/test_switch.py
+++ b/tests/components/squeezebox/test_switch.py
@@ -7,7 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.squeezebox.const import PLAYER_UPDATE_INTERVAL
+from homeassistant.components.squeezebox.const import DOMAIN, PLAYER_UPDATE_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     CONF_ENTITY_ID,
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
-from .conftest import TEST_ALARM_ID
+from .conftest import TEST_ALARM_ID, TEST_MAC
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -70,43 +70,55 @@ async def test_entity_registry(
 
 async def test_switch_state(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the state of the switch."""
-    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "on"
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarm_{TEST_ALARM_ID}"
+    )
+    assert hass.states.get(entity_id).state == "on"
 
     mock_alarms_player.alarms[0]["enabled"] = False
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "off"
+    assert hass.states.get(entity_id).state == "off"
 
 
 async def test_switch_deleted(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test detecting switch deleted."""
-    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}").state == "on"
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarm_{TEST_ALARM_ID}"
+    )
+    assert hass.states.get(entity_id).state == "on"
 
     mock_alarms_player.alarms = []
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(f"switch.alarm_{TEST_ALARM_ID}") is None
+    assert hass.states.get(entity_id) is None
 
 
 async def test_turn_on(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
 ) -> None:
     """Test turning on the switch."""
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarm_{TEST_ALARM_ID}"
+    )
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
-        {CONF_ENTITY_ID: f"switch.alarm_{TEST_ALARM_ID}"},
+        {CONF_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_alarms_player.async_update_alarm.assert_called_once_with(
@@ -116,13 +128,17 @@ async def test_turn_on(
 
 async def test_turn_off(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
 ) -> None:
     """Test turning on the switch."""
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarm_{TEST_ALARM_ID}"
+    )
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
-        {CONF_ENTITY_ID: f"switch.alarm_{TEST_ALARM_ID}"},
+        {CONF_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_alarms_player.async_update_alarm.assert_called_once_with(
@@ -132,30 +148,38 @@ async def test_turn_off(
 
 async def test_alarms_enabled_state(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the alarms enabled switch."""
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarms_enabled"
+    )
 
-    assert hass.states.get("switch.alarms_enabled").state == "on"
+    assert hass.states.get(entity_id).state == "on"
 
     mock_alarms_player.alarms_enabled = False
     freezer.tick(timedelta(seconds=PLAYER_UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.alarms_enabled").state == "off"
+    assert hass.states.get(entity_id).state == "off"
 
 
 async def test_alarms_enabled_turn_on(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
 ) -> None:
     """Test turning on the alarms enabled switch."""
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarms_enabled"
+    )
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
-        {CONF_ENTITY_ID: "switch.alarms_enabled"},
+        {CONF_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_alarms_player.async_set_alarms_enabled.assert_called_once_with(True)
@@ -163,13 +187,17 @@ async def test_alarms_enabled_turn_on(
 
 async def test_alarms_enabled_turn_off(
     hass: HomeAssistant,
+    entity_registry: EntityRegistry,
     mock_alarms_player: MagicMock,
 ) -> None:
     """Test turning off the alarms enabled switch."""
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{TEST_MAC[0]}_alarms_enabled"
+    )
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
-        {CONF_ENTITY_ID: "switch.alarms_enabled"},
+        {CONF_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_alarms_player.async_set_alarms_enabled.assert_called_once_with(False)

--- a/tests/components/statistics/test_init.py
+++ b/tests/components/statistics/test_init.py
@@ -115,7 +115,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -134,7 +136,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("sensor.my_statistics")
+    assert not entity_registry.async_get("sensor.mock_title_my_statistics")
 
     # Check that the device is removed
     assert not device_registry.async_get(sensor_device.id)
@@ -162,7 +164,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -181,7 +185,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("sensor.my_statistics")
+    assert not entity_registry.async_get("sensor.mock_title_my_statistics")
 
     # Check that the source device is not removed
     assert device_registry.async_get(sensor_device.id) is not None
@@ -209,7 +213,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -229,7 +235,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id is None
 
     # Check that the statistics config entry is not in the device
@@ -261,7 +269,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -283,7 +293,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_device_2.id
 
     # Check that the history_stats config entry is not in any of the devices
@@ -311,7 +323,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -380,7 +394,9 @@ async def test_migration_1_1(
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert statistics_config_entry.entry_id not in sensor_device.config_entries
-    statistics_entity_entry = entity_registry.async_get("sensor.my_statistics")
+    statistics_entity_entry = entity_registry.async_get(
+        "sensor.mock_title_my_statistics"
+    )
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert statistics_config_entry.version == 1

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1694,14 +1694,14 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get("sensor.mock_title") is not None
 
     statistics_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
             "name": "Statistics",
-            "entity_id": "sensor.test_source",
+            "entity_id": "sensor.mock_title",
             "state_characteristic": "mean",
             "keep_last_sample": False,
             "percentile": 50.0,
@@ -1715,7 +1715,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(statistics_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    statistics_entity = entity_registry.async_get("sensor.statistics")
+    statistics_entity = entity_registry.async_get("sensor.mock_title_statistics")
     assert statistics_entity is not None
     assert statistics_entity.device_id == source_entity.device_id
 

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -226,7 +226,10 @@ async def test_device_registry_config_entry_1(
     assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    entity_id = entity_registry.async_get_entity_id(
+        target_domain, DOMAIN, switch_as_x_config_entry.entry_id
+    )
+    entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
@@ -305,7 +308,10 @@ async def test_device_registry_config_entry_2(
     assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    entity_id = entity_registry.async_get_entity_id(
+        target_domain, DOMAIN, switch_as_x_config_entry.entry_id
+    )
+    entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
@@ -387,7 +393,10 @@ async def test_device_registry_config_entry_3(
     assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    entity_id = entity_registry.async_get_entity_id(
+        target_domain, DOMAIN, switch_as_x_config_entry.entry_id
+    )
+    entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
@@ -531,7 +540,10 @@ async def test_device(
     assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    entity_id = entity_registry.async_get_entity_id(
+        target_domain, DOMAIN, switch_as_x_config_entry.entry_id
+    )
+    entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
     assert entity_entry.device_id == switch_entity_entry.device_id
 
@@ -1164,8 +1176,8 @@ async def test_migrate(
     assert config_entry.minor_version == SwitchAsXConfigFlowHandler.MINOR_VERSION
 
     # Check the state and entity registry entry are present
-    assert hass.states.get(f"{target_domain}.abc") is not None
-    assert entity_registry.async_get(f"{target_domain}.abc") is not None
+    assert hass.states.get(switch_as_x_entity_entry.entity_id) is not None
+    assert entity_registry.async_get(switch_as_x_entity_entry.entity_id) is not None
 
     # The switch_as_x config entry was never added to the device, so migration does
     # not change the switch_as_x entity's device link

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -642,7 +642,9 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("alarm_control_panel.my_template")
+    template_entity = entity_registry.async_get(
+        "alarm_control_panel.mock_title_my_template"
+    )
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1536,7 +1536,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("binary_sensor.my_template")
+    template_entity = entity_registry.async_get("binary_sensor.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -341,7 +341,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("button.my_template")
+    template_entity = entity_registry.async_get("button.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_device_tracker.py
+++ b/tests/components/template/test_device_tracker.py
@@ -207,7 +207,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("device_tracker.my_template")
+    template_entity = entity_registry.async_get("device_tracker.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_event.py
+++ b/tests/components/template/test_event.py
@@ -194,7 +194,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("event.my_template")
+    template_entity = entity_registry.async_get("event.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_image.py
+++ b/tests/components/template/test_image.py
@@ -597,7 +597,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("image.my_template")
+    template_entity = entity_registry.async_get("image.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -438,7 +438,9 @@ async def test_change_device(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity_id = f"{config_entry_options['template_type']}.my_template"
+    template_entity_id = (
+        f"{config_entry_options['template_type']}.mock_title_my_template"
+    )
 
     # Confirm that the template config entry has not been added to either device
     # and that the entities are linked to device 1
@@ -676,7 +678,7 @@ async def test_migration_1_1(
     # entity is linked to the source device
     device_entry = device_registry.async_get(device_entry.id)
     assert template_config_entry.entry_id not in device_entry.config_entries
-    template_entity_entry = entity_registry.async_get("sensor.my_template")
+    template_entity_entry = entity_registry.async_get("sensor.mock_title_my_template")
     assert template_entity_entry.device_id == device_entry.id
 
     assert template_config_entry.version == 2

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -352,7 +352,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("number.my_template")
+    template_entity = entity_registry.async_get("number.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -324,7 +324,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("select.my_template")
+    template_entity = entity_registry.async_get("select.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1836,7 +1836,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("sensor.my_template")
+    template_entity = entity_registry.async_get("sensor.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -712,7 +712,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get("switch.my_template")
+    template_entity = entity_registry.async_get("switch.mock_title_my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/template/test_update.py
+++ b/tests/components/template/test_update.py
@@ -186,7 +186,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    template_entity = entity_registry.async_get(TEST_UPDATE.entity_id)
+    template_entity = entity_registry.async_get("update.mock_title_template_update")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
 

--- a/tests/components/threshold/test_binary_sensor.py
+++ b/tests/components/threshold/test_binary_sensor.py
@@ -563,13 +563,13 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     utility_meter_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "sensor.test_source",
+            CONF_ENTITY_ID: source_entity.entity_id,
             CONF_HYSTERESIS: 0.0,
             CONF_LOWER: -2.0,
             CONF_NAME: "Threshold",
@@ -583,7 +583,9 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(utility_meter_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    utility_meter_entity = entity_registry.async_get("binary_sensor.threshold")
+    utility_meter_entity = entity_registry.async_get(
+        "binary_sensor.mock_title_threshold"
+    )
     assert utility_meter_entity is not None
     assert utility_meter_entity.device_id == source_entity.device_id
 

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -196,7 +196,9 @@ async def test_entry_changed(hass: HomeAssistant, platform) -> None:
 
     assert config_entry.entry_id not in _get_device_config_entries(run1_entry)
     assert config_entry.entry_id not in _get_device_config_entries(run2_entry)
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.initial_my_threshold"
+    )
     assert threshold_entity_entry.device_id == run1_entry.device_id
 
     hass.config_entries.async_update_entry(
@@ -208,7 +210,9 @@ async def test_entry_changed(hass: HomeAssistant, platform) -> None:
     # Check that the device association has updated
     assert config_entry.entry_id not in _get_device_config_entries(run1_entry)
     assert config_entry.entry_id not in _get_device_config_entries(run2_entry)
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.initial_my_threshold"
+    )
     assert threshold_entity_entry.device_id == run2_entry.device_id
 
 
@@ -225,7 +229,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(threshold_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -244,7 +250,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id is None
 
     # Check that the device is removed
@@ -269,7 +277,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(threshold_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -288,7 +298,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_not_called()
 
     # Check that the entity is no longer linked to the source device
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id is None
 
     # Check that the source device is not removed
@@ -317,7 +329,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(threshold_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -337,7 +351,9 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id is None
 
     # Check that the threshold config entry is not in the device
@@ -369,7 +385,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(threshold_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -391,7 +409,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_device_2.id
 
     # Check that the derivative config entry is not in any of the devices
@@ -419,7 +439,9 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(threshold_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -486,7 +508,9 @@ async def test_migration_1_1(
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert threshold_config_entry.entry_id not in sensor_device.config_entries
-    threshold_entity_entry = entity_registry.async_get("binary_sensor.my_threshold")
+    threshold_entity_entry = entity_registry.async_get(
+        "binary_sensor.mock_title_my_threshold"
+    )
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert threshold_config_entry.version == 1

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -428,14 +428,14 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     trend_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
             "name": "Trend",
-            "entity_id": "sensor.test_source",
+            "entity_id": source_entity.entity_id,
             "invert": False,
         },
         title="Trend",
@@ -445,7 +445,7 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity = entity_registry.async_get("binary_sensor.trend")
+    trend_entity = entity_registry.async_get("binary_sensor.mock_title_trend")
     assert trend_entity is not None
     assert trend_entity.device_id == source_entity.device_id
 

--- a/tests/components/trend/test_init.py
+++ b/tests/components/trend/test_init.py
@@ -147,7 +147,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -166,7 +166,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("binary_sensor.my_trend")
+    assert not entity_registry.async_get(trend_entity_entry.entity_id)
 
     # Check that the device is removed
     assert not device_registry.async_get(sensor_device.id)
@@ -194,7 +194,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -213,7 +213,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     mock_unload_entry.assert_called_once()
 
     # Check that the helper entity is removed
-    assert not entity_registry.async_get("binary_sensor.my_trend")
+    assert not entity_registry.async_get(trend_entity_entry.entity_id)
 
     # Check that the source device is not removed
     assert device_registry.async_get(sensor_device.id) is not None
@@ -241,7 +241,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -261,7 +261,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is no longer linked to the source device
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get(trend_entity_entry.entity_id)
     assert trend_entity_entry.device_id is None
 
     # Check that the trend config entry is not in the device
@@ -293,7 +293,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -315,7 +315,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     mock_unload_entry.assert_called_once()
 
     # Check that the entity is linked to the other device
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get(trend_entity_entry.entity_id)
     assert trend_entity_entry.device_id == sensor_device_2.id
 
     # Check that the trend config entry is not in any of the devices
@@ -343,7 +343,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert await hass.config_entries.async_setup(trend_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
@@ -408,7 +408,7 @@ async def test_migration_1_1(
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
     assert trend_config_entry.entry_id not in sensor_device.config_entries
-    trend_entity_entry = entity_registry.async_get("binary_sensor.my_trend")
+    trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     assert trend_config_entry.version == 1

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -373,9 +373,9 @@ async def test_change_device_source(
 
     await hass.async_block_till_done()
 
-    input_sensor_entity_id_1 = "sensor.test_source1"
-    input_sensor_entity_id_2 = "sensor.test_source2"
-    input_sensor_entity_id_3 = "sensor.test_source3"
+    input_sensor_entity_id_1 = source_entity_1.entity_id
+    input_sensor_entity_id_2 = source_entity_2.entity_id
+    input_sensor_entity_id_3 = source_entity_3.entity_id
 
     # Test the existence of configured source entities
     assert entity_registry.async_get(input_sensor_entity_id_1) is not None

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -560,13 +560,13 @@ async def test_setup_and_remove_config_entry(
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],
@@ -632,13 +632,13 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],
@@ -706,13 +706,13 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],
@@ -779,13 +779,13 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],
@@ -862,13 +862,13 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],
@@ -930,13 +930,13 @@ async def test_async_handle_source_entity_new_entity_id(
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
-        ([], {"sensor.my_utility_meter"}),
+        ([], {"sensor.mock_title_my_utility_meter"}),
         (
             ["peak", "offpeak"],
             {
                 "select.my_utility_meter",
-                "sensor.my_utility_meter_offpeak",
-                "sensor.my_utility_meter_peak",
+                "sensor.mock_title_my_utility_meter_offpeak",
+                "sensor.mock_title_my_utility_meter_peak",
             },
         ),
     ],

--- a/tests/components/utility_meter/test_select.py
+++ b/tests/components/utility_meter/test_select.py
@@ -90,7 +90,7 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     utility_meter_config_entry = MockConfigEntry(
         data={},
@@ -102,7 +102,7 @@ async def test_device_id(
             "net_consumption": False,
             "offset": 0,
             "periodically_resetting": True,
-            "source": "sensor.test_source",
+            "source": source_entity.entity_id,
             "tariffs": ["peak", "offpeak"],
         },
         title="Energy",

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -2059,7 +2059,7 @@ async def test_device_id(
         device_id=source_device_entry.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     utility_meter_config_entry = MockConfigEntry(
         data={},
@@ -2071,7 +2071,7 @@ async def test_device_id(
             "net_consumption": False,
             "offset": 0,
             "periodically_resetting": True,
-            "source": "sensor.test_source",
+            "source": source_entity.entity_id,
             "tariffs": ["peak", "offpeak"],
         },
         title="Energy",
@@ -2082,11 +2082,11 @@ async def test_device_id(
     assert await hass.config_entries.async_setup(utility_meter_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    utility_meter_entity = entity_registry.async_get("sensor.energy_peak")
+    utility_meter_entity = entity_registry.async_get("sensor.mock_title_energy_peak")
     assert utility_meter_entity is not None
     assert utility_meter_entity.device_id == source_entity.device_id
 
-    utility_meter_entity = entity_registry.async_get("sensor.energy_offpeak")
+    utility_meter_entity = entity_registry.async_get("sensor.mock_title_energy_offpeak")
     assert utility_meter_entity is not None
     assert utility_meter_entity.device_id == source_entity.device_id
 
@@ -2100,7 +2100,7 @@ async def test_device_id(
             "net_consumption": False,
             "offset": 0,
             "periodically_resetting": True,
-            "source": "sensor.test_source",
+            "source": source_entity.entity_id,
             "tariffs": [],
         },
         title="Energy",
@@ -2113,7 +2113,9 @@ async def test_device_id(
     )
     await hass.async_block_till_done()
 
-    utility_meter_no_tariffs_entity = entity_registry.async_get("sensor.energy")
+    utility_meter_no_tariffs_entity = entity_registry.async_get(
+        "sensor.mock_title_energy"
+    )
     assert utility_meter_no_tariffs_entity is not None
     assert utility_meter_no_tariffs_entity.device_id == source_entity.device_id
 

--- a/tests/helpers/template/extensions/test_devices.py
+++ b/tests/helpers/template/extensions/test_devices.py
@@ -38,7 +38,7 @@ async def test_device_entities(
     assert info.rate_limit is None
 
     # Test device with single entity, which has no state
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         "light",
         "hue",
         "5678",
@@ -46,7 +46,7 @@ async def test_device_entities(
         device_id=device_entry.id,
     )
     info = render_to_info(hass, f"{{{{ device_entities('{device_entry.id}') }}}}")
-    assert_result_info(info, ["light.hue_5678"], [])
+    assert_result_info(info, [entity_entry.entity_id], [])
     assert info.rate_limit is None
     info = render_to_info(
         hass,
@@ -55,11 +55,11 @@ async def test_device_entities(
             "| sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
-    assert_result_info(info, "", ["light.hue_5678"])
+    assert_result_info(info, "", [entity_entry.entity_id])
     assert info.rate_limit is None
 
     # Test device with single entity, with state
-    hass.states.async_set("light.hue_5678", "happy")
+    hass.states.async_set(entity_entry.entity_id, "happy")
     info = render_to_info(
         hass,
         (
@@ -67,20 +67,20 @@ async def test_device_entities(
             "| sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
-    assert_result_info(info, "light.hue_5678", ["light.hue_5678"])
+    assert_result_info(info, entity_entry.entity_id, [entity_entry.entity_id])
     assert info.rate_limit is None
 
     # Test device with multiple entities, which have a state
-    entity_registry.async_get_or_create(
+    entity_entry_2 = entity_registry.async_get_or_create(
         "light",
         "hue",
         "ABCD",
         config_entry=config_entry,
         device_id=device_entry.id,
     )
-    hass.states.async_set("light.hue_abcd", "camper")
+    hass.states.async_set(entity_entry_2.entity_id, "camper")
     info = render_to_info(hass, f"{{{{ device_entities('{device_entry.id}') }}}}")
-    assert_result_info(info, ["light.hue_5678", "light.hue_abcd"], [])
+    assert_result_info(info, [entity_entry.entity_id, entity_entry_2.entity_id], [])
     assert info.rate_limit is None
     info = render_to_info(
         hass,
@@ -90,7 +90,9 @@ async def test_device_entities(
         ),
     )
     assert_result_info(
-        info, "light.hue_5678, light.hue_abcd", ["light.hue_5678", "light.hue_abcd"]
+        info,
+        f"{entity_entry.entity_id}, {entity_entry_2.entity_id}",
+        [entity_entry.entity_id, entity_entry_2.entity_id],
     )
     assert info.rate_limit is None
 

--- a/tests/helpers/test_device.py
+++ b/tests/helpers/test_device.py
@@ -44,7 +44,7 @@ async def test_entity_id_to_device_device_id(
         device_id=device.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(entity.entity_id) is not None
 
     device_id = async_entity_id_to_device_id(
         hass,
@@ -130,7 +130,7 @@ async def test_device_info_to_link(
         device_id=device.id,
     )
     await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
+    assert entity_registry.async_get(source_entity.entity_id) is not None
 
     # No link device_info is returned, even for an existing entity and device
     with patch("homeassistant.helpers.device.report_usage") as report_usage:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -7162,6 +7162,32 @@ async def test_get_or_create_sets_default_values(
     assert entry.manufacturer == "default manufacturer 1"
 
 
+@pytest.mark.parametrize(
+    ("field", "default_field"),
+    [
+        ("name", "default_name"),
+        ("manufacturer", "default_manufacturer"),
+        ("model", "default_model"),
+    ],
+)
+async def test_get_or_create_rejects_field_and_its_default(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    field: str,
+    default_field: str,
+) -> None:
+    """Test passing both an explicit field and its default_ counterpart is rejected."""
+    with pytest.raises(
+        dr.DeviceInfoError,
+        match=f"passing both `{field}` and `{default_field}` is not allowed",
+    ):
+        device_registry.async_get_or_create(
+            config_entry_id=mock_config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+            **{field: "explicit value", default_field: "default value"},
+        )
+
+
 async def test_verify_suggested_area_does_not_overwrite_area_id(
     device_registry: dr.DeviceRegistry,
     area_registry: ar.AreaRegistry,

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1036,7 +1036,7 @@ async def _test_friendly_name(
         (False, None, "Device Bla", "Device Bla"),
         (True, "Entity Blu", "Device Bla", "Device Bla Entity Blu"),
         (True, None, "Device Bla", "Device Bla"),
-        (True, "Entity Blu", UNDEFINED, "Entity Blu"),
+        (True, "Entity Blu", UNDEFINED, "Mock Title Entity Blu"),
         (True, "Entity Blu", None, "Mock Title Entity Blu"),
     ],
 )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -2784,15 +2784,6 @@ async def test_device_name_defaulting_config_entry(
         ({}, 1),  # Empty device info does not prevent the entity from being created
         ({"name": "bla"}, 0),
         ({"default_name": "bla"}, 0),
-        # Match multiple types
-        (
-            {
-                "identifiers": {("hue", "1234")},
-                "name": "bla",
-                "default_name": "yo",
-            },
-            0,
-        ),
     ],
 )
 async def test_device_type_error_checking(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -210,7 +210,7 @@ def test_get_or_create_updates_data(
     assert set(entity_registry.async_device_ids()) == {orig_device_entry.id}
 
     assert orig_entry == er.RegistryEntry(
-        entity_id="light.hue_5678",
+        entity_id=orig_entry.entity_id,
         unique_id="5678",
         platform="hue",
         aliases=[er.COMPUTED_NAME],
@@ -271,7 +271,7 @@ def test_get_or_create_updates_data(
     )
 
     assert new_entry == er.RegistryEntry(
-        entity_id="light.hue_5678",
+        entity_id=new_entry.entity_id,
         unique_id="5678",
         platform="hue",
         aliases=[er.COMPUTED_NAME],
@@ -327,7 +327,7 @@ def test_get_or_create_updates_data(
     )
 
     assert new_entry == er.RegistryEntry(
-        entity_id="light.hue_5678",
+        entity_id=new_entry.entity_id,
         unique_id="5678",
         platform="hue",
         aliases=[er.COMPUTED_NAME],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the concept of device info types from device registry, it was introduced to guess which integration was the "primary" integration when a device was shared between multiple config entries which is no longer relevant when devices are owned by a single config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request:
  - documentation update: https://github.com/home-assistant/developers.home-assistant/pull/3305
  - blog post: https://github.com/home-assistant/developers.home-assistant/pull/3307
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
