### PR TITLE
Fix missing program keys issue from Home Connect

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -65,6 +65,13 @@ class HomeConnectApplianceData:
     programs: list[EnumerateProgram]
     settings: dict[SettingKey, GetSetting]
     status: dict[StatusKey, Status]
+    """
+    Program keys mapping is to cover API issues
+    where the API returns a different program key
+    than the requested one, which usually it isn't
+    in the list of available programs.
+    """
+    program_keys_mapped: dict[ProgramKey, ProgramKey]
 
     def update(self, other: HomeConnectApplianceData) -> None:
         """Update data with data from other instance."""
@@ -78,6 +85,7 @@ class HomeConnectApplianceData:
         self.programs.extend(other.programs)
         self.settings.update(other.settings)
         self.status.update(other.status)
+        self.program_keys_mapped.update(other.program_keys_mapped)
 
     @classmethod
     def empty(cls, appliance: HomeAppliance) -> HomeConnectApplianceData:
@@ -90,6 +98,7 @@ class HomeConnectApplianceData:
             programs=[],
             settings={},
             status={},
+            program_keys_mapped={},
         )
 
 
@@ -493,7 +502,8 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
 
         programs = []
         events = {}
-        options = {}
+        options: dict[OptionKey, ProgramDefinitionOption] = {}
+        program_keys_mapped: dict[ProgramKey, ProgramKey] = {}
         if appliance.type in APPLIANCES_WITH_PROGRAMS:  # pylint: disable=too-many-nested-blocks
             try:
                 all_programs = await self.client.get_all_programs(appliance.ha_id)
@@ -540,7 +550,9 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                                     break
 
                 if current_program_key:
-                    options = await self.get_options_definitions(current_program_key)
+                    options, program_keys_mapped = await self.get_program_information(
+                        current_program_key
+                    )
                     for option in program_options or []:
                         option_event_key = EventKey(option.key)
                         events[option_event_key] = Event(
@@ -576,25 +588,24 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                 programs=programs,
                 settings=settings,
                 status=status,
+                program_keys_mapped=program_keys_mapped,
             )
         )
 
-    async def get_options_definitions(
+    async def get_program_information(
         self, program_key: ProgramKey
-    ) -> dict[OptionKey, ProgramDefinitionOption]:
-        """Get options with constraints for appliance."""
+    ) -> tuple[dict[OptionKey, ProgramDefinitionOption], dict[ProgramKey, ProgramKey]]:
+        """Get options with constraints and program keys mapping for appliance.
+
+        It returns the program keys mapping only when the requested program and the
+        key from the program definition are different.
+        """
         if program_key is ProgramKey.UNKNOWN:
-            return {}
+            return {}, {}
         try:
-            return {
-                option.key: option
-                for option in (
-                    await self.client.get_available_program(
-                        self.data.info.ha_id, program_key=program_key
-                    )
-                ).options
-                or []
-            }
+            program_definition = await self.client.get_available_program(
+                self.data.info.ha_id, program_key=program_key
+            )
         except TooManyRequestsError:
             raise
         except HomeConnectError as error:
@@ -603,7 +614,10 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                 self.data.info.ha_id,
                 error,
             )
-            return {}
+            return {}, {}
+        return {option.key: option for option in program_definition.options or []}, {
+            program_key: program_definition.key
+        } if program_key != program_definition.key else {}
 
     async def update_options(self, program_key: ProgramKey) -> None:
         """Update options for appliance."""
@@ -622,7 +636,11 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
         else:
             resolved_program_key = program_key
 
-        options.update(await self.get_options_definitions(resolved_program_key))
+        new_options, program_keys_mapped = await self.get_program_information(
+            resolved_program_key
+        )
+        options.update(new_options)
+        self.data.program_keys_mapped.update(program_keys_mapped)
 
         for option in options.values():
             option_event_key = EventKey(option.key)

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -454,6 +454,20 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
             PROGRAMS_TRANSLATION_KEYS_MAP.get(program_key) if program_key else None
         )
 
+        if not hasattr(self, "_attr_options"):
+            self.set_options()
+        # If the current option is not in the options, maybe it is
+        # is the key from the available program endpoint
+        if (
+            self._attr_current_option is not None
+            and program_key is not None
+            and self._attr_current_option not in self._attr_options
+            and (
+                mapped_key := self.coordinator.data.program_keys_mapped.get(program_key)
+            )
+        ):
+            self._attr_current_option = PROGRAMS_TRANSLATION_KEYS_MAP.get(mapped_key)
+
     @override
     async def async_select_option(self, option: str) -> None:
         """Select new program."""

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -37,7 +37,10 @@ from aiohomeconnect.model.program import (
 from aiohomeconnect.model.setting import SettingConstraints
 import pytest
 
-from homeassistant.components.home_connect.const import DOMAIN
+from homeassistant.components.home_connect.const import (
+    DOMAIN,
+    PROGRAMS_TRANSLATION_KEYS_MAP,
+)
 from homeassistant.components.select import (
     ATTR_OPTION,
     ATTR_OPTIONS,
@@ -419,6 +422,70 @@ async def test_select_program_functionality(
     )
     await hass.async_block_till_done()
     assert hass.states.is_state(entity_id, STATE_UNKNOWN)
+
+
+@pytest.mark.parametrize("appliance", ["Oven"], indirect=True)
+async def test_select_program_static_mapping(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+) -> None:
+    """Test the static mapping functionality at select program entities.
+
+    HotAir program is an option given by the API, but the API sends
+    a 3DHotAir which is not in the given options, but as stated by
+    Home Connect team, they are equivalent.
+    """
+    entity_id = "select.oven_active_program"
+    expected_program = "cooking_oven_program_heating_mode_hot_air"
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state != expected_program
+    options = state.attributes[ATTR_OPTIONS]
+    assert expected_program in options
+    assert (
+        PROGRAMS_TRANSLATION_KEYS_MAP[ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR]
+        not in options
+    )
+
+    client.get_available_program = AsyncMock(
+        return_value=ProgramDefinition(
+            ProgramKey.COOKING_OVEN_HEATING_MODE_HOT_AIR,
+        )
+    )
+
+    await client.add_events(
+        [
+            EventMessage(
+                appliance.ha_id,
+                EventType.NOTIFY,
+                ArrayOfEvents(
+                    [
+                        Event(
+                            key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+                            raw_key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR,
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state(entity_id, expected_program)
+    client.get_available_program.assert_awaited_once_with(
+        appliance.ha_id, program_key=ProgramKey.COOKING_OVEN_HEATING_MODE_3D_HOT_AIR
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Home Connect API sometimes sends program values that aren't on the program list, and this causes issues on the select entities related to the active and selected program. AFAIK and based on the information gathered from #175598, we can obtain the right key from the available program endpoint.

For reference:
```
2026-07-07 06:45:47.150 DEBUG (MainThread) [aiohomeconnect] Request: GET /homeappliances/haid/programs/available/Cooking.Oven.Program.HeatingMode.3DHotAir | Data: None
2026-07-07 06:45:47.215 DEBUG (MainThread) [aiohomeconnect] Response:
{
  "data": {
    "key": "Cooking.Oven.Program.HeatingMode.HotAir",
    "name": "3D Hot air",
    ...
  }
}
```

So, this PR adds a dictionary that saves program keys when the requested key and the given key are different. Then, in the select entity, if we cannot find the current option in the list of options, we check that dictionary to find if there's any program that means the right program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175598
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
