### PR TITLE
Bump vizaio to 0.5.0

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["vizaio"],
-  "requirements": ["vizaio==0.4.0"],
+  "requirements": ["vizaio==0.5.0"],
   "zeroconf": ["_viziocast._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3333,7 +3333,7 @@ vilfo-api-client==0.5.0
 visionpluspython==1.1.0
 
 # homeassistant.components.vizio
-vizaio==0.4.0
+vizaio==0.5.0
 
 # homeassistant.components.caldav
 vobject==0.9.9


### PR DESCRIPTION
## Proposed change

Bumps `vizaio` from 0.4.0 to 0.5.0.

Source repository: https://github.com/raman325/vizaio

**Full Changelog**, 0.4.0 → 0.5.0: https://github.com/raman325/vizaio/compare/v0.4.0...v0.5.0

Release notes: [0.4.1](https://github.com/raman325/vizaio/releases/tag/v0.4.1) · [0.5.0](https://github.com/raman325/vizaio/releases/tag/v0.5.0)

### Changelog

**0.5.0** ([v0.4.1...v0.5.0](https://github.com/raman325/vizaio/compare/v0.4.1...v0.5.0))

- Support the flat volume API on newer TV firmware ([#46](https://github.com/raman325/vizaio/pull/46)). Newer TVs expose a flat `/audio/volume/*` family alongside the `menu_native` settings tree, gated on the API version the device reports. The library detects that, routes reads and writes to the matching surface, and falls back automatically when an endpoint turns out to be absent. Adds `get_max_volume()`, `get_api_version()` and `supports_volume_v2()` to the public API.

**0.4.1** ([v0.4.0...v0.4.1](https://github.com/raman325/vizaio/compare/v0.4.0...v0.4.1))

- Don't let identity getters swallow transport errors ([#44](https://github.com/raman325/vizaio/pull/44)). `get_esn()`, `get_serial_number()` and `get_version()` previously turned connection failures into empty strings, hiding an unreachable device.
- Give commands a longer timeout than reads ([#45](https://github.com/raman325/vizaio/pull/45)).

### Impact on this integration

**Backward compatible.** Every method the integration calls keeps the same signature and semantics, so this PR changes no integration code. The existing test suite passes unmodified against 0.5.0.

The endpoint selection added in 0.5.0 is entirely internal — the integration's existing `set_volume()`, `mute()` and `volume_up()` calls take the better path automatically on qualifying TVs, with no code change here.

Consuming the newly public capabilities is left to a follow-up so this stays a pure dependency bump.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Related to #179254. The follow-up that consumes these capabilities addresses the underlying cause; #179431 stopped the crash on its own without needing this bump.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

