### PR TITLE
Add reconfiguration flow to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/config_flow.py
+++ b/homeassistant/components/lyngdorf/config_flow.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, override
 from urllib.parse import urlparse
 
+from lyngdorf.const import LyngdorfModel
 from lyngdorf.device import (
     async_find_receiver_model,
     async_get_device_serial,
@@ -54,31 +55,17 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._host = user_input[CONF_HOST]
+            model, serial, errors = await self._async_probe(self._host)
 
-            try:
-                model = await async_find_receiver_model(self._host)
-            except TimeoutError:
-                errors["base"] = "timeout_connect"
-            except OSError:
-                errors["base"] = "cannot_connect"
-            except Exception:  # noqa: BLE001
-                errors["base"] = "unknown"
-
-            if not errors and not model:
-                errors["base"] = "unsupported_model"
-
-            if not errors and model:
+            if not errors:
+                assert model is not None
+                assert serial is not None
                 self._device_model = model.model_name
                 self._name = model.model_name
-
-                serial = await async_get_device_serial(self._host)
-                if not serial:
-                    errors["base"] = "cannot_determine_id"
-                else:
-                    self._device_serial_number = serial.lower()
-                    await self.async_set_unique_id(self._device_serial_number)
-                    self._abort_if_unique_id_configured()
-                    return await self._create_entry()
+                self._device_serial_number = serial
+                await self.async_set_unique_id(serial)
+                self._abort_if_unique_id_configured()
+                return await self._create_entry()
 
         return self.async_show_form(
             step_id="user",
@@ -86,6 +73,68 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_HOST): cv.string,
                 }
+            ),
+            errors=errors,
+        )
+
+    async def _async_probe(
+        self, host: str
+    ) -> tuple[LyngdorfModel | None, str | None, dict[str, str]]:
+        """Probe a host, returning its model, serial and any errors."""
+        try:
+            model = await async_find_receiver_model(host)
+        except TimeoutError:
+            return None, None, {"base": "timeout_connect"}
+        except OSError:
+            return None, None, {"base": "cannot_connect"}
+        except Exception:  # noqa: BLE001
+            return None, None, {"base": "unknown"}
+
+        if not model:
+            return None, None, {"base": "unsupported_model"}
+
+        if not (serial := await async_get_device_serial(host)):
+            return None, None, {"base": "cannot_determine_id"}
+
+        return model, serial.lower(), {}
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry.
+
+        SSDP rediscovery only recovers a changed address while the device is
+        still announcing somewhere Home Assistant can hear it, which a move to
+        a static address or another subnet can end.
+        """
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            model, serial, errors = await self._async_probe(host)
+
+            if not errors:
+                assert model is not None
+                assert serial is not None
+                await self.async_set_unique_id(serial)
+                # Refuse to point an existing entry at a different device,
+                # which would inherit the first one's entities.
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_HOST: host,
+                        CONF_MODEL: model.model_name,
+                        CONF_SERIAL_NUMBER: serial,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_HOST): cv.string}),
+                reconfigure_entry.data,
             ),
             errors=errors,
         )

--- a/homeassistant/components/lyngdorf/config_flow.py
+++ b/homeassistant/components/lyngdorf/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Lyngdorf integration."""
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 import logging
 from typing import Any, override
 from urllib.parse import urlparse
@@ -59,8 +57,17 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             self._host = user_input[CONF_HOST]
             try:
                 model, serial = await self._async_probe(self._host)
-            except _ProbeError as err:
-                errors["base"] = str(err)
+            except TimeoutConnect:
+                errors["base"] = "timeout_connect"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except UnsupportedModel:
+                errors["base"] = "unsupported_model"
+            except CannotDetermineId:
+                errors["base"] = "cannot_determine_id"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
             else:
                 self._device_model = model.model_name
                 self._name = model.model_name
@@ -81,15 +88,23 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _async_probe(self, host: str) -> tuple[LyngdorfModel, str]:
         """Return the model and serial of the device at a host."""
-        with _probe_errors():
+        try:
             model = await async_find_receiver_model(host)
+        except TimeoutError as err:
+            raise TimeoutConnect from err
+        except OSError as err:
+            raise CannotConnect from err
         if not model:
-            raise _ProbeError("unsupported_model")
+            raise UnsupportedModel
 
-        with _probe_errors():
+        try:
             serial = await async_get_device_serial(host)
+        except TimeoutError as err:
+            raise TimeoutConnect from err
+        except OSError as err:
+            raise CannotConnect from err
         if not serial:
-            raise _ProbeError("cannot_determine_id")
+            raise CannotDetermineId
 
         return model, serial.lower()
 
@@ -109,8 +124,17 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             try:
                 model, serial = await self._async_probe(host)
-            except _ProbeError as err:
-                errors["base"] = str(err)
+            except TimeoutConnect:
+                errors["base"] = "timeout_connect"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except UnsupportedModel:
+                errors["base"] = "unsupported_model"
+            except CannotDetermineId:
+                errors["base"] = "cannot_determine_id"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(serial)
                 self._abort_if_unique_id_mismatch()
@@ -225,21 +249,17 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
 
 
-class _ProbeError(Exception):
-    """Raised when a host could not be identified as a supported device.
-
-    Its argument is the key of the error to show on the form.
-    """
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect."""
 
 
-@contextmanager
-def _probe_errors() -> Iterator[None]:
-    """Map a failure to reach the device onto a form error."""
-    try:
-        yield
-    except TimeoutError:
-        raise _ProbeError("timeout_connect") from None
-    except OSError:
-        raise _ProbeError("cannot_connect") from None
-    except Exception:  # noqa: BLE001
-        raise _ProbeError("unknown") from None
+class TimeoutConnect(Exception):
+    """Error to indicate the device did not answer in time."""
+
+
+class UnsupportedModel(Exception):
+    """Error to indicate the device is not a model we support."""
+
+
+class CannotDetermineId(Exception):
+    """Error to indicate the device did not report a serial."""

--- a/homeassistant/components/lyngdorf/config_flow.py
+++ b/homeassistant/components/lyngdorf/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow for Lyngdorf integration."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import logging
 from typing import Any, override
 from urllib.parse import urlparse
@@ -26,15 +28,6 @@ from homeassistant.helpers.service_info.ssdp import (
 from .const import CONF_SERIAL_NUMBER, DEFAULT_DEVICE_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class _ProbeError(Exception):
-    """Raised when a host could not be identified as a supported device."""
-
-    def __init__(self, error: str) -> None:
-        """Store the error key to show on the form."""
-        super().__init__(error)
-        self.error = error
 
 
 class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -67,7 +60,7 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             try:
                 model, serial = await self._async_probe(self._host)
             except _ProbeError as err:
-                errors["base"] = err.error
+                errors["base"] = str(err)
             else:
                 self._device_model = model.model_name
                 self._name = model.model_name
@@ -88,18 +81,13 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _async_probe(self, host: str) -> tuple[LyngdorfModel, str]:
         """Return the model and serial of the device at a host."""
-        try:
+        with _probe_errors():
             model = await async_find_receiver_model(host)
-            serial = await async_get_device_serial(host) if model else None
-        except TimeoutError:
-            raise _ProbeError("timeout_connect") from None
-        except OSError:
-            raise _ProbeError("cannot_connect") from None
-        except Exception:  # noqa: BLE001
-            raise _ProbeError("unknown") from None
-
         if not model:
             raise _ProbeError("unsupported_model")
+
+        with _probe_errors():
+            serial = await async_get_device_serial(host)
         if not serial:
             raise _ProbeError("cannot_determine_id")
 
@@ -122,7 +110,7 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             try:
                 model, serial = await self._async_probe(host)
             except _ProbeError as err:
-                errors["base"] = err.error
+                errors["base"] = str(err)
             else:
                 await self.async_set_unique_id(serial)
                 self._abort_if_unique_id_mismatch()
@@ -235,3 +223,23 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             raise AbortFlow("cannot_determine_id")
         await self.async_set_unique_id(self._device_serial_number)
         self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
+
+
+class _ProbeError(Exception):
+    """Raised when a host could not be identified as a supported device.
+
+    Its argument is the key of the error to show on the form.
+    """
+
+
+@contextmanager
+def _probe_errors() -> Iterator[None]:
+    """Map a failure to reach the device onto a form error."""
+    try:
+        yield
+    except TimeoutError:
+        raise _ProbeError("timeout_connect") from None
+    except OSError:
+        raise _ProbeError("cannot_connect") from None
+    except Exception:  # noqa: BLE001
+        raise _ProbeError("unknown") from None

--- a/homeassistant/components/lyngdorf/config_flow.py
+++ b/homeassistant/components/lyngdorf/config_flow.py
@@ -28,6 +28,15 @@ from .const import CONF_SERIAL_NUMBER, DEFAULT_DEVICE_NAME, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+class _ProbeError(Exception):
+    """Raised when a host could not be identified as a supported device."""
+
+    def __init__(self, error: str) -> None:
+        """Store the error key to show on the form."""
+        super().__init__(error)
+        self.error = error
+
+
 class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Lyngdorf config flow."""
 
@@ -55,11 +64,11 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._host = user_input[CONF_HOST]
-            model, serial, errors = await self._async_probe(self._host)
-
-            if not errors:
-                assert model is not None
-                assert serial is not None
+            try:
+                model, serial = await self._async_probe(self._host)
+            except _ProbeError as err:
+                errors["base"] = err.error
+            else:
                 self._device_model = model.model_name
                 self._name = model.model_name
                 self._device_serial_number = serial
@@ -77,26 +86,24 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def _async_probe(
-        self, host: str
-    ) -> tuple[LyngdorfModel | None, str | None, dict[str, str]]:
-        """Probe a host, returning its model, serial and any errors."""
+    async def _async_probe(self, host: str) -> tuple[LyngdorfModel, str]:
+        """Return the model and serial of the device at a host."""
         try:
             model = await async_find_receiver_model(host)
+            serial = await async_get_device_serial(host) if model else None
         except TimeoutError:
-            return None, None, {"base": "timeout_connect"}
+            raise _ProbeError("timeout_connect") from None
         except OSError:
-            return None, None, {"base": "cannot_connect"}
+            raise _ProbeError("cannot_connect") from None
         except Exception:  # noqa: BLE001
-            return None, None, {"base": "unknown"}
+            raise _ProbeError("unknown") from None
 
         if not model:
-            return None, None, {"base": "unsupported_model"}
+            raise _ProbeError("unsupported_model")
+        if not serial:
+            raise _ProbeError("cannot_determine_id")
 
-        if not (serial := await async_get_device_serial(host)):
-            return None, None, {"base": "cannot_determine_id"}
-
-        return model, serial.lower(), {}
+        return model, serial.lower()
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -112,14 +119,12 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             host = user_input[CONF_HOST]
-            model, serial, errors = await self._async_probe(host)
-
-            if not errors:
-                assert model is not None
-                assert serial is not None
+            try:
+                model, serial = await self._async_probe(host)
+            except _ProbeError as err:
+                errors["base"] = err.error
+            else:
                 await self.async_set_unique_id(serial)
-                # Refuse to point an existing entry at a different device,
-                # which would inherit the first one's entities.
                 self._abort_if_unique_id_mismatch()
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,

--- a/homeassistant/components/lyngdorf/quality_scale.yaml
+++ b/homeassistant/components/lyngdorf/quality_scale.yaml
@@ -74,7 +74,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: No repair issues needed.

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -6,7 +6,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cannot_determine_id": "[%key:component::lyngdorf::config::error::cannot_determine_id%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unique_id_mismatch": "The device at this address is a different Lyngdorf device to the one this entry was set up with.",
+      "unique_id_mismatch": "The device at this address is a different Lyngdorf device from the one this entry was set up with.",
       "unsupported_model": "This Lyngdorf model is not supported"
     },
     "error": {

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -28,6 +28,7 @@
         "data_description": {
           "host": "[%key:component::lyngdorf::config::step::user::data_description::host%]"
         },
+        "description": "Update the address Home Assistant uses to reach this device. It must be the same device; a different one will be rejected.",
         "title": "[%key:component::lyngdorf::config::step::user::title%]"
       },
       "user": {

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -5,6 +5,8 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cannot_determine_id": "[%key:component::lyngdorf::config::error::cannot_determine_id%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The device at this address is a different Lyngdorf device to the one this entry was set up with.",
       "unsupported_model": "This Lyngdorf model is not supported"
     },
     "error": {
@@ -18,6 +20,15 @@
     "step": {
       "confirm": {
         "description": "Do you want to set up **{name}**?"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::lyngdorf::config::step::user::data_description::host%]"
+        },
+        "title": "[%key:component::lyngdorf::config::step::user::title%]"
       },
       "user": {
         "data": {

--- a/tests/components/lyngdorf/test_config_flow.py
+++ b/tests/components/lyngdorf/test_config_flow.py
@@ -452,3 +452,61 @@ async def test_reconfigure_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (TimeoutError, "timeout_connect"),
+        (OSError, "cannot_connect"),
+    ],
+)
+@pytest.mark.usefixtures("mock_find_receiver_model")
+async def test_user_flow_serial_errors(
+    hass: HomeAssistant,
+    mock_get_device_serial: AsyncMock,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test a failure to read the serial is surfaced on the form."""
+    mock_get_device_serial.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.50"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+
+@pytest.mark.parametrize(
+    ("model", "serial", "error"),
+    [
+        pytest.param(None, "0050c27c76b2", "unsupported_model", id="unsupported"),
+        pytest.param(LyngdorfModel.MP_60, None, "cannot_determine_id", id="no_serial"),
+    ],
+)
+async def test_reconfigure_device_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_find_receiver_model: AsyncMock,
+    mock_get_device_serial: AsyncMock,
+    model: LyngdorfModel | None,
+    serial: str | None,
+    error: str,
+) -> None:
+    """Test reconfigure surfaces a device it cannot identify."""
+    mock_config_entry.add_to_hass(hass)
+    mock_find_receiver_model.return_value = model
+    mock_get_device_serial.return_value = serial
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.50"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}

--- a/tests/components/lyngdorf/test_config_flow.py
+++ b/tests/components/lyngdorf/test_config_flow.py
@@ -368,3 +368,86 @@ async def test_ssdp_discovery_connectivity_check_aborts(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
+
+
+@pytest.mark.usefixtures("mock_find_receiver_model", "mock_get_device_serial")
+async def test_reconfigure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring an entry updates the host."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.50"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.50"
+
+
+@pytest.mark.usefixtures("mock_find_receiver_model")
+async def test_reconfigure_different_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_device_serial: AsyncMock,
+) -> None:
+    """Test an entry cannot be pointed at a different device."""
+    mock_config_entry.add_to_hass(hass)
+    mock_get_device_serial.return_value = "aabbccddeeff"
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.50"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.1"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (TimeoutError, "timeout_connect"),
+        (OSError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_get_device_serial")
+async def test_reconfigure_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_find_receiver_model: AsyncMock,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test reconfigure surfaces connection errors and recovers."""
+    mock_config_entry.add_to_hass(hass)
+    mock_find_receiver_model.side_effect = side_effect
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.50"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_find_receiver_model.side_effect = None
+    mock_find_receiver_model.return_value = LyngdorfModel.MP_60
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.50"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"

--- a/tests/components/lyngdorf/test_config_flow.py
+++ b/tests/components/lyngdorf/test_config_flow.py
@@ -481,6 +481,14 @@ async def test_user_flow_serial_errors(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
+    mock_get_device_serial.side_effect = None
+    mock_get_device_serial.return_value = "0050c27c76b2"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.50"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
 
 @pytest.mark.parametrize(
     ("model", "serial", "error"),
@@ -510,3 +518,12 @@ async def test_reconfigure_device_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
+
+    mock_find_receiver_model.return_value = LyngdorfModel.MP_60
+    mock_get_device_serial.return_value = "0050c27c76b2"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.50"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"

--- a/tests/components/lyngdorf/test_config_flow.py
+++ b/tests/components/lyngdorf/test_config_flow.py
@@ -401,6 +401,7 @@ async def test_reconfigure_different_device(
     """Test an entry cannot be pointed at a different device."""
     mock_config_entry.add_to_hass(hass)
     mock_get_device_serial.return_value = "aabbccddeeff"
+    original_host = mock_config_entry.data[CONF_HOST]
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     result = await hass.config_entries.flow.async_configure(
@@ -410,7 +411,7 @@ async def test_reconfigure_different_device(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
-    assert mock_config_entry.data[CONF_HOST] == "127.0.0.1"
+    assert mock_config_entry.data[CONF_HOST] == original_host
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a reconfigure step so an existing entry can be pointed at a new address.

SSDP rediscovery already updates a changed address, but only while the device is still announcing somewhere Home Assistant can hear it. Moving it to a static address, or onto a subnet the discovery traffic does not cross, leaves the entry pointing at a dead host with no way back except deleting and re-adding it, which loses the entity IDs, history and automations built on them.

The entry is identified by the device serial, so the new address is probed and refused with `unique_id_mismatch` if it answers as a different device. Without that, a second Lyngdorf would inherit the first one's entities.

The probe the user step already performed is factored out and shared, so the two paths cannot drift apart.

Satisfies the `reconfiguration-flow` rule, which is marked done in `quality_scale.yaml`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
