### PR TITLE
Fix TypeError for unconfigured accounts in Steam integration

### DIFF
--- a/homeassistant/components/steam_online/coordinator.py
+++ b/homeassistant/components/steam_online/coordinator.py
@@ -26,7 +26,7 @@ class PlayerData:
 
     steamid: str
     communityvisibilitystate: int
-    profilestate: int
+    profilestate: int | None = None
     personaname: str
     commentpermission: int | None = None
     profileurl: str
@@ -34,7 +34,7 @@ class PlayerData:
     avatarmedium: str
     avatarfull: str
     avatarhash: str
-    lastlogoff: int
+    lastlogoff: int | None = None
     personastate: int
     realname: str | None = None
     primaryclanid: str | None = None
@@ -47,6 +47,7 @@ class PlayerData:
     gameid: str | None = None
     lobbysteamid: str | None = None
     gameserverip: str | None = None
+    gameserversteamid: str | None = None
     level: int | None = None
 
 

--- a/homeassistant/components/steam_online/sensor.py
+++ b/homeassistant/components/steam_online/sensor.py
@@ -86,14 +86,24 @@ SENSOR_DESCRIPTIONS: tuple[SteamSensorEntityDescription, ...] = (
                 if x.gameid is not None and (info := icons.get(x.gameid)) is not None
                 else None
             ),
-            "last_online": dt_util.utc_from_timestamp(x.lastlogoff),
+            "last_online": (
+                dt_util.utc_from_timestamp(x.lastlogoff)
+                if x.lastlogoff is not None
+                else None
+            ),
             "level": x.level,
         },
     ),
     SteamSensorEntityDescription(
         key=SteamSensor.LAST_ONLINE,
         translation_key=SteamSensor.LAST_ONLINE,
-        value_fn=(lambda x: dt_util.utc_from_timestamp(x.lastlogoff)),
+        value_fn=(
+            lambda x: (
+                dt_util.utc_from_timestamp(x.lastlogoff)
+                if x.lastlogoff is not None
+                else None
+            )
+        ),
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SteamSensorEntityDescription(

--- a/tests/components/steam_online/conftest.py
+++ b/tests/components/steam_online/conftest.py
@@ -27,6 +27,12 @@ def mock_config_entry() -> MockConfigEntry:
                 title=ACCOUNT_NAME_2,
                 unique_id=ACCOUNT_2,
             ),
+            ConfigSubentryData(
+                data={},
+                subentry_type=SUBENTRY_TYPE_FRIEND,
+                title="unconfigured_account",
+                unique_id="1234567890",
+            ),
         ],
         version=3,
     )

--- a/tests/components/steam_online/fixtures/GetPlayerSummaries.json
+++ b/tests/components/steam_online/fixtures/GetPlayerSummaries.json
@@ -37,6 +37,20 @@
           "personastate": 2,
           "timecreated": 1303243041,
           "personastateflags": 0
+        },
+        {
+          "steamid": "1234567890",
+          "communityvisibilitystate": 3,
+          "personaname": "unconfigured_account",
+          "profileurl": "https://steamcommunity.com/profiles/1234567890/",
+          "avatar": "https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb.jpg",
+          "avatarmedium": "https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_medium.jpg",
+          "avatarfull": "https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg",
+          "avatarhash": "fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb",
+          "personastate": 0,
+          "primaryclanid": "1234567890",
+          "timecreated": 1786993711,
+          "personastateflags": 0
         }
       ]
     }

--- a/tests/components/steam_online/snapshots/test_image.ambr
+++ b/tests/components/steam_online/snapshots/test_image.ambr
@@ -1030,3 +1030,514 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_images[image.unconfigured_app_icon-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_app_icon',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'App icon',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'App icon',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.APP_ICON: 'app_icon'>,
+    'unique_id': '1234567890_app_icon',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_app_icon-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_app_icon?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured App icon',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_app_icon',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_avatar-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_avatar',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Avatar',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Avatar',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.AVATAR: 'avatar'>,
+    'unique_id': '1234567890_avatar',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_avatar-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '520',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_avatar?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Avatar',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_avatar',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2013-12-13T12:13:12+00:00',
+  })
+# ---
+# name: test_images[image.unconfigured_header_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_header_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Header capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Header capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.HEADER_CAPSULE: 'header_capsule'>,
+    'unique_id': '1234567890_header_capsule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_header_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_header_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Header capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_header_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_library_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_library_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Library capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Library capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.LIBRARY_CAPSULE: 'library_capsule'>,
+    'unique_id': '1234567890_library_capsule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_library_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_library_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_library_hero_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_library_hero_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Library hero capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Library hero capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.LIBRARY_HERO: 'library_hero'>,
+    'unique_id': '1234567890_library_hero',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_library_hero_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_hero_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library hero capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_library_hero_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_library_logo-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_library_logo',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Library logo',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Library logo',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.LIBRARY_LOGO: 'library_logo'>,
+    'unique_id': '1234567890_library_logo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_library_logo-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_logo?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library logo',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_library_logo',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_main_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_main_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Main capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Main capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.MAIN_CAPSULE: 'main_capsule'>,
+    'unique_id': '1234567890_main_capsule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_main_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_main_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Main capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_main_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_page_background-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_page_background',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Page background',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Page background',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.PAGE_BACKGROUND: 'page_background'>,
+    'unique_id': '1234567890_page_background',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_page_background-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_page_background?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Page background',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_page_background',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_small_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_small_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Small capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Small capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.SMALL_CAPSULE: 'small_capsule'>,
+    'unique_id': '1234567890_small_capsule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_small_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_small_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Small capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_small_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_images[image.unconfigured_vertical_capsule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.unconfigured_vertical_capsule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vertical capsule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vertical capsule',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamImage.VERTICAL_CAPSULE: 'vertical_capsule'>,
+    'unique_id': '1234567890_vertical_capsule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[image.unconfigured_vertical_capsule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_vertical_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Vertical capsule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.unconfigured_vertical_capsule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---

--- a/tests/components/steam_online/snapshots/test_image.ambr
+++ b/tests/components/steam_online/snapshots/test_image.ambr
@@ -1030,7 +1030,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_app_icon-entry]
+# name: test_images[image.unconfigured_account_app_icon-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1044,7 +1044,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_app_icon',
+    'entity_id': 'image.unconfigured_account_app_icon',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1067,21 +1067,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_app_icon-state]
+# name: test_images[image.unconfigured_account_app_icon-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_app_icon?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured App icon',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_app_icon?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account App icon',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_app_icon',
+    'entity_id': 'image.unconfigured_account_app_icon',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_avatar-entry]
+# name: test_images[image.unconfigured_account_avatar-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1095,7 +1095,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_avatar',
+    'entity_id': 'image.unconfigured_account_avatar',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1118,22 +1118,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_avatar-state]
+# name: test_images[image.unconfigured_account_avatar-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '520',
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_avatar?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Avatar',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_avatar?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Avatar',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_avatar',
+    'entity_id': 'image.unconfigured_account_avatar',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2013-12-13T12:13:12+00:00',
   })
 # ---
-# name: test_images[image.unconfigured_header_capsule-entry]
+# name: test_images[image.unconfigured_account_header_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1147,7 +1147,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_header_capsule',
+    'entity_id': 'image.unconfigured_account_header_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1170,21 +1170,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_header_capsule-state]
+# name: test_images[image.unconfigured_account_header_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_header_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Header capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_header_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Header capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_header_capsule',
+    'entity_id': 'image.unconfigured_account_header_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_library_capsule-entry]
+# name: test_images[image.unconfigured_account_library_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1198,7 +1198,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_library_capsule',
+    'entity_id': 'image.unconfigured_account_library_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1221,21 +1221,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_library_capsule-state]
+# name: test_images[image.unconfigured_account_library_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_library_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Library capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_library_capsule',
+    'entity_id': 'image.unconfigured_account_library_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_library_hero_capsule-entry]
+# name: test_images[image.unconfigured_account_library_hero_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1249,7 +1249,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_library_hero_capsule',
+    'entity_id': 'image.unconfigured_account_library_hero_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1272,21 +1272,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_library_hero_capsule-state]
+# name: test_images[image.unconfigured_account_library_hero_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_hero_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library hero capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_library_hero_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Library hero capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_library_hero_capsule',
+    'entity_id': 'image.unconfigured_account_library_hero_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_library_logo-entry]
+# name: test_images[image.unconfigured_account_library_logo-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1300,7 +1300,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_library_logo',
+    'entity_id': 'image.unconfigured_account_library_logo',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1323,21 +1323,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_library_logo-state]
+# name: test_images[image.unconfigured_account_library_logo-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_library_logo?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Library logo',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_library_logo?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Library logo',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_library_logo',
+    'entity_id': 'image.unconfigured_account_library_logo',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_main_capsule-entry]
+# name: test_images[image.unconfigured_account_main_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1351,7 +1351,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_main_capsule',
+    'entity_id': 'image.unconfigured_account_main_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1374,21 +1374,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_main_capsule-state]
+# name: test_images[image.unconfigured_account_main_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_main_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Main capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_main_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Main capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_main_capsule',
+    'entity_id': 'image.unconfigured_account_main_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_page_background-entry]
+# name: test_images[image.unconfigured_account_page_background-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1402,7 +1402,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_page_background',
+    'entity_id': 'image.unconfigured_account_page_background',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1425,21 +1425,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_page_background-state]
+# name: test_images[image.unconfigured_account_page_background-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_page_background?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Page background',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_page_background?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Page background',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_page_background',
+    'entity_id': 'image.unconfigured_account_page_background',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_small_capsule-entry]
+# name: test_images[image.unconfigured_account_small_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1453,7 +1453,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_small_capsule',
+    'entity_id': 'image.unconfigured_account_small_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1476,21 +1476,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_small_capsule-state]
+# name: test_images[image.unconfigured_account_small_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_small_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Small capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_small_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Small capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_small_capsule',
+    'entity_id': 'image.unconfigured_account_small_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_images[image.unconfigured_vertical_capsule-entry]
+# name: test_images[image.unconfigured_account_vertical_capsule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1504,7 +1504,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.unconfigured_vertical_capsule',
+    'entity_id': 'image.unconfigured_account_vertical_capsule',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1527,14 +1527,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_images[image.unconfigured_vertical_capsule-state]
+# name: test_images[image.unconfigured_account_vertical_capsule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_vertical_capsule?token=520',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Vertical capsule',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.unconfigured_account_vertical_capsule?token=520',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Vertical capsule',
     }),
     'context': <ANY>,
-    'entity_id': 'image.unconfigured_vertical_capsule',
+    'entity_id': 'image.unconfigured_account_vertical_capsule',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/steam_online/snapshots/test_sensor.ambr
+++ b/tests/components/steam_online/snapshots/test_sensor.ambr
@@ -470,3 +470,238 @@
     'state': 'unknown',
   })
 # ---
+# name: test_sensors[sensor.unconfigured-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'offline',
+        'online',
+        'busy',
+        'away',
+        'snooze',
+        'looking_to_trade',
+        'looking_to_play',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.unconfigured',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamSensor.ACCOUNT: 'account'>,
+    'unique_id': '1234567890_account',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.unconfigured-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'created': datetime.datetime(2026, 8, 17, 12, 8, 31, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured',
+      'game': None,
+      'game_icon': None,
+      'game_id': None,
+      'game_image_header': None,
+      'game_image_main': None,
+      'last_online': None,
+      'level': 10,
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'offline',
+        'online',
+        'busy',
+        'away',
+        'snooze',
+        'looking_to_trade',
+        'looking_to_play',
+      ]),
+      'real_name': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.unconfigured',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'offline',
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_last_online-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.unconfigured_last_online',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Last online',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last online',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamSensor.LAST_ONLINE: 'last_online'>,
+    'unique_id': '1234567890_last_online',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_last_online-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Last online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.unconfigured_last_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.unconfigured_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Level',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Level',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamSensor.LEVEL: 'level'>,
+    'unique_id': '1234567890_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Level',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.unconfigured_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.unconfigured_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Now playing',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'steam_online',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <SteamSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': '1234567890_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.unconfigured_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'app_id': None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.unconfigured_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/steam_online/snapshots/test_sensor.ambr
+++ b/tests/components/steam_online/snapshots/test_sensor.ambr
@@ -470,7 +470,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.unconfigured-entry]
+# name: test_sensors[sensor.unconfigured_account-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -494,7 +494,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.unconfigured',
+    'entity_id': 'sensor.unconfigured_account',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -517,13 +517,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[sensor.unconfigured-state]
+# name: test_sensors[sensor.unconfigured_account-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'created': datetime.datetime(2026, 8, 17, 12, 8, 31, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account',
       'game': None,
       'game_icon': None,
       'game_id': None,
@@ -543,14 +543,14 @@
       'real_name': None,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.unconfigured',
+    'entity_id': 'sensor.unconfigured_account',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'offline',
   })
 # ---
-# name: test_sensors[sensor.unconfigured_last_online-entry]
+# name: test_sensors[sensor.unconfigured_account_last_online-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -564,7 +564,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.unconfigured_last_online',
+    'entity_id': 'sensor.unconfigured_account_last_online',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -587,21 +587,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[sensor.unconfigured_last_online-state]
+# name: test_sensors[sensor.unconfigured_account_last_online-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Last online',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Last online',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.unconfigured_last_online',
+    'entity_id': 'sensor.unconfigured_account_last_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.unconfigured_level-entry]
+# name: test_sensors[sensor.unconfigured_account_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -617,7 +617,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.unconfigured_level',
+    'entity_id': 'sensor.unconfigured_account_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -640,21 +640,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[sensor.unconfigured_level-state]
+# name: test_sensors[sensor.unconfigured_account_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Level',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Level',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.unconfigured_level',
+    'entity_id': 'sensor.unconfigured_account_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10',
   })
 # ---
-# name: test_sensors[sensor.unconfigured_now_playing-entry]
+# name: test_sensors[sensor.unconfigured_account_now_playing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -668,7 +668,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.unconfigured_now_playing',
+    'entity_id': 'sensor.unconfigured_account_now_playing',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -691,14 +691,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[sensor.unconfigured_now_playing-state]
+# name: test_sensors[sensor.unconfigured_account_now_playing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'app_id': None,
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured Now playing',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'unconfigured_account Now playing',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.unconfigured_now_playing',
+    'entity_id': 'sensor.unconfigured_account_now_playing',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When an account is new but configuration hasn't been completed the field `profilestate` is missing. When the account has never logged in in the steam client, the field `lastlogoff` is also missing from the API response.
Also adds the field `gameserversteamid` to the dataclass, as it was reported by a user, but I couldn't verify it actually exists and it is not documented in the API documentation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179234
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
