### PR TITLE
Add VelaSmart integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1973,6 +1973,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/valve/ @home-assistant/core
 /homeassistant/components/vegehub/ @thulrus
 /tests/components/vegehub/ @thulrus
+/homeassistant/components/velasmart/ @liulijun2019
+/tests/components/velasmart/ @liulijun2019
 /homeassistant/components/velbus/ @Cereal2nd @brefra
 /tests/components/velbus/ @Cereal2nd @brefra
 /homeassistant/components/velux/ @Julius2342 @pawlizio @wollew

--- a/homeassistant/components/velasmart/__init__.py
+++ b/homeassistant/components/velasmart/__init__.py
@@ -49,6 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: VelasmartConfigEntry) ->
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
+        config_entry=entry,
         name=DOMAIN,
         update_method=async_update_data,
         update_interval=timedelta(seconds=30),

--- a/homeassistant/components/velasmart/__init__.py
+++ b/homeassistant/components/velasmart/__init__.py
@@ -1,0 +1,68 @@
+"""The VelaSmart integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from velasmart import VelaSmartApiClient, VelaSmartApiError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up VelaSmart from a config entry."""
+    client = VelaSmartApiClient(
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        session=async_get_clientsession(hass),
+    )
+
+    async def async_update_data() -> dict[str, dict[str, Any]]:
+        """Fetch device state from the cloud API."""
+        try:
+            devices = await client.get_devices()
+        except VelaSmartApiError as err:
+            raise UpdateFailed(str(err)) from err
+        return {device["id"]: device for device in devices}
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=DOMAIN,
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=30),
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "coordinator": coordinator,
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow removal of any device."""
+    return True

--- a/homeassistant/components/velasmart/__init__.py
+++ b/homeassistant/components/velasmart/__init__.py
@@ -5,11 +5,12 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from velasmart import VelaSmartApiClient, VelaSmartApiError
+from velasmart import VelaSmartApiAuthError, VelaSmartApiClient, VelaSmartApiError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -42,6 +43,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: VelasmartConfigEntry) ->
         """Fetch device state from the cloud API."""
         try:
             devices = await client.get_devices()
+        except VelaSmartApiAuthError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
         except VelaSmartApiError as err:
             raise UpdateFailed(str(err)) from err
         return {device["id"]: device for device in devices}

--- a/homeassistant/components/velasmart/__init__.py
+++ b/homeassistant/components/velasmart/__init__.py
@@ -1,5 +1,6 @@
 """The VelaSmart integration."""
 
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
@@ -18,7 +19,18 @@ from .const import DOMAIN, PLATFORMS
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+@dataclass
+class VelasmartData:
+    """Runtime data for the VelaSmart integration."""
+
+    client: VelaSmartApiClient
+    coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]]
+
+
+type VelasmartConfigEntry = ConfigEntry[VelasmartData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: VelasmartConfigEntry) -> bool:
     """Set up VelaSmart from a config entry."""
     client = VelaSmartApiClient(
         entry.data[CONF_USERNAME],
@@ -43,24 +55,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "coordinator": coordinator,
-    }
+    entry.runtime_data = VelasmartData(client=client, coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: VelasmartConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.AnyDeviceEntry
+    hass: HomeAssistant,
+    entry: VelasmartConfigEntry,
+    device_entry: dr.AnyDeviceEntry,
 ) -> bool:
     """Allow removal of any device."""
     return True

--- a/homeassistant/components/velasmart/__init__.py
+++ b/homeassistant/components/velasmart/__init__.py
@@ -1,7 +1,5 @@
 """The VelaSmart integration."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 import logging
 from typing import Any
@@ -62,7 +60,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.AnyDeviceEntry
 ) -> bool:
     """Allow removal of any device."""
     return True

--- a/homeassistant/components/velasmart/config_flow.py
+++ b/homeassistant/components/velasmart/config_flow.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any, override
 
-from velasmart import VelaSmartApiClient, VelaSmartApiError
+from velasmart import VelaSmartApiAuthError, VelaSmartApiClient, VelaSmartApiError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -32,8 +32,10 @@ class VelaSmartConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
             try:
                 await self._async_validate(user_input)
-            except VelaSmartApiError:
+            except VelaSmartApiAuthError:
                 errors["base"] = "invalid_auth"
+            except VelaSmartApiError:
+                errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected error validating VelaSmart credentials")
                 errors["base"] = "unknown"
@@ -66,8 +68,10 @@ class VelaSmartConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self._async_validate(user_input)
-            except VelaSmartApiError:
+            except VelaSmartApiAuthError:
                 errors["base"] = "invalid_auth"
+            except VelaSmartApiError:
+                errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected error validating VelaSmart credentials")
                 errors["base"] = "unknown"

--- a/homeassistant/components/velasmart/config_flow.py
+++ b/homeassistant/components/velasmart/config_flow.py
@@ -1,10 +1,11 @@
 """Config flow for the VelaSmart integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any, override
 
-import voluptuous as vol
 from velasmart import VelaSmartApiClient, VelaSmartApiError
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -50,14 +51,12 @@ class VelaSmartConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    @override
     async def async_step_reauth(
-        self, user_input: dict[str, Any] | None = None
+        self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauthentication."""
-        return await self.async_step_reauth_confirm(user_input)
+        return await self.async_step_reauth_confirm()
 
-    @override
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/velasmart/config_flow.py
+++ b/homeassistant/components/velasmart/config_flow.py
@@ -1,16 +1,13 @@
 """Config flow for the VelaSmart integration."""
 
-from __future__ import annotations
-
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 from velasmart import VelaSmartApiClient, VelaSmartApiError
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -18,14 +15,15 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class VelaSmartConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class VelaSmartConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for VelaSmart."""
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
@@ -52,15 +50,17 @@ class VelaSmartConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_reauth(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle reauthentication."""
         return await self.async_step_reauth_confirm(user_input)
 
+    @override
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Confirm reauthentication."""
         errors: dict[str, str] = {}
         entry = self._get_reauth_entry()

--- a/homeassistant/components/velasmart/config_flow.py
+++ b/homeassistant/components/velasmart/config_flow.py
@@ -1,0 +1,102 @@
+"""Config flow for the VelaSmart integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from velasmart import VelaSmartApiClient, VelaSmartApiError
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VelaSmartConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for VelaSmart."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_USERNAME])
+            self._abort_if_unique_id_configured()
+            try:
+                await self._async_validate(user_input)
+            except VelaSmartApiError:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected error validating VelaSmart credentials")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title="VelaSmart", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm(user_input)
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm reauthentication."""
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+        if user_input is not None:
+            try:
+                await self._async_validate(user_input)
+            except VelaSmartApiError:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected error validating VelaSmart credentials")
+                errors["base"] = "unknown"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, **user_input}
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME, default=entry.data.get(CONF_USERNAME)
+                    ): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _async_validate(self, user_input: dict[str, Any]) -> None:
+        """Validate credentials against the cloud API."""
+        client = VelaSmartApiClient(
+            user_input[CONF_USERNAME],
+            user_input[CONF_PASSWORD],
+            session=async_get_clientsession(self.hass),
+        )
+        await client.authenticate()

--- a/homeassistant/components/velasmart/const.py
+++ b/homeassistant/components/velasmart/const.py
@@ -1,0 +1,6 @@
+"""Constants for the VelaSmart integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "velasmart"
+PLATFORMS: list[Platform] = [Platform.COVER]

--- a/homeassistant/components/velasmart/cover.py
+++ b/homeassistant/components/velasmart/cover.py
@@ -10,24 +10,24 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import VelasmartConfigEntry
 from .const import DOMAIN
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: VelasmartConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up VelaSmart cover entities."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data["coordinator"]
-    client: VelaSmartApiClient = data["client"]
+    data = entry.runtime_data
+    coordinator = data.coordinator
+    client = data.client
 
     async_add_entities(
         VelaSmartCover(coordinator, client, device)

--- a/homeassistant/components/velasmart/cover.py
+++ b/homeassistant/components/velasmart/cover.py
@@ -1,8 +1,6 @@
 """Cover platform for the VelaSmart integration."""
 
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, override
 
 from velasmart import VelaSmartApiClient
 
@@ -14,7 +12,8 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -23,7 +22,7 @@ from .const import DOMAIN
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up VelaSmart cover entities."""
     data = hass.data[DOMAIN][entry.entry_id]
@@ -40,6 +39,7 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
     """Representation of a VelaSmart curtain."""
 
     _attr_device_class = CoverDeviceClass.CURTAIN
+    _attr_has_entity_name = True
     _attr_supported_features = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
@@ -57,20 +57,22 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
         self._client = client
         self._device_id: str = device["id"]
         self._curtain_type: int = device["device_type"]
+        self._device_name: str = device["name"]
         self._attr_unique_id = device["id"]
-        self._attr_name = device["name"]
         self._update_from_device(device)
 
     @property
-    def device_info(self) -> dict[str, Any]:
+    @override
+    def device_info(self) -> DeviceInfo | None:
         """Return device registry information."""
         return {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": self._attr_name,
+            "name": self._device_name,
             "manufacturer": "VelaSmart",
             "model": "Smart Curtain",
         }
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = self.coordinator.data.get(self._device_id)
@@ -84,6 +86,7 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
         self._attr_is_opening = False
         self._attr_is_closing = False
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the curtain."""
         await self._client.send_command(self._device_id, self._curtain_type, 100)
@@ -92,6 +95,7 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the curtain."""
         await self._client.send_command(self._device_id, self._curtain_type, 0)
@@ -100,6 +104,7 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the curtain position."""
         position = kwargs.get(ATTR_POSITION)

--- a/homeassistant/components/velasmart/cover.py
+++ b/homeassistant/components/velasmart/cover.py
@@ -78,6 +78,7 @@ class VelaSmartCover(CoordinatorEntity, CoverEntity):
         device = self.coordinator.data.get(self._device_id)
         if device is not None:
             self._update_from_device(device)
+        super()._handle_coordinator_update()
 
     def _update_from_device(self, device: dict[str, Any]) -> None:
         """Update entity state from device data."""

--- a/homeassistant/components/velasmart/cover.py
+++ b/homeassistant/components/velasmart/cover.py
@@ -1,0 +1,111 @@
+"""Cover platform for the VelaSmart integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from velasmart import VelaSmartApiClient
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up VelaSmart cover entities."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    client: VelaSmartApiClient = data["client"]
+
+    async_add_entities(
+        VelaSmartCover(coordinator, client, device)
+        for device in coordinator.data.values()
+    )
+
+
+class VelaSmartCover(CoordinatorEntity, CoverEntity):
+    """Representation of a VelaSmart curtain."""
+
+    _attr_device_class = CoverDeviceClass.CURTAIN
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+    )
+
+    def __init__(
+        self,
+        coordinator: Any,
+        client: VelaSmartApiClient,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the cover entity."""
+        super().__init__(coordinator)
+        self._client = client
+        self._device_id: str = device["id"]
+        self._curtain_type: int = device["device_type"]
+        self._attr_unique_id = device["id"]
+        self._attr_name = device["name"]
+        self._update_from_device(device)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information."""
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._attr_name,
+            "manufacturer": "VelaSmart",
+            "model": "Smart Curtain",
+        }
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        device = self.coordinator.data.get(self._device_id)
+        if device is not None:
+            self._update_from_device(device)
+
+    def _update_from_device(self, device: dict[str, Any]) -> None:
+        """Update entity state from device data."""
+        self._attr_current_cover_position = device.get("position")
+        self._attr_is_closed = device.get("is_closed", False)
+        self._attr_is_opening = False
+        self._attr_is_closing = False
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the curtain."""
+        await self._client.send_command(self._device_id, self._curtain_type, 100)
+        self._attr_current_cover_position = 100
+        self._attr_is_opening = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the curtain."""
+        await self._client.send_command(self._device_id, self._curtain_type, 0)
+        self._attr_current_cover_position = 0
+        self._attr_is_closing = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the curtain position."""
+        position = kwargs.get(ATTR_POSITION)
+        if position is None:
+            return
+        await self._client.send_command(self._device_id, self._curtain_type, position)
+        self._attr_current_cover_position = position
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/velasmart/diagnostics.py
+++ b/homeassistant/components/velasmart/diagnostics.py
@@ -2,11 +2,14 @@
 
 from typing import Any
 
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+
+TO_REDACT = {CONF_PASSWORD, CONF_USERNAME, "gateway_mac"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -15,6 +18,6 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     return {
-        "config_entry": {k: v for k, v in entry.data.items() if k != CONF_PASSWORD},
-        "devices": coordinator.data,
+        "config_entry": async_redact_data(entry.data, TO_REDACT),
+        "devices": async_redact_data(coordinator.data, TO_REDACT),
     }

--- a/homeassistant/components/velasmart/diagnostics.py
+++ b/homeassistant/components/velasmart/diagnostics.py
@@ -1,7 +1,5 @@
 """Diagnostics support for the VelaSmart integration."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/velasmart/diagnostics.py
+++ b/homeassistant/components/velasmart/diagnostics.py
@@ -3,20 +3,19 @@
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from . import VelasmartConfigEntry
 
 TO_REDACT = {CONF_PASSWORD, CONF_USERNAME, "gateway_mac"}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: VelasmartConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator = entry.runtime_data.coordinator
     return {
         "config_entry": async_redact_data(entry.data, TO_REDACT),
         "devices": async_redact_data(coordinator.data, TO_REDACT),

--- a/homeassistant/components/velasmart/diagnostics.py
+++ b/homeassistant/components/velasmart/diagnostics.py
@@ -1,0 +1,22 @@
+"""Diagnostics support for the VelaSmart integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    return {
+        "config_entry": {k: v for k, v in entry.data.items() if k != CONF_PASSWORD},
+        "devices": coordinator.data,
+    }

--- a/homeassistant/components/velasmart/manifest.json
+++ b/homeassistant/components/velasmart/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/velasmart",
   "integration_type": "device",
   "iot_class": "cloud_polling",
+  "quality_scale": "bronze",
   "requirements": ["velasmart==0.1.0"]
 }

--- a/homeassistant/components/velasmart/manifest.json
+++ b/homeassistant/components/velasmart/manifest.json
@@ -4,8 +4,8 @@
   "codeowners": ["@liulijun2019"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/velasmart",
-  "integration_type": "device",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["velasmart==0.1.0"]
+  "requirements": ["velasmart==0.1.1"]
 }

--- a/homeassistant/components/velasmart/manifest.json
+++ b/homeassistant/components/velasmart/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "velasmart",
+  "name": "VelaSmart",
+  "codeowners": ["@liulijun2019"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/velasmart",
+  "integration_type": "device",
+  "iot_class": "cloud_polling",
+  "requirements": ["velasmart==0.1.0"]
+}

--- a/homeassistant/components/velasmart/quality_scale.yaml
+++ b/homeassistant/components/velasmart/quality_scale.yaml
@@ -12,9 +12,15 @@ rules:
   docs-actions:
     status: exempt
     comment: The integration does not expose any actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
   entity-event-setup:
     status: exempt
     comment: Entities do not explicitly subscribe to events.

--- a/homeassistant/components/velasmart/quality_scale.yaml
+++ b/homeassistant/components/velasmart/quality_scale.yaml
@@ -4,37 +4,23 @@ rules:
     status: exempt
     comment: The integration does not expose any actions.
   appropriate-polling: done
-  brands:
-    status: todo
-    comment: Brand logo needs to be added to the brands repository.
+  brands: done
   common-modules: done
   config-flow: done
-  config-flow-test-coverage:
-    status: todo
-    comment: Config flow tests are not yet implemented.
+  config-flow-test-coverage: done
   dependency-transparency: done
   docs-actions:
     status: exempt
     comment: The integration does not expose any actions.
-  docs-high-level-description:
-    status: todo
-    comment: Documentation needs to be added to home-assistant.io.
-  docs-installation-instructions:
-    status: todo
-    comment: Documentation needs to be added to home-assistant.io.
-  docs-removal-instructions:
-    status: todo
-    comment: Documentation needs to be added to home-assistant.io.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: Entities do not explicitly subscribe to events.
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
-  test-before-configure:
-    status: todo
-    comment: Tests are not yet implemented.
-  test-before-setup:
-    status: todo
-    comment: Tests are not yet implemented.
+  test-before-configure: done
+  test-before-setup: done
   unique-config-entry: done

--- a/homeassistant/components/velasmart/quality_scale.yaml
+++ b/homeassistant/components/velasmart/quality_scale.yaml
@@ -1,0 +1,40 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: The integration does not expose any actions.
+  appropriate-polling: done
+  brands:
+    status: todo
+    comment: Brand logo needs to be added to the brands repository.
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage:
+    status: todo
+    comment: Config flow tests are not yet implemented.
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: The integration does not expose any actions.
+  docs-high-level-description:
+    status: todo
+    comment: Documentation needs to be added to home-assistant.io.
+  docs-installation-instructions:
+    status: todo
+    comment: Documentation needs to be added to home-assistant.io.
+  docs-removal-instructions:
+    status: todo
+    comment: Documentation needs to be added to home-assistant.io.
+  entity-event-setup:
+    status: exempt
+    comment: Entities do not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure:
+    status: todo
+    comment: Tests are not yet implemented.
+  test-before-setup:
+    status: todo
+    comment: Tests are not yet implemented.
+  unique-config-entry: done

--- a/homeassistant/components/velasmart/quality_scale.yaml
+++ b/homeassistant/components/velasmart/quality_scale.yaml
@@ -6,8 +6,8 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow: done
   config-flow-test-coverage: done
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -30,3 +30,43 @@ rules:
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: todo
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: todo
+  integration-owner: todo
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: todo
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/velasmart/strings.json
+++ b/homeassistant/components/velasmart/strings.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to VelaSmart",
+        "description": "Enter your VelaSmart account credentials.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate VelaSmart",
+        "description": "Update your VelaSmart account credentials.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid username or password",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Reauthentication successful"
+    }
+  }
+}

--- a/homeassistant/components/velasmart/strings.json
+++ b/homeassistant/components/velasmart/strings.json
@@ -5,6 +5,7 @@
       "reauth_successful": "Reauthentication successful"
     },
     "error": {
+      "cannot_connect": "Cannot connect to the VelaSmart cloud",
       "invalid_auth": "Invalid username or password",
       "unknown": "Unexpected error"
     },

--- a/homeassistant/components/velasmart/strings.json
+++ b/homeassistant/components/velasmart/strings.json
@@ -14,6 +14,10 @@
           "password": "Password",
           "username": "Username"
         },
+        "data_description": {
+          "password": "Your VelaSmart account password",
+          "username": "Your VelaSmart account username"
+        },
         "description": "Update your VelaSmart account credentials.",
         "title": "Reauthenticate VelaSmart"
       },
@@ -21,6 +25,10 @@
         "data": {
           "password": "Password",
           "username": "Username"
+        },
+        "data_description": {
+          "password": "Your VelaSmart account password",
+          "username": "Your VelaSmart account username"
         },
         "description": "Enter your VelaSmart account credentials.",
         "title": "Connect to VelaSmart"

--- a/homeassistant/components/velasmart/strings.json
+++ b/homeassistant/components/velasmart/strings.json
@@ -1,30 +1,30 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "title": "Connect to VelaSmart",
-        "description": "Enter your VelaSmart account credentials.",
-        "data": {
-          "username": "Username",
-          "password": "Password"
-        }
-      },
-      "reauth_confirm": {
-        "title": "Reauthenticate VelaSmart",
-        "description": "Update your VelaSmart account credentials.",
-        "data": {
-          "username": "Username",
-          "password": "Password"
-        }
-      }
+    "abort": {
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Reauthentication successful"
     },
     "error": {
       "invalid_auth": "Invalid username or password",
       "unknown": "Unexpected error"
     },
-    "abort": {
-      "already_configured": "This account is already configured",
-      "reauth_successful": "Reauthentication successful"
+    "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        },
+        "description": "Update your VelaSmart account credentials.",
+        "title": "Reauthenticate VelaSmart"
+      },
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        },
+        "description": "Enter your VelaSmart account credentials.",
+        "title": "Connect to VelaSmart"
+      }
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -834,6 +834,7 @@ FLOWS = {
         "v2c",
         "vallox",
         "vegehub",
+        "velasmart",
         "velbus",
         "velux",
         "venstar",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7767,6 +7767,12 @@
       "config_flow": true,
       "iot_class": "local_push"
     },
+    "velasmart": {
+      "name": "VelaSmart",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "velbus": {
       "name": "Velbus",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3308,6 +3308,9 @@ vegehub==0.1.26
 # homeassistant.components.rdw
 vehicle==3.0.0
 
+# homeassistant.components.velasmart
+velasmart==0.1.0
+
 # homeassistant.components.velbus
 velbus-aio==2026.7.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3309,7 +3309,7 @@ vegehub==0.1.26
 vehicle==3.0.0
 
 # homeassistant.components.velasmart
-velasmart==0.1.0
+velasmart==0.1.1
 
 # homeassistant.components.velbus
 velbus-aio==2026.7.2

--- a/tests/components/velasmart/__init__.py
+++ b/tests/components/velasmart/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the VelaSmart integration."""

--- a/tests/components/velasmart/conftest.py
+++ b/tests/components/velasmart/conftest.py
@@ -1,0 +1,18 @@
+"""Fixtures for VelaSmart tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.velasmart.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/velasmart/conftest.py
+++ b/tests/components/velasmart/conftest.py
@@ -5,8 +5,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.core import HomeAssistant
-
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:

--- a/tests/components/velasmart/test_config_flow.py
+++ b/tests/components/velasmart/test_config_flow.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from velasmart import VelaSmartApiClient, VelaSmartApiError
 
 from homeassistant.components.velasmart.const import DOMAIN

--- a/tests/components/velasmart/test_config_flow.py
+++ b/tests/components/velasmart/test_config_flow.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from velasmart import VelaSmartApiClient, VelaSmartApiError
+from velasmart import VelaSmartApiAuthError, VelaSmartApiClient, VelaSmartApiError
 
 from homeassistant.components.velasmart.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -24,8 +24,19 @@ async def test_user_step_shows_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_invalid_auth(hass: HomeAssistant) -> None:
-    """Test that invalid credentials show an error."""
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (VelaSmartApiAuthError("invalid credentials"), "invalid_auth"),
+        (VelaSmartApiError("network error"), "cannot_connect"),
+    ],
+)
+async def test_validation_error(
+    hass: HomeAssistant,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test that validation errors are surfaced on the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )
@@ -33,14 +44,14 @@ async def test_invalid_auth(hass: HomeAssistant) -> None:
         VelaSmartApiClient,
         "authenticate",
         new_callable=AsyncMock,
-        side_effect=VelaSmartApiError("invalid credentials"),
+        side_effect=side_effect,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "wrong"},
         )
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["errors"] == {"base": expected_error}
 
 
 async def test_successful_config(hass: HomeAssistant) -> None:
@@ -65,10 +76,31 @@ async def test_successful_config(hass: HomeAssistant) -> None:
     }
 
 
-async def test_reauth_flow(hass: HomeAssistant) -> None:
-    """Test that reauthentication can be triggered."""
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test that a duplicate account aborts the flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        unique_id="test@example.com",
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "correct"},
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_reauth_flow_shows_form(hass: HomeAssistant) -> None:
+    """Test that reauthentication shows the confirm form."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test@example.com",
         data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
     )
     entry.add_to_hass(hass)
@@ -79,3 +111,56 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     )
     assert result["type"] == "form"
     assert result["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_invalid_auth(hass: HomeAssistant) -> None:
+    """Test that reauthentication surfaces invalid credentials."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test@example.com",
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reauth", "entry_id": entry.entry_id},
+    )
+    with patch.object(
+        VelaSmartApiClient,
+        "authenticate",
+        new_callable=AsyncMock,
+        side_effect=VelaSmartApiAuthError("invalid credentials"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "wrong"},
+        )
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_reauth_successful(hass: HomeAssistant) -> None:
+    """Test that reauthentication updates the entry and aborts."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test@example.com",
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "old"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reauth", "entry_id": entry.entry_id},
+    )
+    with patch.object(
+        VelaSmartApiClient,
+        "authenticate",
+        new_callable=AsyncMock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "new"},
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/velasmart/test_config_flow.py
+++ b/tests/components/velasmart/test_config_flow.py
@@ -1,0 +1,82 @@
+"""Tests for the VelaSmart config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from velasmart import VelaSmartApiClient, VelaSmartApiError
+
+from homeassistant.components.velasmart.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+async def test_user_step_shows_form(hass: HomeAssistant) -> None:
+    """Test that the user step shows the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+async def test_invalid_auth(hass: HomeAssistant) -> None:
+    """Test that invalid credentials show an error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    with patch.object(
+        VelaSmartApiClient,
+        "authenticate",
+        new_callable=AsyncMock,
+        side_effect=VelaSmartApiError("invalid credentials"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "wrong"},
+        )
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_successful_config(hass: HomeAssistant) -> None:
+    """Test that valid credentials create the entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    with patch.object(
+        VelaSmartApiClient,
+        "authenticate",
+        new_callable=AsyncMock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "test@example.com", CONF_PASSWORD: "correct"},
+        )
+    assert result["type"] == "create_entry"
+    assert result["title"] == "VelaSmart"
+    assert result["data"] == {
+        CONF_USERNAME: "test@example.com",
+        CONF_PASSWORD: "correct",
+    }
+
+
+async def test_reauth_flow(hass: HomeAssistant) -> None:
+    """Test that reauthentication can be triggered."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reauth", "entry_id": entry.entry_id},
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"

--- a/tests/components/velasmart/test_cover.py
+++ b/tests/components/velasmart/test_cover.py
@@ -1,0 +1,115 @@
+"""Tests for the VelaSmart cover platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from velasmart import VelaSmartApiClient
+
+from homeassistant.components.velasmart.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+DEVICE = {
+    "id": "device1",
+    "name": "Living Room Curtain",
+    "gateway_mac": "aa:bb:cc:dd:ee:ff",
+    "device_type": 3,
+    "position": 50,
+    "is_closed": False,
+    "online": True,
+    "battery": 100,
+}
+
+
+async def _setup_entry(hass: HomeAssistant) -> None:
+    """Set up a config entry with a single mocked device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_cover_entities_created(hass: HomeAssistant) -> None:
+    """Test that cover entities are created from coordinator data."""
+    with patch.object(
+        VelaSmartApiClient, "get_devices", new_callable=AsyncMock, return_value=[DEVICE]
+    ):
+        await _setup_entry(hass)
+
+    state = hass.states.get("cover.living_room_curtain")
+    assert state is not None
+    assert state.state == "open"
+    assert state.attributes["current_position"] == 50
+
+
+async def test_open_cover(hass: HomeAssistant) -> None:
+    """Test opening a curtain sends the correct command."""
+    with (
+        patch.object(
+            VelaSmartApiClient,
+            "get_devices",
+            new_callable=AsyncMock,
+            return_value=[DEVICE],
+        ),
+        patch.object(
+            VelaSmartApiClient, "send_command", new_callable=AsyncMock
+        ) as mock_send,
+    ):
+        await _setup_entry(hass)
+        await hass.services.async_call(
+            "cover",
+            "open_cover",
+            {"entity_id": "cover.living_room_curtain"},
+            blocking=True,
+        )
+        mock_send.assert_called_once_with("device1", 3, 100)
+
+
+async def test_close_cover(hass: HomeAssistant) -> None:
+    """Test closing a curtain sends the correct command."""
+    with (
+        patch.object(
+            VelaSmartApiClient,
+            "get_devices",
+            new_callable=AsyncMock,
+            return_value=[DEVICE],
+        ),
+        patch.object(
+            VelaSmartApiClient, "send_command", new_callable=AsyncMock
+        ) as mock_send,
+    ):
+        await _setup_entry(hass)
+        await hass.services.async_call(
+            "cover",
+            "close_cover",
+            {"entity_id": "cover.living_room_curtain"},
+            blocking=True,
+        )
+        mock_send.assert_called_once_with("device1", 3, 0)
+
+
+async def test_set_cover_position(hass: HomeAssistant) -> None:
+    """Test setting the position sends the correct command."""
+    with (
+        patch.object(
+            VelaSmartApiClient,
+            "get_devices",
+            new_callable=AsyncMock,
+            return_value=[DEVICE],
+        ),
+        patch.object(
+            VelaSmartApiClient, "send_command", new_callable=AsyncMock
+        ) as mock_send,
+    ):
+        await _setup_entry(hass)
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": "cover.living_room_curtain", "position": 75},
+            blocking=True,
+        )
+        mock_send.assert_called_once_with("device1", 3, 75)

--- a/tests/components/velasmart/test_init.py
+++ b/tests/components/velasmart/test_init.py
@@ -1,0 +1,49 @@
+"""Tests for the VelaSmart integration."""
+
+from unittest.mock import AsyncMock, patch
+
+from velasmart import VelaSmartApiClient
+
+from homeassistant.components.velasmart import async_setup_entry, async_unload_entry
+from homeassistant.components.velasmart.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(hass: HomeAssistant) -> None:
+    """Test setting up the config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        VelaSmartApiClient, "get_devices", new_callable=AsyncMock, return_value=[]
+    ):
+        assert await async_setup_entry(hass, entry) is True
+        await hass.async_block_till_done()
+
+    assert DOMAIN in hass.data
+    assert entry.entry_id in hass.data[DOMAIN]
+    assert "coordinator" in hass.data[DOMAIN][entry.entry_id]
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test unloading the config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test@example.com", CONF_PASSWORD: "test"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        VelaSmartApiClient, "get_devices", new_callable=AsyncMock, return_value=[]
+    ):
+        assert await async_setup_entry(hass, entry) is True
+        await hass.async_block_till_done()
+
+    assert await async_unload_entry(hass, entry) is True
+    assert entry.entry_id not in hass.data[DOMAIN]

--- a/tests/components/velasmart/test_init.py
+++ b/tests/components/velasmart/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from velasmart import VelaSmartApiClient
 
-from homeassistant.components.velasmart import async_setup_entry, async_unload_entry
+from homeassistant.components.velasmart import VelasmartData
 from homeassistant.components.velasmart.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -23,12 +23,10 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     with patch.object(
         VelaSmartApiClient, "get_devices", new_callable=AsyncMock, return_value=[]
     ):
-        assert await async_setup_entry(hass, entry) is True
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
         await hass.async_block_till_done()
 
-    assert DOMAIN in hass.data
-    assert entry.entry_id in hass.data[DOMAIN]
-    assert "coordinator" in hass.data[DOMAIN][entry.entry_id]
+    assert isinstance(entry.runtime_data, VelasmartData)
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
@@ -42,8 +40,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     with patch.object(
         VelaSmartApiClient, "get_devices", new_callable=AsyncMock, return_value=[]
     ):
-        assert await async_setup_entry(hass, entry) is True
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
         await hass.async_block_till_done()
 
-    assert await async_unload_entry(hass, entry) is True
-    assert entry.entry_id not in hass.data[DOMAIN]
+    assert await hass.config_entries.async_unload(entry.entry_id) is True


### PR DESCRIPTION
## Proposed change

Add the VelaSmart integration, which allows controlling VelaSmart smart curtains and blinds from Home Assistant.

The integration communicates with the VelaSmart cloud API via the [`velasmart`](https://github.com/liulijun2019/velasmart) Python library (available on [PyPI](https://pypi.org/project/velasmart/)).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47476
- Link to developer documentation pull request:
- Link to frontend pull request:
- Link to brands repository pull request: https://github.com/home-assistant/brands/pull/10996
- Updated dependency: `velasmart` 0.1.0 -> 0.1.1 adds `VelaSmartApiAuthError` to distinguish authentication failures from connection failures. Changelog: https://github.com/liulijun2019/velasmart/compare/v0.1.0...v0.1.1

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure