### PR TITLE
Fix friendly name for device trackers in FRITZ!Box tools

### DIFF
--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DEFAULT_DEVICE_NAME, LOGGER
+from .const import LOGGER
 from .coordinator import FRITZ_DATA_KEY, AvmWrapper, FritzConfigEntry, FritzData
 from .entity import FritzDeviceBase
 from .helpers import device_filter_out_from_trackers
@@ -67,7 +67,6 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Initialize a FRITZ!Box device."""
         super().__init__(avm_wrapper, device)
-        self._attr_name: str = device.hostname or DEFAULT_DEVICE_NAME
         self._last_activity: datetime.datetime | None = device.last_activity
 
     @property

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -63,6 +63,7 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
     """Class which queries a FRITZ!Box device."""
 
     _attr_translation_key = "device_tracker"
+    _attr_name = None
 
     def __init__(self, avm_wrapper: AvmWrapper, device: FritzDevice) -> None:
         """Initialize a FRITZ!Box device."""

--- a/tests/components/fritz/snapshots/test_device_tracker.ambr
+++ b/tests/components/fritz/snapshots/test_device_tracker.ambr
@@ -1,0 +1,128 @@
+# serializer version: 1
+# name: test_device_tracker_setup[Mock Title-device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': 'http://fake_host',
+    'connections': set({
+      tuple(
+        'mac',
+        '1c:ed:6f:12:34:11',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'fritz',
+        '1CED6F123411',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'FRITZ!',
+    'model': 'FRITZ!Box 7530 AX',
+    'model_id': None,
+    'name': 'Mock Title',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': '7.29',
+    'via_device_id': None,
+  })
+# ---
+# name: test_device_tracker_setup[device_tracker.printer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <DeviceTrackerEntityCapabilityAttribute.TRACKING_TYPE: 'tracking_type'>: <TrackingType.CONNECTION: 'connection'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'device_tracker',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'device_tracker.printer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'printer',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'printer',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_tracker',
+    'unique_id': 'AA:BB:CC:00:11:22_tracker',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device_tracker_setup[device_tracker.printer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'connected_to': 'fritz.box',
+      'connection_type': 'LAN',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'printer printer',
+      <ScannerEntityStateAttribute.HOST_NAME: 'host_name'>: 'printer',
+      <DeviceTrackerEntityStateAttribute.IN_ZONES: 'in_zones'>: list([
+        'zone.home',
+      ]),
+      <ScannerEntityStateAttribute.IP: 'ip'>: '192.168.178.2',
+      'last_time_reachable': '2026-08-18T20:00:00+00:00',
+      <ScannerEntityStateAttribute.MAC: 'mac'>: 'AA:BB:CC:00:11:22',
+      <DeviceTrackerEntityStateAttribute.SOURCE_TYPE: 'source_type'>: <SourceType.ROUTER: 'router'>,
+      <DeviceTrackerEntityCapabilityAttribute.TRACKING_TYPE: 'tracking_type'>: <TrackingType.CONNECTION: 'connection'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.printer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'home',
+  })
+# ---
+# name: test_device_tracker_setup[printer-device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:00:11:22',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'FRITZ!',
+    'model': 'FRITZ!Box Tracked device',
+    'model_id': None,
+    'name': 'printer',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---

--- a/tests/components/fritz/snapshots/test_device_tracker.ambr
+++ b/tests/components/fritz/snapshots/test_device_tracker.ambr
@@ -33,7 +33,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_device_tracker_setup[device_tracker.printer-entry]
+# name: test_device_tracker_setup[device_tracker.fritz_aa_bb_cc_00_11_22_tracker-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -49,7 +49,7 @@
     'disabled_by': None,
     'domain': 'device_tracker',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'device_tracker.printer',
+    'entity_id': 'device_tracker.fritz_aa_bb_cc_00_11_22_tracker',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -57,12 +57,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'printer',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'printer',
+    'original_name': None,
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -72,12 +72,12 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_device_tracker_setup[device_tracker.printer-state]
+# name: test_device_tracker_setup[device_tracker.fritz_aa_bb_cc_00_11_22_tracker-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'connected_to': 'fritz.box',
       'connection_type': 'LAN',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'printer printer',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'printer',
       <ScannerEntityStateAttribute.HOST_NAME: 'host_name'>: 'printer',
       <DeviceTrackerEntityStateAttribute.IN_ZONES: 'in_zones'>: list([
         'zone.home',
@@ -89,7 +89,7 @@
       <DeviceTrackerEntityCapabilityAttribute.TRACKING_TYPE: 'tracking_type'>: <TrackingType.CONNECTION: 'connection'>,
     }),
     'context': <ANY>,
-    'entity_id': 'device_tracker.printer',
+    'entity_id': 'device_tracker.fritz_aa_bb_cc_00_11_22_tracker',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/fritz/test_device_tracker.py
+++ b/tests/components/fritz/test_device_tracker.py
@@ -1,0 +1,40 @@
+"""Tests for Fritz!Tools device tracker platform."""
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.fritz.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .const import MOCK_USER_DATA
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.freeze_time(datetime(2026, 8, 18, 20, tzinfo=UTC))
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_tracker_setup(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fc_class_mock,
+    fh_class_mock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test setup of Fritz!Tools device_tracker."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.fritz.PLATFORMS", [Platform.DEVICE_TRACKER]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+    for device in device_registry.devices.values():
+        assert device == snapshot(name=f"{device.name}-device")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the `friendly_name` for device trackers is build as `{device.name} {entity.name}`, as we set `has_entity_name=True` and `self._attr_name` - that's expected [entity-naming](https://developers.home-assistant.io/docs/core/entity#entity-naming) behavior.

But we shouldn't need to set a name for the device_tracker, as we already have the proper name on the device entry. So I removed the definition for `self._attr_name` from the `device_tracker` entity, which results in the wanted `friendly_name` as `{device.name}`. but it also changes the entity_id from `device_tracker.{entity.name}` (_eq. `device_tracker.printer`_) to `device_tracker.{entity.unique_id}` (_eq. `device_tracker.fritz_aa_bb_cc_00_11_22_tracker`_) - I've show cased it in 088f07d090e12c8bbb784565aed9ddae16213c2e

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163086
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
