### PR TITLE
Revert host update on Overkiz local gateway rediscovery

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -476,18 +476,13 @@ class OverkizConfigFlow(
         if discovery_info.type == "_kizboxdev._tcp.local.":
             self._host = f"{discovery_info.hostname[:-1]}:{discovery_info.port}"
             self._api_type = APIType.LOCAL
-            return await self._process_discovery(
-                gateway_id, updates={CONF_HOST: self._host}
-            )
 
         return await self._process_discovery(gateway_id)
 
-    async def _process_discovery(
-        self, gateway_id: str, *, updates: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def _process_discovery(self, gateway_id: str) -> ConfigFlowResult:
         """Handle discovery of a gateway."""
         await self.async_set_unique_id(gateway_id)
-        self._abort_if_unique_id_configured(updates=updates)
+        self._abort_if_unique_id_configured()
         self.context["title_placeholders"] = {"gateway_id": gateway_id}
 
         return await self.async_step_user()

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
 
   # Gold
   docs-examples: todo
-  discovery-update-info: done
+  discovery-update-info: todo
   entity-device-class: done
   entity-translations: todo
   docs-data-update: done

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -1322,32 +1322,6 @@ async def test_zeroconf_flow_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_local_zeroconf_flow_updates_host(hass: HomeAssistant) -> None:
-    """Test that rediscovery of a local gateway refreshes the stored host."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id=TEST_GATEWAY_ID,
-        data={
-            "host": "gateway-1234-5678-9123.local:9999",
-            "token": TEST_TOKEN,
-            "verify_ssl": False,
-            "hub": TEST_SERVER,
-            "api_type": "local",
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        data=FAKE_ZERO_CONF_INFO_LOCAL,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert config_entry.data["host"] == "gateway-1234-5678-9123.local:8443"
-
-
 @pytest.fixture
 async def setup_rexel_credentials(hass: HomeAssistant) -> None:
     """Set up the application credential used by the Rexel OAuth2 flow."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reverts #176857, a regression in 2026.8.0.

That PR refreshed `CONF_HOST` on every `_kizboxdev` zeroconf rediscovery. Because a gateway re-announces itself continuously, an entry configured by IP address was silently rewritten to `gateway-XXXX-XXXX-XXXX.local:8443`, and on networks that cannot resolve `.local` all entities became unavailable.

Doing this correctly requires preserving the form of the configured address, since the gateway certificate is only valid for its `.local` name. That is more than a one-line `updates=`, so this reverts to the previous behaviour (`discovery-update-info` back to `todo`) and a proper implementation follows separately.

Affected users have to reconfigure once — an entry that was already rewritten cannot be restored automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178357
- This PR is related to issue: reverts #176857
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
