### PR TITLE
Handle unconfigured ismartgate devices in config flow

### DIFF
--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -32,6 +32,7 @@ DEVICE_NAMES = {
     DEVICE_TYPE_GOGOGATE2: "Gogogate2",
     DEVICE_TYPE_ISMARTGATE: "ismartgate",
 }
+ISMARTGATE_DEVICE_NOT_CONFIGURED_ERROR_CODE = 23
 
 
 class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
@@ -115,7 +116,12 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
                     )
                 )
 
-                if is_invalid_auth:
+                if (
+                    device_type == DEVICE_TYPE_ISMARTGATE
+                    and api_error.code == ISMARTGATE_DEVICE_NOT_CONFIGURED_ERROR_CODE
+                ):
+                    errors["base"] = "device_not_configured"
+                elif is_invalid_auth:
                     errors["base"] = "invalid_auth"
                 else:
                     errors["base"] = "cannot_connect"

--- a/homeassistant/components/gogogate2/strings.json
+++ b/homeassistant/components/gogogate2/strings.json
@@ -5,6 +5,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "device_not_configured": "The ismartgate local API is not configured. Complete the device setup before adding it to Home Assistant.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "flow_title": "{device} ({ip_address})",

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -104,6 +104,32 @@ async def test_auth_fail(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+@patch("homeassistant.components.gogogate2.common.ISmartGateApi")
+async def test_ismartgate_device_not_configured(
+    ismartgateapi_mock: MagicMock, hass: HomeAssistant
+) -> None:
+    """Test an ismartgate with an unconfigured local API."""
+    api: ISmartGateApi = MagicMock(spec=ISmartGateApi)
+    ismartgateapi_mock.return_value = api
+    api.async_info.side_effect = ApiError(23, "Error: device not configured")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_DEVICE: DEVICE_TYPE_ISMARTGATE,
+            CONF_IP_ADDRESS: "127.0.0.2",
+            CONF_USERNAME: "user0",
+            CONF_PASSWORD: "password0",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "device_not_configured"}
+
+
 async def test_form_homekit_unique_id_already_setup(hass: HomeAssistant) -> None:
     """Test that we abort from homekit if gogogate2 is already setup."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The ismartgate API returns error code 23 when its local API is not configured. The Gogogate2 config flow currently treats this as a generic connection failure, which gives users no indication that the device itself requires setup.

Recognize error code 23 for ismartgate devices and show a specific `device_not_configured` config-flow error. Other API errors and Gogogate2 behavior are unchanged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Targeted validation: all 7 tests in `tests/components/gogogate2/test_config_flow.py` pass.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
