### PR TITLE
Add number, select and sensor platforms to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/const.py
+++ b/homeassistant/components/lyngdorf/const.py
@@ -7,5 +7,8 @@ DEFAULT_DEVICE_NAME = "Lyngdorf"
 
 PLATFORMS: list[Platform] = [
     Platform.MEDIA_PLAYER,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
 ]
 CONF_SERIAL_NUMBER = "serial_number"

--- a/homeassistant/components/lyngdorf/icons.json
+++ b/homeassistant/components/lyngdorf/icons.json
@@ -1,0 +1,35 @@
+{
+  "entity": {
+    "select": {
+      "room_perfect_position": {
+        "default": "mdi:home-sound-out"
+      },
+      "voicing": {
+        "default": "mdi:equalizer"
+      }
+    },
+    "sensor": {
+      "audio_information": {
+        "default": "mdi:surround-sound"
+      },
+      "audio_input": {
+        "default": "mdi:audio-input-stereo-minijack"
+      },
+      "streaming_source": {
+        "default": "mdi:cast-audio"
+      },
+      "video_information": {
+        "default": "mdi:television"
+      },
+      "video_input": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "zone_b_audio_input": {
+        "default": "mdi:audio-input-stereo-minijack"
+      },
+      "zone_b_streaming_source": {
+        "default": "mdi:cast-audio"
+      }
+    }
+  }
+}

--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.4.9"],
+  "requirements": ["lyngdorf==1.6.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/homeassistant/components/lyngdorf/number.py
+++ b/homeassistant/components/lyngdorf/number.py
@@ -1,0 +1,211 @@
+"""Number platform for Lyngdorf integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from lyngdorf.device import Receiver
+from lyngdorf.models.base import NumericRange
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.const import EntityCategory, UnitOfSoundPressure, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import LyngdorfEntity
+from .models import LyngdorfConfigEntry
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class LyngdorfNumberEntityDescription(NumberEntityDescription):
+    """Describe a Lyngdorf number entity."""
+
+    value_fn: Callable[[Receiver], float | None]
+    set_value_fn: Callable[[Receiver, float], None]
+    range_fn: Callable[[Receiver], NumericRange | None]
+
+
+def _set_lipsync(receiver: Receiver, value: float) -> None:
+    receiver.lipsync = int(value)
+
+
+def _set_trim_bass(receiver: Receiver, value: float) -> None:
+    receiver.trim_bass = value
+
+
+def _set_trim_centre(receiver: Receiver, value: float) -> None:
+    receiver.trim_centre = value
+
+
+def _set_trim_height(receiver: Receiver, value: float) -> None:
+    receiver.trim_height = value
+
+
+def _set_trim_lfe(receiver: Receiver, value: float) -> None:
+    receiver.trim_lfe = value
+
+
+def _set_trim_surround(receiver: Receiver, value: float) -> None:
+    receiver.trim_surround = value
+
+
+def _set_trim_treble(receiver: Receiver, value: float) -> None:
+    receiver.trim_treble = value
+
+
+NUMBER_ENTITIES: tuple[LyngdorfNumberEntityDescription, ...] = (
+    LyngdorfNumberEntityDescription(
+        key="lipsync",
+        translation_key="lipsync",
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: float(r.lipsync) if r.lipsync is not None else None,
+        set_value_fn=_set_lipsync,
+        range_fn=lambda r: r.lipsync_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_bass",
+        translation_key="trim_bass",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_bass,
+        set_value_fn=_set_trim_bass,
+        range_fn=lambda r: r.trim_bass_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_treble",
+        translation_key="trim_treble",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_treble,
+        set_value_fn=_set_trim_treble,
+        range_fn=lambda r: r.trim_treble_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_centre",
+        translation_key="trim_centre",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_centre,
+        set_value_fn=_set_trim_centre,
+        range_fn=lambda r: r.trim_centre_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_height",
+        translation_key="trim_height",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_height,
+        set_value_fn=_set_trim_height,
+        range_fn=lambda r: r.trim_height_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_lfe",
+        translation_key="trim_lfe",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_lfe,
+        set_value_fn=_set_trim_lfe,
+        range_fn=lambda r: r.trim_lfe_range,
+    ),
+    LyngdorfNumberEntityDescription(
+        key="trim_surround",
+        translation_key="trim_surround",
+        device_class=NumberDeviceClass.SOUND_PRESSURE,
+        native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda r: r.trim_surround,
+        set_value_fn=_set_trim_surround,
+        range_fn=lambda r: r.trim_surround_range,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LyngdorfConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Lyngdorf number entities from a config entry."""
+    runtime_data = config_entry.runtime_data
+    receiver = runtime_data.receiver
+
+    # A None range means the model has no such control at all.
+    async_add_entities(
+        LyngdorfNumber(receiver, config_entry, runtime_data.device_info, description)
+        for description in NUMBER_ENTITIES
+        if description.range_fn(receiver) is not None
+    )
+
+
+class LyngdorfNumber(LyngdorfEntity, NumberEntity):
+    """Lyngdorf number entity."""
+
+    entity_description: LyngdorfNumberEntityDescription
+
+    def __init__(
+        self,
+        receiver: Receiver,
+        config_entry: LyngdorfConfigEntry,
+        device_info: DeviceInfo,
+        description: LyngdorfNumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(receiver, device_info)
+        assert config_entry.unique_id
+        self.entity_description = description
+        self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
+
+    @property
+    def _range(self) -> NumericRange:
+        """Return the device's range for this setting."""
+        range_ = self.entity_description.range_fn(self._receiver)
+        # Entities are only created for controls the model actually has.
+        assert range_ is not None
+        return range_
+
+    @override
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value the device accepts."""
+        return self._range.min
+
+    @override
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value the device accepts."""
+        return self._range.max
+
+    @override
+    @property
+    def native_step(self) -> float:
+        """Return the step the device resolves."""
+        return self._range.step
+
+    @override
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        return self.entity_description.value_fn(self._receiver)
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value.
+
+        Async so the library's write lands on the event loop: it enqueues
+        onto an asyncio primitive, which is not safe from an executor thread.
+        """
+        self.entity_description.set_value_fn(self._receiver, value)

--- a/homeassistant/components/lyngdorf/quality_scale.yaml
+++ b/homeassistant/components/lyngdorf/quality_scale.yaml
@@ -64,18 +64,16 @@ rules:
   dynamic-devices:
     status: exempt
     comment: Single device per config entry.
-  entity-category:
-    status: exempt
-    comment: Media player entities do not need entity categories.
+  entity-category: done
   entity-device-class: done
   entity-disabled-by-default:
-    status: exempt
-    comment: All entities are useful by default.
+    status: done
+    comment: >-
+      All entities are useful by default; the diagnostic sensors change only on
+      source or content changes.
   entity-translations: done
   exception-translations: done
-  icon-translations:
-    status: exempt
-    comment: Media player uses default platform icons.
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues:
     status: exempt

--- a/homeassistant/components/lyngdorf/select.py
+++ b/homeassistant/components/lyngdorf/select.py
@@ -1,0 +1,104 @@
+"""Select platform for Lyngdorf integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from lyngdorf.device import Receiver
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import LyngdorfEntity
+from .models import LyngdorfConfigEntry
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class LyngdorfSelectEntityDescription(SelectEntityDescription):
+    """Describe a Lyngdorf select entity."""
+
+    current_option_fn: Callable[[Receiver], str | None]
+    options_fn: Callable[[Receiver], list[str]]
+    select_option_fn: Callable[[Receiver, str], None]
+
+
+def _set_room_perfect(receiver: Receiver, option: str) -> None:
+    receiver.room_perfect_position = option
+
+
+def _set_voicing(receiver: Receiver, option: str) -> None:
+    receiver.voicing = option
+
+
+SELECT_ENTITIES: tuple[LyngdorfSelectEntityDescription, ...] = (
+    LyngdorfSelectEntityDescription(
+        key="room_perfect_position",
+        translation_key="room_perfect_position",
+        current_option_fn=lambda r: r.room_perfect_position,
+        options_fn=lambda r: r.available_room_perfect_positions or [],
+        select_option_fn=_set_room_perfect,
+    ),
+    LyngdorfSelectEntityDescription(
+        key="voicing",
+        translation_key="voicing",
+        current_option_fn=lambda r: r.voicing,
+        options_fn=lambda r: r.available_voicings or [],
+        select_option_fn=_set_voicing,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LyngdorfConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Lyngdorf select entities from a config entry."""
+    runtime_data = config_entry.runtime_data
+
+    async_add_entities(
+        LyngdorfSelect(
+            runtime_data.receiver, config_entry, runtime_data.device_info, description
+        )
+        for description in SELECT_ENTITIES
+    )
+
+
+class LyngdorfSelect(LyngdorfEntity, SelectEntity):
+    """Lyngdorf select entity."""
+
+    entity_description: LyngdorfSelectEntityDescription
+
+    def __init__(
+        self,
+        receiver: Receiver,
+        config_entry: LyngdorfConfigEntry,
+        device_info: DeviceInfo,
+        description: LyngdorfSelectEntityDescription,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(receiver, device_info)
+        assert config_entry.unique_id
+        self.entity_description = description
+        self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
+
+    @override
+    @property
+    def current_option(self) -> str | None:
+        """Return the current option."""
+        return self.entity_description.current_option_fn(self._receiver)
+
+    @override
+    @property
+    def options(self) -> list[str]:
+        """Return available options."""
+        return self.entity_description.options_fn(self._receiver)
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Set the selected option."""
+        self.entity_description.select_option_fn(self._receiver, option)

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -1,0 +1,161 @@
+"""Sensor platform for Lyngdorf integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from lyngdorf.device import Receiver
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import LyngdorfEntity
+from .models import LyngdorfConfigEntry
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class LyngdorfSensorEntityDescription(SensorEntityDescription):
+    """Describe a Lyngdorf sensor entity."""
+
+    value_fn: Callable[[Receiver], str | None]
+    options_fn: Callable[[Receiver], list[str]] | None = None
+
+
+def _known(value: str | None, options: list[str]) -> str | None:
+    """Return value only if the device reported a name we know.
+
+    Unrecognised values deliberately escape the library's lookup tables as
+    synthetic strings, which would fall outside an enum's options.
+    """
+    return value if value in options else None
+
+
+MAIN_ZONE_SENSORS: tuple[LyngdorfSensorEntityDescription, ...] = (
+    LyngdorfSensorEntityDescription(
+        key="audio_information",
+        translation_key="audio_information",
+        value_fn=lambda r: r.audio_information,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="video_information",
+        translation_key="video_information",
+        value_fn=lambda r: r.video_information,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="audio_input",
+        translation_key="audio_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.audio_input, r.available_audio_inputs),
+        options_fn=lambda r: r.available_audio_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="video_input",
+        translation_key="video_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.video_input, r.available_video_inputs),
+        options_fn=lambda r: r.available_video_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="streaming_source",
+        translation_key="streaming_source",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.streaming_source, r.available_stream_types),
+        options_fn=lambda r: r.available_stream_types,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+ZONE_B_SENSORS: tuple[LyngdorfSensorEntityDescription, ...] = (
+    LyngdorfSensorEntityDescription(
+        key="zone_b_audio_input",
+        translation_key="zone_b_audio_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.zone_b_audio_input, r.available_audio_inputs),
+        options_fn=lambda r: r.available_audio_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="zone_b_streaming_source",
+        translation_key="zone_b_streaming_source",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.zone_b_streaming_source, r.available_stream_types),
+        options_fn=lambda r: r.available_stream_types,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LyngdorfConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Lyngdorf sensors from a config entry."""
+    runtime_data = config_entry.runtime_data
+
+    entities: list[LyngdorfSensor] = [
+        LyngdorfSensor(
+            runtime_data.receiver, config_entry, runtime_data.device_info, description
+        )
+        for description in MAIN_ZONE_SENSORS
+    ]
+    # Zone B sensors stay on the main device so they read "Zone B audio input"
+    # rather than repeating the zone in the Zone B device's own name.
+    if runtime_data.zone_b_device_info is not None:
+        entities.extend(
+            LyngdorfSensor(
+                runtime_data.receiver,
+                config_entry,
+                runtime_data.device_info,
+                description,
+            )
+            for description in ZONE_B_SENSORS
+        )
+
+    async_add_entities(entities)
+
+
+class LyngdorfSensor(LyngdorfEntity, SensorEntity):
+    """Lyngdorf sensor entity."""
+
+    entity_description: LyngdorfSensorEntityDescription
+
+    def __init__(
+        self,
+        receiver: Receiver,
+        config_entry: LyngdorfConfigEntry,
+        device_info: DeviceInfo,
+        description: LyngdorfSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(receiver, device_info)
+        assert config_entry.unique_id
+        self.entity_description = description
+        self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
+
+    @override
+    @property
+    def options(self) -> list[str] | None:
+        """Return the device-reported options for enum sensors."""
+        if (options_fn := self.entity_description.options_fn) is None:
+            return None
+        return options_fn(self._receiver)
+
+    @override
+    @property
+    def native_value(self) -> str | None:
+        """Return the current sensor value."""
+        return self.entity_description.value_fn(self._receiver)

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -40,6 +40,60 @@
       "main_zone": {
         "name": "Main zone"
       }
+    },
+    "number": {
+      "lipsync": {
+        "name": "Lip sync"
+      },
+      "trim_bass": {
+        "name": "Trim bass"
+      },
+      "trim_centre": {
+        "name": "Trim centre"
+      },
+      "trim_height": {
+        "name": "Trim height"
+      },
+      "trim_lfe": {
+        "name": "Trim LFE"
+      },
+      "trim_surround": {
+        "name": "Trim surround"
+      },
+      "trim_treble": {
+        "name": "Trim treble"
+      }
+    },
+    "select": {
+      "room_perfect_position": {
+        "name": "RoomPerfect position"
+      },
+      "voicing": {
+        "name": "Voicing"
+      }
+    },
+    "sensor": {
+      "audio_information": {
+        "name": "Audio information"
+      },
+      "audio_input": {
+        "name": "Audio input"
+      },
+      "streaming_source": {
+        "name": "Streaming source"
+      },
+      "video_information": {
+        "name": "Video information"
+      },
+      "video_input": {
+        "name": "Video input"
+      },
+      "zone_b_audio_input": {
+        "name": "Zone B audio input"
+      },
+      "zone_b_streaming_source": {
+        "name": "Zone B streaming source"
+      }
     }
   },
   "exceptions": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1537,7 +1537,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.4.9
+lyngdorf==1.6.0
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -127,6 +127,12 @@ def mock_find_receiver_model() -> Generator[AsyncMock]:
         yield find_mock
 
 
+def notify_receiver_update(receiver: MagicMock) -> None:
+    """Fire every notification callback the entities registered."""
+    for call in receiver.register_notification_callback.call_args_list:
+        call.args[0]()
+
+
 @pytest.fixture
 def platforms() -> list[Platform]:
     """Platforms to load; override per module to isolate a single platform."""

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -7,10 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from lyngdorf.const import LyngdorfModel
 from lyngdorf.device import Receiver
+from lyngdorf.models.base import NumericRange
 import pytest
 
-from homeassistant.components.lyngdorf.const import CONF_SERIAL_NUMBER, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_MODEL
+from homeassistant.components.lyngdorf.const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    PLATFORMS,
+)
+from homeassistant.const import CONF_HOST, CONF_MODEL, Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -67,11 +72,36 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver.sound_mode = None
         receiver.available_sound_modes = []
 
+        receiver.audio_information = None
+        receiver.video_information = None
+        receiver.audio_input = None
+        receiver.video_input = None
+        receiver.streaming_source = None
+        receiver.available_audio_inputs = []
+        receiver.available_video_inputs = []
+        receiver.available_stream_types = []
+
+        receiver.room_perfect_position = None
+        receiver.available_room_perfect_positions = []
+        receiver.voicing = None
+        receiver.available_voicings = []
+
+        receiver.lipsync = None
+        receiver.lipsync_range = NumericRange(0, 500, 1)
+        for _trim in ("bass", "treble", "centre", "height", "lfe", "surround"):
+            setattr(receiver, f"trim_{_trim}", None)
+        receiver.trim_bass_range = NumericRange(-12.0, 12.0, 0.1)
+        receiver.trim_treble_range = NumericRange(-12.0, 12.0, 0.1)
+        for _trim in ("centre", "height", "lfe", "surround"):
+            setattr(receiver, f"trim_{_trim}_range", NumericRange(-10.0, 10.0, 0.1))
+
         receiver.zone_b_power_on = False
         receiver.zone_b_volume = -40.0
         receiver.zone_b_mute_enabled = False
         receiver.zone_b_source = None
         receiver.zone_b_available_sources = []
+        receiver.zone_b_audio_input = None
+        receiver.zone_b_streaming_source = None
 
         create_mock.return_value = receiver
         yield receiver
@@ -98,15 +128,25 @@ def mock_find_receiver_model() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms to load; override per module to isolate a single platform."""
+    return list(PLATFORMS)
+
+
+@pytest.fixture
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_receiver: MagicMock,
+    platforms: list[Platform],
 ) -> MockConfigEntry:
     """Set up the Lyngdorf integration for testing."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.lyngdorf.lookup_receiver_model") as lookup:
+    with (
+        patch("homeassistant.components.lyngdorf.lookup_receiver_model") as lookup,
+        patch("homeassistant.components.lyngdorf.PLATFORMS", platforms),
+    ):
         lookup.return_value = LyngdorfModel.MP_60
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
     STATE_UNAVAILABLE,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -35,6 +36,12 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 MAIN_ZONE = "media_player.mock_lyngdorf_main_zone"
 ZONE_B = "media_player.mock_lyngdorf_zone_b"
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Only load the media player platform."""
+    return [Platform.MEDIA_PLAYER]
 
 
 async def test_entities(

--- a/tests/components/lyngdorf/test_number.py
+++ b/tests/components/lyngdorf/test_number.py
@@ -1,12 +1,15 @@
 """Tests for the Lyngdorf number platform."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from lyngdorf.const import LyngdorfModel
 import pytest
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+
+from .conftest import notify_receiver_update
 
 from tests.common import MockConfigEntry
 
@@ -53,12 +56,7 @@ async def test_number_values(
     mock_receiver.trim_lfe = 5.0
     mock_receiver.trim_surround = -1.0
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get(LIPSYNC_ENTITY_ID).state == "50.0"
@@ -78,12 +76,7 @@ async def test_set_lipsync(
     """Test setting the lipsync value."""
     mock_receiver.lipsync = 0
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -120,12 +113,7 @@ async def test_set_trim(
     """Test setting each trim value."""
     setattr(mock_receiver, attribute, 0.0)
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -149,8 +137,38 @@ async def test_number_none_values(
     """Test number entities show unknown when receiver values are None."""
     state = hass.states.get(LIPSYNC_ENTITY_ID)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     state = hass.states.get(TRIM_BASS_ENTITY_ID)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("mock_receiver")
+async def test_entities_absent_for_controls_the_model_lacks(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_receiver: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test no entity is created where the model has no such control.
+
+    Absence alone would also be produced by an entity that was created and
+    then failed, so this checks the setup stayed clean too.
+    """
+    mock_receiver.lipsync_range = None
+    mock_receiver.trim_surround_range = None
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.lyngdorf.lookup_receiver_model",
+        return_value=LyngdorfModel.MP_60,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(LIPSYNC_ENTITY_ID) is None
+    assert hass.states.get(TRIM_SURROUND_ENTITY_ID) is None
+    assert hass.states.get(TRIM_BASS_ENTITY_ID) is not None
+    assert "Error adding entity" not in caplog.text
+    assert "AssertionError" not in caplog.text

--- a/tests/components/lyngdorf/test_number.py
+++ b/tests/components/lyngdorf/test_number.py
@@ -1,0 +1,156 @@
+"""Tests for the Lyngdorf number platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+LIPSYNC_ENTITY_ID = "number.mock_lyngdorf_lip_sync"
+TRIM_BASS_ENTITY_ID = "number.mock_lyngdorf_trim_bass"
+TRIM_TREBLE_ENTITY_ID = "number.mock_lyngdorf_trim_treble"
+TRIM_CENTRE_ENTITY_ID = "number.mock_lyngdorf_trim_centre"
+TRIM_HEIGHT_ENTITY_ID = "number.mock_lyngdorf_trim_height"
+TRIM_LFE_ENTITY_ID = "number.mock_lyngdorf_trim_lfe"
+TRIM_SURROUND_ENTITY_ID = "number.mock_lyngdorf_trim_surround"
+
+
+async def test_number_entities_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that number entities are created."""
+    assert init_integration.state.value == "loaded"
+
+    for entity_id in (
+        LIPSYNC_ENTITY_ID,
+        TRIM_BASS_ENTITY_ID,
+        TRIM_TREBLE_ENTITY_ID,
+        TRIM_CENTRE_ENTITY_ID,
+        TRIM_HEIGHT_ENTITY_ID,
+        TRIM_LFE_ENTITY_ID,
+        TRIM_SURROUND_ENTITY_ID,
+    ):
+        assert hass.states.get(entity_id) is not None, f"{entity_id} not found"
+
+
+async def test_number_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that number entities reflect receiver values."""
+    mock_receiver.lipsync = 50
+    mock_receiver.trim_bass = -3.0
+    mock_receiver.trim_treble = 1.5
+    mock_receiver.trim_centre = -2.0
+    mock_receiver.trim_height = 0.0
+    mock_receiver.trim_lfe = 5.0
+    mock_receiver.trim_surround = -1.0
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(LIPSYNC_ENTITY_ID).state == "50.0"
+    assert hass.states.get(TRIM_BASS_ENTITY_ID).state == "-3.0"
+    assert hass.states.get(TRIM_TREBLE_ENTITY_ID).state == "1.5"
+    assert hass.states.get(TRIM_CENTRE_ENTITY_ID).state == "-2.0"
+    assert hass.states.get(TRIM_HEIGHT_ENTITY_ID).state == "0.0"
+    assert hass.states.get(TRIM_LFE_ENTITY_ID).state == "5.0"
+    assert hass.states.get(TRIM_SURROUND_ENTITY_ID).state == "-1.0"
+
+
+async def test_set_lipsync(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test setting the lipsync value."""
+    mock_receiver.lipsync = 0
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        "set_value",
+        {
+            ATTR_ENTITY_ID: LIPSYNC_ENTITY_ID,
+            "value": 75,
+        },
+        blocking=True,
+    )
+
+    assert mock_receiver.lipsync == 75
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "attribute"),
+    [
+        pytest.param(TRIM_BASS_ENTITY_ID, "trim_bass", id="bass"),
+        pytest.param(TRIM_TREBLE_ENTITY_ID, "trim_treble", id="treble"),
+        pytest.param(TRIM_CENTRE_ENTITY_ID, "trim_centre", id="centre"),
+        pytest.param(TRIM_HEIGHT_ENTITY_ID, "trim_height", id="height"),
+        pytest.param(TRIM_LFE_ENTITY_ID, "trim_lfe", id="lfe"),
+        pytest.param(TRIM_SURROUND_ENTITY_ID, "trim_surround", id="surround"),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_set_trim(
+    hass: HomeAssistant,
+    mock_receiver: MagicMock,
+    entity_id: str,
+    attribute: str,
+) -> None:
+    """Test setting each trim value."""
+    setattr(mock_receiver, attribute, 0.0)
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        "set_value",
+        {
+            ATTR_ENTITY_ID: entity_id,
+            "value": -6.0,
+        },
+        blocking=True,
+    )
+
+    assert getattr(mock_receiver, attribute) == -6.0
+
+
+async def test_number_none_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test number entities show unknown when receiver values are None."""
+    state = hass.states.get(LIPSYNC_ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+
+    state = hass.states.get(TRIM_BASS_ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"

--- a/tests/components/lyngdorf/test_select.py
+++ b/tests/components/lyngdorf/test_select.py
@@ -1,0 +1,127 @@
+"""Tests for the Lyngdorf select platform."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ROOM_PERFECT_ENTITY_ID = "select.mock_lyngdorf_roomperfect_position"
+VOICING_ENTITY_ID = "select.mock_lyngdorf_voicing"
+
+
+async def test_select_entities_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that select entities are created."""
+    assert init_integration.state.value == "loaded"
+    assert hass.states.get(ROOM_PERFECT_ENTITY_ID) is not None
+    assert hass.states.get(VOICING_ENTITY_ID) is not None
+
+
+async def test_room_perfect_current_option(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that the RoomPerfect select entity reflects the current position."""
+    mock_receiver.room_perfect_position = "focus"
+    mock_receiver.available_room_perfect_positions = ["focus", "global"]
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ROOM_PERFECT_ENTITY_ID)
+    assert state is not None
+    assert state.state == "focus"
+
+
+async def test_room_perfect_select_option(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test selecting a RoomPerfect position."""
+    mock_receiver.room_perfect_position = "focus"
+    mock_receiver.available_room_perfect_positions = ["focus", "global"]
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {
+            ATTR_ENTITY_ID: ROOM_PERFECT_ENTITY_ID,
+            "option": "global",
+        },
+        blocking=True,
+    )
+
+    assert mock_receiver.room_perfect_position == "global"
+
+
+async def test_voicing_current_option(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that the voicing select entity reflects the current voicing."""
+    mock_receiver.voicing = "Neutral"
+    mock_receiver.available_voicings = ["Neutral", "Music", "Movie"]
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(VOICING_ENTITY_ID)
+    assert state is not None
+    assert state.state == "Neutral"
+
+
+async def test_voicing_select_option(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test selecting a voicing."""
+    mock_receiver.voicing = "Neutral"
+    mock_receiver.available_voicings = ["Neutral", "Music", "Movie"]
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {
+            ATTR_ENTITY_ID: VOICING_ENTITY_ID,
+            "option": "Movie",
+        },
+        blocking=True,
+    )
+
+    assert mock_receiver.voicing == "Movie"

--- a/tests/components/lyngdorf/test_select.py
+++ b/tests/components/lyngdorf/test_select.py
@@ -6,6 +6,8 @@ from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
+from .conftest import notify_receiver_update
+
 from tests.common import MockConfigEntry
 
 ROOM_PERFECT_ENTITY_ID = "select.mock_lyngdorf_roomperfect_position"
@@ -32,12 +34,7 @@ async def test_room_perfect_current_option(
     mock_receiver.room_perfect_position = "focus"
     mock_receiver.available_room_perfect_positions = ["focus", "global"]
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     state = hass.states.get(ROOM_PERFECT_ENTITY_ID)
@@ -54,12 +51,7 @@ async def test_room_perfect_select_option(
     mock_receiver.room_perfect_position = "focus"
     mock_receiver.available_room_perfect_positions = ["focus", "global"]
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -84,12 +76,7 @@ async def test_voicing_current_option(
     mock_receiver.voicing = "Neutral"
     mock_receiver.available_voicings = ["Neutral", "Music", "Movie"]
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     state = hass.states.get(VOICING_ENTITY_ID)
@@ -106,12 +93,7 @@ async def test_voicing_select_option(
     mock_receiver.voicing = "Neutral"
     mock_receiver.available_voicings = ["Neutral", "Music", "Movie"]
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -1,0 +1,118 @@
+"""Tests for the Lyngdorf sensor platform."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensor_entities_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that sensor entities are created."""
+    assert init_integration.state.value == "loaded"
+
+    sensor_keys = [
+        "audio_information",
+        "video_information",
+        "audio_input",
+        "video_input",
+        "streaming_source",
+        "zone_b_audio_input",
+        "zone_b_streaming_source",
+    ]
+    for key in sensor_keys:
+        state = hass.states.get(f"sensor.mock_lyngdorf_{key}")
+        assert state is not None, f"sensor.mock_lyngdorf_{key} not found"
+
+
+async def test_main_zone_sensor_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test main zone sensor values update from receiver."""
+    mock_receiver.audio_information = "Stereo"
+    mock_receiver.video_information = "4K HDR"
+    mock_receiver.audio_input = "optical"
+    mock_receiver.video_input = "hdmi"
+    mock_receiver.streaming_source = "AirPlay"
+    mock_receiver.available_audio_inputs = ["optical", "aux"]
+    mock_receiver.available_video_inputs = ["hdmi"]
+    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
+
+    # Trigger callback to update states
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_audio_information").state == "Stereo"
+    assert hass.states.get("sensor.mock_lyngdorf_video_information").state == "4K HDR"
+    assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == "optical"
+    assert hass.states.get("sensor.mock_lyngdorf_video_input").state == "hdmi"
+    assert hass.states.get("sensor.mock_lyngdorf_streaming_source").state == "AirPlay"
+
+
+async def test_zone_b_sensor_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test zone B sensor values update from receiver."""
+    mock_receiver.zone_b_audio_input = "aux"
+    mock_receiver.zone_b_streaming_source = "DLNA"
+    mock_receiver.available_audio_inputs = ["optical", "aux"]
+    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
+
+    # Trigger callback to update states
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_zone_b_audio_input").state == "aux"
+    assert (
+        hass.states.get("sensor.mock_lyngdorf_zone_b_streaming_source").state == "DLNA"
+    )
+
+
+async def test_sensor_none_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test sensors show unknown when receiver values are None."""
+    state = hass.states.get("sensor.mock_lyngdorf_audio_information")
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_enum_sensor_ignores_unknown_device_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test an input the library could not name is reported as unknown."""
+    mock_receiver.available_audio_inputs = ["optical"]
+    mock_receiver.audio_input = "audio-37"
+
+    callbacks = [
+        call.args[0]
+        for call in mock_receiver.register_notification_callback.call_args_list
+    ]
+    for cb in callbacks:
+        cb()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == STATE_UNKNOWN

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
+from .conftest import notify_receiver_update
+
 from tests.common import MockConfigEntry
 
 
@@ -46,12 +48,7 @@ async def test_main_zone_sensor_values(
     mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
 
     # Trigger callback to update states
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.mock_lyngdorf_audio_information").state == "Stereo"
@@ -73,12 +70,7 @@ async def test_zone_b_sensor_values(
     mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
 
     # Trigger callback to update states
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.mock_lyngdorf_zone_b_audio_input").state == "aux"
@@ -95,7 +87,7 @@ async def test_sensor_none_values(
     """Test sensors show unknown when receiver values are None."""
     state = hass.states.get("sensor.mock_lyngdorf_audio_information")
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_enum_sensor_ignores_unknown_device_value(
@@ -107,12 +99,7 @@ async def test_enum_sensor_ignores_unknown_device_value(
     mock_receiver.available_audio_inputs = ["optical"]
     mock_receiver.audio_input = "audio-37"
 
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> [!NOTE]
> Based on #179410, so that bump appears here until it merges, after which this diff is the platforms alone.

Restores the three platforms removed in fbe8e774bf4 so the initial pull request covered a single platform, as the reviewer asked at the time.

**Numbers** cover lip sync and the six trims. Their ranges and step come from the library rather than being hardcoded here: the values removed earlier had the trim step and the lip sync maximum wrong, and the device reports both. Entities are created only where the model has the control, which the library signals with a `None` range, so a TDAI gets neither lip sync nor the surround trims.

**Selects** cover the RoomPerfect position and voicing. The library already takes and returns their names and raises on an unknown one, so nothing needs translating here.

**Sensors** report the active inputs, the incoming signal formats and the streaming source, as diagnostic entities. The three backed by lookup tables use `SensorDeviceClass.ENUM`. Values the library could not name deliberately escape those tables as synthetic strings, which cannot be in a closed options list, so those are reported as unknown rather than as an option outside the list.

Zone B sensors are created only on models that have a Zone B.

Settles `entity-category`, `entity-disabled-by-default` and `icon-translations`, which were previously exempt on the grounds that the media player was the only platform.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47460
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
