### PR TITLE
Reduce Tesla Fleet vehicle polling to enabled entities' endpoints

### DIFF
--- a/homeassistant/components/tesla_fleet/button.py
+++ b/homeassistant/components/tesla_fleet/button.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, override
 
-from tesla_fleet_api.const import Scope
+from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -30,6 +30,7 @@ class TeslaFleetButtonEntityDescription(ButtonEntityDescription):
     """Describes a TeslaFleet Button entity."""
 
     func: Callable[[TeslaFleetButtonEntity], Awaitable[Any]]
+    endpoints: frozenset[VehicleDataEndpoint] = frozenset()
 
 
 DESCRIPTIONS: tuple[TeslaFleetButtonEntityDescription, ...] = (
@@ -51,6 +52,9 @@ DESCRIPTIONS: tuple[TeslaFleetButtonEntityDescription, ...] = (
     TeslaFleetButtonEntityDescription(
         key="homelink",
         func=lambda self: self.async_trigger_homelink(),
+        endpoints=frozenset(
+            {VehicleDataEndpoint.DRIVE_STATE, VehicleDataEndpoint.LOCATION_DATA}
+        ),
     ),
 )
 
@@ -82,6 +86,7 @@ class TeslaFleetButtonEntity(TeslaFleetVehicleEntity, ButtonEntity):
     ) -> None:
         """Initialize the button."""
         self.entity_description = description
+        self._endpoints = description.endpoints
         super().__init__(data, description.key)
 
     @override

--- a/homeassistant/components/tesla_fleet/climate.py
+++ b/homeassistant/components/tesla_fleet/climate.py
@@ -3,7 +3,11 @@
 from itertools import chain
 from typing import Any, cast, override
 
-from tesla_fleet_api.const import CabinOverheatProtectionTemp, Scope
+from tesla_fleet_api.const import (
+    CabinOverheatProtectionTemp,
+    Scope,
+    VehicleDataEndpoint,
+)
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -61,6 +65,7 @@ async def async_setup_entry(
 class TeslaFleetClimateEntity(TeslaFleetVehicleEntity, ClimateEntity):
     """Tesla Fleet vehicle climate entity."""
 
+    _endpoints = frozenset({VehicleDataEndpoint.CLIMATE_STATE})
     _attr_precision = PRECISION_HALVES
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -212,6 +217,10 @@ TEMP_LEVELS = {
 class TeslaFleetCabinOverheatProtectionEntity(TeslaFleetVehicleEntity, ClimateEntity):
     """Tesla Fleet vehicle cabin overheat protection entity."""
 
+    # supported_features additionally reads vehicle_config.
+    _endpoints = frozenset(
+        {VehicleDataEndpoint.CLIMATE_STATE, VehicleDataEndpoint.VEHICLE_CONFIG}
+    )
     _attr_precision = PRECISION_WHOLE
     _attr_target_temperature_step = 5
     _attr_min_temp = COP_LEVELS["Low"]

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -143,6 +143,19 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else [ep for ep in ENDPOINTS if ep != VehicleDataEndpoint.LOCATION_DATA]
         )
 
+    def _active_endpoints(self) -> list[VehicleDataEndpoint]:
+        """Return the endpoints needed by currently enabled entities.
+
+        Entities register the endpoint groups they read as their coordinator
+        context, so disabling every entity backed by a group drops it from the
+        request. Falls back to the full set when no entity has registered a
+        context yet, such as the unconditional first refresh at setup.
+        """
+        requested: set[VehicleDataEndpoint] = set()
+        for context in self.async_contexts():
+            requested.update(context)
+        return [ep for ep in self.endpoints if ep in requested] or self.endpoints
+
     @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using TeslaFleet API."""
@@ -155,7 +168,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self.data["state"] != TeslaFleetState.ONLINE:
                 return self.data
 
-            response = await self.api.vehicle_data(endpoints=self.endpoints)
+            response = await self.api.vehicle_data(endpoints=self._active_endpoints())
             data = response["response"]
 
         except VehicleOffline:

--- a/homeassistant/components/tesla_fleet/cover.py
+++ b/homeassistant/components/tesla_fleet/cover.py
@@ -2,7 +2,13 @@
 
 from typing import Any, override
 
-from tesla_fleet_api.const import Scope, SunRoofCommand, Trunk, WindowCommand
+from tesla_fleet_api.const import (
+    Scope,
+    SunRoofCommand,
+    Trunk,
+    VehicleDataEndpoint,
+    WindowCommand,
+)
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -46,6 +52,7 @@ async def async_setup_entry(
 class TeslaFleetWindowEntity(TeslaFleetVehicleEntity, CoverEntity):
     """Cover entity for the windows."""
 
+    _endpoints = frozenset({VehicleDataEndpoint.VEHICLE_STATE})
     _attr_device_class = CoverDeviceClass.WINDOW
 
     def __init__(self, data: TeslaFleetVehicleData, scopes: list[Scope]) -> None:

--- a/homeassistant/components/tesla_fleet/device_tracker.py
+++ b/homeassistant/components/tesla_fleet/device_tracker.py
@@ -2,6 +2,8 @@
 
 from typing import override
 
+from tesla_fleet_api.const import VehicleDataEndpoint
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityStateAttribute
@@ -36,6 +38,10 @@ class TeslaFleetDeviceTrackerEntity(
     TeslaFleetVehicleEntity, TrackerEntity, RestoreEntity
 ):
     """Base class for Tesla Fleet device tracker entities."""
+
+    _endpoints = frozenset(
+        {VehicleDataEndpoint.DRIVE_STATE, VehicleDataEndpoint.LOCATION_DATA}
+    )
 
     def __init__(
         self,

--- a/homeassistant/components/tesla_fleet/entity.py
+++ b/homeassistant/components/tesla_fleet/entity.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import Any, override
 
-from tesla_fleet_api.const import Scope
+from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 from tesla_fleet_api.tesla.energysite import EnergySite
 from tesla_fleet_api.tesla.vehicle.fleet import VehicleFleet
 
@@ -21,6 +21,27 @@ from .coordinator import (
 )
 from .helpers import wake_up_vehicle
 from .models import TeslaFleetEnergyData, TeslaFleetVehicleData
+
+# Location data is returned within the drive_state group, so requesting a
+# drive_state field also requires the location_data endpoint.
+_VEHICLE_ENDPOINT_BY_PREFIX: tuple[tuple[str, frozenset[VehicleDataEndpoint]], ...] = (
+    ("charge_state", frozenset({VehicleDataEndpoint.CHARGE_STATE})),
+    ("climate_state", frozenset({VehicleDataEndpoint.CLIMATE_STATE})),
+    (
+        "drive_state",
+        frozenset({VehicleDataEndpoint.DRIVE_STATE, VehicleDataEndpoint.LOCATION_DATA}),
+    ),
+    ("vehicle_state", frozenset({VehicleDataEndpoint.VEHICLE_STATE})),
+    ("vehicle_config", frozenset({VehicleDataEndpoint.VEHICLE_CONFIG})),
+)
+
+
+def endpoints_for_key(key: str) -> frozenset[VehicleDataEndpoint]:
+    """Return the vehicle data endpoints a flattened data key is sourced from."""
+    for prefix, endpoints in _VEHICLE_ENDPOINT_BY_PREFIX:
+        if key.startswith(prefix):
+            return endpoints
+    return frozenset()
 
 
 class TeslaFleetEntity[_ApiT: VehicleFleet | EnergySite](
@@ -46,9 +67,10 @@ class TeslaFleetEntity[_ApiT: VehicleFleet | EnergySite](
         | TeslaFleetEnergySiteInfoCoordinator,
         api: _ApiT,
         key: str,
+        context: Any = None,
     ) -> None:
         """Initialize common aspects of a TeslaFleet entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, context)
         self.api = api
         self.key = key
         self._attr_translation_key = self.key
@@ -108,6 +130,9 @@ class TeslaFleetVehicleEntity(TeslaFleetEntity[VehicleFleet]):
     """Parent class for TeslaFleet Vehicle entities."""
 
     _last_update: int = 0
+    # Vehicle data endpoints this entity needs polled. None derives them from
+    # the flattened key prefix; set explicitly when the key does not encode it.
+    _endpoints: frozenset[VehicleDataEndpoint] | None = None
 
     def __init__(
         self,
@@ -120,7 +145,10 @@ class TeslaFleetVehicleEntity(TeslaFleetEntity[VehicleFleet]):
         self.vehicle = data
 
         self._attr_device_info = data.device
-        super().__init__(data.coordinator, data.api, key)
+        endpoints = (
+            self._endpoints if self._endpoints is not None else endpoints_for_key(key)
+        )
+        super().__init__(data.coordinator, data.api, key, endpoints)
 
     @property
     @override

--- a/homeassistant/components/tesla_fleet/media_player.py
+++ b/homeassistant/components/tesla_fleet/media_player.py
@@ -2,7 +2,7 @@
 
 from typing import override
 
-from tesla_fleet_api.const import Scope
+from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -46,6 +46,7 @@ async def async_setup_entry(
 class TeslaFleetMediaEntity(TeslaFleetVehicleEntity, MediaPlayerEntity):
     """Vehicle media player class."""
 
+    _endpoints = frozenset({VehicleDataEndpoint.VEHICLE_STATE})
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
     _attr_supported_features = (
         MediaPlayerEntityFeature.NEXT_TRACK

--- a/homeassistant/components/tesla_fleet/select.py
+++ b/homeassistant/components/tesla_fleet/select.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import override
 
-from tesla_fleet_api.const import EnergyExportMode, EnergyOperationMode, Scope, Seat
+from tesla_fleet_api.const import (
+    EnergyExportMode,
+    EnergyOperationMode,
+    Scope,
+    Seat,
+    VehicleDataEndpoint,
+)
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
@@ -112,6 +118,10 @@ async def async_setup_entry(
 class TeslaFleetSeatHeaterSelectEntity(TeslaFleetVehicleEntity, SelectEntity):
     """Select entity for vehicle seat heater."""
 
+    # available_fn additionally reads vehicle_config.
+    _endpoints = frozenset(
+        {VehicleDataEndpoint.CLIMATE_STATE, VehicleDataEndpoint.VEHICLE_CONFIG}
+    )
     entity_description: SeatHeaterDescription
 
     _attr_options = [

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -21,6 +21,11 @@ from tesla_fleet_api.exceptions import (
     VehicleOffline,
 )
 
+from homeassistant.components.application_credentials import (
+    DOMAIN as APPLICATION_CREDENTIALS_DOMAIN,
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
 from homeassistant.components.tesla_fleet.coordinator import (
     ENERGY_HISTORY_INTERVAL,
@@ -33,21 +38,28 @@ from homeassistant.components.tesla_fleet.coordinator import (
 )
 from homeassistant.components.tesla_fleet.models import TeslaFleetData
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_TOKEN
+from homeassistant.const import CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
     OAuth2TokenRequestTransientError,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
+from homeassistant.setup import async_setup_component
 
 from . import setup_platform
 from .conftest import create_config_entry
-from .const import LIVE_STATUS, SITE_INFO, VEHICLE_ASLEEP, VEHICLE_DATA_ALT
+from .const import (
+    LIVE_STATUS,
+    SITE_INFO,
+    VEHICLE_ASLEEP,
+    VEHICLE_DATA,
+    VEHICLE_DATA_ALT,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -970,6 +982,58 @@ async def test_vehicle_with_location_scope(
     assert VehicleDataEndpoint.DRIVE_STATE in endpoints
     assert VehicleDataEndpoint.VEHICLE_STATE in endpoints
     assert VehicleDataEndpoint.VEHICLE_CONFIG in endpoints
+
+
+async def test_vehicle_endpoints_follow_enabled_entities(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_vehicle_data: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a disabled entity's endpoint group is dropped from vehicle polling."""
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential("CLIENT_ID", "CLIENT_SECRET", "Home Assistant"),
+        DOMAIN,
+    )
+    normal_config_entry.add_to_hass(hass)
+
+    # Disable every sensor enabled by default that is backed by the drive_state
+    # group, so nothing needs that group. Several charge_state sensors remain
+    # enabled by default.
+    vin = VEHICLE_DATA["response"]["vin"]
+    for key in (
+        "drive_state_active_route_miles_to_arrival",
+        "drive_state_active_route_minutes_to_arrival",
+    ):
+        entity_registry.async_get_or_create(
+            Platform.SENSOR,
+            DOMAIN,
+            f"{vin}-{key}",
+            config_entry=normal_config_entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+
+    with patch("homeassistant.components.tesla_fleet.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(normal_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Inspect a scheduled cycle, which reads the enabled entities' contexts.
+        mock_vehicle_data.reset_mock()
+        freezer.tick(VEHICLE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    endpoints = mock_vehicle_data.call_args.kwargs["endpoints"]
+    # No enabled entity needs drive_state, so it and its coupled location_data
+    # endpoint are dropped from the request.
+    assert VehicleDataEndpoint.DRIVE_STATE not in endpoints
+    assert VehicleDataEndpoint.LOCATION_DATA not in endpoints
+    # A group still needed by enabled siblings is retained.
+    assert VehicleDataEndpoint.CHARGE_STATE in endpoints
 
 
 async def test_oauth_implementation_not_available(


### PR DESCRIPTION
## Proposed change

Disabling a `tesla_fleet` entity previously did nothing to what the vehicle
coordinator polled: every cycle sent the same fixed list of six `vehicle_data`
endpoint groups regardless of which entities were enabled, because no entity
passed a coordinator context and `_async_update_data` never consulted
`async_contexts()`.

Each vehicle entity now registers the `vehicle_data` endpoint group(s) its data
comes from as its coordinator context (derived from the flattened key prefix,
with explicit overrides where the key does not encode it), and the vehicle
coordinator derives the `endpoints` argument from `async_contexts()` each cycle.
When every entity backed by a group is disabled, that group is dropped from the
request. The existing OAuth `vehicle_location` scope filter still applies
independently, and the request falls back to the full scope-filtered set when no
entity has registered a context yet, such as the unconditional first refresh at
setup.

This works at endpoint-group granularity, which is the floor Tesla's API allows:

- Several entities share one indivisible Fleet response, so suppression below an
  endpoint group is not possible.
- The energy endpoints (`live_status`, `site_info`, `calendar_history`) expose
  no field selection, so nothing is saved there; this PR only touches vehicle
  polling.
- The unconditional first reads at setup and reload ignore entity state and are
  left as-is.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179367

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
