### PR TITLE
Add diagnostics to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/const.py
+++ b/homeassistant/components/lyngdorf/const.py
@@ -10,3 +10,4 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
 ]
 CONF_SERIAL_NUMBER = "serial_number"
+SSDP_ST = "urn:schemas-upnp-org:device:MediaRenderer:2"

--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -12,7 +12,10 @@ from homeassistant.helpers.service_info.ssdp import ATTR_UPNP_SERIAL
 from .const import CONF_SERIAL_NUMBER, SSDP_ST
 from .models import LyngdorfConfigEntry
 
-TRIMS = ("bass", "treble", "centre", "height", "lfe", "surround")
+_TRIM_NAMES = tuple(
+    f"trim_{trim}" for trim in ("bass", "treble", "centre", "height", "lfe", "surround")
+)
+_RANGE_NAMES = ("lipsync_range", *(f"{name}_range" for name in _TRIM_NAMES))
 
 # The serial doubles as the device MAC and as the config entry unique_id, so it
 # needs redacting wherever it surfaces, including inside the UPnP description.
@@ -85,11 +88,11 @@ async def async_get_config_entry_diagnostics(
         "zone_b_audio_input": receiver.zone_b_audio_input,
         "zone_b_streaming_source": receiver.zone_b_streaming_source,
     }
-    state |= {f"trim_{trim}": getattr(receiver, f"trim_{trim}") for trim in TRIMS}
+    state |= {name: getattr(receiver, name) for name in _TRIM_NAMES}
 
     ranges = {
         name: asdict(value) if (value := getattr(receiver, name)) is not None else None
-        for name in ("lipsync_range", *(f"trim_{trim}_range" for trim in TRIMS))
+        for name in _RANGE_NAMES
     }
 
     return async_redact_data(

--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -1,0 +1,105 @@
+"""Diagnostics support for the Lyngdorf integration."""
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.ssdp import async_get_discovery_info_by_st
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.ssdp import ATTR_UPNP_SERIAL
+
+from .const import CONF_SERIAL_NUMBER, SSDP_ST
+from .models import LyngdorfConfigEntry
+
+TRIMS = ("bass", "treble", "centre", "height", "lfe", "surround")
+
+# The serial doubles as the device MAC and as the config entry unique_id, so it
+# needs redacting wherever it surfaces, including inside the UPnP description.
+TO_REDACT = {
+    CONF_HOST,
+    CONF_SERIAL_NUMBER,
+    "unique_id",
+    ATTR_UPNP_SERIAL,
+    "presentationURL",
+    "ssdp_location",
+    "ssdp_all_locations",
+    "ssdp_headers",
+    "ssdp_usn",
+    "ssdp_udn",
+}
+
+
+async def _async_ssdp_description(
+    hass: HomeAssistant, serial: str
+) -> dict[str, Any] | None:
+    """Return the UPnP description this device is currently announcing."""
+    for info in await async_get_discovery_info_by_st(hass, SSDP_ST):
+        if (info.upnp.get(ATTR_UPNP_SERIAL) or "").lower() == serial.lower():
+            return {
+                "ssdp_usn": info.ssdp_usn,
+                "ssdp_st": info.ssdp_st,
+                "ssdp_udn": info.ssdp_udn,
+                "ssdp_server": info.ssdp_server,
+                "ssdp_location": info.ssdp_location,
+                "upnp": dict(info.upnp),
+            }
+    # Null when SSDP has not seen the device, which is worth knowing in itself.
+    return None
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: LyngdorfConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    receiver = config_entry.runtime_data.receiver
+
+    state: dict[str, Any] = {
+        "connected": receiver.connected,
+        "model": receiver.model.name if receiver.model else None,
+        "power_on": receiver.power_on,
+        "volume": receiver.volume,
+        "max_volume": receiver.max_volume,
+        "mute_enabled": receiver.mute_enabled,
+        "source": receiver.source,
+        "available_sources": receiver.available_sources,
+        "sound_mode": receiver.sound_mode,
+        "available_sound_modes": receiver.available_sound_modes,
+        "audio_input": receiver.audio_input,
+        "available_audio_inputs": receiver.available_audio_inputs,
+        "video_input": receiver.video_input,
+        "available_video_inputs": receiver.available_video_inputs,
+        "audio_information": receiver.audio_information,
+        "video_information": receiver.video_information,
+        "streaming_source": receiver.streaming_source,
+        "available_stream_types": receiver.available_stream_types,
+        "room_perfect_position": receiver.room_perfect_position,
+        "available_room_perfect_positions": receiver.available_room_perfect_positions,
+        "voicing": receiver.voicing,
+        "available_voicings": receiver.available_voicings,
+        "lipsync": receiver.lipsync,
+        "zone_b_power_on": receiver.zone_b_power_on,
+        "zone_b_volume": receiver.zone_b_volume,
+        "zone_b_mute_enabled": receiver.zone_b_mute_enabled,
+        "zone_b_source": receiver.zone_b_source,
+        "zone_b_audio_input": receiver.zone_b_audio_input,
+        "zone_b_streaming_source": receiver.zone_b_streaming_source,
+    }
+    state |= {f"trim_{trim}": getattr(receiver, f"trim_{trim}") for trim in TRIMS}
+
+    ranges = {
+        name: asdict(value) if (value := getattr(receiver, name)) is not None else None
+        for name in ("lipsync_range", *(f"trim_{trim}_range" for trim in TRIMS))
+    }
+
+    return async_redact_data(
+        {
+            "entry": config_entry.as_dict(),
+            "ssdp": await _async_ssdp_description(
+                hass, config_entry.data[CONF_SERIAL_NUMBER]
+            ),
+            "state": state,
+            "ranges": ranges,
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/lyngdorf/quality_scale.yaml
+++ b/homeassistant/components/lyngdorf/quality_scale.yaml
@@ -51,7 +51,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery: done
   discovery-update-info: todo
   docs-data-update: todo

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from lyngdorf.const import LyngdorfModel
 from lyngdorf.device import Receiver
+from lyngdorf.models.base import NumericRange
 import pytest
 
 from homeassistant.components.lyngdorf.const import (
@@ -62,6 +63,23 @@ def mock_receiver() -> Generator[MagicMock]:
         receiver = MagicMock(spec=Receiver)
         receiver.name = "Mock Lyngdorf"
         receiver.connected = True
+
+        # Diagnostics reports the whole receiver, so every property it reads
+        # needs a value here; an unset one is a mock the response cannot encode.
+        receiver.model = LyngdorfModel.MP_60
+        receiver.max_volume = 0.0
+        receiver.room_perfect_position = None
+        receiver.available_room_perfect_positions = []
+        receiver.voicing = None
+        receiver.available_voicings = []
+        receiver.lipsync = None
+        receiver.lipsync_range = NumericRange(0, 500, 1)
+        for _t in ("bass", "treble"):
+            setattr(receiver, f"trim_{_t}", None)
+            setattr(receiver, f"trim_{_t}_range", NumericRange(-12.0, 12.0, 0.1))
+        for _t in ("centre", "height", "lfe", "surround"):
+            setattr(receiver, f"trim_{_t}", None)
+            setattr(receiver, f"trim_{_t}_range", NumericRange(-10.0, 10.0, 0.1))
 
         receiver.power_on = False
         receiver.volume = -40.0

--- a/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
+++ b/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
@@ -1,0 +1,130 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'entry': dict({
+      'data': dict({
+        'host': '**REDACTED**',
+        'model': 'MP-60',
+        'serial_number': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'lyngdorf',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'Mock Lyngdorf',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+    'ranges': dict({
+      'lipsync_range': dict({
+        'max': 500,
+        'min': 0,
+        'step': 1,
+      }),
+      'trim_bass_range': dict({
+        'max': 12.0,
+        'min': -12.0,
+        'step': 0.1,
+      }),
+      'trim_centre_range': dict({
+        'max': 10.0,
+        'min': -10.0,
+        'step': 0.1,
+      }),
+      'trim_height_range': dict({
+        'max': 10.0,
+        'min': -10.0,
+        'step': 0.1,
+      }),
+      'trim_lfe_range': dict({
+        'max': 10.0,
+        'min': -10.0,
+        'step': 0.1,
+      }),
+      'trim_surround_range': dict({
+        'max': 10.0,
+        'min': -10.0,
+        'step': 0.1,
+      }),
+      'trim_treble_range': dict({
+        'max': 12.0,
+        'min': -12.0,
+        'step': 0.1,
+      }),
+    }),
+    'ssdp': None,
+    'state': dict({
+      'audio_information': 'Stereo',
+      'audio_input': 'optical',
+      'available_audio_inputs': list([
+        'optical',
+        'aux',
+      ]),
+      'available_room_perfect_positions': list([
+      ]),
+      'available_sound_modes': list([
+      ]),
+      'available_sources': list([
+      ]),
+      'available_stream_types': list([
+        'AirPlay',
+        'DLNA',
+      ]),
+      'available_video_inputs': list([
+        'hdmi',
+      ]),
+      'available_voicings': list([
+      ]),
+      'connected': True,
+      'lipsync': None,
+      'max_volume': 0.0,
+      'model': 'MP_60',
+      'mute_enabled': False,
+      'power_on': False,
+      'room_perfect_position': None,
+      'sound_mode': None,
+      'source': None,
+      'streaming_source': 'AirPlay',
+      'trim_bass': None,
+      'trim_centre': None,
+      'trim_height': None,
+      'trim_lfe': None,
+      'trim_surround': None,
+      'trim_treble': None,
+      'video_information': '4K HDR',
+      'video_input': 'hdmi',
+      'voicing': None,
+      'volume': -40.0,
+      'zone_b_audio_input': 'aux',
+      'zone_b_mute_enabled': False,
+      'zone_b_power_on': False,
+      'zone_b_source': None,
+      'zone_b_streaming_source': 'DLNA',
+      'zone_b_volume': -40.0,
+    }),
+  })
+# ---
+# name: test_diagnostics_includes_ssdp_description
+  dict({
+    'ssdp_location': '**REDACTED**',
+    'ssdp_server': None,
+    'ssdp_st': 'urn:schemas-upnp-org:device:MediaRenderer:2',
+    'ssdp_udn': '**REDACTED**',
+    'ssdp_usn': '**REDACTED**',
+    'upnp': dict({
+      'deviceType': 'urn:schemas-upnp-org:device:MediaRenderer:2',
+      'friendlyName': 'Solar',
+      'manufacturer': 'Lyngdorf',
+      'modelName': 'MP-60',
+      'serialNumber': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/lyngdorf/test_diagnostics.py
+++ b/tests/components/lyngdorf/test_diagnostics.py
@@ -1,0 +1,66 @@
+"""Tests for the Lyngdorf diagnostics."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.components.lyngdorf.const import SSDP_ST
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Only load the media player platform."""
+    return [Platform.MEDIA_PLAYER]
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the diagnostics output."""
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    ) == snapshot(exclude=props("entry_id", "created_at", "modified_at"))
+
+
+async def test_diagnostics_includes_ssdp_description(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the UPnP description is captured, with the serial redacted."""
+    discovery = SsdpServiceInfo(
+        ssdp_usn="uuid:864ab4c0-0fdb-46a7-84ad-aae23ee0d44f::upnp:rootdevice",
+        ssdp_st=SSDP_ST,
+        ssdp_udn="uuid:864ab4c0-0fdb-46a7-84ad-aae23ee0d44f",
+        ssdp_location="http://127.0.0.1:55088/description.xml",
+        upnp={
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+            "friendlyName": "Solar",
+            "manufacturer": "Lyngdorf",
+            "modelName": "MP-60",
+            "serialNumber": "0050c27c76b2",
+        },
+    )
+
+    with patch(
+        "homeassistant.components.lyngdorf.diagnostics.async_get_discovery_info_by_st",
+        return_value=[discovery],
+    ):
+        result = await get_diagnostics_for_config_entry(
+            hass, hass_client, init_integration
+        )
+
+    assert result["ssdp"] == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds diagnostics, reporting the receiver state the integration already holds along with the UPnP description the device is currently announcing.

The UPnP description is the part worth having: when the complaint is that a device stopped being discovered, this says whether SSDP can still see it and what it is claiming to be. It is `null` when SSDP has not seen the device, which is equally worth knowing.

**The library's own capability probe is deliberately not used.** It opens a second connection alongside the live one, and sweeping its command list takes about a minute against a device that is not answering, which is not something to do behind a download button. The receiver the integration already holds has everything, cached from the push updates.

The serial doubles as the device MAC and as the config entry unique ID, so it is redacted wherever it appears, along with the address and the UUIDs the UPnP description carries.

One note on the tests: unlike a platform's, these exercise nearly the whole receiver surface, so the fixture gives every property a value. An unset one is a mock, and a mock in the payload aborts the response while it is being written, which presents as a hang rather than an error.

Satisfies the `diagnostics` rule.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
