### PR TITLE
Fix Vizio media player crash when volume is missing from audio settings

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -154,9 +154,12 @@ class VizioDevice(VizioEntity, MediaPlayerEntity):
 
         # Audio settings
         if data.audio_settings:
-            self._attr_volume_level = (
-                float(data.audio_settings[VIZIO_VOLUME].value) / self._max_volume
-            )
+            if VIZIO_VOLUME in data.audio_settings:
+                self._attr_volume_level = (
+                    float(data.audio_settings[VIZIO_VOLUME].value) / self._max_volume
+                )
+            else:
+                self._attr_volume_level = None
             if VIZIO_MUTE in data.audio_settings:
                 self._attr_is_volume_muted = (
                     str(data.audio_settings[VIZIO_MUTE].value).lower() == VIZIO_MUTE_ON

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -290,6 +290,27 @@ async def _test_service(
 
 
 @pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_tv_without_volume_in_audio_settings(
+    hass: HomeAssistant, mock_tv_config_entry: MockConfigEntry
+) -> None:
+    """Test a TV whose audio settings omit volume.
+
+    Some firmware does not list `volume` (or `mute`) in the `audio`
+    settings collection even though the individual settings still work.
+    The entity must still load, with the unavailable attributes reported
+    as None instead of raising on every coordinator update.
+    """
+    async with _cm_for_test_setup_without_apps({"eq": CURRENT_EQ}, True):
+        await setup_integration(hass, mock_tv_config_entry)
+
+        attr = _get_attr_and_assert_base_attr(hass, MediaPlayerDeviceClass.TV, STATE_ON)
+        # Unset attributes are omitted from the state entirely.
+        assert attr.get("volume_level") is None
+        assert attr.get("is_volume_muted") is None
+        assert attr[ATTR_SOUND_MODE] == CURRENT_EQ
+
+
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
 async def test_speaker_on(
     hass: HomeAssistant, mock_speaker_config_entry: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
## Proposed change

Some Vizio firmware does not list `volume` in the `audio` settings collection, even though the individual `tv_settings/audio/volume` resource still returns a perfectly good value. The lookup in `_handle_coordinator_update` is unguarded, so it raises `KeyError: 'volume'` on every coordinator update (~every 30 s) and the `media_player` entity stays permanently unavailable. The `remote` entity from the same config entry keeps working, which makes this look like a partial setup failure rather than a crash loop.

The two lines immediately after it — for mute and sound mode — are already guarded, so this reads as an oversight rather than a deliberate assumption. This guards `volume` the same way.

Affected firmware generally omits `mute` from the collection as well, so both attributes now report as unknown instead of taking the entity down.

Deliberately scoped to stopping the crash, with no dependency bump, so it can be backported. Actually *reporting* volume on these devices needs a library change and is left to a follow-up.

This has been reported several times and closed as stale without being root-caused: #143807, #146391 (with two additional users confirming), and #163886.

There is direct precedent for this class of fix in this integration: #32151 switched `volume_step` to `.get()` because it is optional, and #34730 / #34782 added the mute guard after an identical `KeyError: 'mute'`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179254

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
