### PR TITLE
Provide matched entry placeholders in _async_abort_entries_match()

### DIFF
--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -335,7 +335,11 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             if port:
                 self.port = port
                 match_dict[CONF_PORT] = port
-            self._async_abort_entries_match(match_dict)
+            self._async_abort_entries_match(
+                match_dict,
+                error="host_already_configured",
+                description_placeholders={"host": host},
+            )
 
             self.host = host
             credentials = await get_credentials(self.hass)

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "host_already_configured": "The device at {host} is already configured as {title}.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2991,16 +2991,21 @@ class ConfigEntries:
 
 @callback
 def _async_abort_entries_match(
-    other_entries: list[ConfigEntry], match_dict: dict[str, Any] | None = None
+    other_entries: list[ConfigEntry],
+    match_dict: dict[str, Any] | None = None,
+    *,
+    error: str = "already_configured",
+    description_placeholders: Mapping[str, str] | None = None,
 ) -> None:
     """Abort if current entries match all data.
 
-    Requires `already_configured` in strings.json in user visible flows.
+    The matched entry's title is provided as a description placeholder,
+    merged with any caller provided placeholders.
+    Requires a strings.json entry corresponding to the `error` parameter
+    in user visible flows.
     """
     if match_dict is None:
-        if other_entries:
-            raise data_entry_flow.AbortFlow("already_configured")  # Match any entry
-        return
+        match_dict = {}  # Match any entry
     for entry in other_entries:
         options_items = entry.options.items()
         data_items = entry.data.items()
@@ -3008,7 +3013,13 @@ def _async_abort_entries_match(
             if kv not in options_items and kv not in data_items:
                 break
         else:
-            raise data_entry_flow.AbortFlow("already_configured")
+            raise data_entry_flow.AbortFlow(
+                error,
+                description_placeholders={
+                    "title": entry.title,
+                    **(description_placeholders or {}),
+                },
+            )
 
 
 class ConfigEntryBaseFlow(
@@ -3084,12 +3095,19 @@ class ConfigFlow(ConfigEntryBaseFlow):
 
     @callback
     def _async_abort_entries_match(
-        self, match_dict: dict[str, Any] | None = None
+        self,
+        match_dict: dict[str, Any] | None = None,
+        *,
+        error: str = "already_configured",
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> None:
         """Abort if current entries match all data.
 
         Do not abort for the entry that is being updated by the current flow.
-        Requires `already_configured` in strings.json in user visible flows.
+        The matched entry's title is provided as a description placeholder,
+        merged with any caller provided placeholders.
+        Requires a strings.json entry corresponding to the `error` parameter
+        in user visible flows.
         """
         _async_abort_entries_match(
             [
@@ -3098,6 +3116,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
                 if entry.entry_id != self.context.get("entry_id")
             ],
             match_dict,
+            error=error,
+            description_placeholders=description_placeholders,
         )
 
     @callback
@@ -3132,6 +3152,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
     ) -> None:
         """Abort if the unique ID is already configured.
 
+        The matched entry's title is provided as a description placeholder,
+        merged with any caller provided placeholders.
         Requires strings.json entry corresponding to the `error` parameter
         in user visible flows.
         """
@@ -3176,7 +3198,13 @@ class ConfigFlow(ConfigEntryBaseFlow):
             return
         if should_reload:
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
-        raise data_entry_flow.AbortFlow(error, description_placeholders)
+        raise data_entry_flow.AbortFlow(
+            error,
+            description_placeholders={
+                "title": entry.title,
+                **(description_placeholders or {}),
+            },
+        )
 
     async def async_set_unique_id(
         self, unique_id: str | None = None, *, raise_on_progress: bool = True
@@ -3975,11 +4003,18 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
     @callback
     def _async_abort_entries_match(
-        self, match_dict: dict[str, Any] | None = None
+        self,
+        match_dict: dict[str, Any] | None = None,
+        *,
+        error: str = "already_configured",
+        description_placeholders: Mapping[str, str] | None = None,
     ) -> None:
         """Abort if another current entry matches all data.
 
-        Requires `already_configured` in strings.json in user visible flows.
+        The matched entry's title is provided as a description placeholder,
+        merged with any caller provided placeholders.
+        Requires a strings.json entry corresponding to the `error` parameter
+        in user visible flows.
         """
         _async_abort_entries_match(
             [
@@ -3990,6 +4025,8 @@ class OptionsFlow(ConfigEntryBaseFlow):
                 if entry is not self.config_entry and entry.source != SOURCE_IGNORE
             ],
             match_dict,
+            error=error,
+            description_placeholders=description_placeholders,
         )
 
     @property

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -736,7 +736,11 @@ async def test_manual(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result2["reason"] == "host_already_configured"
+    assert result2["description_placeholders"] == {
+        "host": IP_ADDRESS,
+        "title": DEFAULT_ENTRY_TITLE,
+    }
 
 
 async def test_manual_camera(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6226,6 +6226,167 @@ async def test_async_abort_entries_match_options_flow(
     assert result["reason"] == reason
 
 
+@pytest.mark.parametrize(
+    ("matchers", "kwargs", "reason", "placeholders"),
+    [
+        pytest.param(
+            {"host": "3.4.5.6", "port": 23},
+            {},
+            "already_configured",
+            {"title": "Existing entry"},
+            id="title_of_matched_entry",
+        ),
+        pytest.param(
+            None,
+            {},
+            "already_configured",
+            {"title": "Existing entry"},
+            id="match_any_entry",
+        ),
+        pytest.param(
+            {"host": "3.4.5.6"},
+            {"error": "host_already_configured"},
+            "host_already_configured",
+            {"title": "Existing entry"},
+            id="custom_error",
+        ),
+        pytest.param(
+            {"host": "3.4.5.6"},
+            {"description_placeholders": {"host": "3.4.5.6", "extra": "value"}},
+            "already_configured",
+            {"host": "3.4.5.6", "title": "Existing entry", "extra": "value"},
+            id="caller_placeholders_merged",
+        ),
+        pytest.param(
+            {"host": "3.4.5.6"},
+            {"description_placeholders": {"title": "Override"}},
+            "already_configured",
+            {"title": "Override"},
+            id="caller_placeholders_take_precedence",
+        ),
+    ],
+)
+async def test_async_abort_entries_match_placeholders(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    matchers: dict[str, Any] | None,
+    kwargs: dict[str, Any],
+    reason: str,
+    placeholders: dict[str, str],
+) -> None:
+    """Test description placeholders provided when matching config entries exist."""
+    MockConfigEntry(
+        domain="comp",
+        title="Existing entry",
+        data={"host": "3.4.5.6", "port": 23},
+    ).add_to_hass(hass)
+
+    mock_integration(hass, MockModule("comp"))
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            self._async_abort_entries_match(matchers, **kwargs)
+            return self.async_abort(reason="no_match")
+
+    with mock_config_flow("comp", TestFlow):
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+    assert result["description_placeholders"] == placeholders
+
+
+async def test_async_abort_entries_match_options_flow_placeholders(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Test the options flow variant passes error and placeholders through."""
+    MockConfigEntry(
+        domain="test_abort",
+        title="Existing entry",
+        data={"host": "3.4.5.6"},
+    ).add_to_hass(hass)
+    original_entry = MockConfigEntry(domain="test_abort", data={})
+    original_entry.add_to_hass(hass)
+
+    mock_integration(hass, MockModule("test_abort"))
+    mock_platform(hass, "test_abort.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry):
+            """Test options flow."""
+
+            class _OptionsFlow(config_entries.OptionsFlow):
+                """Test flow."""
+
+                async def async_step_init(self, user_input=None):
+                    """Test user step."""
+                    self._async_abort_entries_match(
+                        user_input,
+                        error="host_already_configured",
+                        description_placeholders={"extra": "value"},
+                    )
+                    return self.async_abort(reason="no_match")
+
+            return _OptionsFlow()
+
+    with mock_config_flow("test_abort", TestFlow):
+        result = await hass.config_entries.options.async_init(
+            original_entry.entry_id, data={"host": "3.4.5.6"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "host_already_configured"
+    assert result["description_placeholders"] == {
+        "title": "Existing entry",
+        "extra": "value",
+    }
+
+
+async def test_abort_if_unique_id_configured_provides_title(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Test the conflicting entry title is provided as a description placeholder."""
+    MockConfigEntry(
+        domain="comp", unique_id="mock-unique-id", title="Existing entry"
+    ).add_to_hass(hass)
+
+    mock_integration(hass, MockModule("comp"))
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            await self.async_set_unique_id("mock-unique-id")
+            self._abort_if_unique_id_configured()
+            return self.async_abort(reason="no_match")
+
+    with mock_config_flow("comp", TestFlow):
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert result["description_placeholders"] == {"title": "Existing entry"}
+
+
 async def test_loading_old_data(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `error` and `description_placeholders` arguments to `_async_abort_entries_match()` to make identification of the entry that blocks entry creation easier, matching `_abort_if_unique_id_configured`. We also auto-provide the title as a placeholder as it will be quite common. This makes a message like "The device at 192.168.0.5 is already configured as *Living Room Plug*" possible without re-implementing `_async_abort_entries_match()` within the integration.

Spotted in #177955. I've used that PR as a showcase for the usecase of this extended helper functionality. Other integrations which could benefit from this also exist: blebox (config_flow.py:208), esphome (config_flow.py:731), deluge (config_flow.py:38)

With this, an integration can opt into a specific duplicate message via strings.json alone:

```json
"abort": {
  "already_configured": "The device is already configured as {title}."
}
```

or, where a distinct reason key and/or additional description placeholders are wanted:

```python
self._async_abort_entries_match(
    {CONF_HOST: host},
    error="host_already_configured",
    description_placeholders={"host": host},
)
```

```json
"abort": {
  "host_already_configured": "The device at {host} is already configured as {title}."
}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
