### PR TITLE
Don't let zeroconf prompts block Z-Wave JS USB and add-on discovery

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.components.hassio import (
 from homeassistant.config_entries import (
     SOURCE_ESPHOME,
     SOURCE_USB,
+    SOURCE_ZEROCONF,
     ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
@@ -494,12 +495,14 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         if any(
             flow
             for flow in self._async_in_progress()
-            if flow["context"].get("source") != SOURCE_USB
+            if flow["context"].get("source") not in (SOURCE_USB, SOURCE_ZEROCONF)
         ):
             # Allow multiple USB discovery flows to be in progress.
             # Migration requires more than one USB stick to be connected,
             # which can cause more than one discovery flow to be in progress,
             # at least for a short time.
+            # Zeroconf flows never touch the add-on,
+            # so an idle discovery prompt should not block USB discovery.
             return self.async_abort(reason="already_in_progress")
         if current_config_entries := self._async_current_entries(include_ignore=False):
             self._reconfigure_config_entry = next(
@@ -641,7 +644,13 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the Z-Wave JS add-on.
         """
-        if self._async_in_progress():
+        if any(
+            flow
+            for flow in self._async_in_progress()
+            # Zeroconf flows never touch the add-on, so an idle discovery
+            # prompt should not block the add-on discovery.
+            if flow["context"].get("source") != SOURCE_ZEROCONF
+        ):
             return self.async_abort(reason="already_in_progress")
 
         if discovery_info.slug != ADDON_SLUG:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -973,6 +973,21 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 str(self.version_info.home_id), raise_on_progress=False
             )
 
+        if (
+            existing_entry := next(
+                (
+                    entry
+                    for entry in self._async_current_entries(include_ignore=False)
+                    if entry.unique_id == self.unique_id
+                ),
+                None,
+            )
+        ) and not existing_entry.data.get(CONF_USE_ADDON):
+            # The controller is already configured against another server,
+            # e.g. via zeroconf discovery, so don't rewrite that entry
+            # with add-on data.
+            return self.async_abort(reason="already_configured")
+
         # When we came from discovery, make sure we update the add-on
         if self._adapter_discovered and self.use_addon:
             await self._async_set_addon_config(

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2009,6 +2009,48 @@ async def test_discovery_not_blocked_by_zeroconf_flow(hass: HomeAssistant) -> No
     assert result["reason"] == "already_in_progress"
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running")
+async def test_usb_discovery_leaves_manual_entry_alone(
+    hass: HomeAssistant,
+    addon_options: dict[str, Any],
+    set_addon_options: AsyncMock,
+    mock_usb_serial_by_id: MagicMock,
+) -> None:
+    """Test USB discovery does not rewrite a manual entry with add-on data.
+
+    A manual entry for the same controller may be created while the USB
+    flow is waiting at the installation type menu, e.g. by confirming a
+    zeroconf discovery of the server that already serves the controller.
+    """
+    addon_options["device"] = "/dev/ttyUSB0"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"url": "ws://external-server:3000"},
+        title=TITLE,
+        unique_id="1234",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "intent_recommended"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data == {"url": "ws://external-server:3000"}
+    set_addon_options.assert_not_called()
+
+
 @pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:
     """Test usb discovery aborted when existing entry not using add-on."""
@@ -2344,15 +2386,16 @@ async def test_addon_running_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert entry.data["url"] == "ws://host1:3001"
-    assert entry.data["usb_path"] == "/test_new"
-    assert entry.data["socket_path"] is None
-    assert entry.data["s0_legacy_key"] == "new123"
-    assert entry.data["s2_access_control_key"] == "new456"
-    assert entry.data["s2_authenticated_key"] == "new789"
-    assert entry.data["s2_unauthenticated_key"] == "new987"
-    assert entry.data["lr_s2_access_control_key"] == "new654"
-    assert entry.data["lr_s2_authenticated_key"] == "new321"
+    # The existing entry is not using the add-on,
+    # so it must not be rewritten with add-on data.
+    assert entry.data["url"] == "ws://localhost:3000"
+    assert entry.data["usb_path"] == "/test"
+    assert entry.data["s0_legacy_key"] == "old123"
+    assert entry.data["s2_access_control_key"] == "old456"
+    assert entry.data["s2_authenticated_key"] == "old789"
+    assert entry.data["s2_unauthenticated_key"] == "old987"
+    assert entry.data["lr_s2_access_control_key"] == "old654"
+    assert entry.data["lr_s2_authenticated_key"] == "old321"
 
 
 @pytest.mark.usefixtures("supervisor", "addon_installed", "addon_info")
@@ -2895,15 +2938,16 @@ async def test_addon_installed_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert entry.data["url"] == "ws://host1:3001"
-    assert entry.data["usb_path"] == "/new"
-    assert entry.data["socket_path"] is None
-    assert entry.data["s0_legacy_key"] == "new123"
-    assert entry.data["s2_access_control_key"] == "new456"
-    assert entry.data["s2_authenticated_key"] == "new789"
-    assert entry.data["s2_unauthenticated_key"] == "new987"
-    assert entry.data["lr_s2_access_control_key"] == "new654"
-    assert entry.data["lr_s2_authenticated_key"] == "new321"
+    # The existing entry is not using the add-on,
+    # so it must not be rewritten with add-on data.
+    assert entry.data["url"] == "ws://localhost:3000"
+    assert entry.data["usb_path"] == "/test"
+    assert entry.data["s0_legacy_key"] == "old123"
+    assert entry.data["s2_access_control_key"] == "old456"
+    assert entry.data["s2_authenticated_key"] == "old789"
+    assert entry.data["s2_unauthenticated_key"] == "old987"
+    assert entry.data["lr_s2_access_control_key"] == "old654"
+    assert entry.data["lr_s2_authenticated_key"] == "old321"
 
 
 @pytest.mark.usefixtures("supervisor", "addon_info")

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1926,6 +1926,53 @@ async def test_usb_discovery_with_existing_usb_flow(hass: HomeAssistant) -> None
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
+@pytest.mark.usefixtures("supervisor", "addon_installed")
+async def test_discovery_not_blocked_by_zeroconf_flow(hass: HomeAssistant) -> None:
+    """Test USB and add-on discovery are not blocked by a zeroconf prompt."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            hostname="mock_hostname",
+            name="mock_name",
+            port=3000,
+            type="_zwave-js-server._tcp.local.",
+            properties={"homeId": "5678"},
+        ),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
+
+    # A USB flow does touch the add-on, so it still blocks add-on discovery.
+    hass.config_entries.flow.async_abort(result["flow_id"])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Z-Wave JS",
+            slug=ADDON_SLUG,
+            uuid="1234",
+        ),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "hassio_confirm"
+
+
 @pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:
     """Test usb discovery aborted when existing entry not using add-on."""

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1972,6 +1972,42 @@ async def test_discovery_not_blocked_by_zeroconf_flow(hass: HomeAssistant) -> No
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "hassio_confirm"
 
+    hass.config_entries.flow.async_abort(result["flow_id"])
+
+    # A zeroconf discovery of the same controller as the add-on discovery
+    # means another server is already connected to it, so it does block
+    # the add-on discovery, via the unique id in progress check.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("127.0.0.1"),
+            ip_addresses=[ip_address("127.0.0.1")],
+            hostname="mock_hostname",
+            name="mock_name",
+            port=3000,
+            type="_zwave-js-server._tcp.local.",
+            properties={"homeId": "1234"},
+        ),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=HassioServiceInfo(
+            config=ADDON_DISCOVERY_INFO,
+            name="Z-Wave JS",
+            slug=ADDON_SLUG,
+            uuid="1234",
+        ),
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+
 
 @pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An idle zeroconf discovery prompt blocked USB and add-on discovery indefinitely. Zeroconf flows never touch the add-on, so they should not block.

Extracted from #176135.

cc @AlCalzone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
