### PR TITLE
Add icon for free disk space

### DIFF
--- a/homeassistant/components/transmission/icons.json
+++ b/homeassistant/components/transmission/icons.json
@@ -12,7 +12,9 @@
       "completed_torrents": {
         "default": "mdi:counter"
       },
-      "download_dir_free_space": { "default": "mdi:harddisk" },
+      "download_dir_free_space": {
+        "default": "mdi:harddisk"
+      },
       "download_speed": {
         "default": "mdi:cloud-download"
       },

--- a/homeassistant/components/transmission/icons.json
+++ b/homeassistant/components/transmission/icons.json
@@ -12,6 +12,7 @@
       "completed_torrents": {
         "default": "mdi:counter"
       },
+      "download_dir_free_space": { "default": "mdi:harddisk" },
       "download_speed": {
         "default": "mdi:cloud-download"
       },


### PR DESCRIPTION
## Proposed change

Adds the `mdi:harddisk` icon for the Transmission free disk space sensor merged in #179487

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179487
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
