### PR TITLE
Invalidate conversation slot-list cache on device registry changes

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -83,6 +83,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_ERROR_TEXT = "Sorry, I couldn't understand that"
 _ENTITY_REGISTRY_UPDATE_FIELDS = ["aliases", "name", "original_name"]
+_DEVICE_REGISTRY_UPDATE_FIELDS = ["name", "name_by_user"]
 
 _DEFAULT_EXPOSED_ATTRIBUTES = {"device_class"}
 
@@ -289,6 +290,15 @@ class DefaultAgent(ConversationEntity):
         )
 
     @callback
+    def _filter_device_registry_changes(
+        self, event_data: dr.EventDeviceRegistryUpdatedData
+    ) -> bool:
+        """Filter device registry changed events."""
+        return event_data["action"] == "update" and any(
+            field in event_data["changes"] for field in _DEVICE_REGISTRY_UPDATE_FIELDS
+        )
+
+    @callback
     def _filter_state_changes(self, event_data: EventStateChangedData) -> bool:
         """Filter state changed events."""
         return not event_data["old_state"] or not event_data["new_state"]
@@ -311,6 +321,11 @@ class DefaultAgent(ConversationEntity):
                 er.EVENT_ENTITY_REGISTRY_UPDATED,
                 self._async_clear_slot_list,
                 event_filter=self._filter_entity_registry_changes,
+            ),
+            self.hass.bus.async_listen(
+                dr.EVENT_DEVICE_REGISTRY_UPDATED,
+                self._async_clear_slot_list,
+                event_filter=self._filter_device_registry_changes,
             ),
             self.hass.bus.async_listen(
                 EVENT_STATE_CHANGED,

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -492,6 +492,77 @@ async def test_duplicated_names_resolved_with_device_area(
         assert result.response.intent.slots.get("name", {}).get("text") == name
 
 
+@pytest.mark.xfail(
+    reason=(
+        "The slot list cache is not invalidated when a device is renamed, so the new "
+        "computed entity name is not matchable until another event clears the cache"
+    ),
+    strict=True,
+)
+@pytest.mark.usefixtures("init_components")
+async def test_device_rename_refreshes_slot_list(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test renaming a device makes the entity matchable by its new computed name.
+
+    The default agent's slot list is a cache invalidated only by area/floor registry
+    changes, entity registry name/alias/original_name changes, entity add/remove state
+    changes, and exposed-entity changes (see ``_listen_clear_slot_list`` and
+    ``_ENTITY_REGISTRY_UPDATE_FIELDS``). Renaming a device changes the exposed name of
+    a ``has_entity_name`` entity but is none of those events, so the stale name keeps
+    matching and the new one does not.
+
+    Marked xfail as a demonstration of that limitation.
+    """
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "device-1")},
+        name="Kitchen",
+    )
+
+    light = entity_registry.async_get_or_create(
+        "light",
+        "demo",
+        "1234",
+        device_id=device.id,
+        has_entity_name=True,
+        original_name="Light",
+    )
+    # COMPUTED_NAME resolves to the full "<device name> <entity name>" name.
+    light = entity_registry.async_update_entity(
+        light.entity_id, aliases=[er.COMPUTED_NAME]
+    )
+    hass.states.async_set(
+        light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "Kitchen Light"}
+    )
+    expose_entity(hass, light.entity_id, True)
+
+    # Populate the slot list cache: the current computed name matches.
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on Kitchen Light", None, Context(), None
+    )
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+
+    # Rename the device; the light's computed name becomes "Bedroom Light".
+    device_registry.async_update_device(device.id, name_by_user="Bedroom")
+    await hass.async_block_till_done()
+
+    # The new name should now be matchable, but the slot list cache is stale.
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on Bedroom Light", None, Context(), None
+    )
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+
+
 @pytest.mark.usefixtures("init_components")
 async def test_trigger_sentences(hass: HomeAssistant) -> None:
     """Test registering/unregistering/matching a few trigger sentences."""

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -492,30 +492,13 @@ async def test_duplicated_names_resolved_with_device_area(
         assert result.response.intent.slots.get("name", {}).get("text") == name
 
 
-@pytest.mark.xfail(
-    reason=(
-        "The slot list cache is not invalidated when a device is renamed, so the new "
-        "computed entity name is not matchable until another event clears the cache"
-    ),
-    strict=True,
-)
 @pytest.mark.usefixtures("init_components")
 async def test_device_rename_refreshes_slot_list(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test renaming a device makes the entity matchable by its new computed name.
-
-    The default agent's slot list is a cache invalidated only by area/floor registry
-    changes, entity registry name/alias/original_name changes, entity add/remove state
-    changes, and exposed-entity changes (see ``_listen_clear_slot_list`` and
-    ``_ENTITY_REGISTRY_UPDATE_FIELDS``). Renaming a device changes the exposed name of
-    a ``has_entity_name`` entity but is none of those events, so the stale name keeps
-    matching and the new one does not.
-
-    Marked xfail as a demonstration of that limitation.
-    """
+    """Test renaming a device makes the entity matchable by its new computed name."""
     config_entry = MockConfigEntry()
     config_entry.add_to_hass(hass)
     device = device_registry.async_get_or_create(
@@ -533,13 +516,7 @@ async def test_device_rename_refreshes_slot_list(
         has_entity_name=True,
         original_name="Light",
     )
-    # COMPUTED_NAME resolves to the full "<device name> <entity name>" name.
-    light = entity_registry.async_update_entity(
-        light.entity_id, aliases=[er.COMPUTED_NAME]
-    )
-    hass.states.async_set(
-        light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "Kitchen Light"}
-    )
+    hass.states.async_set(light.entity_id, "off")
     expose_entity(hass, light.entity_id, True)
 
     # Populate the slot list cache: the current computed name matches.
@@ -550,11 +527,11 @@ async def test_device_rename_refreshes_slot_list(
     assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
 
-    # Rename the device; the light's computed name becomes "Bedroom Light".
+    # Renaming the device changes the light's computed name to "Bedroom Light".
     device_registry.async_update_device(device.id, name_by_user="Bedroom")
     await hass.async_block_till_done()
 
-    # The new name should now be matchable, but the slot list cache is stale.
+    # The new name is now matchable.
     calls = async_mock_service(hass, "light", "turn_on")
     result = await conversation.async_converse(
         hass, "turn on Bedroom Light", None, Context(), None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Invalidate conversation slot-list cache on device registry changes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
