### PR TITLE
Bump matter-python-client to 1.4.0

### DIFF
--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -8,6 +8,6 @@
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "requirements": ["matter-python-client==1.3.0", "matter-ble-proxy==0.7.1"],
+  "requirements": ["matter-python-client==1.4.0", "matter-ble-proxy==0.7.1"],
   "zeroconf": ["_matter._tcp.local.", "_matterc._udp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1546,7 +1546,7 @@ matrix-nio==0.26.0
 matter-ble-proxy==0.7.1
 
 # homeassistant.components.matter
-matter-python-client==1.3.0
+matter-python-client==1.4.0
 
 # homeassistant.components.maxcube
 maxcube-api==0.4.3


### PR DESCRIPTION
## Proposed change

This PR bumps the [matter-python-client](https://github.com/matter-js/matterjs-server/tree/main/python_client) to [v1.4.0](https://github.com/matter-js/matterjs-server/releases/tag/v1.4.0), which introduces WebSocket schema 13 (backward compatible). The client's declared schema version stays at 11, so the minimum required Matter server version is unchanged.

### Diff

The diff is a bit hard to see, as it shares the repo with Matter.js-server. The `python_client` folder contains the entire Python library. Diff: https://github.com/matter-js/matterjs-server/compare/v1.3.0...v1.4.0

It's likely easier to see the individual commits for the Python client here: https://github.com/matter-js/matterjs-server/commits/main/python_client?since=2026-07-23&until=2026-08-08
- The deprecated global `EventList` attribute (0xFFFA) is no longer generated and is gone from every cluster definition: https://github.com/matter-js/matterjs-server/pull/977. Home Assistant does not reference it, and unknown attribute paths are skipped by the client.
- Manufacturer-specific attributes on standard clusters are now supported, which adds the WAGO Home Blind Control travel time attributes to Window Covering plus a new WAGO custom cluster: https://github.com/matter-js/matterjs-server/pull/973 and https://github.com/matter-js/matterjs-server/pull/978. All are optional and default to `None`.
- `write_attribute()` now serializes struct and list-of-struct values keyed by TLV tag instead of field name, as the server's `WRITE_ATTRIBUTE` handler expects: https://github.com/matter-js/matterjs-server/pull/958. Every Home Assistant call site passes a scalar, which the new serializer returns unchanged.
- New `get_network_topology` command, `network_topology_updated` event and local OTA image upload API: https://github.com/matter-js/matterjs-server/pull/832, https://github.com/matter-js/matterjs-server/pull/917 and https://github.com/matter-js/matterjs-server/pull/939. None of these are consumed by Home Assistant yet.

You can find the full cluster definitions here to diff them: [new clusters](https://github.com/matter-js/matterjs-server/tree/v1.4.0/python_client/chip/clusters/cluster_defs) and [old clusters](https://github.com/matter-js/matterjs-server/tree/v1.3.0/python_client/chip/clusters/cluster_defs). The only removal is `EventList`, the only additions are the WAGO attributes. These do not affect us.

Full changelog: https://github.com/matter-js/matterjs-server/blob/v1.4.0/CHANGELOG.md

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
