### PR TITLE
Add available disk space sensor to Transmission integration

### DIFF
--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -155,6 +155,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_DOWNLOADED_TORRENT,
                     {
@@ -185,6 +186,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_STARTED_TORRENT,
                     {
@@ -211,6 +213,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_REMOVED_TORRENT,
                     {

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -69,6 +69,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         self._started_torrents: list[transmission_rpc.Torrent] = []
         self._event_listeners: dict[str, EventCallback] = {}
         self.torrents: list[transmission_rpc.Torrent] = []
+        self.download_dir_free_space: int | None = None
         super().__init__(
             hass,
             config_entry=entry,
@@ -80,12 +81,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     @property
     def limit(self) -> int:
         """Return limit."""
-        return self.config_entry.options.get(CONF_LIMIT, DEFAULT_LIMIT)  # type: ignore[no-any-return]
+        return self.config_entry.options.get(CONF_LIMIT, DEFAULT_LIMIT)
 
     @property
     def order(self) -> str:
         """Return order."""
-        return self.config_entry.options.get(CONF_ORDER, DEFAULT_ORDER)  # type: ignore[no-any-return]
+        return self.config_entry.options.get(CONF_ORDER, DEFAULT_ORDER)
 
     @callback
     def async_add_event_listener(
@@ -121,6 +122,9 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             data = self.api.session_stats()
             self.torrents = self.api.get_torrents()
             self._session = self.api.get_session()
+            self.download_dir_free_space = self.api.free_space(
+                self._session.download_dir
+            )
         except transmission_rpc.TransmissionError as err:
             raise UpdateFailed("Unable to connect to Transmission client") from err
 
@@ -146,7 +150,6 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
-                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_DOWNLOADED_TORRENT,
                     {
@@ -177,7 +180,6 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
-                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_STARTED_TORRENT,
                     {
@@ -204,7 +206,6 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
-                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_REMOVED_TORRENT,
                     {

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -81,12 +81,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     @property
     def limit(self) -> int:
         """Return limit."""
-        return self.config_entry.options.get(CONF_LIMIT, DEFAULT_LIMIT)
+        return self.config_entry.options.get(CONF_LIMIT, DEFAULT_LIMIT)  # type: ignore[no-any-return]
 
     @property
     def order(self) -> str:
         """Return order."""
-        return self.config_entry.options.get(CONF_ORDER, DEFAULT_ORDER)
+        return self.config_entry.options.get(CONF_ORDER, DEFAULT_ORDER)  # type: ignore[no-any-return]
 
     @callback
     def async_add_event_listener(
@@ -122,11 +122,16 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             data = self.api.session_stats()
             self.torrents = self.api.get_torrents()
             self._session = self.api.get_session()
+        except transmission_rpc.TransmissionError as err:
+            raise UpdateFailed("Unable to connect to Transmission client") from err
+
+        try:
             self.download_dir_free_space = self.api.free_space(
                 self._session.download_dir
             )
-        except transmission_rpc.TransmissionError as err:
-            raise UpdateFailed("Unable to connect to Transmission client") from err
+        except (transmission_rpc.TransmissionError, KeyError) as err:
+            _LOGGER.debug("Unable to fetch download directory free space: %s", err)
+            self.download_dir_free_space = None
 
         return data
 

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -80,6 +80,16 @@ SENSOR_TYPES: tuple[TransmissionSensorEntityDescription, ...] = (
         ),
     ),
     TransmissionSensorEntityDescription(
+        key="download_dir_free_space",
+        translation_key="download_dir_free_space",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        val_func=lambda coordinator: coordinator.download_dir_free_space,
+    ),
+    TransmissionSensorEntityDescription(
         key="active_torrents",
         translation_key="active_torrents",
         val_func=lambda coordinator: coordinator.data.active_torrent_count,

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -65,6 +65,9 @@
         "name": "Completed torrents",
         "unit_of_measurement": "[%key:component::transmission::entity::sensor::active_torrents::unit_of_measurement%]"
       },
+      "download_dir_free_space": {
+        "name": "Available disk space"
+      },
       "download_speed": {
         "name": "Download speed"
       },

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -66,7 +66,7 @@ def mock_transmission_client() -> Generator[AsyncMock]:
         }
         client.session_stats.return_value = SessionStats(fields=session_stats_data)
 
-        session_data = {"alt-speed-enabled": False}
+        session_data = {"alt-speed-enabled": False, "download-dir": "/downloads"}
         client.get_session.return_value = Session(fields=session_data)
 
         client.get_torrents.return_value = []

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -70,6 +70,7 @@ def mock_transmission_client() -> Generator[AsyncMock]:
         client.get_session.return_value = Session(fields=session_data)
 
         client.get_torrents.return_value = []
+        client.free_space.return_value = 42949672960  # 40 GiB
 
         yield mock_client_class
 

--- a/tests/components/transmission/snapshots/test_sensor.ambr
+++ b/tests/components/transmission/snapshots/test_sensor.ambr
@@ -52,6 +52,67 @@
     'state': '0',
   })
 # ---
+# name: test_sensors[sensor.transmission_available_disk_space-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.transmission_available_disk_space',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Available disk space',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfInformation.GIBIBYTES: 'GiB'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_SIZE: 'data_size'>,
+    'original_icon': None,
+    'original_name': 'Available disk space',
+    'platform': 'transmission',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'download_dir_free_space',
+    'unique_id': '01J0BC4QM2YBRP6H5G933AETT7-download_dir_free_space',
+    'unit_of_measurement': <UnitOfInformation.GIBIBYTES: 'GiB'>,
+  })
+# ---
+# name: test_sensors[sensor.transmission_available_disk_space-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'data_size',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Transmission Available disk space',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfInformation.GIBIBYTES: 'GiB'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.transmission_available_disk_space',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---
 # name: test_sensors[sensor.transmission_completed_torrents-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/transmission/test_sensor.py
+++ b/tests/components/transmission/test_sensor.py
@@ -73,6 +73,11 @@ async def test_stats_sensors(
     assert state is not None
     assert float(state.state) == pytest.approx(0.8, rel=1e-3)
 
+    # Free disk space: 40 GiB = 40.0 GiB
+    state = hass.states.get("sensor.transmission_download_dir_free_space")
+    assert state is not None
+    assert float(state.state) == pytest.approx(40.0, rel=1e-3)
+
 
 def test_get_state_combinations() -> None:
     """Test get_state with all upload/download combinations."""

--- a/tests/components/transmission/test_sensor.py
+++ b/tests/components/transmission/test_sensor.py
@@ -74,7 +74,7 @@ async def test_stats_sensors(
     assert float(state.state) == pytest.approx(0.8, rel=1e-3)
 
     # Free disk space: 40 GiB = 40.0 GiB
-    state = hass.states.get("sensor.transmission_download_dir_free_space")
+    state = hass.states.get("sensor.transmission_available_disk_space")
     assert state is not None
     assert float(state.state) == pytest.approx(40.0, rel=1e-3)
 


### PR DESCRIPTION
## Proposed change

Adds a sensor exposing the Transmission download directory's free disk space, using `transmission_rpc`'s existing `free_space()` call.

The lookup runs in its own try/except, separate from the main polling. If the daemon doesn't report `download-dir` (or the RPC call fails), the sensor just goes unavailable instead of taking down the whole integration setup.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47478
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
