### PR TITLE
Log warning when event triggers filter on composite device

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -1,16 +1,29 @@
 """Offer event listening automation rules."""
 
 from collections.abc import ItemsView, Mapping
+import logging
 from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EVENT_DATA, CONF_PLATFORM, EVENT_STATE_REPORTED
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_EVENT_DATA,
+    CONF_PLATFORM,
+    EVENT_STATE_REPORTED,
+)
 from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    template,
+)
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import yaml as yaml_util
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_EVENT_TYPE = "event_type"
 CONF_EVENT_CONTEXT = "context"
@@ -37,6 +50,58 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
         vol.Optional(CONF_EVENT_CONTEXT): vol.All(dict, cv.template_complex),
     }
 )
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate trigger config.
+
+    Warn if the trigger filters event_data.device_id on a pre-migration composite device
+    id - a device that was split into one device per config entry.
+    A templated device id is a Template (not a plain string) and is left alone.
+    """
+    validated_config: ConfigType = TRIGGER_SCHEMA(config)
+    if (
+        CONF_EVENT_DATA in validated_config
+        and isinstance(
+            device_id := validated_config[CONF_EVENT_DATA].get(CONF_DEVICE_ID), str
+        )
+        and (
+            split_devices := dr.async_get(
+                hass
+            ).async_get_devices_for_composite_device_id(device_id)
+        )
+    ):
+        _log_composite_device_id_warning(hass, config, device_id, split_devices)
+    return validated_config
+
+
+@callback
+def _log_composite_device_id_warning(
+    hass: HomeAssistant,
+    config: ConfigType,
+    device_id: str,
+    split_devices: list[dr.DeviceEntry],
+) -> None:
+    """Warn that an event trigger filters on a split (pre-migration) device id."""
+
+    device_summaries: list[str] = []
+    for device in split_devices:
+        entry = hass.config_entries.async_get_entry(device.config_entry_id)
+        domain = entry.domain if entry else "unknown"
+        name = device.name_by_user or device.name or device.id
+        device_summaries.append(f"{name} ({device.id}) from the {domain} integration")
+
+    _LOGGER.warning(
+        "Event trigger filters on device '%s', which was split into one device per "
+        "integration and no longer exists, so the trigger can no longer fire. Update the "
+        "automation, script or template entity to filter on one of these devices instead: "
+        "%s.\nThe affected trigger is configured as:\n%s",
+        device_id,
+        ", ".join(device_summaries),
+        yaml_util.dump(config),
+    )
 
 
 def _schema_value(value: Any) -> Any:

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -1,13 +1,17 @@
 """The tests for the Event automation."""
 
+import logging
+
+import attr
 import pytest
 
 from homeassistant.components import automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
 from homeassistant.core import Context, HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr, script, trigger
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_component
+from tests.common import MockConfigEntry, mock_component
 
 
 @pytest.fixture
@@ -629,3 +633,109 @@ async def test_templated_state_reported_event(
         "Got error 'Can't listen to state_reported in event trigger' "
         "when setting up triggers for automation 0" in caplog.text
     )
+
+
+COMPOSITE_ID = "composite00000000000000000000ab"
+
+
+@pytest.fixture
+def split_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> tuple[dr.DeviceEntry, dr.DeviceEntry]:
+    """Create two devices which are splits of a pre-migration composite device."""
+    entry_1 = MockConfigEntry(domain="itg1")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="itg2")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        identifiers={("itg1", "1")},
+        name="Split device 1",
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id,
+        identifiers={("itg2", "1")},
+        name="Split device 2",
+    )
+    device_registry.devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=COMPOSITE_ID
+    )
+    device_registry.devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=COMPOSITE_ID
+    )
+    return device_registry.devices[device_1.id], device_registry.devices[device_2.id]
+
+
+_EVENT_TRIGGER = {
+    "platform": "event",
+    "event_type": "my_event",
+    "event_data": {"device_id": COMPOSITE_ID},
+}
+
+
+def _expected_composite_warning(
+    device_1: dr.DeviceEntry, device_2: dr.DeviceEntry
+) -> str:
+    """Return the exact warning the event validator logs for a composite device id."""
+    return (
+        f"Event trigger filters on device '{COMPOSITE_ID}', which was split into one "
+        "device per integration and no longer exists, so the trigger can no longer fire. "
+        "Update the automation, script or template entity to filter on one of these "
+        "devices instead: "
+        f"Split device 1 ({device_1.id}) from the itg1 integration, "
+        f"Split device 2 ({device_2.id}) from the itg2 integration.\n"
+        "The affected trigger is configured as:\n"
+        "platform: event\n"
+        "event_type: my_event\n"
+        "event_data:\n"
+        f"  device_id: {COMPOSITE_ID}\n"
+    )
+
+
+async def test_composite_device_id_logs_warning(
+    hass: HomeAssistant,
+    split_devices: tuple[dr.DeviceEntry, dr.DeviceEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a composite event_data.device_id filter logs the full warning."""
+    with caplog.at_level(logging.WARNING):
+        await trigger.async_validate_trigger_config(hass, [_EVENT_TRIGGER])
+    assert caplog.messages == [_expected_composite_warning(*split_devices)]
+
+
+async def test_live_device_id_no_warning(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a live event_data.device_id filter does not warn."""
+    entry = MockConfigEntry(domain="itg")
+    entry.add_to_hass(hass)
+    live_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={("itg", "1")}
+    )
+    with caplog.at_level(logging.WARNING):
+        await trigger.async_validate_trigger_config(
+            hass,
+            [
+                {
+                    "platform": "event",
+                    "event_type": "my_event",
+                    "event_data": {"device_id": live_device.id},
+                }
+            ],
+        )
+    assert caplog.messages == []
+
+
+async def test_wait_for_trigger_composite_device_id_logs_warning(
+    hass: HomeAssistant,
+    split_devices: tuple[dr.DeviceEntry, dr.DeviceEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a composite device_id in a wait_for_trigger event trigger warns too."""
+    with caplog.at_level(logging.WARNING):
+        await script.async_validate_actions_config(
+            hass, [{"wait_for_trigger": [_EVENT_TRIGGER]}]
+        )
+    assert caplog.messages == [_expected_composite_warning(*split_devices)]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Log a warning when event triggers filter on composite device

This PR is meant as a quick fix which can be included in a patch release and will be replaced by a version creating repair issues

Related issue: https://github.com/home-assistant/core/issues/178332

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
