### PR TITLE
Add sensor platform to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/const.py
+++ b/homeassistant/components/lyngdorf/const.py
@@ -7,5 +7,6 @@ DEFAULT_DEVICE_NAME = "Lyngdorf"
 
 PLATFORMS: list[Platform] = [
     Platform.MEDIA_PLAYER,
+    Platform.SENSOR,
 ]
 CONF_SERIAL_NUMBER = "serial_number"

--- a/homeassistant/components/lyngdorf/icons.json
+++ b/homeassistant/components/lyngdorf/icons.json
@@ -1,0 +1,27 @@
+{
+  "entity": {
+    "sensor": {
+      "audio_information": {
+        "default": "mdi:surround-sound"
+      },
+      "audio_input": {
+        "default": "mdi:audio-input-stereo-minijack"
+      },
+      "streaming_source": {
+        "default": "mdi:cast-audio"
+      },
+      "video_information": {
+        "default": "mdi:television"
+      },
+      "video_input": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "zone_b_audio_input": {
+        "default": "mdi:audio-input-stereo-minijack"
+      },
+      "zone_b_streaming_source": {
+        "default": "mdi:cast-audio"
+      }
+    }
+  }
+}

--- a/homeassistant/components/lyngdorf/quality_scale.yaml
+++ b/homeassistant/components/lyngdorf/quality_scale.yaml
@@ -64,18 +64,16 @@ rules:
   dynamic-devices:
     status: exempt
     comment: Single device per config entry.
-  entity-category:
-    status: exempt
-    comment: Media player entities do not need entity categories.
+  entity-category: done
   entity-device-class: done
   entity-disabled-by-default:
-    status: exempt
-    comment: All entities are useful by default.
+    status: done
+    comment: >-
+      All entities are useful by default; the diagnostic sensors change only on
+      source or content changes.
   entity-translations: done
   exception-translations: done
-  icon-translations:
-    status: exempt
-    comment: Media player uses default platform icons.
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues:
     status: exempt

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -1,0 +1,161 @@
+"""Sensor platform for Lyngdorf integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from lyngdorf.device import Receiver
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import LyngdorfEntity
+from .models import LyngdorfConfigEntry
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class LyngdorfSensorEntityDescription(SensorEntityDescription):
+    """Describe a Lyngdorf sensor entity."""
+
+    value_fn: Callable[[Receiver], str | None]
+    options_fn: Callable[[Receiver], list[str]] | None = None
+
+
+def _known(value: str | None, options: list[str]) -> str | None:
+    """Return value only if the device reported a name we know.
+
+    Unrecognised values deliberately escape the library's lookup tables as
+    synthetic strings, which would fall outside an enum's options.
+    """
+    return value if value in options else None
+
+
+MAIN_ZONE_SENSORS: tuple[LyngdorfSensorEntityDescription, ...] = (
+    LyngdorfSensorEntityDescription(
+        key="audio_information",
+        translation_key="audio_information",
+        value_fn=lambda r: r.audio_information,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="video_information",
+        translation_key="video_information",
+        value_fn=lambda r: r.video_information,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="audio_input",
+        translation_key="audio_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.audio_input, r.available_audio_inputs),
+        options_fn=lambda r: r.available_audio_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="video_input",
+        translation_key="video_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.video_input, r.available_video_inputs),
+        options_fn=lambda r: r.available_video_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="streaming_source",
+        translation_key="streaming_source",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.streaming_source, r.available_stream_types),
+        options_fn=lambda r: r.available_stream_types,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+ZONE_B_SENSORS: tuple[LyngdorfSensorEntityDescription, ...] = (
+    LyngdorfSensorEntityDescription(
+        key="zone_b_audio_input",
+        translation_key="zone_b_audio_input",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.zone_b_audio_input, r.available_audio_inputs),
+        options_fn=lambda r: r.available_audio_inputs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    LyngdorfSensorEntityDescription(
+        key="zone_b_streaming_source",
+        translation_key="zone_b_streaming_source",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda r: _known(r.zone_b_streaming_source, r.available_stream_types),
+        options_fn=lambda r: r.available_stream_types,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LyngdorfConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Lyngdorf sensors from a config entry."""
+    runtime_data = config_entry.runtime_data
+
+    entities: list[LyngdorfSensor] = [
+        LyngdorfSensor(
+            runtime_data.receiver, config_entry, runtime_data.device_info, description
+        )
+        for description in MAIN_ZONE_SENSORS
+    ]
+    # Zone B sensors stay on the main device so they read "Zone B audio input"
+    # rather than repeating the zone in the Zone B device's own name.
+    if runtime_data.zone_b_device_info is not None:
+        entities.extend(
+            LyngdorfSensor(
+                runtime_data.receiver,
+                config_entry,
+                runtime_data.device_info,
+                description,
+            )
+            for description in ZONE_B_SENSORS
+        )
+
+    async_add_entities(entities)
+
+
+class LyngdorfSensor(LyngdorfEntity, SensorEntity):
+    """Lyngdorf sensor entity."""
+
+    entity_description: LyngdorfSensorEntityDescription
+
+    def __init__(
+        self,
+        receiver: Receiver,
+        config_entry: LyngdorfConfigEntry,
+        device_info: DeviceInfo,
+        description: LyngdorfSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(receiver, device_info)
+        assert config_entry.unique_id
+        self.entity_description = description
+        self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
+
+    @override
+    @property
+    def options(self) -> list[str] | None:
+        """Return the device-reported options for enum sensors."""
+        if (options_fn := self.entity_description.options_fn) is None:
+            return None
+        return options_fn(self._receiver)
+
+    @override
+    @property
+    def native_value(self) -> str | None:
+        """Return the current sensor value."""
+        return self.entity_description.value_fn(self._receiver)

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from lyngdorf.device import Receiver
 
@@ -31,11 +31,7 @@ class LyngdorfSensorEntityDescription(SensorEntityDescription):
 
 
 def _known(value: str | None, options: list[str]) -> str | None:
-    """Return value only if the device reported a name we know.
-
-    Unrecognised values deliberately escape the library's lookup tables as
-    synthetic strings, which would fall outside an enum's options.
-    """
+    """Return the value only if it is one of the device's known names."""
     return value if value in options else None
 
 
@@ -142,7 +138,8 @@ class LyngdorfSensor(LyngdorfEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(receiver, device_info)
-        assert config_entry.unique_id
+        if TYPE_CHECKING:
+            assert config_entry.unique_id
         self.entity_description = description
         self._attr_unique_id = f"{config_entry.unique_id}_{description.key}"
 

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -40,6 +40,29 @@
       "main_zone": {
         "name": "Main zone"
       }
+    },
+    "sensor": {
+      "audio_information": {
+        "name": "Audio information"
+      },
+      "audio_input": {
+        "name": "Audio input"
+      },
+      "streaming_source": {
+        "name": "Streaming source"
+      },
+      "video_information": {
+        "name": "Video information"
+      },
+      "video_input": {
+        "name": "Video input"
+      },
+      "zone_b_audio_input": {
+        "name": "Zone B audio input"
+      },
+      "zone_b_streaming_source": {
+        "name": "Zone B streaming source"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -9,8 +9,12 @@ from lyngdorf.const import LyngdorfModel
 from lyngdorf.device import Receiver
 import pytest
 
-from homeassistant.components.lyngdorf.const import CONF_SERIAL_NUMBER, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_MODEL
+from homeassistant.components.lyngdorf.const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    PLATFORMS,
+)
+from homeassistant.const import CONF_HOST, CONF_MODEL, Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -67,11 +71,22 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver.sound_mode = None
         receiver.available_sound_modes = []
 
+        receiver.audio_information = None
+        receiver.video_information = None
+        receiver.audio_input = None
+        receiver.video_input = None
+        receiver.streaming_source = None
+        receiver.available_audio_inputs = []
+        receiver.available_video_inputs = []
+        receiver.available_stream_types = []
+
         receiver.zone_b_power_on = False
         receiver.zone_b_volume = -40.0
         receiver.zone_b_mute_enabled = False
         receiver.zone_b_source = None
         receiver.zone_b_available_sources = []
+        receiver.zone_b_audio_input = None
+        receiver.zone_b_streaming_source = None
 
         create_mock.return_value = receiver
         yield receiver
@@ -97,16 +112,32 @@ def mock_find_receiver_model() -> Generator[AsyncMock]:
         yield find_mock
 
 
+def notify_receiver_update(receiver: MagicMock) -> None:
+    """Fire every notification callback the entities registered."""
+    for call in receiver.register_notification_callback.call_args_list:
+        call.args[0]()
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms to load; override per module to isolate a single platform."""
+    return list(PLATFORMS)
+
+
 @pytest.fixture
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_receiver: MagicMock,
+    platforms: list[Platform],
 ) -> MockConfigEntry:
     """Set up the Lyngdorf integration for testing."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.lyngdorf.lookup_receiver_model") as lookup:
+    with (
+        patch("homeassistant.components.lyngdorf.lookup_receiver_model") as lookup,
+        patch("homeassistant.components.lyngdorf.PLATFORMS", platforms),
+    ):
         lookup.return_value = LyngdorfModel.MP_60
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -71,22 +71,22 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver.sound_mode = None
         receiver.available_sound_modes = []
 
-        receiver.audio_information = None
-        receiver.video_information = None
-        receiver.audio_input = None
-        receiver.video_input = None
-        receiver.streaming_source = None
-        receiver.available_audio_inputs = []
-        receiver.available_video_inputs = []
-        receiver.available_stream_types = []
+        receiver.audio_information = "Stereo"
+        receiver.video_information = "4K HDR"
+        receiver.audio_input = "optical"
+        receiver.video_input = "hdmi"
+        receiver.streaming_source = "AirPlay"
+        receiver.available_audio_inputs = ["optical", "aux"]
+        receiver.available_video_inputs = ["hdmi"]
+        receiver.available_stream_types = ["AirPlay", "DLNA"]
 
         receiver.zone_b_power_on = False
         receiver.zone_b_volume = -40.0
         receiver.zone_b_mute_enabled = False
         receiver.zone_b_source = None
         receiver.zone_b_available_sources = []
-        receiver.zone_b_audio_input = None
-        receiver.zone_b_streaming_source = None
+        receiver.zone_b_audio_input = "aux"
+        receiver.zone_b_streaming_source = "DLNA"
 
         create_mock.return_value = receiver
         yield receiver

--- a/tests/components/lyngdorf/snapshots/test_sensor.ambr
+++ b/tests/components/lyngdorf/snapshots/test_sensor.ambr
@@ -1,0 +1,356 @@
+# serializer version: 1
+# name: test_entities[sensor.mock_lyngdorf_audio_information-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_audio_information',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Audio information',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio information',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_information',
+    'unique_id': '0050c27c76b2_audio_information',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_audio_information-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Audio information',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_audio_information',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_audio_input-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_audio_input',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Audio input',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Audio input',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_input',
+    'unique_id': '0050c27c76b2_audio_input',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_audio_input-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Audio input',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_audio_input',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_streaming_source-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_streaming_source',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Streaming source',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Streaming source',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'streaming_source',
+    'unique_id': '0050c27c76b2_streaming_source',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_streaming_source-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Streaming source',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_streaming_source',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_video_information-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_video_information',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Video information',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Video information',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'video_information',
+    'unique_id': '0050c27c76b2_video_information',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_video_information-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Video information',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_video_information',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_video_input-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_video_input',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Video input',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Video input',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'video_input',
+    'unique_id': '0050c27c76b2_video_input',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_video_input-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Video input',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_video_input',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_zone_b_audio_input-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_zone_b_audio_input',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B audio input',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Zone B audio input',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'zone_b_audio_input',
+    'unique_id': '0050c27c76b2_zone_b_audio_input',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_zone_b_audio_input-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Zone B audio input',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_zone_b_audio_input',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_zone_b_streaming_source-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_zone_b_streaming_source',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B streaming source',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Zone B streaming source',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'zone_b_streaming_source',
+    'unique_id': '0050c27c76b2_zone_b_streaming_source',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_zone_b_streaming_source-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Zone B streaming source',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_zone_b_streaming_source',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/lyngdorf/snapshots/test_sensor.ambr
+++ b/tests/components/lyngdorf/snapshots/test_sensor.ambr
@@ -46,7 +46,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'Stereo',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_audio_input-entry]
@@ -55,7 +55,12 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'optical',
+        'aux',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -91,13 +96,17 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Audio input',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'optical',
+        'aux',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_lyngdorf_audio_input',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'optical',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_streaming_source-entry]
@@ -106,7 +115,12 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'AirPlay',
+        'DLNA',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -142,13 +156,17 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Streaming source',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'AirPlay',
+        'DLNA',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_lyngdorf_streaming_source',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'AirPlay',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_video_information-entry]
@@ -198,7 +216,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '4K HDR',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_video_input-entry]
@@ -207,7 +225,11 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'hdmi',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -243,13 +265,16 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Video input',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'hdmi',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_lyngdorf_video_input',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'hdmi',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_zone_b_audio_input-entry]
@@ -258,7 +283,12 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'optical',
+        'aux',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -294,13 +324,17 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Zone B audio input',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'optical',
+        'aux',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_lyngdorf_zone_b_audio_input',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'aux',
   })
 # ---
 # name: test_entities[sensor.mock_lyngdorf_zone_b_streaming_source-entry]
@@ -309,7 +343,12 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'AirPlay',
+        'DLNA',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -345,12 +384,16 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Zone B streaming source',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'AirPlay',
+        'DLNA',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_lyngdorf_zone_b_streaming_source',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'DLNA',
   })
 # ---

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
     STATE_UNAVAILABLE,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -35,6 +36,12 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 MAIN_ZONE = "media_player.mock_lyngdorf_main_zone"
 ZONE_B = "media_player.mock_lyngdorf_zone_b"
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Only load the media player platform."""
+    return [Platform.MEDIA_PLAYER]
 
 
 async def test_entities(

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -31,62 +31,19 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
-async def test_main_zone_sensor_values(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_receiver: MagicMock,
-) -> None:
-    """Test main zone sensor values update from receiver."""
-    mock_receiver.audio_information = "Stereo"
-    mock_receiver.video_information = "4K HDR"
-    mock_receiver.audio_input = "optical"
-    mock_receiver.video_input = "hdmi"
-    mock_receiver.streaming_source = "AirPlay"
-    mock_receiver.available_audio_inputs = ["optical", "aux"]
-    mock_receiver.available_video_inputs = ["hdmi"]
-    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
-
-    # Trigger callback to update states
-    notify_receiver_update(mock_receiver)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("sensor.mock_lyngdorf_audio_information").state == "Stereo"
-    assert hass.states.get("sensor.mock_lyngdorf_video_information").state == "4K HDR"
-    assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == "optical"
-    assert hass.states.get("sensor.mock_lyngdorf_video_input").state == "hdmi"
-    assert hass.states.get("sensor.mock_lyngdorf_streaming_source").state == "AirPlay"
-
-
-async def test_zone_b_sensor_values(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_receiver: MagicMock,
-) -> None:
-    """Test zone B sensor values update from receiver."""
-    mock_receiver.zone_b_audio_input = "aux"
-    mock_receiver.zone_b_streaming_source = "DLNA"
-    mock_receiver.available_audio_inputs = ["optical", "aux"]
-    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
-
-    # Trigger callback to update states
-    notify_receiver_update(mock_receiver)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("sensor.mock_lyngdorf_zone_b_audio_input").state == "aux"
-    assert (
-        hass.states.get("sensor.mock_lyngdorf_zone_b_streaming_source").state == "DLNA"
-    )
-
-
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_none_values(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_receiver: MagicMock,
 ) -> None:
-    """Test sensors show unknown when receiver values are None."""
-    state = hass.states.get("sensor.mock_lyngdorf_audio_information")
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
+    """Test a sensor shows unknown when the device reports nothing."""
+    mock_receiver.audio_information = None
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.mock_lyngdorf_audio_information").state == STATE_UNKNOWN
+    )
 
 
 async def test_enum_sensor_ignores_unknown_device_value(

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -3,14 +3,15 @@
 from unittest.mock import MagicMock
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import notify_receiver_update
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture
@@ -20,25 +21,14 @@ def platforms() -> list[Platform]:
 
 
 @pytest.mark.usefixtures("mock_receiver")
-async def test_sensor_entities_created(
+async def test_entities(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that sensor entities are created."""
-    assert init_integration.state is ConfigEntryState.LOADED
-
-    sensor_keys = [
-        "audio_information",
-        "video_information",
-        "audio_input",
-        "video_input",
-        "streaming_source",
-        "zone_b_audio_input",
-        "zone_b_streaming_source",
-    ]
-    for key in sensor_keys:
-        state = hass.states.get(f"sensor.mock_lyngdorf_{key}")
-        assert state is not None, f"sensor.mock_lyngdorf_{key} not found"
+    """Test the sensor entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
 async def test_main_zone_sensor_values(

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from homeassistant.const import STATE_UNKNOWN
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 
 from .conftest import notify_receiver_update
@@ -10,13 +13,19 @@ from .conftest import notify_receiver_update
 from tests.common import MockConfigEntry
 
 
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Only load the sensor platform."""
+    return [Platform.SENSOR]
+
+
+@pytest.mark.usefixtures("mock_receiver")
 async def test_sensor_entities_created(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
-    mock_receiver: MagicMock,
 ) -> None:
     """Test that sensor entities are created."""
-    assert init_integration.state.value == "loaded"
+    assert init_integration.state is ConfigEntryState.LOADED
 
     sensor_keys = [
         "audio_information",
@@ -103,3 +112,25 @@ async def test_enum_sensor_ignores_unknown_device_value(
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_enum_options_follow_the_device(
+    hass: HomeAssistant,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test enum options track the lists the device reports."""
+    mock_receiver.available_audio_inputs = ["HDMI", "optical"]
+    mock_receiver.audio_input = "HDMI"
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mock_lyngdorf_audio_input")
+    assert state.attributes["options"] == ["HDMI", "optical"]
+
+    mock_receiver.available_audio_inputs = ["HDMI", "optical", "ARC"]
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mock_lyngdorf_audio_input")
+    assert state.attributes["options"] == ["HDMI", "optical", "ARC"]

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -1,0 +1,105 @@
+"""Tests for the Lyngdorf sensor platform."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from .conftest import notify_receiver_update
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensor_entities_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test that sensor entities are created."""
+    assert init_integration.state.value == "loaded"
+
+    sensor_keys = [
+        "audio_information",
+        "video_information",
+        "audio_input",
+        "video_input",
+        "streaming_source",
+        "zone_b_audio_input",
+        "zone_b_streaming_source",
+    ]
+    for key in sensor_keys:
+        state = hass.states.get(f"sensor.mock_lyngdorf_{key}")
+        assert state is not None, f"sensor.mock_lyngdorf_{key} not found"
+
+
+async def test_main_zone_sensor_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test main zone sensor values update from receiver."""
+    mock_receiver.audio_information = "Stereo"
+    mock_receiver.video_information = "4K HDR"
+    mock_receiver.audio_input = "optical"
+    mock_receiver.video_input = "hdmi"
+    mock_receiver.streaming_source = "AirPlay"
+    mock_receiver.available_audio_inputs = ["optical", "aux"]
+    mock_receiver.available_video_inputs = ["hdmi"]
+    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
+
+    # Trigger callback to update states
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_audio_information").state == "Stereo"
+    assert hass.states.get("sensor.mock_lyngdorf_video_information").state == "4K HDR"
+    assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == "optical"
+    assert hass.states.get("sensor.mock_lyngdorf_video_input").state == "hdmi"
+    assert hass.states.get("sensor.mock_lyngdorf_streaming_source").state == "AirPlay"
+
+
+async def test_zone_b_sensor_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test zone B sensor values update from receiver."""
+    mock_receiver.zone_b_audio_input = "aux"
+    mock_receiver.zone_b_streaming_source = "DLNA"
+    mock_receiver.available_audio_inputs = ["optical", "aux"]
+    mock_receiver.available_stream_types = ["AirPlay", "DLNA"]
+
+    # Trigger callback to update states
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_zone_b_audio_input").state == "aux"
+    assert (
+        hass.states.get("sensor.mock_lyngdorf_zone_b_streaming_source").state == "DLNA"
+    )
+
+
+async def test_sensor_none_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test sensors show unknown when receiver values are None."""
+    state = hass.states.get("sensor.mock_lyngdorf_audio_information")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_enum_sensor_ignores_unknown_device_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test an input the library could not name is reported as unknown."""
+    mock_receiver.available_audio_inputs = ["optical"]
+    mock_receiver.audio_input = "audio-37"
+
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_audio_input").state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> [!NOTE]
> Split out of #179412, one platform per pull request as requested. Based on #179410, so that bump appears here until it merges.

Restores the sensor platform removed in fbe8e774bf4 so the initial pull request covered a single platform.

Reports the active inputs, the incoming signal formats and the streaming source, as diagnostic entities. The three backed by lookup tables use `SensorDeviceClass.ENUM`, which is why this one needs the 1.6.0 bump: the library only gained the enumerable `available_audio_inputs` / `available_video_inputs` / `available_stream_types` there.

Values the library could not name deliberately escape those tables as synthetic strings, which cannot appear in a closed options list, so they are reported as unknown rather than as an option outside it.

Zone B sensors are created only on models that have a Zone B.

Settles `entity-category`, `entity-disabled-by-default` and `icon-translations`, which were exempt on the grounds that the media player was the only platform.

This carries the `lyngdorf` 1.4.9 to 1.6.0 bump from #179410 until that merges:

- PyPI: https://pypi.org/project/lyngdorf/1.6.0/
- Release notes: https://github.com/fishloa/lyngdorf/releases/tag/v1.6.0
- Diff, 1.4.9 to 1.6.0: https://github.com/fishloa/lyngdorf/compare/v1.4.9...v1.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47460
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

