### PR TITLE
Add now playing, position and transport control to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -118,7 +118,6 @@ class LyngdorfDevice(LyngdorfEntity, MediaPlayerEntity):
         device_info: DeviceInfo,
         translation_key: str | None,
         entity_id_suffix: str,
-        features: MediaPlayerEntityFeature = MediaPlayerEntityFeature(0),
     ) -> None:
         """Initialize the device."""
         super().__init__(receiver, device_info)
@@ -126,11 +125,12 @@ class LyngdorfDevice(LyngdorfEntity, MediaPlayerEntity):
             assert config_entry.unique_id
         self._attr_unique_id = f"{config_entry.unique_id}_{entity_id_suffix}"
         self._attr_translation_key = translation_key
-        self._attr_supported_features = features
 
 
 class LyngdorfZoneBDevice(LyngdorfDevice):
     """Lyngdorf Zone B device."""
+
+    _attr_supported_features = FEATURES_ZONE_B
 
     def __init__(
         self,
@@ -145,7 +145,6 @@ class LyngdorfZoneBDevice(LyngdorfDevice):
             device_info,
             None,
             "zone_b",
-            FEATURES_ZONE_B,
         )
 
     @override
@@ -245,7 +244,6 @@ class LyngdorfMainDevice(LyngdorfDevice):
             device_info,
             "main_zone",
             "main_zone",
-            FEATURES_MAIN,
         )
 
     @override
@@ -255,7 +253,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
         # drift, rather than once a second, which is all Home Assistant
         # needs: it stores a position and a timestamp and extrapolates.
         await super().async_added_to_hass()
-        if self._streaming:
+        if self._has_streamer:
             self.async_on_remove(
                 self._receiver.register_position_jump_callback(self._handle_position)
             )
@@ -266,7 +264,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
         self.async_write_ha_state()
 
     @property
-    def _streaming(self) -> bool:
+    def _has_streamer(self) -> bool:
         """Return whether this model has a streaming module at all."""
         return self._receiver.model is not None and (
             self._receiver.model.has_streaming_feature()
@@ -275,7 +273,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def _now_playing(self) -> NowPlaying | None:
         """Return the current track, or None if this model has no streamer."""
-        if not self._streaming:
+        if not self._has_streamer:
             return None
         return self._receiver.now_playing
 
@@ -353,7 +351,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def media_position(self) -> int | None:
         """Return the position of the current track, in seconds."""
-        if not self._streaming or not self._receiver.has_position:
+        if not self._has_streamer or not self._receiver.has_position:
             return None
         return round(self._receiver.position_ms / 1000)
 
@@ -361,7 +359,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def media_position_updated_at(self) -> datetime | None:
         """Return when the position was last valid."""
-        if not self._streaming or not self._receiver.has_position:
+        if not self._has_streamer or not self._receiver.has_position:
             return None
         return self._receiver.position_updated_at
 
@@ -369,13 +367,13 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def shuffle(self) -> bool | None:
         """Return whether shuffle is enabled."""
-        return self._receiver.shuffle if self._streaming else None
+        return self._receiver.shuffle if self._has_streamer else None
 
     @override
     @property
     def repeat(self) -> RepeatMode | None:
         """Return the current repeat mode."""
-        if not self._streaming or (repeat := self._receiver.repeat) is None:
+        if not self._has_streamer or (repeat := self._receiver.repeat) is None:
             return None
         return REPEAT_MODES.get(repeat)
 

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -266,9 +266,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def _has_streamer(self) -> bool:
         """Return whether this model has a streaming module at all."""
-        return self._receiver.model is not None and (
-            self._receiver.model.has_streaming_feature()
-        )
+        return self._receiver.model.has_streaming_feature()
 
     @property
     def _now_playing(self) -> NowPlaying | None:

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -54,6 +54,14 @@ CONTROL_FEATURES: tuple[tuple[Control, MediaPlayerEntityFeature], ...] = (
     (Control.SEEK, MediaPlayerEntityFeature.SEEK),
 )
 
+REPEAT_MODES: dict[Repeat, RepeatMode] = {
+    Repeat.OFF: RepeatMode.OFF,
+    Repeat.ONE: RepeatMode.ONE,
+    Repeat.ALL: RepeatMode.ALL,
+}
+
+LYNGDORF_REPEATS: dict[RepeatMode, Repeat] = {v: k for k, v in REPEAT_MODES.items()}
+
 PLAYBACK_STATES: dict[PlaybackState, MediaPlayerState] = {
     PlaybackState.PLAYING: MediaPlayerState.PLAYING,
     PlaybackState.PAUSED: MediaPlayerState.PAUSED,
@@ -114,7 +122,8 @@ class LyngdorfDevice(LyngdorfEntity, MediaPlayerEntity):
     ) -> None:
         """Initialize the device."""
         super().__init__(receiver, device_info)
-        assert config_entry.unique_id
+        if TYPE_CHECKING:
+            assert config_entry.unique_id
         self._attr_unique_id = f"{config_entry.unique_id}_{entity_id_suffix}"
         self._attr_translation_key = translation_key
         self._attr_supported_features = features
@@ -241,14 +250,10 @@ class LyngdorfMainDevice(LyngdorfDevice):
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Subscribe to position discontinuities.
-
-        Position is deliberately not routed through the receiver's
-        notification callbacks. The jump callback fires only on a seek,
-        track change, play/pause or drift, rather than roughly once a
-        second, which is what Home Assistant wants: it stores the position
-        and a timestamp and the frontend extrapolates between them.
-        """
+        """Subscribe to position discontinuities."""
+        # The jump callback fires on a seek, track change, play/pause or
+        # drift, rather than once a second, which is all Home Assistant
+        # needs: it stores a position and a timestamp and extrapolates.
         await super().async_added_to_hass()
         if self._streaming:
             self.async_on_remove(
@@ -256,7 +261,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
             )
 
     @callback
-    def _handle_position(self, position_ms: int | None) -> None:
+    def _handle_position(self, _position_ms: int | None) -> None:
         """Handle a position discontinuity."""
         self.async_write_ha_state()
 
@@ -277,11 +282,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @override
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:
-        """Return the features the device currently offers.
-
-        Transport is source-dependent and changes at runtime, so it is
-        recomputed rather than fixed at construction.
-        """
+        """Return the features the device currently offers."""
         features = FEATURES_MAIN
         if (now_playing := self._now_playing) is None:
             return features
@@ -376,16 +377,14 @@ class LyngdorfMainDevice(LyngdorfDevice):
         """Return the current repeat mode."""
         if not self._streaming or (repeat := self._receiver.repeat) is None:
             return None
-        return RepeatMode(repeat.value)
+        return REPEAT_MODES.get(repeat)
 
     @override
     async def async_media_pause(self) -> None:
-        """Pause playback.
-
-        On controller-driven sources such as AirPlay the device ends the
-        session outright and cannot restart it; only the controlling app
-        can. There is no separate resume command.
-        """
+        """Pause playback."""
+        # On a controller-driven source such as AirPlay the device ends the
+        # session rather than pausing, and only the controlling app can
+        # start it again.
         await self._receiver.async_pause()
 
     @override
@@ -411,7 +410,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @override
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set the repeat mode, leaving shuffle alone."""
-        await self._receiver.async_set_repeat(Repeat(repeat.value))
+        await self._receiver.async_set_repeat(LYNGDORF_REPEATS[repeat])
 
     @override
     @property

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -1,17 +1,22 @@
 """Media player platform for Lyngdorf integration."""
 
+from datetime import datetime
 from typing import TYPE_CHECKING, override
 
 from lyngdorf.device import Receiver
 from lyngdorf.models.base import NumericRange
+from lyngdorf.states import Control, PlaybackState, Repeat
+from lyngdorf.streaming import NowPlaying
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
+    MediaType,
+    RepeatMode,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -38,6 +43,23 @@ FEATURES_MAIN = (
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
     | MediaPlayerEntityFeature.SELECT_SOURCE
 )
+
+# The streaming module advertises transport per source and it changes at
+# runtime, so these are added to FEATURES_MAIN only while the device offers
+# them: AirPlay has no seek, a stopped device offers nothing at all.
+CONTROL_FEATURES: tuple[tuple[Control, MediaPlayerEntityFeature], ...] = (
+    (Control.PAUSE, MediaPlayerEntityFeature.PAUSE),
+    (Control.NEXT_TRACK, MediaPlayerEntityFeature.NEXT_TRACK),
+    (Control.PREVIOUS_TRACK, MediaPlayerEntityFeature.PREVIOUS_TRACK),
+    (Control.SEEK, MediaPlayerEntityFeature.SEEK),
+)
+
+PLAYBACK_STATES: dict[PlaybackState, MediaPlayerState] = {
+    PlaybackState.PLAYING: MediaPlayerState.PLAYING,
+    PlaybackState.PAUSED: MediaPlayerState.PAUSED,
+    PlaybackState.STOPPED: MediaPlayerState.IDLE,
+    PlaybackState.TRANSITIONING: MediaPlayerState.BUFFERING,
+}
 
 
 async def async_setup_entry(
@@ -218,12 +240,178 @@ class LyngdorfMainDevice(LyngdorfDevice):
         )
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to position discontinuities.
+
+        Position is deliberately not routed through the receiver's
+        notification callbacks. The jump callback fires only on a seek,
+        track change, play/pause or drift, rather than roughly once a
+        second, which is what Home Assistant wants: it stores the position
+        and a timestamp and the frontend extrapolates between them.
+        """
+        await super().async_added_to_hass()
+        if self._streaming:
+            self.async_on_remove(
+                self._receiver.register_position_jump_callback(self._handle_position)
+            )
+
+    @callback
+    def _handle_position(self, position_ms: int | None) -> None:
+        """Handle a position discontinuity."""
+        self.async_write_ha_state()
+
+    @property
+    def _streaming(self) -> bool:
+        """Return whether this model has a streaming module at all."""
+        return self._receiver.model is not None and (
+            self._receiver.model.has_streaming_feature()
+        )
+
+    @property
+    def _now_playing(self) -> NowPlaying | None:
+        """Return the current track, or None if this model has no streamer."""
+        if not self._streaming:
+            return None
+        return self._receiver.now_playing
+
+    @override
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Return the features the device currently offers.
+
+        Transport is source-dependent and changes at runtime, so it is
+        recomputed rather than fixed at construction.
+        """
+        features = FEATURES_MAIN
+        if (now_playing := self._now_playing) is None:
+            return features
+
+        for control, feature in CONTROL_FEATURES:
+            if control in now_playing.controls:
+                features |= feature
+        if self._receiver.can_shuffle:
+            features |= MediaPlayerEntityFeature.SHUFFLE_SET
+        if self._receiver.available_repeat_modes:
+            features |= MediaPlayerEntityFeature.REPEAT_SET
+        return features
+
+    @override
     @property
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
-        if self._receiver.power_on:
-            return MediaPlayerState.ON
-        return MediaPlayerState.OFF
+        if not self._receiver.power_on:
+            return MediaPlayerState.OFF
+        if (now_playing := self._now_playing) is not None:
+            if (state := PLAYBACK_STATES.get(now_playing.state)) is not None:
+                return state
+        return MediaPlayerState.ON
+
+    @override
+    @property
+    def media_content_type(self) -> MediaType | None:
+        """Return the type of media currently playing."""
+        if self._now_playing is None:
+            return None
+        return MediaType.MUSIC
+
+    @override
+    @property
+    def media_title(self) -> str | None:
+        """Return the title of the current track."""
+        return now_playing.title if (now_playing := self._now_playing) else None
+
+    @override
+    @property
+    def media_artist(self) -> str | None:
+        """Return the artist of the current track."""
+        return now_playing.artist if (now_playing := self._now_playing) else None
+
+    @override
+    @property
+    def media_album_name(self) -> str | None:
+        """Return the album of the current track."""
+        return now_playing.album if (now_playing := self._now_playing) else None
+
+    @override
+    @property
+    def media_image_url(self) -> str | None:
+        """Return the album art of the current track."""
+        return now_playing.art_url if (now_playing := self._now_playing) else None
+
+    @override
+    @property
+    def media_duration(self) -> int | None:
+        """Return the duration of the current track, in seconds."""
+        if (
+            now_playing := self._now_playing
+        ) is None or now_playing.duration_ms is None:
+            return None
+        return round(now_playing.duration_ms / 1000)
+
+    @override
+    @property
+    def media_position(self) -> int | None:
+        """Return the position of the current track, in seconds."""
+        if not self._streaming or not self._receiver.has_position:
+            return None
+        return round(self._receiver.position_ms / 1000)
+
+    @override
+    @property
+    def media_position_updated_at(self) -> datetime | None:
+        """Return when the position was last valid."""
+        if not self._streaming or not self._receiver.has_position:
+            return None
+        return self._receiver.position_updated_at
+
+    @override
+    @property
+    def shuffle(self) -> bool | None:
+        """Return whether shuffle is enabled."""
+        return self._receiver.shuffle if self._streaming else None
+
+    @override
+    @property
+    def repeat(self) -> RepeatMode | None:
+        """Return the current repeat mode."""
+        if not self._streaming or (repeat := self._receiver.repeat) is None:
+            return None
+        return RepeatMode(repeat.value)
+
+    @override
+    async def async_media_pause(self) -> None:
+        """Pause playback.
+
+        On controller-driven sources such as AirPlay the device ends the
+        session outright and cannot restart it; only the controlling app
+        can. There is no separate resume command.
+        """
+        await self._receiver.async_pause()
+
+    @override
+    async def async_media_next_track(self) -> None:
+        """Skip to the next track."""
+        await self._receiver.async_next()
+
+    @override
+    async def async_media_previous_track(self) -> None:
+        """Skip to the previous track."""
+        await self._receiver.async_previous()
+
+    @override
+    async def async_media_seek(self, position: float) -> None:
+        """Seek to a position, given in seconds."""
+        await self._receiver.async_seek(round(position * 1000))
+
+    @override
+    async def async_set_shuffle(self, shuffle: bool) -> None:
+        """Enable or disable shuffle, leaving the repeat mode alone."""
+        await self._receiver.async_set_shuffle(shuffle)
+
+    @override
+    async def async_set_repeat(self, repeat: RepeatMode) -> None:
+        """Set the repeat mode, leaving shuffle alone."""
+        await self._receiver.async_set_repeat(Repeat(repeat.value))
 
     @override
     @property

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -149,6 +149,12 @@ def notify_receiver_update(receiver: MagicMock) -> None:
         call.args[0]()
 
 
+def notify_position_jump(receiver: MagicMock, position_ms: int | None) -> None:
+    """Fire every position jump callback the entities registered."""
+    for call in receiver.register_position_jump_callback.call_args_list:
+        call.args[0](position_ms)
+
+
 @pytest.fixture
 def platforms() -> list[Platform]:
     """Platforms to load; override per module to isolate a single platform."""

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -63,6 +63,7 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver = MagicMock(spec=Receiver)
         receiver.name = "Mock Lyngdorf"
         receiver.connected = True
+        receiver.model = LyngdorfModel.MP_60
 
         # Diagnostics reports the whole receiver, so every property it reads
         # needs a value here; an unset one is a mock the response cannot encode.
@@ -100,6 +101,15 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver.available_audio_inputs = ["optical", "aux"]
         receiver.available_video_inputs = ["hdmi"]
         receiver.available_stream_types = ["AirPlay", "DLNA"]
+
+        receiver.now_playing = None
+        receiver.has_position = False
+        receiver.position_ms = None
+        receiver.position_updated_at = None
+        receiver.shuffle = None
+        receiver.repeat = None
+        receiver.can_shuffle = False
+        receiver.available_repeat_modes = frozenset()
 
         receiver.zone_b_power_on = False
         receiver.zone_b_volume = -40.0

--- a/tests/components/lyngdorf/snapshots/test_media_player.ambr
+++ b/tests/components/lyngdorf/snapshots/test_media_player.ambr
@@ -160,7 +160,7 @@
       <MediaPlayerEntityStateAttribute.MEDIA_REPEAT: 'repeat'>: <RepeatMode.OFF: 'off'>,
       <MediaPlayerEntityStateAttribute.MEDIA_SHUFFLE: 'shuffle'>: False,
       <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <MediaPlayerEntityFeature: 363967>,
-      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL: 'volume_level'>: 0.40816326530612246,
+      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL: 'volume_level'>: 0.48345439870863605,
     }),
     'context': <ANY>,
     'entity_id': 'media_player.mock_lyngdorf_main_zone',

--- a/tests/components/lyngdorf/snapshots/test_media_player.ambr
+++ b/tests/components/lyngdorf/snapshots/test_media_player.ambr
@@ -105,3 +105,121 @@
     'state': 'off',
   })
 # ---
+# name: test_now_playing[media_player.mock_lyngdorf_main_zone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.mock_lyngdorf_main_zone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Main zone',
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.RECEIVER: 'receiver'>,
+    'original_icon': None,
+    'original_name': 'Main zone',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 363967>,
+    'translation_key': 'main_zone',
+    'unique_id': '0050c27c76b2_main_zone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_now_playing[media_player.mock_lyngdorf_main_zone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'receiver',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/media_player_proxy/media_player.mock_lyngdorf_main_zone?token=mock_token&cache=88df577ff5b5b90f',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Main zone',
+      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_MUTED: 'is_volume_muted'>: False,
+      <MediaPlayerEntityStateAttribute.MEDIA_ALBUM_NAME: 'media_album_name'>: 'Songs to Learn & Sing',
+      <MediaPlayerEntityStateAttribute.MEDIA_ARTIST: 'media_artist'>: 'Echo & the Bunnymen',
+      <MediaPlayerEntityStateAttribute.MEDIA_CONTENT_TYPE: 'media_content_type'>: <MediaType.MUSIC: 'music'>,
+      <MediaPlayerEntityStateAttribute.MEDIA_DURATION: 'media_duration'>: 346,
+      <MediaPlayerEntityStateAttribute.MEDIA_POSITION: 'media_position'>: 319,
+      <MediaPlayerEntityStateAttribute.MEDIA_POSITION_UPDATED_AT: 'media_position_updated_at'>: datetime.datetime(2026, 8, 17, 13, 0, tzinfo=datetime.timezone.utc),
+      <MediaPlayerEntityStateAttribute.MEDIA_TITLE: 'media_title'>: 'The Killing Moon',
+      <MediaPlayerEntityStateAttribute.MEDIA_REPEAT: 'repeat'>: <RepeatMode.OFF: 'off'>,
+      <MediaPlayerEntityStateAttribute.MEDIA_SHUFFLE: 'shuffle'>: False,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <MediaPlayerEntityFeature: 363967>,
+      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL: 'volume_level'>: 0.40816326530612246,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.mock_lyngdorf_main_zone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'playing',
+  })
+# ---
+# name: test_now_playing[media_player.mock_lyngdorf_zone_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.mock_lyngdorf_zone_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.RECEIVER: 'receiver'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 3468>,
+    'translation_key': None,
+    'unique_id': '0050c27c76b2_zone_b',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_now_playing[media_player.mock_lyngdorf_zone_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'receiver',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Zone B',
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <MediaPlayerEntityFeature: 3468>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.mock_lyngdorf_zone_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -1,6 +1,7 @@
 """Tests for the Lyngdorf media player platform."""
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from lyngdorf.const import LyngdorfModel
@@ -9,6 +10,7 @@ from lyngdorf.streaming import NowPlaying
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.lyngdorf.media_player import FEATURES_MAIN
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
@@ -17,6 +19,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_DURATION,
     ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_REPEAT,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SHUFFLE,
@@ -58,6 +61,8 @@ from .conftest import notify_receiver_update
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+POSITION_UPDATED_AT = datetime(2026, 8, 17, 13, tzinfo=UTC)
+
 MAIN_ZONE = "media_player.mock_lyngdorf_main_zone"
 ZONE_B = "media_player.mock_lyngdorf_zone_b"
 
@@ -66,6 +71,38 @@ ZONE_B = "media_player.mock_lyngdorf_zone_b"
 def platforms() -> list[Platform]:
     """Only load the media player platform."""
     return [Platform.MEDIA_PLAYER]
+
+
+@pytest.fixture
+def playing_receiver(mock_receiver: MagicMock) -> MagicMock:
+    """Return a receiver that is streaming a track."""
+    mock_receiver.power_on = True
+    mock_receiver.now_playing = NowPlaying(
+        state=PlaybackState.PLAYING,
+        title="The Killing Moon",
+        artist="Echo & the Bunnymen",
+        album="Songs to Learn & Sing",
+        source="Total Solar Eclipse Playlist",
+        art_url="https://example.test/art.jpg",
+        duration_ms=346280,
+        controls=frozenset(
+            {
+                Control.PAUSE,
+                Control.NEXT_TRACK,
+                Control.PREVIOUS_TRACK,
+                Control.SEEK,
+            }
+        ),
+        play_modes=frozenset(),
+    )
+    mock_receiver.has_position = True
+    mock_receiver.position_ms = 318544
+    mock_receiver.position_updated_at = POSITION_UPDATED_AT
+    mock_receiver.shuffle = False
+    mock_receiver.repeat = Repeat.OFF
+    mock_receiver.can_shuffle = True
+    mock_receiver.available_repeat_modes = frozenset({Repeat.OFF, Repeat.ALL})
+    return mock_receiver
 
 
 async def test_entities(
@@ -347,49 +384,13 @@ async def test_zone_b_state_properties(
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI", "Optical"]
 
 
-@pytest.fixture
-def playing_receiver(mock_receiver: MagicMock) -> MagicMock:
-    """Return a receiver that is streaming a track."""
-    mock_receiver.power_on = True
-    mock_receiver.now_playing = NowPlaying(
-        state=PlaybackState.PLAYING,
-        title="The Killing Moon",
-        artist="Echo & the Bunnymen",
-        album="Songs to Learn & Sing",
-        source="Total Solar Eclipse Playlist",
-        art_url="https://example.test/art.jpg",
-        duration_ms=346280,
-        controls=frozenset(
-            {
-                Control.PAUSE,
-                Control.NEXT_TRACK,
-                Control.PREVIOUS_TRACK,
-                Control.SEEK,
-            }
-        ),
-        play_modes=frozenset(),
-    )
-    mock_receiver.has_position = True
-    mock_receiver.position_ms = 318544
-    mock_receiver.position_updated_at = datetime(2026, 8, 17, 13, tzinfo=UTC)
-    mock_receiver.shuffle = False
-    mock_receiver.repeat = Repeat.OFF
-    mock_receiver.can_shuffle = True
-    mock_receiver.available_repeat_modes = frozenset({Repeat.OFF, Repeat.ALL})
-    return mock_receiver
-
-
 @pytest.mark.usefixtures("init_integration")
 async def test_now_playing_metadata(
     hass: HomeAssistant,
     playing_receiver: MagicMock,
 ) -> None:
     """Test now-playing metadata and position are reported."""
-    for cb in [
-        call.args[0]
-        for call in playing_receiver.register_notification_callback.call_args_list
-    ]:
-        cb()
+    notify_receiver_update(playing_receiver)
     await hass.async_block_till_done()
 
     state = hass.states.get(MAIN_ZONE)
@@ -410,29 +411,24 @@ async def test_transport_features_follow_the_device(
     playing_receiver: MagicMock,
 ) -> None:
     """Test supported features track what the source currently offers."""
-    for cb in [
-        call.args[0]
-        for call in playing_receiver.register_notification_callback.call_args_list
-    ]:
-        cb()
+    notify_receiver_update(playing_receiver)
     await hass.async_block_till_done()
 
-    features = hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES]
-    for feature in (
-        MediaPlayerEntityFeature.PAUSE,
-        MediaPlayerEntityFeature.NEXT_TRACK,
-        MediaPlayerEntityFeature.PREVIOUS_TRACK,
-        MediaPlayerEntityFeature.SEEK,
-        MediaPlayerEntityFeature.SHUFFLE_SET,
-        MediaPlayerEntityFeature.REPEAT_SET,
-    ):
-        assert features & feature
+    assert hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES] == (
+        FEATURES_MAIN
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.SEEK
+        | MediaPlayerEntityFeature.SHUFFLE_SET
+        | MediaPlayerEntityFeature.REPEAT_SET
+    )
 
 
 @pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("mock_receiver")
 async def test_transport_features_absent_when_idle(
     hass: HomeAssistant,
-    mock_receiver: MagicMock,
 ) -> None:
     """Test no transport is offered when nothing is playing."""
     features = hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES]
@@ -481,26 +477,42 @@ async def test_seek_converts_to_milliseconds(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_set_shuffle_and_repeat(
+@pytest.mark.parametrize(
+    ("service", "payload", "method", "expected"),
+    [
+        pytest.param(
+            SERVICE_SHUFFLE_SET,
+            {ATTR_MEDIA_SHUFFLE: True},
+            "async_set_shuffle",
+            True,
+            id="shuffle",
+        ),
+        pytest.param(
+            SERVICE_REPEAT_SET,
+            {ATTR_MEDIA_REPEAT: RepeatMode.ALL},
+            "async_set_repeat",
+            Repeat.ALL,
+            id="repeat",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_set_play_mode(
     hass: HomeAssistant,
     playing_receiver: MagicMock,
+    service: str,
+    payload: dict[str, Any],
+    method: str,
+    expected: bool | Repeat,
 ) -> None:
     """Test shuffle and repeat are set on their own axes."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
-        SERVICE_SHUFFLE_SET,
-        {ATTR_ENTITY_ID: MAIN_ZONE, ATTR_MEDIA_SHUFFLE: True},
+        service,
+        {ATTR_ENTITY_ID: MAIN_ZONE} | payload,
         blocking=True,
     )
-    playing_receiver.async_set_shuffle.assert_awaited_once_with(True)
-
-    await hass.services.async_call(
-        MEDIA_PLAYER_DOMAIN,
-        SERVICE_REPEAT_SET,
-        {ATTR_ENTITY_ID: MAIN_ZONE, ATTR_MEDIA_REPEAT: RepeatMode.ALL},
-        blocking=True,
-    )
-    playing_receiver.async_set_repeat.assert_awaited_once_with(Repeat.ALL)
+    getattr(playing_receiver, method).assert_awaited_once_with(expected)
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -537,4 +549,6 @@ async def test_position_jump_updates_state(
         cb(1000)
     await hass.async_block_till_done()
 
-    assert hass.states.get(MAIN_ZONE).attributes[ATTR_MEDIA_POSITION] == 1
+    state = hass.states.get(MAIN_ZONE)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 1
+    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == POSITION_UPDATED_AT

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -57,7 +57,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import notify_receiver_update
+from .conftest import notify_position_jump, notify_receiver_update
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -538,15 +538,8 @@ async def test_position_jump_updates_state(
     playing_receiver: MagicMock,
 ) -> None:
     """Test a position discontinuity refreshes the reported position."""
-    jump_callbacks = [
-        call.args[0]
-        for call in playing_receiver.register_position_jump_callback.call_args_list
-    ]
-    assert jump_callbacks
-
     playing_receiver.position_ms = 1000
-    for cb in jump_callbacks:
-        cb(1000)
+    notify_position_jump(playing_receiver, 1000)
     await hass.async_block_till_done()
 
     state = hass.states.get(MAIN_ZONE)

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -1,25 +1,47 @@
 """Tests for the Lyngdorf media player platform."""
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from lyngdorf.const import LyngdorfModel
+from lyngdorf.states import Control, PlaybackState, Repeat
+from lyngdorf.streaming import NowPlaying
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
+    ATTR_MEDIA_ALBUM_NAME,
+    ATTR_MEDIA_ARTIST,
+    ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_REPEAT,
+    ATTR_MEDIA_SEEK_POSITION,
+    ATTR_MEDIA_SHUFFLE,
+    ATTR_MEDIA_TITLE,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
     DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_MEDIA_SEEK,
     SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
+    MediaPlayerEntityFeature,
     MediaPlayerState,
+    MediaType,
+    RepeatMode,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    SERVICE_REPEAT_SET,
+    SERVICE_SHUFFLE_SET,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_DOWN,
@@ -31,6 +53,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import notify_receiver_update
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -321,3 +345,196 @@ async def test_zone_b_state_properties(
     assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is True
     assert state.attributes[ATTR_INPUT_SOURCE] == "Optical"
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI", "Optical"]
+
+
+@pytest.fixture
+def playing_receiver(mock_receiver: MagicMock) -> MagicMock:
+    """Return a receiver that is streaming a track."""
+    mock_receiver.power_on = True
+    mock_receiver.now_playing = NowPlaying(
+        state=PlaybackState.PLAYING,
+        title="The Killing Moon",
+        artist="Echo & the Bunnymen",
+        album="Songs to Learn & Sing",
+        source="Total Solar Eclipse Playlist",
+        art_url="https://example.test/art.jpg",
+        duration_ms=346280,
+        controls=frozenset(
+            {
+                Control.PAUSE,
+                Control.NEXT_TRACK,
+                Control.PREVIOUS_TRACK,
+                Control.SEEK,
+            }
+        ),
+        play_modes=frozenset(),
+    )
+    mock_receiver.has_position = True
+    mock_receiver.position_ms = 318544
+    mock_receiver.position_updated_at = datetime(2026, 8, 17, 13, tzinfo=UTC)
+    mock_receiver.shuffle = False
+    mock_receiver.repeat = Repeat.OFF
+    mock_receiver.can_shuffle = True
+    mock_receiver.available_repeat_modes = frozenset({Repeat.OFF, Repeat.ALL})
+    return mock_receiver
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_now_playing_metadata(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test now-playing metadata and position are reported."""
+    for cb in [
+        call.args[0]
+        for call in playing_receiver.register_notification_callback.call_args_list
+    ]:
+        cb()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(MAIN_ZONE)
+    assert state.state == MediaPlayerState.PLAYING
+    assert state.attributes[ATTR_MEDIA_TITLE] == "The Killing Moon"
+    assert state.attributes[ATTR_MEDIA_ARTIST] == "Echo & the Bunnymen"
+    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "Songs to Learn & Sing"
+    assert state.attributes[ATTR_MEDIA_DURATION] == 346
+    assert state.attributes[ATTR_MEDIA_POSITION] == 319
+    assert state.attributes[ATTR_MEDIA_CONTENT_TYPE] == MediaType.MUSIC
+    assert state.attributes[ATTR_MEDIA_SHUFFLE] is False
+    assert state.attributes[ATTR_MEDIA_REPEAT] == RepeatMode.OFF
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_transport_features_follow_the_device(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test supported features track what the source currently offers."""
+    for cb in [
+        call.args[0]
+        for call in playing_receiver.register_notification_callback.call_args_list
+    ]:
+        cb()
+    await hass.async_block_till_done()
+
+    features = hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES]
+    for feature in (
+        MediaPlayerEntityFeature.PAUSE,
+        MediaPlayerEntityFeature.NEXT_TRACK,
+        MediaPlayerEntityFeature.PREVIOUS_TRACK,
+        MediaPlayerEntityFeature.SEEK,
+        MediaPlayerEntityFeature.SHUFFLE_SET,
+        MediaPlayerEntityFeature.REPEAT_SET,
+    ):
+        assert features & feature
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_transport_features_absent_when_idle(
+    hass: HomeAssistant,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test no transport is offered when nothing is playing."""
+    features = hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES]
+    assert not features & MediaPlayerEntityFeature.PAUSE
+    assert not features & MediaPlayerEntityFeature.SEEK
+
+
+@pytest.mark.parametrize(
+    ("service", "method"),
+    [
+        pytest.param(SERVICE_MEDIA_PAUSE, "async_pause", id="pause"),
+        pytest.param(SERVICE_MEDIA_NEXT_TRACK, "async_next", id="next"),
+        pytest.param(SERVICE_MEDIA_PREVIOUS_TRACK, "async_previous", id="previous"),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_transport_actions(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+    service: str,
+    method: str,
+) -> None:
+    """Test transport actions reach the receiver."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: MAIN_ZONE},
+        blocking=True,
+    )
+    getattr(playing_receiver, method).assert_awaited_once()
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_seek_converts_to_milliseconds(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test seek converts the position Home Assistant gives in seconds."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_MEDIA_SEEK,
+        {ATTR_ENTITY_ID: MAIN_ZONE, ATTR_MEDIA_SEEK_POSITION: 42.5},
+        blocking=True,
+    )
+    playing_receiver.async_seek.assert_awaited_once_with(42500)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_set_shuffle_and_repeat(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test shuffle and repeat are set on their own axes."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SHUFFLE_SET,
+        {ATTR_ENTITY_ID: MAIN_ZONE, ATTR_MEDIA_SHUFFLE: True},
+        blocking=True,
+    )
+    playing_receiver.async_set_shuffle.assert_awaited_once_with(True)
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_REPEAT_SET,
+        {ATTR_ENTITY_ID: MAIN_ZONE, ATTR_MEDIA_REPEAT: RepeatMode.ALL},
+        blocking=True,
+    )
+    playing_receiver.async_set_repeat.assert_awaited_once_with(Repeat.ALL)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_no_streaming_features_on_model_without_streamer(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test a model with no streaming module offers no transport."""
+    playing_receiver.model = LyngdorfModel.TDAI_2170
+    notify_receiver_update(playing_receiver)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(MAIN_ZONE)
+    assert (
+        not state.attributes[ATTR_SUPPORTED_FEATURES] & MediaPlayerEntityFeature.PAUSE
+    )
+    assert state.attributes.get(ATTR_MEDIA_TITLE) is None
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_position_jump_updates_state(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test a position discontinuity refreshes the reported position."""
+    jump_callbacks = [
+        call.args[0]
+        for call in playing_receiver.register_position_jump_callback.call_args_list
+    ]
+    assert jump_callbacks
+
+    playing_receiver.position_ms = 1000
+    for cb in jump_callbacks:
+        cb(1000)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MAIN_ZONE).attributes[ATTR_MEDIA_POSITION] == 1

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -287,23 +287,15 @@ async def test_availability(
     mock_receiver: MagicMock,
 ) -> None:
     """Test availability when device disconnects and reconnects."""
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-    assert callbacks
-
     mock_receiver.connected = False
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get(MAIN_ZONE).state == STATE_UNAVAILABLE
     assert hass.states.get(ZONE_B).state == STATE_UNAVAILABLE
 
     mock_receiver.connected = True
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     assert hass.states.get(MAIN_ZONE).state != STATE_UNAVAILABLE
@@ -316,11 +308,6 @@ async def test_main_zone_state_properties(
     mock_receiver: MagicMock,
 ) -> None:
     """Test main zone state properties are reported correctly."""
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-
     mock_receiver.power_on = True
     mock_receiver.volume = -40.0
     mock_receiver.mute_enabled = False
@@ -328,8 +315,7 @@ async def test_main_zone_state_properties(
     mock_receiver.sound_mode = "Movie"
     mock_receiver.available_sources = ["HDMI", "Optical"]
     mock_receiver.available_sound_modes = ["Movie", "Stereo"]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     state = hass.states.get(MAIN_ZONE)
@@ -342,15 +328,13 @@ async def test_main_zone_state_properties(
     assert state.attributes[ATTR_SOUND_MODE_LIST] == ["Movie", "Stereo"]
 
     mock_receiver.volume = None
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
     state = hass.states.get(MAIN_ZONE)
     assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) is None
 
     mock_receiver.power_on = False
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
     state = hass.states.get(MAIN_ZONE)
     assert state.state == MediaPlayerState.OFF
@@ -362,18 +346,12 @@ async def test_zone_b_state_properties(
     mock_receiver: MagicMock,
 ) -> None:
     """Test zone B state properties are reported correctly."""
-    callbacks = [
-        call.args[0]
-        for call in mock_receiver.register_notification_callback.call_args_list
-    ]
-
     mock_receiver.zone_b_power_on = True
     mock_receiver.zone_b_volume = -30.0
     mock_receiver.zone_b_mute_enabled = True
     mock_receiver.zone_b_source = "Optical"
     mock_receiver.zone_b_available_sources = ["HDMI", "Optical"]
-    for cb in callbacks:
-        cb()
+    notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
     state = hass.states.get(ZONE_B)

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -1,5 +1,6 @@
 """Tests for the Lyngdorf media player platform."""
 
+from collections.abc import Generator
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -10,14 +11,9 @@ from lyngdorf.streaming import NowPlaying
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.lyngdorf.media_player import FEATURES_MAIN
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
-    ATTR_MEDIA_ALBUM_NAME,
-    ATTR_MEDIA_ARTIST,
-    ATTR_MEDIA_CONTENT_TYPE,
-    ATTR_MEDIA_DURATION,
     ATTR_MEDIA_POSITION,
     ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_REPEAT,
@@ -37,7 +33,6 @@ from homeassistant.components.media_player import (
     SERVICE_SELECT_SOURCE,
     MediaPlayerEntityFeature,
     MediaPlayerState,
-    MediaType,
     RepeatMode,
 )
 from homeassistant.const import (
@@ -71,6 +66,13 @@ ZONE_B = "media_player.mock_lyngdorf_zone_b"
 def platforms() -> list[Platform]:
     """Only load the media player platform."""
     return [Platform.MEDIA_PLAYER]
+
+
+@pytest.fixture(autouse=True)
+def media_proxy_token() -> Generator[None]:
+    """Freeze the media proxy token, which otherwise varies per run."""
+    with patch("secrets.token_hex", return_value="mock_token"):
+        yield
 
 
 @pytest.fixture
@@ -362,45 +364,18 @@ async def test_zone_b_state_properties(
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI", "Optical"]
 
 
-@pytest.mark.usefixtures("init_integration")
-async def test_now_playing_metadata(
+async def test_now_playing(
     hass: HomeAssistant,
+    init_integration: MockConfigEntry,
     playing_receiver: MagicMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test now-playing metadata and position are reported."""
+    """Test now-playing metadata, position and transport features while playing."""
     notify_receiver_update(playing_receiver)
     await hass.async_block_till_done()
 
-    state = hass.states.get(MAIN_ZONE)
-    assert state.state == MediaPlayerState.PLAYING
-    assert state.attributes[ATTR_MEDIA_TITLE] == "The Killing Moon"
-    assert state.attributes[ATTR_MEDIA_ARTIST] == "Echo & the Bunnymen"
-    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "Songs to Learn & Sing"
-    assert state.attributes[ATTR_MEDIA_DURATION] == 346
-    assert state.attributes[ATTR_MEDIA_POSITION] == 319
-    assert state.attributes[ATTR_MEDIA_CONTENT_TYPE] == MediaType.MUSIC
-    assert state.attributes[ATTR_MEDIA_SHUFFLE] is False
-    assert state.attributes[ATTR_MEDIA_REPEAT] == RepeatMode.OFF
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_transport_features_follow_the_device(
-    hass: HomeAssistant,
-    playing_receiver: MagicMock,
-) -> None:
-    """Test supported features track what the source currently offers."""
-    notify_receiver_update(playing_receiver)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(MAIN_ZONE).attributes[ATTR_SUPPORTED_FEATURES] == (
-        FEATURES_MAIN
-        | MediaPlayerEntityFeature.PAUSE
-        | MediaPlayerEntityFeature.NEXT_TRACK
-        | MediaPlayerEntityFeature.PREVIOUS_TRACK
-        | MediaPlayerEntityFeature.SEEK
-        | MediaPlayerEntityFeature.SHUFFLE_SET
-        | MediaPlayerEntityFeature.REPEAT_SET
-    )
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The media player reports power, volume, source and sound mode, but nothing about what is playing. On models with a streaming module the device also reports the current track, its position, and the transport actions it will accept.

This adds the track title, artist, album, artwork and duration; the playback position; play, pause, next, previous and seek; and shuffle and repeat.

**Position uses the library's jump callback, not its per-tick one.** Home Assistant stores a position with a timestamp and extrapolates between them, so it only needs telling on a discontinuity: a seek, a track change, a play or pause, or the position drifting from where the clock says it should be. Subscribing to the raw stream would be roughly 86,400 state writes per player per day, each fanning out over websockets and re-evaluating every automation bound to the entity.

**Supported features are recomputed rather than fixed**, because the device advertises transport per source and changes it at runtime. Spotify Connect offers seek and five play modes; AirPlay offers neither; a stopped device offers nothing at all.

Nothing streaming-derived is reported on a model without a streaming module — the TDAI-2170 and the P series have none — and Zone B is left out, since it has no streamer either.

**One behaviour worth knowing about:** pausing is offered wherever the device advertises it, including on controller-driven sources such as AirPlay, where the device ends the session rather than pausing it and cannot restart it; only the controlling app can. That is inherent to those protocols rather than specific to Home Assistant, and it is recorded under known limitations in the documentation.

Verified against an MP-60 on firmware 5.4.2 while it was streaming.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47460
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
