### PR TITLE
Make DeviceRegistry.child_devices protected

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -12,6 +12,7 @@ import logging
 import os
 import shutil
 import time
+from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1761,7 +1762,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     """Class to hold a registry of devices."""
 
     devices: ActiveDeviceRegistryItems
-    child_devices: ChildDeviceRegistryItems
+    _child_devices: ChildDeviceRegistryItems
     deleted_devices: DeletedDeviceRegistryItems
     _device_data: dict[str, DeviceEntry]
     _child_device_data: dict[str, ChildDeviceEntry]
@@ -1782,6 +1783,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             minor_version=STORAGE_VERSION_MINOR,
             serialize_in_event_loop=False,
         )
+
+    @under_cached_property
+    def child_devices(self) -> MappingProxyType[str, ChildDeviceEntry]:
+        """Return a read-only view of the child devices, keyed by child device id."""
+        return MappingProxyType(self._child_device_data)
 
     @overload
     def async_get(
@@ -1961,7 +1967,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         Identifiers are unique within a config entry, so the lookup cannot be
         ambiguous.
         """
-        return self.child_devices.get_entry(
+        return self._child_devices.get_entry(
             identifiers={identifier}, config_entry_id=config_entry_id
         )
 
@@ -2265,7 +2271,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # We do not allow registering a device without parent_device_id if the
         # identifiers match an existing child.
         if (
-            matched_child_device := self.child_devices.get_entry(
+            matched_child_device := self._child_devices.get_entry(
                 identifiers=identifiers, config_entry_id=config_entry_id
             )
         ) is not None:
@@ -2605,7 +2611,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 f"parent device {parent.id}",
             )
 
-        child_device = self.child_devices.get_entry(
+        child_device = self._child_devices.get_entry(
             identifiers=identifiers, config_entry_id=config_entry_id
         )
 
@@ -2613,7 +2619,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # owned by another child device.
         for identifier in sorted(identifiers):
             if (
-                other_child := self.child_devices.get_entry(
+                other_child := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) is not None and (
@@ -2709,7 +2715,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 )
                 disabled_by = UNDEFINED
 
-            self.child_devices[child_device.id] = child_device
+            self._child_devices[child_device.id] = child_device
 
         self._async_purge_colliding_deleted_devices(child_device, identifiers, set())
 
@@ -2746,7 +2752,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             raise DeviceInfoError(
                 config_entry.domain, device_info, "a device can't be its own parent"
             )
-        if self.child_devices.get_children_for_device_id(device.id):
+        if self._child_devices.get_children_for_device_id(device.id):
             raise DeviceInfoError(
                 config_entry.domain,
                 device_info,
@@ -2839,7 +2845,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             parent_device_id=parent.id,
         )
         del self.devices[device.id]
-        self.child_devices[child_device.id] = child_device
+        self._child_devices[child_device.id] = child_device
 
         # A via_device_id must not resolve to a child device; detach inbound via
         # links to the converted device, as async_remove_device does, before firing
@@ -3079,7 +3085,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 # A parent with child devices can't move (enforced again below); reject
                 # here before mutating the runtime-only sibling pending moves, so the
                 # rejected move leaves no partial state behind.
-                if self.child_devices.get_children_for_device_id(device_id):
+                if self._child_devices.get_children_for_device_id(device_id):
                     raise HomeAssistantError(
                         f"Can't move device {device_id}: it has child devices"
                     )
@@ -3148,7 +3154,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # supported.
         if (
             is_move or "config_subentry_id" in new_values
-        ) and self.child_devices.get_children_for_device_id(device_id):
+        ) and self._child_devices.get_children_for_device_id(device_id):
             raise HomeAssistantError(
                 f"Can't move device {device_id}: it has child devices"
             )
@@ -3350,7 +3356,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # async_config_entry_disabled_by_changed, which iterates all the config
         # entry's devices.
         if "disabled_by" in old_values and (
-            children := self.child_devices.get_children_for_device_id(device_id)
+            children := self._child_devices.get_children_for_device_id(device_id)
         ):
             if new.disabled_by is None:
                 for child in children:
@@ -3380,7 +3386,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
     ) -> ChildDeviceEntry | None:
         """Private update child device attributes."""
-        old = self.child_devices[child_device_id]
+        old = self._child_devices[child_device_id]
 
         new_values: dict[str, Any] = {}  # Dict with new key/value pairs
         old_values: dict[str, Any] = {}  # Dict with old key/value pairs
@@ -3505,7 +3511,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         self.hass.verify_event_loop_thread("device_registry._async_update_child_device")
         new = attr.evolve(old, **new_values)
-        self.child_devices[child_device_id] = new
+        self._child_devices[child_device_id] = new
 
         # A deleted device holding an identity the child device now owns can never
         # restore
@@ -3893,7 +3899,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             ) and existing_device.id != device_id:
                 raise DeviceIdentifierCollisionError(identifiers, existing_device)
             if (
-                existing_child_device := self.child_devices.get_entry(
+                existing_child_device := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) is not None:
@@ -3915,7 +3921,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """
         for identifier in identifiers:
             if (
-                existing_child_device := self.child_devices.get_entry(
+                existing_child_device := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) and existing_child_device.id != child_device_id:
@@ -3983,7 +3989,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             return
         self.hass.verify_event_loop_thread("device_registry.async_remove_device")
         # Removing the parent removes its child devices
-        for child in self.child_devices.get_children_for_device_id(device_id):
+        for child in self._child_devices.get_children_for_device_id(device_id):
             self._async_remove_child_device(child)
         device = self.devices.pop(device_id)
         config_entry = self.hass.config_entries.async_get_entry(device.config_entry_id)
@@ -4017,7 +4023,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     def _async_remove_child_device(self, child_device: ChildDeviceEntry) -> None:
         """Remove a child device from the device registry."""
         self.hass.verify_event_loop_thread("device_registry.async_remove_device")
-        del self.child_devices[child_device.id]
+        del self._child_devices[child_device.id]
         config_entry = self.hass.config_entries.async_get_entry(
             child_device.config_entry_id
         )
@@ -4195,7 +4201,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             )
 
         self.devices = devices
-        self.child_devices = child_devices
+        self._child_devices = child_devices
         self.deleted_devices = deleted_devices
         self._device_data = devices.data
         self._child_device_data = child_devices.data
@@ -4222,7 +4228,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 entry.as_storage_fragment for entry in list(self.devices.values())
             ],
             "child_devices": [
-                entry.as_storage_fragment for entry in list(self.child_devices.values())
+                entry.as_storage_fragment
+                for entry in list(self._child_devices.values())
             ],
             "deleted_devices": [
                 entry.as_storage_fragment
@@ -4290,7 +4297,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self.async_remove_device(device.id)
         # Child devices share their parent's config entry, so the loop above removes
         # them through the parent cascade; guard against store corruption anyway.
-        for child_device in self.child_devices.get_devices_for_config_entry_id(
+        for child_device in self._child_devices.get_devices_for_config_entry_id(
             config_entry_id
         ):
             self.async_remove_device(child_device.id)
@@ -4331,7 +4338,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self.async_remove_device(device.id)
         # Child devices share their parent's subentry, so the loop above removes them
         # through the parent cascade; guard against store corruption anyway.
-        for child_device in self.child_devices.get_devices_for_config_entry_id(
+        for child_device in self._child_devices.get_devices_for_config_entry_id(
             config_entry_id
         ):
             if child_device.config_subentry_id != config_subentry_id:
@@ -4379,7 +4386,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """Clear area id from registry entries."""
         for device in self.devices.get_devices_for_area_id(area_id):
             self._async_update_device(device.id, area_id=None)
-        for child_device in self.child_devices.get_devices_for_area_id(area_id):
+        for child_device in self._child_devices.get_devices_for_area_id(area_id):
             self._async_update_child_device(child_device.id, area_id=None)
         for deleted_device in list(self.deleted_devices.values()):
             if deleted_device.area_id != area_id:
@@ -4394,7 +4401,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """Clear label from registry entries."""
         for device in self.devices.get_devices_for_label(label_id):
             self._async_update_device(device.id, labels=device.labels - {label_id})
-        for child_device in self.child_devices.get_devices_for_label(label_id):
+        for child_device in self._child_devices.get_devices_for_label(label_id):
             self._async_update_child_device(
                 child_device.id, labels=child_device.labels - {label_id}
             )
@@ -4462,11 +4469,13 @@ def async_entries_for_area(
     """
     devices = registry.devices.get_devices_for_area_id(area_id)
     entries: list[AnyDeviceEntry] = list(devices)
-    entries.extend(registry.child_devices.get_devices_for_area_id(area_id))
+    entries.extend(
+        registry._child_devices.get_devices_for_area_id(area_id)  # noqa: SLF001
+    )
     for device in devices:
         entries.extend(
             child_device
-            for child_device in registry.child_devices.get_children_for_device_id(
+            for child_device in registry._child_devices.get_children_for_device_id(  # noqa: SLF001
                 device.id
             )
             if child_device.area_id is None
@@ -4505,7 +4514,9 @@ def async_entries_for_label(
     entries: list[AnyDeviceEntry] = list(
         registry.devices.get_devices_for_label(label_id)
     )
-    entries.extend(registry.child_devices.get_devices_for_label(label_id))
+    entries.extend(
+        registry._child_devices.get_devices_for_label(label_id)  # noqa: SLF001
+    )
     return entries
 
 
@@ -4522,7 +4533,9 @@ def async_entries_for_parent_device(
     registry: DeviceRegistry, parent_device_id: str
 ) -> list[ChildDeviceEntry]:
     """Return the child device entries of a parent device."""
-    return registry.child_devices.get_children_for_device_id(parent_device_id)
+    return registry._child_devices.get_children_for_device_id(  # noqa: SLF001
+        parent_device_id
+    )
 
 
 @callback
@@ -4530,7 +4543,9 @@ def async_child_entries_for_config_entry(
     registry: DeviceRegistry, config_entry_id: str
 ) -> list[ChildDeviceEntry]:
     """Return child device entries that match a config entry."""
-    return registry.child_devices.get_devices_for_config_entry_id(config_entry_id)
+    return registry._child_devices.get_devices_for_config_entry_id(  # noqa: SLF001
+        config_entry_id
+    )
 
 
 @callback

--- a/homeassistant/helpers/target.py
+++ b/homeassistant/helpers/target.py
@@ -165,8 +165,8 @@ def _resolve_referenced_devices(
             selected.referenced_devices.add(device_id)
             selected.referenced_devices.update(
                 child_device.id
-                for child_device in dev_reg.child_devices.get_children_for_device_id(
-                    device_id
+                for child_device in dr.async_entries_for_parent_device(
+                    dev_reg, device_id
                 )
             )
         elif device_id in dev_reg.child_devices:
@@ -183,10 +183,8 @@ def _resolve_referenced_devices(
                 selected.referenced_devices.add(split_device.id)
                 selected.referenced_devices.update(
                     child_device.id
-                    for child_device in (
-                        dev_reg.child_devices.get_children_for_device_id(
-                            split_device.id
-                        )
+                    for child_device in dr.async_entries_for_parent_device(
+                        dev_reg, split_device.id
                     )
                 )
         else:

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -249,7 +249,7 @@ def test_entities_areas_area_inherited_from_parent(hass: HomeAssistant) -> None:
         },
     )
     # The child has no area of its own and inherits the parent's area.
-    device_registry.child_devices["mock-child-id"] = ChildDeviceEntry(
+    device_registry._child_devices["mock-child-id"] = ChildDeviceEntry(
         config_entry_id="mock-config-entry",
         id="mock-child-id",
         parent_device_id="mock-parent-id",

--- a/tests/common.py
+++ b/tests/common.py
@@ -761,8 +761,8 @@ def mock_device_registry(
     registry = dr.DeviceRegistry(hass)
     registry.devices = dr.ActiveDeviceRegistryItems()
     registry._device_data = registry.devices.data
-    registry.child_devices = dr.ChildDeviceRegistryItems()
-    registry._child_device_data = registry.child_devices.data
+    registry._child_devices = dr.ChildDeviceRegistryItems()
+    registry._child_device_data = registry._child_devices.data
     if mock_entries is None:
         mock_entries = {}
     for key, entry in mock_entries.items():

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -12001,7 +12001,7 @@ async def test_recreate_child_clears_stale_config_entry_disable(
     _, child_device = _create_parent_and_child(
         device_registry, mock_config_entry.entry_id
     )
-    device_registry.child_devices[child_device.id] = attr.evolve(
+    device_registry._child_devices[child_device.id] = attr.evolve(
         device_registry.async_get(child_device.id, include_main_devices=False),
         disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `DeviceRegistry.child_devices` protected and add a property which returns a `MappingProxy` wrapper of the underlying containers to allow iterating and member checks

Rationale:
`DeviceRegistry.child_devices` contains a lot of details which we don't want integrations to rely on. We also don't want integrations to mutate the container.

In follow-up PRs, `DeviceRegistry.devices` and `DeviceRegistry.deleted_devices` will also be protected

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
