### PR TITLE
Fix OpenRGB turn_off being a no-op for devices without Off mode in non-color modes

### DIFF
--- a/homeassistant/components/openrgb/light.py
+++ b/homeassistant/components/openrgb/light.py
@@ -407,7 +407,12 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
         if self._supports_off_mode:
             await self._async_apply_mode(OpenRGBMode.OFF)
         else:
-            # If the device does not support Off mode, set color to black
+            # If the device does not support Off mode, set color to black.
+            # Color writes are ignored while a mode without PER_LED color
+            # support (e.g. a firmware effect) is active — switch to the
+            # preferred no-effect mode first so the black actually lands.
+            if self._mode not in self._supports_color_modes:
+                await self._async_apply_mode(self._preferred_no_effect_mode)
             await self._async_apply_color(OFF_COLOR, 0)
 
         await self._async_refresh_data()

--- a/tests/components/openrgb/test_light.py
+++ b/tests/components/openrgb/test_light.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 import copy
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from openrgb.utils import OpenRGBDisconnected, RGBColor
@@ -620,8 +620,69 @@ async def test_turn_off_light_without_off_mode(
         blocking=True,
     )
 
-    # Device should have set_color called with black/off color instead
+    # Device should have set_color called with black/off color instead,
+    # without any mode switch (the active mode is already color-capable)
+    mock_openrgb_device.set_mode.assert_not_called()
     mock_openrgb_device.set_color.assert_called_once_with(RGBColor(*OFF_COLOR), True)
+
+
+@pytest.mark.usefixtures("mock_openrgb_client")
+async def test_turn_off_light_without_off_mode_in_non_color_mode(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test turning off a light without Off mode while a non-color mode is active.
+
+    Color writes are ignored by the device while a mode without PER_LED
+    color support (e.g. a firmware effect) is active, so turning off must
+    first switch to the preferred no-effect mode — otherwise painting
+    black is a silent no-op and the light never turns off.
+    """
+    # Modify the device to not have Off mode
+    mock_openrgb_device.modes = [
+        mode_data
+        for mode_data in mock_openrgb_device.modes
+        if mode_data.name != OpenRGBMode.OFF
+    ]
+    # Activate a mode without PER_LED color support ("Spectrum Cycle")
+    mock_openrgb_device.active_mode = next(
+        index
+        for index, mode_data in enumerate(mock_openrgb_device.modes)
+        if mode_data.name == "Spectrum Cycle"
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # Verify light is initially on
+    state = hass.states.get("light.ene_dram")
+    assert state
+    assert state.state == STATE_ON
+
+    # Turn off the light
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "light.ene_dram"},
+        blocking=True,
+    )
+
+    # The device must first be switched to the preferred no-effect mode
+    # (color-capable), then painted black — in that order
+    mock_openrgb_device.set_mode.assert_called_once_with(OpenRGBMode.DIRECT)
+    mock_openrgb_device.set_color.assert_called_once_with(RGBColor(*OFF_COLOR), True)
+    assert [
+        call
+        for call in mock_openrgb_device.mock_calls
+        if call[0] in ("set_mode", "set_color")
+    ] == [
+        call.set_mode(OpenRGBMode.DIRECT),
+        call.set_color(RGBColor(*OFF_COLOR), True),
+    ]
 
 
 # Test error handling


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Proposed change

For OpenRGB devices **without** a native `Off` mode, `async_turn_off` falls back to painting the LEDs black via `set_color()`. However, the device ignores color writes entirely while a mode without PER_LED color support (e.g. a firmware effect like `Color Shift`) is active — so the fallback is a silent no-op: the LEDs keep animating and the entity bounces back to `on` on the next coordinator refresh. Since `supported_color_modes` collapses to `onoff` in those modes, the user is left with a toggle that visibly does nothing and no color controls to escape with.

This PR makes the fallback switch the device to `_preferred_no_effect_mode` first when the active mode has no PER_LED color support, so the black actually reaches the LEDs.

Reproduced on hardware (Corsair Vengeance RGB DDR5 over SMBus, OpenRGB server 1.0rc3) with an SDK-level state trace — full analysis in the linked issue.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179514
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
