### PR TITLE
Fix stale WiiM artwork when media image URLs are reused

### DIFF
--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -15,6 +15,7 @@ from wiim.models import (
     WiimTransportCapabilities,
 )
 from wiim.wiim_device import WiimDevice
+from yarl import URL
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -258,7 +259,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             return None, None
 
         if (image_hash := self.media_image_hash) is not None:
-            url = f"{url}#{image_hash}"
+            url = str(URL(url).with_fragment(image_hash))
 
         return await self._async_fetch_image_from_cache(url)
 

--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
 from hashlib import sha256
+import json
 from typing import Any, Concatenate, override
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
@@ -15,7 +16,6 @@ from wiim.models import (
     WiimTransportCapabilities,
 )
 from wiim.wiim_device import WiimDevice
-from yarl import URL
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -247,7 +247,11 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             self._attr_media_image_hash = None
             return
 
-        digest_source = repr((image_url, media_uri, title, artist, album))
+        digest_source = json.dumps(
+            [image_url, media_uri, title, artist, album],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
         self._attr_media_image_hash = sha256(
             digest_source.encode("utf-8"), usedforsecurity=False
         ).hexdigest()
@@ -259,7 +263,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             return None, None
 
         if (image_hash := self.media_image_hash) is not None:
-            url = str(URL(url).with_fragment(image_hash))
+            url = f"{url.partition('#')[0]}#{image_hash}"
 
         return await self._async_fetch_image_from_cache(url)
 

--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
+from hashlib import sha256
 from typing import Any, Concatenate, override
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
@@ -219,11 +220,47 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
         self._attr_media_artist = None
         self._attr_media_album_name = None
         self._attr_media_image_url = None
+        self._attr_media_image_hash = None
         self._attr_media_content_id = None
         self._attr_media_content_type = None
         self._attr_media_duration = None
         self._attr_media_position = None
         self._attr_media_position_updated_at = None
+
+    @callback
+    def _set_media_image_hash(
+        self,
+        *,
+        image_url: str | None,
+        media_uri: str | None,
+        title: str | None,
+        artist: str | None,
+        album: str | None,
+    ) -> None:
+        """Set a cache-busting media image hash for Home Assistant.
+
+        Some WiiM sources reuse the same artwork URL across tracks, so the
+        default HA URL-based hash is not sufficient to invalidate the image cache.
+        """
+        if not image_url:
+            self._attr_media_image_hash = None
+            return
+
+        digest_source = repr((image_url, media_uri, title, artist, album))
+        self._attr_media_image_hash = sha256(
+            digest_source.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
+
+    @override
+    async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
+        """Fetch the media image using a track-aware cache key."""
+        if (url := self.media_image_url) is None:
+            return None, None
+
+        if (image_hash := self.media_image_hash) is not None:
+            url = f"{url}#{image_hash}"
+
+        return await self._async_fetch_image_from_cache(url)
 
     @callback
     def _get_command_target_device(self, action_name: str) -> WiimDevice:
@@ -342,6 +379,13 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             self._attr_media_artist = media.artist
             self._attr_media_album_name = media.album
             self._attr_media_image_url = media.image_url
+            self._set_media_image_hash(
+                image_url=media.image_url,
+                media_uri=media.uri,
+                title=media.title,
+                artist=media.artist,
+                album=media.album,
+            )
             self._attr_media_content_id = media.uri
             self._attr_media_content_type = MediaType.MUSIC
             self._attr_media_duration = media.duration

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -66,11 +66,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import fire_general_update, fire_transport_update, setup_integration
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 MEDIA_PLAYER_ENTITY_ID = "media_player.test_wiim_device"
@@ -1328,21 +1328,13 @@ async def test_media_image_hash_changes_for_same_local_artwork_url(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_wiim_device: MagicMock,
+    aioclient_mock: AiohttpClientMocker,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the media proxy returns new artwork when its URL is reused."""
     await setup_integration(hass, mock_config_entry)
-    image_url = "https://192.168.1.100/changing-album-art.jpg"
+    image_url = "https://192.168.1.100/changing-album-art.jpg#existing-fragment"
 
-    responses = []
-    for image_bytes in (b"first-image", b"second-image"):
-        response = MagicMock()
-        response.status = 200
-        response.headers = {"Content-Type": "image/jpeg"}
-        response.read = AsyncMock(return_value=image_bytes)
-        responses.append(response)
-
-    websession = async_get_clientsession(hass)
     client = await hass_client()
 
     mock_wiim_device.current_media = WiimMediaMetadata(
@@ -1358,11 +1350,16 @@ async def test_media_image_hash_changes_for_same_local_artwork_url(
     assert state.attributes[ATTR_ENTITY_PICTURE] == image_url
     first_local_image = state.attributes[ATTR_ENTITY_PICTURE_LOCAL]
 
-    with patch.object(websession, "get", AsyncMock(return_value=responses[0])):
-        media_response = await client.get(first_local_image)
+    aioclient_mock.get(
+        image_url,
+        content=b"first-image",
+        headers={"Content-Type": "image/jpeg"},
+    )
+    media_response = await client.get(first_local_image)
     assert media_response.status == 200
     first_image = await media_response.read()
     assert first_image == b"first-image"
+    assert "existing-fragment" not in aioclient_mock.mock_calls[0][1].fragment
 
     mock_wiim_device.current_media = WiimMediaMetadata(
         title="Second Song",
@@ -1379,8 +1376,13 @@ async def test_media_image_hash_changes_for_same_local_artwork_url(
     second_local_image = state.attributes[ATTR_ENTITY_PICTURE_LOCAL]
     assert second_local_image != first_local_image
 
-    with patch.object(websession, "get", AsyncMock(return_value=responses[1])):
-        media_response = await client.get(second_local_image)
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(
+        image_url,
+        content=b"second-image",
+        headers={"Content-Type": "image/jpeg"},
+    )
+    media_response = await client.get(second_local_image)
     assert media_response.status == 200
     second_image = await media_response.read()
     assert second_image == b"second-image"

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -19,6 +19,7 @@ from wiim.models import (
 from wiim.wiim_device import WiimDevice
 
 from homeassistant.components.media_player import (
+    ATTR_ENTITY_PICTURE_LOCAL,
     ATTR_GROUP_MEMBERS,
     ATTR_INPUT_SOURCE,
     ATTR_MEDIA_ALBUM_NAME,
@@ -57,13 +58,20 @@ from homeassistant.components.media_player import (
 )
 import homeassistant.components.wiim as wiim_component
 from homeassistant.components.wiim.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_ENTITY_PICTURE,
+    CONF_HOST,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import fire_general_update, fire_transport_update, setup_integration
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 MEDIA_PLAYER_ENTITY_ID = "media_player.test_wiim_device"
 
@@ -1313,3 +1321,67 @@ async def test_join_service_invalid_member_uses_translation(
     assert exc_info.value.translation_key == "invalid_grouping_entity"
     assert exc_info.value.translation_placeholders == {"entity_id": invalid_entity_id}
     mock_wiim_controller.async_join_group.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_wiim_controller")
+async def test_media_image_hash_changes_for_same_local_artwork_url(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the media proxy returns new artwork when its URL is reused."""
+    await setup_integration(hass, mock_config_entry)
+    image_url = "https://192.168.1.100/changing-album-art.jpg"
+
+    responses = []
+    for image_bytes in (b"first-image", b"second-image"):
+        response = MagicMock()
+        response.status = 200
+        response.headers = {"Content-Type": "image/jpeg"}
+        response.read = AsyncMock(return_value=image_bytes)
+        responses.append(response)
+
+    websession = async_get_clientsession(hass)
+    client = await hass_client()
+
+    mock_wiim_device.current_media = WiimMediaMetadata(
+        title="First Song",
+        artist="Artist",
+        album="Album",
+        uri="http://example.com/first.flac",
+        image_url=image_url,
+    )
+    await fire_general_update(hass, mock_wiim_device)
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state is not None
+    assert state.attributes[ATTR_ENTITY_PICTURE] == image_url
+    first_local_image = state.attributes[ATTR_ENTITY_PICTURE_LOCAL]
+
+    with patch.object(websession, "get", AsyncMock(return_value=responses[0])):
+        media_response = await client.get(first_local_image)
+    assert media_response.status == 200
+    first_image = await media_response.read()
+    assert first_image == b"first-image"
+
+    mock_wiim_device.current_media = WiimMediaMetadata(
+        title="Second Song",
+        artist="Artist",
+        album="Album",
+        uri="http://example.com/second.flac",
+        image_url=image_url,
+    )
+    await fire_general_update(hass, mock_wiim_device)
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state is not None
+
+    assert state.attributes[ATTR_ENTITY_PICTURE] == image_url
+    second_local_image = state.attributes[ATTR_ENTITY_PICTURE_LOCAL]
+    assert second_local_image != first_local_image
+
+    with patch.object(websession, "get", AsyncMock(return_value=responses[1])):
+        media_response = await client.get(second_local_image)
+    assert media_response.status == 200
+    second_image = await media_response.read()
+    assert second_image == b"second-image"
+    assert second_image != first_image

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -1333,7 +1333,7 @@ async def test_media_image_hash_changes_for_same_local_artwork_url(
 ) -> None:
     """Test the media proxy returns new artwork when its URL is reused."""
     await setup_integration(hass, mock_config_entry)
-    image_url = "https://192.168.1.100/changing-album-art.jpg#existing-fragment"
+    image_url = "https://192.168.1.100/changing-album-art.jpg"
 
     client = await hass_client()
 
@@ -1359,7 +1359,6 @@ async def test_media_image_hash_changes_for_same_local_artwork_url(
     assert media_response.status == 200
     first_image = await media_response.read()
     assert first_image == b"first-image"
-    assert "existing-fragment" not in aioclient_mock.mock_calls[0][1].fragment
 
     mock_wiim_device.current_media = WiimMediaMetadata(
         title="Second Song",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix stale artwork for WiiM media players when the device reuses the same image URL across different tracks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
