### PR TITLE
weatherflow_cloud: Fix Reload

### DIFF
--- a/homeassistant/components/weatherflow_cloud/__init__.py
+++ b/homeassistant/components/weatherflow_cloud/__init__.py
@@ -1,6 +1,7 @@
 """The WeatherflowCloud integration."""
 
 import asyncio
+from contextlib import suppress
 
 from weatherflow4py.api import WeatherFlowRestAPI
 from weatherflow4py.ws import WeatherFlowWebsocketAPI
@@ -72,7 +73,8 @@ async def async_setup_entry(
 
     async def _async_disconnect_websocket() -> None:
         """Disconnect the WeatherFlow websocket."""
-        await websocket_api.stop_all_listeners()
+        with suppress(WebSocketException):
+            await websocket_api.stop_all_listeners()
         await websocket_api.close()
 
     # Connect once because both websocket coordinators share this API instance.

--- a/homeassistant/components/weatherflow_cloud/__init__.py
+++ b/homeassistant/components/weatherflow_cloud/__init__.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from weatherflow4py.api import WeatherFlowRestAPI
 from weatherflow4py.ws import WeatherFlowWebsocketAPI
 from websockets.exceptions import WebSocketException
+from websockets.protocol import State as WebSocketState
 
 from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -73,11 +74,23 @@ async def async_setup_entry(
 
     async def _async_disconnect_websocket() -> None:
         """Disconnect the WeatherFlow websocket."""
-        with suppress(WebSocketException):
-            await websocket_api.stop_all_listeners()
-        await websocket_api.close()
+        websocket = websocket_api.websocket
+        try:
+            with suppress(WebSocketException):
+                await websocket_api.close()
+        finally:
+            if WeatherFlowWebsocketAPI._shared_websocket is websocket:  # noqa: SLF001
+                WeatherFlowWebsocketAPI._shared_websocket = None  # noqa: SLF001
 
     # Connect once because both websocket coordinators share this API instance.
+    shared_websocket = WeatherFlowWebsocketAPI._shared_websocket  # noqa: SLF001
+    if (
+        shared_websocket is not None
+        and shared_websocket.state is not WebSocketState.OPEN
+    ):
+        # weatherflow4py does not clear a closed shared socket.
+        WeatherFlowWebsocketAPI._shared_websocket = None  # noqa: SLF001
+
     try:
         await websocket_api.connect(client_context())
     except (OSError, WebSocketException) as err:

--- a/homeassistant/components/weatherflow_cloud/config_flow.py
+++ b/homeassistant/components/weatherflow_cloud/config_flow.py
@@ -9,15 +9,17 @@ from weatherflow4py.api import WeatherFlowRestAPI
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
 
-async def _validate_api_token(api_token: str) -> dict[str, Any]:
+async def _validate_api_token(hass: HomeAssistant, api_token: str) -> dict[str, Any]:
     """Validate the API token."""
     try:
-        async with WeatherFlowRestAPI(api_token) as api:
-            await api.async_get_stations()
+        api = WeatherFlowRestAPI(api_token, session=async_get_clientsession(hass))
+        await api.async_get_stations()
     except ClientResponseError as err:
         if err.status == 401:
             return {"base": "invalid_api_key"}
@@ -44,7 +46,7 @@ class WeatherFlowCloudConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             api_token = user_input[CONF_API_TOKEN]
-            errors = await _validate_api_token(api_token)
+            errors = await _validate_api_token(self.hass, api_token)
             if not errors:
                 # Update the existing entry and abort
                 existing_entry = self._get_reauth_entry()
@@ -70,7 +72,7 @@ class WeatherFlowCloudConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._async_abort_entries_match(user_input)
             api_token = user_input[CONF_API_TOKEN]
-            errors = await _validate_api_token(api_token)
+            errors = await _validate_api_token(self.hass, api_token)
             if not errors:
                 return self.async_create_entry(
                     title="Weatherflow REST",

--- a/tests/components/weatherflow_cloud/test_init.py
+++ b/tests/components/weatherflow_cloud/test_init.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from websockets.exceptions import ConnectionClosedError
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -37,6 +37,26 @@ async def test_entry_unload(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_websocket_api.stop_all_listeners.assert_awaited_once()
+    mock_websocket_api.close.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("mock_rest_api")
+async def test_entry_unload_with_closed_websocket(
+    hass: HomeAssistant,
+    mock_websocket_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading an entry whose websocket is already closed."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    mock_websocket_api.stop_all_listeners.side_effect = ConnectionClosedOK(None, None)
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/weatherflow_cloud/test_init.py
+++ b/tests/components/weatherflow_cloud/test_init.py
@@ -1,10 +1,12 @@
 """Tests for weatherflow_cloud __init__ setup."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.protocol import State as WebSocketState
 
+from homeassistant.components import weatherflow_cloud
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util.ssl import client_context
@@ -28,6 +30,29 @@ async def test_websocket_connect_called_once(
 
 
 @pytest.mark.usefixtures("mock_rest_api")
+async def test_stale_shared_websocket_is_replaced(
+    hass: HomeAssistant,
+    mock_websocket_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that setup replaces the closed shared websocket after a reload."""
+    weatherflow_cloud.WeatherFlowWebsocketAPI._shared_websocket = Mock(
+        state=WebSocketState.CLOSED
+    )
+
+    async def _assert_stale_websocket_cleared(*args: object) -> None:
+        assert weatherflow_cloud.WeatherFlowWebsocketAPI._shared_websocket is None
+
+    mock_websocket_api.connect.side_effect = _assert_stale_websocket_cleared
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("mock_rest_api")
 async def test_entry_unload(
     hass: HomeAssistant,
     mock_websocket_api: AsyncMock,
@@ -42,7 +67,7 @@ async def test_entry_unload(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    mock_websocket_api.stop_all_listeners.assert_awaited_once()
+    mock_websocket_api.stop_all_listeners.assert_not_awaited()
     mock_websocket_api.close.assert_awaited_once()
 
 
@@ -56,13 +81,13 @@ async def test_entry_unload_with_closed_websocket(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    mock_websocket_api.stop_all_listeners.side_effect = ConnectionClosedOK(None, None)
+    mock_websocket_api.close.side_effect = ConnectionClosedOK(None, None)
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    mock_websocket_api.stop_all_listeners.assert_awaited_once()
+    mock_websocket_api.stop_all_listeners.assert_not_awaited()
     mock_websocket_api.close.assert_awaited_once()
 
 
@@ -80,7 +105,7 @@ async def test_setup_failure_cleans_up_websocket(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-    mock_websocket_api.stop_all_listeners.assert_awaited_once()
+    mock_websocket_api.stop_all_listeners.assert_not_awaited()
     mock_websocket_api.close.assert_awaited_once()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reloading the weatherflow cloud integration doesn't work. Instead you have to restart home assistant. There were a couple issues, but this cleanly restarts on my copy of HA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
