### PR TITLE
USB Websocket API to list serial ports

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -543,6 +543,33 @@ async def websocket_usb_scan(
     connection.send_result(msg["id"])
 
 
+@hass_callback
+def _async_serialize_port(
+    hass: HomeAssistant, port: USBDevice | SerialDevice
+) -> dict[str, Any]:
+    """Serialize a serial port for the websocket API."""
+    entry: dict[str, Any] = {
+        "device": port.device,
+        "serial_number": port.serial_number,
+        "manufacturer": port.manufacturer,
+        "description": port.description,
+        "interface_description": port.interface_description,
+        "interface_num": port.interface_num,
+        "matching_integrations": [],
+    }
+
+    if isinstance(port, USBDevice):
+        entry["vid"] = port.vid
+        entry["pid"] = port.pid
+        entry["bcd_device"] = port.bcd_device
+        matchers = async_get_usb_matchers_for_device(hass, port)
+        entry["matching_integrations"] = list(
+            dict.fromkeys(matcher["domain"] for matcher in matchers)
+        )
+
+    return entry
+
+
 @websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "usb/list_serial_ports"})
 @websocket_api.async_response
@@ -558,21 +585,9 @@ async def websocket_usb_list_serial_ports(
         connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
         return
 
-    result = []
-    for port in ports:
-        entry = dataclasses.asdict(port)
-
-        if isinstance(port, USBDevice):
-            matchers = async_get_usb_matchers_for_device(hass, port)
-            entry["matching_integrations"] = list(
-                dict.fromkeys(matcher["domain"] for matcher in matchers)
-            )
-        else:
-            entry["matching_integrations"] = []
-
-        result.append(entry)
-
-    connection.send_result(msg["id"], result)
+    connection.send_result(
+        msg["id"], [_async_serialize_port(hass, port) for port in ports]
+    )
 
 
 @websocket_api.require_admin
@@ -592,44 +607,24 @@ async def websocket_usb_serial_ports(
 
     consumers = await async_get_serial_port_consumers(hass, ports)
     scanned_devices = {port.device for port in ports}
-    result = []
 
+    result_ports = []
     for port in ports:
-        entry = dataclasses.asdict(port)
-        entry["present"] = True
-
-        if isinstance(port, USBDevice):
-            matchers = async_get_usb_matchers_for_device(hass, port)
-            entry["matching_integrations"] = list(
-                dict.fromkeys(matcher["domain"] for matcher in matchers)
-            )
-        else:
-            entry["matching_integrations"] = []
-
+        entry = _async_serialize_port(hass, port)
         entry["consumers"] = [
             dataclasses.asdict(consumer) for consumer in consumers.get(port.device, [])
         ]
+        result_ports.append(entry)
 
-        result.append(entry)
+    missing = [
+        {
+            "device": device,
+            "consumers": [
+                dataclasses.asdict(consumer) for consumer in device_consumers
+            ],
+        }
+        for device, device_consumers in consumers.items()
+        if device not in scanned_devices
+    ]
 
-    for device, device_consumers in consumers.items():
-        if device in scanned_devices:
-            continue
-
-        entry = dataclasses.asdict(
-            SerialDevice(
-                device=device,
-                serial_number=None,
-                manufacturer=None,
-                description=None,
-            )
-        )
-        entry["present"] = False
-        entry["matching_integrations"] = []
-        entry["consumers"] = [
-            dataclasses.asdict(consumer) for consumer in device_consumers
-        ]
-
-        result.append(entry)
-
-    connection.send_result(msg["id"], result)
+    connection.send_result(msg["id"], {"ports": result_ports, "missing": missing})

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -617,32 +617,35 @@ async def websocket_usb_list_serial_ports(
 
     result = [_async_serialize_port(hass, port) for port in ports]
 
-    if msg["include_usage"]:
-        consumers = await async_get_serial_port_consumers(hass, ports)
+    if not msg["include_usage"]:
+        connection.send_result(msg["id"], result)
+        return
 
-        # Configured ports missing from the scan are absent, except for URLs no
-        # scanner can contribute, which are assumed present while claimed
-        scanned_devices = {port.device for port in ports}
-        result.extend(
-            _async_serialize_port(
-                hass,
-                SerialDevice(
-                    device=device,
-                    serial_number=None,
-                    manufacturer=None,
-                    description=None,
-                ),
-                present=device.startswith(UNSCANNABLE_PORT_SCHEMES),
-            )
-            for device in consumers
-            if device not in scanned_devices
+    consumers = await async_get_serial_port_consumers(hass, ports)
+
+    # Configured ports missing from the scan are absent, except for URLs no
+    # scanner can contribute, which are assumed present while claimed
+    scanned_devices = {port.device for port in ports}
+    result.extend(
+        _async_serialize_port(
+            hass,
+            SerialDevice(
+                device=device,
+                serial_number=None,
+                manufacturer=None,
+                description=None,
+            ),
+            present=device.startswith(UNSCANNABLE_PORT_SCHEMES),
         )
+        for device in consumers
+        if device not in scanned_devices
+    )
 
-        for entry in result:
-            device = entry["device"]
-            entry["consumers"] = [
-                _serialize_consumer(consumer) for consumer in consumers.get(device, [])
-            ]
-            entry["discovery_flows"] = _async_get_discovery_flows(hass, device)
+    for entry in result:
+        device = entry["device"]
+        entry["consumers"] = [
+            _serialize_consumer(consumer) for consumer in consumers.get(device, [])
+        ]
+        entry["discovery_flows"] = _async_get_discovery_flows(hass, device)
 
     connection.send_result(msg["id"], result)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -548,6 +548,7 @@ def _async_serialize_port(
     """Serialize a serial port for the websocket API."""
     entry: dict[str, Any] = {
         "device": port.device,
+        "resolved_device": port.resolved_device,
         "serial_number": port.serial_number,
         "manufacturer": port.manufacturer,
         "description": port.description,
@@ -600,6 +601,7 @@ def _serialize_absent_port(
     """Serialize a port that is configured but was not found in the scan."""
     return {
         "device": device,
+        "resolved_device": None,
         "serial_number": None,
         "manufacturer": None,
         "description": None,

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Callable, Coroutine, Sequence
 from contextlib import suppress
-import dataclasses
 from datetime import datetime, timedelta
 import logging
 import os
@@ -188,7 +187,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[_USB_DATA] = usb_discovery
     websocket_api.async_register_command(hass, websocket_usb_scan)
     websocket_api.async_register_command(hass, websocket_usb_list_serial_ports)
-    websocket_api.async_register_command(hass, websocket_usb_serial_ports)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, register_serialx_transport())
 
@@ -556,6 +554,7 @@ def _async_serialize_port(
         "interface_description": port.interface_description,
         "interface_num": port.interface_num,
         "matching_integrations": [],
+        "present": True,
     }
 
     if isinstance(port, USBDevice):
@@ -570,61 +569,86 @@ def _async_serialize_port(
     return entry
 
 
+@hass_callback
+def _async_get_discovery_flows(
+    hass: HomeAssistant, device: str
+) -> list[dict[str, str]]:
+    """Return the in-progress USB discovery flows for a device path."""
+    return [
+        {"flow_id": flow["flow_id"], "domain": flow["handler"]}
+        for flow in hass.config_entries.flow.async_progress_by_init_data_type(
+            UsbServiceInfo, lambda service_info: service_info.device == device
+        )
+    ]
+
+
+def _serialize_consumer(consumer: SerialPortConsumer) -> dict[str, Any]:
+    """Serialize a serial port consumer for the websocket API."""
+    return {
+        "kind": consumer.kind,
+        "title": consumer.title,
+        "active": consumer.active,
+        "domain": consumer.domain,
+        "config_entry_id": consumer.config_entry_id,
+        "slug": consumer.slug,
+    }
+
+
+def _serialize_absent_port(
+    device: str, consumers: list[SerialPortConsumer]
+) -> dict[str, Any]:
+    """Serialize a port that is configured but was not found in the scan."""
+    return {
+        "device": device,
+        "serial_number": None,
+        "manufacturer": None,
+        "description": None,
+        "interface_description": None,
+        "interface_num": None,
+        "matching_integrations": [],
+        "present": False,
+        "consumers": [_serialize_consumer(consumer) for consumer in consumers],
+        "discovery_flows": [],
+    }
+
+
 @websocket_api.require_admin
-@websocket_api.websocket_command({vol.Required("type"): "usb/list_serial_ports"})
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "usb/list_serial_ports",
+        vol.Optional("include_usage", default=False): bool,
+    }
+)
 @websocket_api.async_response
 async def websocket_usb_list_serial_ports(
     hass: HomeAssistant,
     connection: ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """List available serial ports."""
+    """List serial ports, optionally with the integrations and apps using them."""
     try:
         ports = await async_scan_serial_ports(hass)
     except OSError as err:
         connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
         return
 
-    connection.send_result(
-        msg["id"], [_async_serialize_port(hass, port) for port in ports]
-    )
+    result = [_async_serialize_port(hass, port) for port in ports]
 
+    if msg["include_usage"]:
+        consumers = await async_get_serial_port_consumers(hass, ports)
 
-@websocket_api.require_admin
-@websocket_api.websocket_command({vol.Required("type"): "usb/serial_ports"})
-@websocket_api.async_response
-async def websocket_usb_serial_ports(
-    hass: HomeAssistant,
-    connection: ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
-    """List serial ports along with the integrations and apps using them."""
-    try:
-        ports = await async_scan_serial_ports(hass)
-    except OSError as err:
-        connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
-        return
+        for entry in result:
+            device = entry["device"]
+            entry["consumers"] = [
+                _serialize_consumer(consumer) for consumer in consumers.get(device, [])
+            ]
+            entry["discovery_flows"] = _async_get_discovery_flows(hass, device)
 
-    consumers = await async_get_serial_port_consumers(hass, ports)
-    scanned_devices = {port.device for port in ports}
+        scanned_devices = {port.device for port in ports}
+        result.extend(
+            _serialize_absent_port(device, device_consumers)
+            for device, device_consumers in consumers.items()
+            if device not in scanned_devices
+        )
 
-    result_ports = []
-    for port in ports:
-        entry = _async_serialize_port(hass, port)
-        entry["consumers"] = [
-            dataclasses.asdict(consumer) for consumer in consumers.get(port.device, [])
-        ]
-        result_ports.append(entry)
-
-    missing = [
-        {
-            "device": device,
-            "consumers": [
-                dataclasses.asdict(consumer) for consumer in device_consumers
-            ],
-        }
-        for device, device_consumers in consumers.items()
-        if device not in scanned_devices
-    ]
-
-    connection.send_result(msg["id"], {"ports": result_ports, "missing": missing})
+    connection.send_result(msg["id"], result)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -543,7 +543,7 @@ async def websocket_usb_scan(
 
 @hass_callback
 def _async_serialize_port(
-    hass: HomeAssistant, port: USBDevice | SerialDevice
+    hass: HomeAssistant, port: USBDevice | SerialDevice, *, present: bool = True
 ) -> dict[str, Any]:
     """Serialize a serial port for the websocket API."""
     entry: dict[str, Any] = {
@@ -555,7 +555,7 @@ def _async_serialize_port(
         "interface_description": port.interface_description,
         "interface_num": port.interface_num,
         "matching_integrations": [],
-        "present": True,
+        "present": present,
     }
 
     if isinstance(port, USBDevice):
@@ -595,25 +595,6 @@ def _serialize_consumer(consumer: SerialPortConsumer) -> dict[str, Any]:
     }
 
 
-def _serialize_absent_port(
-    device: str, consumers: list[SerialPortConsumer]
-) -> dict[str, Any]:
-    """Serialize a port that is configured but was not found in the scan."""
-    return {
-        "device": device,
-        "resolved_device": None,
-        "serial_number": None,
-        "manufacturer": None,
-        "description": None,
-        "interface_description": None,
-        "interface_num": None,
-        "matching_integrations": [],
-        "present": False,
-        "consumers": [_serialize_consumer(consumer) for consumer in consumers],
-        "discovery_flows": [],
-    }
-
-
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
@@ -639,18 +620,28 @@ async def websocket_usb_list_serial_ports(
     if msg["include_usage"]:
         consumers = await async_get_serial_port_consumers(hass, ports)
 
+        # Ports that are configured but missing from the scan are shown as absent
+        scanned_devices = {port.device for port in ports}
+        result.extend(
+            _async_serialize_port(
+                hass,
+                SerialDevice(
+                    device=device,
+                    serial_number=None,
+                    manufacturer=None,
+                    description=None,
+                ),
+                present=False,
+            )
+            for device in consumers
+            if device not in scanned_devices
+        )
+
         for entry in result:
             device = entry["device"]
             entry["consumers"] = [
                 _serialize_consumer(consumer) for consumer in consumers.get(device, [])
             ]
             entry["discovery_flows"] = _async_get_discovery_flows(hass, device)
-
-        scanned_devices = {port.device for port in ports}
-        result.extend(
-            _serialize_absent_port(device, device_consumers)
-            for device, device_consumers in consumers.items()
-            if device not in scanned_devices
-        )
 
     connection.send_result(msg["id"], result)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.loader import USBMatcher, async_get_usb
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
-from .consumers import async_get_serial_port_consumers
+from .consumers import UNSCANNABLE_PORT_SCHEMES, async_get_serial_port_consumers
 from .models import SerialDevice, SerialPortConsumer, USBDevice
 from .serial_proxy_stub import register_serialx_transport
 from .utils import (
@@ -620,7 +620,8 @@ async def websocket_usb_list_serial_ports(
     if msg["include_usage"]:
         consumers = await async_get_serial_port_consumers(hass, ports)
 
-        # Ports that are configured but missing from the scan are shown as absent
+        # Configured ports missing from the scan are absent, except for URLs no
+        # scanner can contribute, which are assumed present while claimed
         scanned_devices = {port.device for port in ports}
         result.extend(
             _async_serialize_port(
@@ -631,7 +632,7 @@ async def websocket_usb_list_serial_ports(
                     manufacturer=None,
                     description=None,
                 ),
-                present=False,
+                present=device.startswith(UNSCANNABLE_PORT_SCHEMES),
             )
             for device in consumers
             if device not in scanned_devices

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -32,7 +32,8 @@ from homeassistant.loader import USBMatcher, async_get_usb
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
-from .models import SerialDevice, USBDevice
+from .consumers import async_get_serial_port_consumers
+from .models import SerialDevice, SerialPortConsumer, USBDevice
 from .serial_proxy_stub import register_serialx_transport
 from .utils import (
     scan_serial_ports,
@@ -54,8 +55,10 @@ ADD_REMOVE_SCAN_COOLDOWN = 5  # 5 second cooldown to give devices a chance to re
 
 __all__ = [
     "SerialDevice",
+    "SerialPortConsumer",
     "USBCallbackMatcher",
     "USBDevice",
+    "async_get_serial_port_consumers",
     "async_register_port_event_callback",
     "async_register_scan_request_callback",
     "async_register_serial_port_scanner",
@@ -185,6 +188,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[_USB_DATA] = usb_discovery
     websocket_api.async_register_command(hass, websocket_usb_scan)
     websocket_api.async_register_command(hass, websocket_usb_list_serial_ports)
+    websocket_api.async_register_command(hass, websocket_usb_serial_ports)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, register_serialx_transport())
 
@@ -565,6 +569,66 @@ async def websocket_usb_list_serial_ports(
             )
         else:
             entry["matching_integrations"] = []
+
+        result.append(entry)
+
+    connection.send_result(msg["id"], result)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "usb/serial_ports"})
+@websocket_api.async_response
+async def websocket_usb_serial_ports(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List serial ports along with the integrations and apps using them."""
+    try:
+        ports = await async_scan_serial_ports(hass)
+    except OSError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
+        return
+
+    consumers = await async_get_serial_port_consumers(hass, ports)
+    scanned_devices = {port.device for port in ports}
+    result = []
+
+    for port in ports:
+        entry = dataclasses.asdict(port)
+        entry["present"] = True
+
+        if isinstance(port, USBDevice):
+            matchers = async_get_usb_matchers_for_device(hass, port)
+            entry["matching_integrations"] = list(
+                dict.fromkeys(matcher["domain"] for matcher in matchers)
+            )
+        else:
+            entry["matching_integrations"] = []
+
+        entry["consumers"] = [
+            dataclasses.asdict(consumer) for consumer in consumers.get(port.device, [])
+        ]
+
+        result.append(entry)
+
+    for device, device_consumers in consumers.items():
+        if device in scanned_devices:
+            continue
+
+        entry = dataclasses.asdict(
+            SerialDevice(
+                device=device,
+                serial_number=None,
+                manufacturer=None,
+                description=None,
+            )
+        )
+        entry["present"] = False
+        entry["matching_integrations"] = []
+        entry["consumers"] = [
+            dataclasses.asdict(consumer) for consumer in device_consumers
+        ]
 
         result.append(entry)
 

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -24,10 +24,14 @@ SERIAL_PORT_KEY_PATHS: tuple[tuple[str, ...], ...] = (
     ("serial_port",),  # edl21, teleinfo
 )
 
+# States in which the entry claims its configured port, even if the port is not
+# open right now: a retrying setup typically failed to open the port and a
+# failed unload may still hold it
 ACTIVE_CONFIG_ENTRY_STATES = (
     ConfigEntryState.LOADED,
     ConfigEntryState.SETUP_RETRY,
     ConfigEntryState.SETUP_IN_PROGRESS,
+    ConfigEntryState.FAILED_UNLOAD,
 )
 
 # Schemes of remote serial port URLs, listed even when they cannot be tied to

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -76,7 +76,7 @@ async def _async_get_config_entry_consumers(
     hass: HomeAssistant, known_devices: set[str]
 ) -> dict[str, list[SerialPortConsumer]]:
     """Return serial ports configured in config entries of `usb` integrations."""
-    entries = hass.config_entries.async_entries()
+    entries = hass.config_entries.async_entries(include_ignore=False)
     integrations = await async_get_integrations(
         hass, {entry.domain for entry in entries}
     )

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -88,6 +88,10 @@ def _serial_port_from_value(
     if value.startswith(SCANNED_PORT_SCHEMES):
         return value
 
+    if value.startswith(UNSCANNABLE_PORT_SCHEMES):
+        # zwave_js's esphome:// socket path embeds the noise PSK as `?key=`
+        return value.partition("?")[0]
+
     path = value
 
     if domain in ("elkm1", "upb"):

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -1,0 +1,198 @@
+"""Attribution of serial ports to the integrations and apps using them."""
+
+from collections.abc import Mapping, Sequence
+import os
+from typing import Any
+
+from homeassistant.components.hassio import HassioNotReadyError, get_addons_info
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.hassio import is_hassio
+from homeassistant.loader import async_get_integrations
+
+from .const import DOMAIN
+from .models import SerialDevice, SerialPortConsumer, USBDevice
+
+# Key paths holding a serial port in the config entry data and options of
+# integrations depending on `usb`. Traversed literally, never recursively.
+SERIAL_PORT_KEY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("device",),
+    ("device", "path"),  # zha
+    ("port",),
+    ("usb_path",),  # zwave_js, crownstone
+    ("serial_port",),  # edl21, teleinfo
+)
+
+ACTIVE_CONFIG_ENTRY_STATES = (
+    ConfigEntryState.LOADED,
+    ConfigEntryState.SETUP_RETRY,
+    ConfigEntryState.SETUP_IN_PROGRESS,
+)
+
+# Local ports can be wrapped in a URL by integrations such as upb
+SERIAL_URL_PREFIX = "serial://"
+
+# Supervisor app state, mirrors `aiohasupervisor.models.AddonState.STARTED`
+APP_STATE_STARTED = "started"
+
+
+def _resolve_key_path(data: Mapping[str, Any], key_path: tuple[str, ...]) -> Any:
+    """Return the value at a key path, or `None` if the path does not exist."""
+    value: Any = data
+
+    for key in key_path:
+        if not isinstance(value, Mapping) or key not in value:
+            return None
+        value = value[key]
+
+    return value
+
+
+def _serial_port_from_value(value: Any, known_devices: set[str]) -> str | None:
+    """Return the serial port a config entry value refers to."""
+    if not isinstance(value, str):
+        return None
+
+    # Remote ports are only identifiable by matching a scanned port exactly
+    if value in known_devices:
+        return value
+
+    path = value.removeprefix(SERIAL_URL_PREFIX)
+
+    if path.startswith("/dev/"):
+        return path
+
+    return None
+
+
+def _resolve_paths(paths: set[str]) -> dict[str, str]:
+    """Resolve symlinks of local device paths, passing other values through."""
+    return {
+        path: os.path.realpath(path) if path.startswith("/") else path for path in paths
+    }
+
+
+async def _async_get_config_entry_consumers(
+    hass: HomeAssistant, known_devices: set[str]
+) -> dict[str, list[SerialPortConsumer]]:
+    """Return serial ports configured in config entries of `usb` integrations."""
+    entries = hass.config_entries.async_entries()
+    integrations = await async_get_integrations(
+        hass, {entry.domain for entry in entries}
+    )
+    consumers: dict[str, list[SerialPortConsumer]] = {}
+
+    for entry in entries:
+        integration = integrations[entry.domain]
+
+        if isinstance(integration, Exception):
+            continue
+
+        if (
+            DOMAIN not in integration.dependencies
+            and DOMAIN not in integration.after_dependencies
+        ):
+            continue
+
+        for key_path in SERIAL_PORT_KEY_PATHS:
+            for data in (entry.data, entry.options):
+                port = _serial_port_from_value(
+                    _resolve_key_path(data, key_path), known_devices
+                )
+
+                if port is None:
+                    continue
+
+                consumers.setdefault(port, []).append(
+                    SerialPortConsumer(
+                        kind="config_entry",
+                        title=entry.title,
+                        active=entry.state in ACTIVE_CONFIG_ENTRY_STATES,
+                        domain=entry.domain,
+                        config_entry_id=entry.entry_id,
+                    )
+                )
+
+    return consumers
+
+
+@callback
+def _async_get_app_consumers(
+    hass: HomeAssistant,
+) -> dict[str, list[SerialPortConsumer]]:
+    """Return devices mapped into apps, either statically or through options.
+
+    Supervisor resolves `device(subsystem=tty)` options into real devices, so device
+    paths that no longer exist are missing and non-serial devices are included.
+    """
+    if not is_hassio(hass):
+        return {}
+
+    try:
+        apps_info = get_addons_info(hass)
+    except HassioNotReadyError:
+        return {}
+
+    consumers: dict[str, list[SerialPortConsumer]] = {}
+
+    for slug, info in apps_info.items():
+        if info is None:
+            continue
+
+        for device in info["devices"]:
+            consumers.setdefault(device, []).append(
+                SerialPortConsumer(
+                    kind="app",
+                    title=info["name"],
+                    active=info["state"] == APP_STATE_STARTED,
+                    slug=slug,
+                )
+            )
+
+    return consumers
+
+
+async def async_get_serial_port_consumers(
+    hass: HomeAssistant, ports: Sequence[USBDevice | SerialDevice]
+) -> dict[str, list[SerialPortConsumer]]:
+    """Return the consumers of every serial port, keyed by device path.
+
+    Scanned ports are keyed by their scanned device path, ports that are configured
+    but not currently present are keyed by their configured path.
+    """
+    known_devices = {port.device for port in ports}
+
+    entry_consumers = await _async_get_config_entry_consumers(hass, known_devices)
+    app_consumers = _async_get_app_consumers(hass)
+
+    resolved = await hass.async_add_executor_job(
+        _resolve_paths, known_devices | set(entry_consumers) | set(app_consumers)
+    )
+
+    # A port can be referred to by any of its symlinks, e.g. `/dev/serial/by-id`
+    aliases: dict[str, str] = {}
+
+    for port in ports:
+        aliases[resolved[port.device]] = port.device
+        aliases[port.device] = port.device
+
+    consumers: dict[str, list[SerialPortConsumer]] = {}
+
+    for path, path_consumers in entry_consumers.items():
+        # Ports that are configured but missing are kept and shown as absent
+        device = aliases.get(resolved[path], path)
+        consumers.setdefault(device, []).extend(path_consumers)
+
+    for path, path_consumers in app_consumers.items():
+        # Apps also map non-serial devices, only scanned ports are of interest
+        resolved_path = resolved[path]
+
+        if resolved_path not in aliases:
+            continue
+
+        consumers.setdefault(aliases[resolved_path], []).extend(path_consumers)
+
+    return {
+        device: list(dict.fromkeys(device_consumers))
+        for device, device_consumers in consumers.items()
+    }

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -15,29 +15,40 @@ from .const import DOMAIN
 from .models import SerialDevice, SerialPortConsumer, USBDevice
 
 # Key paths holding a serial port in the config entry data and options of
-# integrations depending on `usb`. Traversed literally, never recursively.
+# searched integrations. Traversed literally, never recursively.
 SERIAL_PORT_KEY_PATHS: tuple[tuple[str, ...], ...] = (
     ("device",),
     ("device", "path"),  # zha
+    ("device_path",),  # alarmdecoder
+    ("filename",),  # bryant_evolution
+    ("host",),  # elkm1
     ("port",),
-    ("usb_path",),  # zwave_js, crownstone
     ("serial_port",),  # edl21, teleinfo
+    ("socket_path",),  # zwave_js
+    ("usb_path",),  # zwave_js, crownstone
 )
 
+# Integrations configured with a serial port but not depending on `usb`
+NON_USB_SERIAL_DOMAINS = ("alarmdecoder", "bryant_evolution", "elkm1", "mysensors")
+
 # States in which the entry claims its configured port, even if the port is not
-# open right now: a retrying setup typically failed to open the port and a
-# failed unload may still hold it
+# open right now: a retrying setup typically failed to open the port, while an
+# unloading or failed-to-unload entry may still hold it
 ACTIVE_CONFIG_ENTRY_STATES = (
     ConfigEntryState.LOADED,
     ConfigEntryState.SETUP_RETRY,
     ConfigEntryState.SETUP_IN_PROGRESS,
+    ConfigEntryState.UNLOAD_IN_PROGRESS,
     ConfigEntryState.FAILED_UNLOAD,
 )
 
-# Schemes of remote serial port URLs, listed even when they cannot be tied to
-# a scanned port, e.g. when the providing integration is offline
-REMOTE_PORT_SCHEMES = (
-    "esphome-hass://",
+# Remote ports contributed by serial port scanners; a configured port missing
+# from the scan is absent, e.g. because the providing integration is offline
+SCANNED_PORT_SCHEMES = ("esphome-hass://",)
+
+# Serial port URLs no scanner contributes; they can never be scanned, so a
+# claiming consumer is the only evidence such a port exists
+UNSCANNABLE_PORT_SCHEMES = (
     "esphome://",
     "rfc2217://",
     "socket://",
@@ -74,12 +85,12 @@ def _serial_port_from_value(
     if value in known_devices:
         return value
 
-    if value.startswith(REMOTE_PORT_SCHEMES):
+    if value.startswith(SCANNED_PORT_SCHEMES):
         return value
 
     path = value
 
-    if domain == "upb":
+    if domain in ("elkm1", "upb"):
         path = path.removeprefix("serial://").removeprefix("device://")
         path = BAUD_SUFFIX_RE.sub("", path)
 
@@ -113,7 +124,8 @@ async def _async_get_config_entry_consumers(
             continue
 
         if (
-            DOMAIN not in integration.dependencies
+            entry.domain not in NON_USB_SERIAL_DOMAINS
+            and DOMAIN not in integration.dependencies
             and DOMAIN not in integration.after_dependencies
         ):
             continue

--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping, Sequence
 import os
+import re
 from typing import Any
 
 from homeassistant.components.hassio import HassioNotReadyError, get_addons_info
@@ -29,8 +30,19 @@ ACTIVE_CONFIG_ENTRY_STATES = (
     ConfigEntryState.SETUP_IN_PROGRESS,
 )
 
-# Local ports can be wrapped in a URL by integrations such as upb
-SERIAL_URL_PREFIX = "serial://"
+# Schemes of remote serial port URLs, listed even when they cannot be tied to
+# a scanned port, e.g. when the providing integration is offline
+REMOTE_PORT_SCHEMES = (
+    "esphome-hass://",
+    "esphome://",
+    "rfc2217://",
+    "socket://",
+    "tcp://",
+)
+
+# upb wraps the port in a URL with an optional baud rate, e.g.
+# `serial:///dev/ttyS0:4800`, which upb_lib strips itself when connecting
+BAUD_SUFFIX_RE = re.compile(r":\d+$")
 
 # Supervisor app state, mirrors `aiohasupervisor.models.AddonState.STARTED`
 APP_STATE_STARTED = "started"
@@ -48,16 +60,24 @@ def _resolve_key_path(data: Mapping[str, Any], key_path: tuple[str, ...]) -> Any
     return value
 
 
-def _serial_port_from_value(value: Any, known_devices: set[str]) -> str | None:
+def _serial_port_from_value(
+    value: Any, known_devices: set[str], domain: str
+) -> str | None:
     """Return the serial port a config entry value refers to."""
     if not isinstance(value, str):
         return None
 
-    # Remote ports are only identifiable by matching a scanned port exactly
     if value in known_devices:
         return value
 
-    path = value.removeprefix(SERIAL_URL_PREFIX)
+    if value.startswith(REMOTE_PORT_SCHEMES):
+        return value
+
+    path = value
+
+    if domain == "upb":
+        path = path.removeprefix("serial://").removeprefix("device://")
+        path = BAUD_SUFFIX_RE.sub("", path)
 
     if path.startswith("/dev/"):
         return path
@@ -97,7 +117,7 @@ async def _async_get_config_entry_consumers(
         for key_path in SERIAL_PORT_KEY_PATHS:
             for data in (entry.data, entry.options):
                 port = _serial_port_from_value(
-                    _resolve_key_path(data, key_path), known_devices
+                    _resolve_key_path(data, key_path), known_devices, entry.domain
                 )
 
                 if port is None:

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "usb",
   "name": "USB Discovery",
+  "after_dependencies": ["hassio"],
   "codeowners": ["@bdraco"],
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/usb",

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -1,6 +1,7 @@
 """Models helper class for the usb integration."""
 
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -24,3 +25,15 @@ class USBDevice(SerialDevice):
 
     # bcdDevice descriptor, often the firmware revision
     bcd_device: int | None = None
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class SerialPortConsumer:
+    """An integration or app configured to use a serial port."""
+
+    kind: Literal["config_entry", "app"]
+    title: str
+    active: bool
+    domain: str | None = None
+    config_entry_id: str | None = None
+    slug: str | None = None

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -9,6 +9,8 @@ class SerialDevice:
     """A serial device."""
 
     device: str
+    resolved_device: str | None = None
+
     serial_number: str | None
     manufacturer: str | None
     description: str | None

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -19,6 +19,7 @@ def usb_device_from_port(port: SerialPortInfo) -> USBDevice:
 
     return USBDevice(
         device=port.device,
+        resolved_device=port.resolved_device,
         vid=f"{hex(port.vid)[2:]:0>4}".upper(),
         pid=f"{hex(port.pid)[2:]:0>4}".upper(),
         serial_number=port.serial_number,
@@ -34,6 +35,7 @@ def serial_device_from_port(port: SerialPortInfo) -> SerialDevice:
     """Convert serialx SerialPortInfo to SerialDevice."""
     return SerialDevice(
         device=port.device,
+        resolved_device=port.resolved_device,
         serial_number=port.serial_number,
         manufacturer=port.manufacturer,
         description=port.description,

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -108,9 +108,10 @@ async def test_config_entry_consumers(
 ) -> None:
     """Test detecting serial ports configured in config entries."""
     mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
-    MockConfigEntry(
+    entry = MockConfigEntry(
         domain="test_usb", title="Test USB", data=data, options=options
-    ).add_to_hass(hass)
+    )
+    entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.usb.consumers.os.path.realpath",
@@ -118,8 +119,7 @@ async def test_config_entry_consumers(
     ):
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    ports = result
-    assert [(port["device"], port["consumers"]) for port in ports] == [
+    assert [(port["device"], port["consumers"]) for port in result] == [
         (
             TTY_USB0,
             [
@@ -128,7 +128,7 @@ async def test_config_entry_consumers(
                     "title": "Test USB",
                     "active": False,
                     "domain": "test_usb",
-                    "config_entry_id": ports[0]["consumers"][0]["config_entry_id"],
+                    "config_entry_id": entry.entry_id,
                     "slug": None,
                 }
             ],

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -8,13 +8,29 @@ import pytest
 
 from homeassistant.components.usb import DOMAIN
 from homeassistant.components.usb.models import SerialDevice, USBDevice
-from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_USER, ConfigEntryDisabler
+from homeassistant.components.usb.utils import usb_service_info_from_device
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    SOURCE_USB,
+    SOURCE_USER,
+    ConfigEntryDisabler,
+    ConfigFlow,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.setup import async_setup_component
 
 from . import patch_scanned_serial_ports
 
-from tests.common import MockConfigEntry, MockModule, MockUser, mock_integration
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockUser,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
 from tests.typing import WebSocketGenerator
 
 TTY_USB0 = "/dev/ttyUSB0"
@@ -58,10 +74,12 @@ async def setup_ports_fixture(
 
 async def _async_get_serial_ports(
     hass_ws_client: WebSocketGenerator, hass: HomeAssistant
-) -> dict[str, Any]:
-    """Return the result of the `usb/serial_ports` command."""
+) -> list[dict[str, Any]]:
+    """Return the result of the `usb/list_serial_ports` command with usage."""
     ws_client = await hass_ws_client(hass)
-    await ws_client.send_json({"id": 1, "type": "usb/serial_ports"})
+    await ws_client.send_json(
+        {"id": 1, "type": "usb/list_serial_ports", "include_usage": True}
+    )
     response = await ws_client.receive_json()
 
     assert response["success"]
@@ -101,8 +119,7 @@ async def test_config_entry_consumers(
     ):
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    ports = result["ports"]
-    assert result["missing"] == []
+    ports = result
     assert [(port["device"], port["consumers"]) for port in ports] == [
         (
             TTY_USB0,
@@ -143,8 +160,7 @@ async def test_config_entry_non_serial_values(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert result["missing"] == []
-    assert [port["consumers"] for port in result["ports"]] == [[], []]
+    assert [port["consumers"] for port in result] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -176,7 +192,7 @@ async def test_config_entry_ignored_and_disabled(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [len(port["consumers"]) for port in result["ports"]] == [num_consumers, 0]
+    assert [len(port["consumers"]) for port in result] == [num_consumers, 0]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -192,8 +208,7 @@ async def test_config_entry_without_usb_dependency(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert result["missing"] == []
-    assert [port["consumers"] for port in result["ports"]] == [[], []]
+    assert [port["consumers"] for port in result] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -212,7 +227,7 @@ async def test_config_entry_after_dependency(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [len(port["consumers"]) for port in result["ports"]] == [1, 0]
+    assert [len(port["consumers"]) for port in result] == [1, 0]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -228,8 +243,7 @@ async def test_remote_port_consumer(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert result["missing"] == []
-    assert [(port["device"], len(port["consumers"])) for port in result["ports"]] == [
+    assert [(port["device"], len(port["consumers"])) for port in result] == [
         (TTY_USB0, 0),
         (ESPHOME_PORT, 1),
     ]
@@ -248,24 +262,32 @@ async def test_absent_configured_port(
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [port["consumers"] for port in result["ports"]] == [[], []]
-    assert result["missing"] == [
-        {
-            "device": TTY_USB1,
-            "consumers": [
-                {
-                    "kind": "config_entry",
-                    "title": "Test USB",
-                    "active": False,
-                    "domain": "test_usb",
-                    "config_entry_id": result["missing"][0]["consumers"][0][
-                        "config_entry_id"
-                    ],
-                    "slug": None,
-                }
-            ],
-        }
+    assert [(port["device"], port["present"]) for port in result] == [
+        (TTY_USB0, True),
+        (ESPHOME_PORT, True),
+        (TTY_USB1, False),
     ]
+    assert result[2] == {
+        "device": TTY_USB1,
+        "serial_number": None,
+        "manufacturer": None,
+        "description": None,
+        "interface_description": None,
+        "interface_num": None,
+        "matching_integrations": [],
+        "present": False,
+        "discovery_flows": [],
+        "consumers": [
+            {
+                "kind": "config_entry",
+                "title": "Test USB",
+                "active": False,
+                "domain": "test_usb",
+                "config_entry_id": result[2]["consumers"][0]["config_entry_id"],
+                "slug": None,
+            }
+        ],
+    }
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -301,8 +323,7 @@ async def test_app_consumers(
     ):
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert result["missing"] == []
-    assert [(port["device"], port["consumers"]) for port in result["ports"]] == [
+    assert [(port["device"], port["consumers"]) for port in result] == [
         (
             TTY_USB0,
             [
@@ -332,7 +353,7 @@ async def test_app_consumers_without_supervisor(
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert len(mock_apps_info.mock_calls) == 0
-    assert [port["consumers"] for port in result["ports"]] == [[], []]
+    assert [port["consumers"] for port in result] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -361,8 +382,7 @@ async def test_multiple_consumers(
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert [
-        (consumer["kind"], consumer["title"])
-        for consumer in result["ports"][0]["consumers"]
+        (consumer["kind"], consumer["title"]) for consumer in result[0]["consumers"]
     ] == [("config_entry", "Test USB"), ("app", "Some App")]
 
 
@@ -376,8 +396,48 @@ async def test_serial_ports_require_admin(
     hass_admin_user.groups = []
 
     ws_client = await hass_ws_client(hass)
-    await ws_client.send_json({"id": 1, "type": "usb/serial_ports"})
+    await ws_client.send_json(
+        {"id": 1, "type": "usb/list_serial_ports", "include_usage": True}
+    )
     response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "unauthorized"
+
+
+class MockUsbFlow(ConfigFlow):
+    """Config flow that keeps USB discoveries in progress."""
+
+    async def async_step_usb(self, discovery_info: UsbServiceInfo) -> FlowResult:
+        """Show a form so the discovery flow stays in progress."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Show a form so the discovery flow stays in progress."""
+        return self.async_show_form(step_id="confirm")
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_discovery_flows(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that in-progress discovery flows are listed for their serial port."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    mock_platform(hass, "test_usb.config_flow", None)
+
+    with mock_config_flow("test_usb", MockUsbFlow):
+        flow = await hass.config_entries.flow.async_init(
+            "test_usb",
+            context={"source": SOURCE_USB},
+            data=usb_service_info_from_device(USB0_PORT),
+        )
+
+        result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [(port["device"], port["discovery_flows"]) for port in result] == [
+        (TTY_USB0, [{"flow_id": flow["flow_id"], "domain": "test_usb"}]),
+        (ESPHOME_PORT, []),
+    ]

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -269,6 +269,7 @@ async def test_absent_configured_port(
     ]
     assert result[2] == {
         "device": TTY_USB1,
+        "resolved_device": None,
         "serial_number": None,
         "manufacturer": None,
         "description": None,

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -16,9 +16,9 @@ from homeassistant.config_entries import (
     ConfigEntryDisabler,
     ConfigEntryState,
     ConfigFlow,
+    ConfigFlowResult,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.setup import async_setup_component
 
@@ -457,13 +457,13 @@ async def test_multiple_consumers(
 class MockUsbFlow(ConfigFlow):
     """Config flow that keeps USB discoveries in progress."""
 
-    async def async_step_usb(self, discovery_info: UsbServiceInfo) -> FlowResult:
+    async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Show a form so the discovery flow stays in progress."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Show a form so the discovery flow stays in progress."""
         return self.async_show_form(step_id="confirm")
 

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -252,6 +252,21 @@ async def test_config_entry_ignored_and_disabled(
 
 
 @pytest.mark.usefixtures("setup_ports")
+async def test_config_entry_unknown_integration(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test config entries of integrations that fail to resolve are ignored."""
+    MockConfigEntry(
+        domain="removed_custom_component", title="Test", data={"device": TTY_USB0}
+    ).add_to_hass(hass)
+
+    result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [port["consumers"] for port in result] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
 async def test_config_entry_without_usb_dependency(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.hassio import HassioNotReadyError
 from homeassistant.components.usb import DOMAIN
 from homeassistant.components.usb.models import SerialDevice, USBDevice
 from homeassistant.components.usb.utils import usb_service_info_from_device
@@ -421,6 +422,24 @@ async def test_app_consumers_without_supervisor(
         result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert len(mock_apps_info.mock_calls) == 0
+    assert [port["consumers"] for port in result] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_app_consumers_supervisor_not_ready(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test apps are not considered when the supervisor is not ready yet."""
+    with (
+        patch("homeassistant.components.usb.consumers.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.usb.consumers.get_addons_info",
+            side_effect=HassioNotReadyError("Not ready"),
+        ),
+    ):
+        result = await _async_get_serial_ports(hass_ws_client, hass)
+
     assert [port["consumers"] for port in result] == [[], []]
 
 

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components.usb import DOMAIN
 from homeassistant.components.usb.models import SerialDevice, USBDevice
+from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_USER, ConfigEntryDisabler
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -141,6 +142,38 @@ async def test_config_entry_non_serial_values(
     ports = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert [port["consumers"] for port in ports] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    ("source", "disabled_by", "num_consumers"),
+    [
+        pytest.param(SOURCE_IGNORE, None, 0, id="ignored_entry_hidden"),
+        pytest.param(
+            SOURCE_USER, ConfigEntryDisabler.USER, 1, id="disabled_entry_shown"
+        ),
+    ],
+)
+async def test_config_entry_ignored_and_disabled(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    source: str,
+    disabled_by: ConfigEntryDisabler | None,
+    num_consumers: int,
+) -> None:
+    """Test ignored entries are hidden while disabled entries are shown."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb",
+        title="Test USB",
+        data={"device": TTY_USB0},
+        source=source,
+        disabled_by=disabled_by,
+    ).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [len(port["consumers"]) for port in ports] == [num_consumers, 0]
 
 
 @pytest.mark.usefixtures("setup_ports")

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -58,7 +58,7 @@ async def setup_ports_fixture(
 
 async def _async_get_serial_ports(
     hass_ws_client: WebSocketGenerator, hass: HomeAssistant
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     """Return the result of the `usb/serial_ports` command."""
     ws_client = await hass_ws_client(hass)
     await ws_client.send_json({"id": 1, "type": "usb/serial_ports"})
@@ -99,8 +99,10 @@ async def test_config_entry_consumers(
         "homeassistant.components.usb.consumers.os.path.realpath",
         side_effect=lambda path: TTY_USB0 if path == TTY_USB0_BY_ID else path,
     ):
-        ports = await _async_get_serial_ports(hass_ws_client, hass)
+        result = await _async_get_serial_ports(hass_ws_client, hass)
 
+    ports = result["ports"]
+    assert result["missing"] == []
     assert [(port["device"], port["consumers"]) for port in ports] == [
         (
             TTY_USB0,
@@ -139,9 +141,10 @@ async def test_config_entry_non_serial_values(
     mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
     MockConfigEntry(domain="test_usb", title="Test USB", data=data).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [port["consumers"] for port in ports] == [[], []]
+    assert result["missing"] == []
+    assert [port["consumers"] for port in result["ports"]] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -171,9 +174,9 @@ async def test_config_entry_ignored_and_disabled(
         disabled_by=disabled_by,
     ).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [len(port["consumers"]) for port in ports] == [num_consumers, 0]
+    assert [len(port["consumers"]) for port in result["ports"]] == [num_consumers, 0]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -187,9 +190,10 @@ async def test_config_entry_without_usb_dependency(
         domain="test_no_usb", title="Test", data={"device": TTY_USB0}
     ).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [port["consumers"] for port in ports] == [[], []]
+    assert result["missing"] == []
+    assert [port["consumers"] for port in result["ports"]] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -206,9 +210,9 @@ async def test_config_entry_after_dependency(
         domain="test_after_usb", title="Test", data={"device": TTY_USB0}
     ).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [len(port["consumers"]) for port in ports] == [1, 0]
+    assert [len(port["consumers"]) for port in result["ports"]] == [1, 0]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -222,9 +226,10 @@ async def test_remote_port_consumer(
         domain="test_usb", title="Test USB", data={"device": ESPHOME_PORT}
     ).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [(port["device"], len(port["consumers"])) for port in ports] == [
+    assert result["missing"] == []
+    assert [(port["device"], len(port["consumers"])) for port in result["ports"]] == [
         (TTY_USB0, 0),
         (ESPHOME_PORT, 1),
     ]
@@ -241,28 +246,26 @@ async def test_absent_configured_port(
         domain="test_usb", title="Test USB", data={"device": TTY_USB1}
     ).add_to_hass(hass)
 
-    ports = await _async_get_serial_ports(hass_ws_client, hass)
+    result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert ports[-1] == {
-        "device": TTY_USB1,
-        "serial_number": None,
-        "manufacturer": None,
-        "description": None,
-        "interface_description": None,
-        "interface_num": None,
-        "present": False,
-        "matching_integrations": [],
-        "consumers": [
-            {
-                "kind": "config_entry",
-                "title": "Test USB",
-                "active": False,
-                "domain": "test_usb",
-                "config_entry_id": ports[-1]["consumers"][0]["config_entry_id"],
-                "slug": None,
-            }
-        ],
-    }
+    assert [port["consumers"] for port in result["ports"]] == [[], []]
+    assert result["missing"] == [
+        {
+            "device": TTY_USB1,
+            "consumers": [
+                {
+                    "kind": "config_entry",
+                    "title": "Test USB",
+                    "active": False,
+                    "domain": "test_usb",
+                    "config_entry_id": result["missing"][0]["consumers"][0][
+                        "config_entry_id"
+                    ],
+                    "slug": None,
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -296,9 +299,10 @@ async def test_app_consumers(
             side_effect=lambda path: TTY_USB0 if path == TTY_USB0_BY_ID else path,
         ),
     ):
-        ports = await _async_get_serial_ports(hass_ws_client, hass)
+        result = await _async_get_serial_ports(hass_ws_client, hass)
 
-    assert [(port["device"], port["consumers"]) for port in ports] == [
+    assert result["missing"] == []
+    assert [(port["device"], port["consumers"]) for port in result["ports"]] == [
         (
             TTY_USB0,
             [
@@ -325,10 +329,10 @@ async def test_app_consumers_without_supervisor(
     with patch(
         "homeassistant.components.usb.consumers.get_addons_info"
     ) as mock_apps_info:
-        ports = await _async_get_serial_ports(hass_ws_client, hass)
+        result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert len(mock_apps_info.mock_calls) == 0
-    assert [port["consumers"] for port in ports] == [[], []]
+    assert [port["consumers"] for port in result["ports"]] == [[], []]
 
 
 @pytest.mark.usefixtures("setup_ports")
@@ -354,10 +358,11 @@ async def test_multiple_consumers(
             return_value=apps_info,
         ),
     ):
-        ports = await _async_get_serial_ports(hass_ws_client, hass)
+        result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert [
-        (consumer["kind"], consumer["title"]) for consumer in ports[0]["consumers"]
+        (consumer["kind"], consumer["title"])
+        for consumer in result["ports"][0]["consumers"]
     ] == [("config_entry", "Test USB"), ("app", "Some App")]
 
 

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -252,6 +252,30 @@ async def test_config_entry_ignored_and_disabled(
 
 
 @pytest.mark.usefixtures("setup_ports")
+async def test_socket_path_psk_not_exposed(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the noise PSK in zwave_js's esphome socket path is stripped."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb",
+        title="Test USB",
+        data={"socket_path": "esphome://192.0.2.5:6053/?key=secret-psk"},
+    ).add_to_hass(hass)
+
+    result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [
+        (port["device"], port["present"], len(port["consumers"])) for port in result
+    ] == [
+        (TTY_USB0, True, 0),
+        (ESPHOME_PORT, True, 0),
+        ("esphome://192.0.2.5:6053/", True, 1),
+    ]
+    assert "secret-psk" not in str(result)
+
+
 @pytest.mark.usefixtures("setup_ports")
 @pytest.mark.parametrize(
     ("domain", "data"),

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -1,0 +1,345 @@
+"""Tests for serial port consumer attribution."""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.usb import DOMAIN
+from homeassistant.components.usb.models import SerialDevice, USBDevice
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import patch_scanned_serial_ports
+
+from tests.common import MockConfigEntry, MockModule, MockUser, mock_integration
+from tests.typing import WebSocketGenerator
+
+TTY_USB0 = "/dev/ttyUSB0"
+TTY_USB0_BY_ID = "/dev/serial/by-id/usb-Silicon_Labs_CP2102-if00-port0"
+TTY_USB1 = "/dev/ttyUSB1"
+ESPHOME_PORT = "esphome-hass://01JZ/uart0"
+
+USB0_PORT = USBDevice(
+    device=TTY_USB0,
+    vid="10C4",
+    pid="EA60",
+    serial_number="001234",
+    manufacturer="Silicon Labs",
+    description="CP2102 USB to UART",
+)
+
+
+@pytest.fixture(name="setup_ports")
+async def setup_ports_fixture(
+    hass: HomeAssistant, force_usb_polling_watcher: None
+) -> AsyncGenerator[None]:
+    """Set up the USB integration with a local and a remote serial port."""
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
+        patch_scanned_serial_ports(
+            return_value=[
+                USB0_PORT,
+                SerialDevice(
+                    device=ESPHOME_PORT,
+                    serial_number="01JZ-uart0",
+                    manufacturer="ESPHome",
+                    description="Serial proxy",
+                ),
+            ]
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+        yield
+
+
+async def _async_get_serial_ports(
+    hass_ws_client: WebSocketGenerator, hass: HomeAssistant
+) -> list[dict[str, Any]]:
+    """Return the result of the `usb/serial_ports` command."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "usb/serial_ports"})
+    response = await ws_client.receive_json()
+
+    assert response["success"]
+    return response["result"]
+
+
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    ("data", "options"),
+    [
+        pytest.param({"device": TTY_USB0}, {}, id="device"),
+        pytest.param({"device": {"path": TTY_USB0}}, {}, id="nested_device_path"),
+        pytest.param({"port": TTY_USB0}, {}, id="port"),
+        pytest.param({"usb_path": TTY_USB0}, {}, id="usb_path"),
+        pytest.param({}, {"usb_path": TTY_USB0}, id="usb_path_in_options"),
+        pytest.param({"serial_port": TTY_USB0}, {}, id="serial_port"),
+        pytest.param({"device": f"serial://{TTY_USB0}"}, {}, id="serial_url"),
+        pytest.param({"device": TTY_USB0_BY_ID}, {}, id="by_id_symlink"),
+        pytest.param({"device": TTY_USB0}, {"device": TTY_USB0}, id="data_and_options"),
+    ],
+)
+async def test_config_entry_consumers(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    data: dict[str, Any],
+    options: dict[str, Any],
+) -> None:
+    """Test detecting serial ports configured in config entries."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb", title="Test USB", data=data, options=options
+    ).add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.usb.consumers.os.path.realpath",
+        side_effect=lambda path: TTY_USB0 if path == TTY_USB0_BY_ID else path,
+    ):
+        ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [(port["device"], port["consumers"]) for port in ports] == [
+        (
+            TTY_USB0,
+            [
+                {
+                    "kind": "config_entry",
+                    "title": "Test USB",
+                    "active": False,
+                    "domain": "test_usb",
+                    "config_entry_id": ports[0]["consumers"][0]["config_entry_id"],
+                    "slug": None,
+                }
+            ],
+        ),
+        (ESPHOME_PORT, []),
+    ]
+
+
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({"port": 8080}, id="tcp_port"),
+        pytest.param({"port": "192.0.2.1:1234"}, id="host_and_port"),
+        pytest.param({"device": {"other": TTY_USB0}}, id="unknown_nested_key"),
+        pytest.param({"other": TTY_USB0}, id="unknown_key"),
+        pytest.param({"device": "socket://192.0.2.1:1234"}, id="socket_url"),
+    ],
+)
+async def test_config_entry_non_serial_values(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    data: dict[str, Any],
+) -> None:
+    """Test values that do not refer to a serial port are ignored."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(domain="test_usb", title="Test USB", data=data).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [port["consumers"] for port in ports] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_config_entry_without_usb_dependency(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test config entries of integrations not depending on `usb` are ignored."""
+    mock_integration(hass, MockModule("test_no_usb"))
+    MockConfigEntry(
+        domain="test_no_usb", title="Test", data={"device": TTY_USB0}
+    ).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [port["consumers"] for port in ports] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_config_entry_after_dependency(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test config entries of integrations depending on `usb` after setup."""
+    mock_integration(
+        hass,
+        MockModule("test_after_usb", partial_manifest={"after_dependencies": ["usb"]}),
+    )
+    MockConfigEntry(
+        domain="test_after_usb", title="Test", data={"device": TTY_USB0}
+    ).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [len(port["consumers"]) for port in ports] == [1, 0]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_remote_port_consumer(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a config entry using a remote serial port."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb", title="Test USB", data={"device": ESPHOME_PORT}
+    ).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [(port["device"], len(port["consumers"])) for port in ports] == [
+        (TTY_USB0, 0),
+        (ESPHOME_PORT, 1),
+    ]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_absent_configured_port(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a configured port that is not currently present."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb", title="Test USB", data={"device": TTY_USB1}
+    ).add_to_hass(hass)
+
+    ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert ports[-1] == {
+        "device": TTY_USB1,
+        "serial_number": None,
+        "manufacturer": None,
+        "description": None,
+        "interface_description": None,
+        "interface_num": None,
+        "present": False,
+        "matching_integrations": [],
+        "consumers": [
+            {
+                "kind": "config_entry",
+                "title": "Test USB",
+                "active": False,
+                "domain": "test_usb",
+                "config_entry_id": ports[-1]["consumers"][0]["config_entry_id"],
+                "slug": None,
+            }
+        ],
+    }
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_app_consumers(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test detecting serial ports mapped into apps."""
+    apps_info = {
+        "core_zwave_js": {
+            "name": "Z-Wave JS",
+            "state": "started",
+            "devices": [TTY_USB0_BY_ID, "/dev/dri/card0"],
+        },
+        "some_app": {
+            "name": "Some App",
+            "state": "stopped",
+            "devices": [TTY_USB1],
+        },
+        "uninstalled_app": None,
+    }
+
+    with (
+        patch("homeassistant.components.usb.consumers.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.usb.consumers.get_addons_info",
+            return_value=apps_info,
+        ),
+        patch(
+            "homeassistant.components.usb.consumers.os.path.realpath",
+            side_effect=lambda path: TTY_USB0 if path == TTY_USB0_BY_ID else path,
+        ),
+    ):
+        ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [(port["device"], port["consumers"]) for port in ports] == [
+        (
+            TTY_USB0,
+            [
+                {
+                    "kind": "app",
+                    "title": "Z-Wave JS",
+                    "active": True,
+                    "domain": None,
+                    "config_entry_id": None,
+                    "slug": "core_zwave_js",
+                }
+            ],
+        ),
+        (ESPHOME_PORT, []),
+    ]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_app_consumers_without_supervisor(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test apps are not considered without a supervisor."""
+    with patch(
+        "homeassistant.components.usb.consumers.get_addons_info"
+    ) as mock_apps_info:
+        ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert len(mock_apps_info.mock_calls) == 0
+    assert [port["consumers"] for port in ports] == [[], []]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_multiple_consumers(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a port used by both an integration and an app."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    entry = MockConfigEntry(
+        domain="test_usb", title="Test USB", data={"device": TTY_USB0}
+    )
+    entry.add_to_hass(hass)
+
+    apps_info = {
+        "some_app": {"name": "Some App", "state": "started", "devices": [TTY_USB0]}
+    }
+
+    with (
+        patch("homeassistant.components.usb.consumers.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.usb.consumers.get_addons_info",
+            return_value=apps_info,
+        ),
+    ):
+        ports = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [
+        (consumer["kind"], consumer["title"]) for consumer in ports[0]["consumers"]
+    ] == [("config_entry", "Test USB"), ("app", "Some App")]
+
+
+@pytest.mark.usefixtures("setup_ports")
+async def test_serial_ports_require_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that listing serial ports with consumers requires admin."""
+    hass_admin_user.groups = []
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "usb/serial_ports"})
+    response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "unauthorized"

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -27,7 +27,6 @@ from . import patch_scanned_serial_ports
 from tests.common import (
     MockConfigEntry,
     MockModule,
-    MockUser,
     mock_config_flow,
     mock_integration,
     mock_platform,
@@ -453,25 +452,6 @@ async def test_multiple_consumers(
     assert [
         (consumer["kind"], consumer["title"]) for consumer in result[0]["consumers"]
     ] == [("config_entry", "Test USB"), ("app", "Some App")]
-
-
-@pytest.mark.usefixtures("setup_ports")
-async def test_serial_ports_require_admin(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    hass_admin_user: MockUser,
-) -> None:
-    """Test that listing serial ports with consumers requires admin."""
-    hass_admin_user.groups = []
-
-    ws_client = await hass_ws_client(hass)
-    await ws_client.send_json(
-        {"id": 1, "type": "usb/list_serial_ports", "include_usage": True}
-    )
-    response = await ws_client.receive_json()
-
-    assert not response["success"]
-    assert response["error"]["code"] == "unauthorized"
 
 
 class MockUsbFlow(ConfigFlow):

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -173,9 +173,14 @@ async def test_config_entry_upb_url(
     [
         pytest.param(ConfigEntryState.LOADED, True, id="loaded"),
         pytest.param(ConfigEntryState.SETUP_RETRY, True, id="setup_retry"),
+        pytest.param(ConfigEntryState.SETUP_IN_PROGRESS, True, id="setup_in_progress"),
+        pytest.param(
+            ConfigEntryState.UNLOAD_IN_PROGRESS, True, id="unload_in_progress"
+        ),
         pytest.param(ConfigEntryState.FAILED_UNLOAD, True, id="failed_unload"),
         pytest.param(ConfigEntryState.NOT_LOADED, False, id="not_loaded"),
         pytest.param(ConfigEntryState.SETUP_ERROR, False, id="setup_error"),
+        pytest.param(ConfigEntryState.MIGRATION_ERROR, False, id="migration_error"),
     ],
 )
 async def test_config_entry_active_states(

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import (
     SOURCE_USB,
     SOURCE_USER,
     ConfigEntryDisabler,
+    ConfigEntryState,
     ConfigFlow,
 )
 from homeassistant.core import HomeAssistant
@@ -96,7 +97,6 @@ async def _async_get_serial_ports(
         pytest.param({"usb_path": TTY_USB0}, {}, id="usb_path"),
         pytest.param({}, {"usb_path": TTY_USB0}, id="usb_path_in_options"),
         pytest.param({"serial_port": TTY_USB0}, {}, id="serial_port"),
-        pytest.param({"device": f"serial://{TTY_USB0}"}, {}, id="serial_url"),
         pytest.param({"device": TTY_USB0_BY_ID}, {}, id="by_id_symlink"),
         pytest.param({"device": TTY_USB0}, {"device": TTY_USB0}, id="data_and_options"),
     ],
@@ -140,13 +140,69 @@ async def test_config_entry_consumers(
 
 @pytest.mark.usefixtures("setup_ports")
 @pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param(f"serial://{TTY_USB0}", id="serial_url"),
+        pytest.param(f"serial://{TTY_USB0}:4800", id="serial_url_with_baud"),
+        pytest.param(f"device://{TTY_USB0}:4800", id="device_url_with_baud"),
+        pytest.param(f"{TTY_USB0}:4800", id="bare_path_with_baud"),
+    ],
+)
+async def test_config_entry_upb_url(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device: str,
+) -> None:
+    """Test upb's URL forms with an optional baud rate suffix."""
+    mock_integration(hass, MockModule("upb", dependencies=["usb"]))
+    MockConfigEntry(domain="upb", title="UPB", data={"device": device}).add_to_hass(
+        hass
+    )
+
+    result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [(port["device"], len(port["consumers"])) for port in result] == [
+        (TTY_USB0, 1),
+        (ESPHOME_PORT, 0),
+    ]
+
+
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    ("state", "active"),
+    [
+        pytest.param(ConfigEntryState.LOADED, True, id="loaded"),
+        pytest.param(ConfigEntryState.SETUP_RETRY, True, id="setup_retry"),
+        pytest.param(ConfigEntryState.FAILED_UNLOAD, True, id="failed_unload"),
+        pytest.param(ConfigEntryState.NOT_LOADED, False, id="not_loaded"),
+        pytest.param(ConfigEntryState.SETUP_ERROR, False, id="setup_error"),
+    ],
+)
+async def test_config_entry_active_states(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    state: ConfigEntryState,
+    active: bool,
+) -> None:
+    """Test which config entry states mark the consumer as active."""
+    mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
+    MockConfigEntry(
+        domain="test_usb", title="Test USB", data={"device": TTY_USB0}, state=state
+    ).add_to_hass(hass)
+
+    result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [consumer["active"] for consumer in result[0]["consumers"]] == [active]
+
+
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
     "data",
     [
         pytest.param({"port": 8080}, id="tcp_port"),
         pytest.param({"port": "192.0.2.1:1234"}, id="host_and_port"),
         pytest.param({"device": {"other": TTY_USB0}}, id="unknown_nested_key"),
         pytest.param({"other": TTY_USB0}, id="unknown_key"),
-        pytest.param({"device": "socket://192.0.2.1:1234"}, id="socket_url"),
     ],
 )
 async def test_config_entry_non_serial_values(
@@ -250,25 +306,37 @@ async def test_remote_port_consumer(
 
 
 @pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param(TTY_USB1, id="local"),
+        pytest.param("esphome-hass://02AB/uart0", id="esphome_proxy"),
+        pytest.param("esphome://ttl-to-serial.local/uart1", id="esphome"),
+        pytest.param("socket://192.0.2.1:1234", id="socket"),
+        pytest.param("rfc2217://192.0.2.1:1234", id="rfc2217"),
+    ],
+)
 async def test_absent_configured_port(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    device: str,
 ) -> None:
     """Test a configured port that is not currently present."""
     mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
-    MockConfigEntry(
-        domain="test_usb", title="Test USB", data={"device": TTY_USB1}
-    ).add_to_hass(hass)
+    entry = MockConfigEntry(
+        domain="test_usb", title="Test USB", data={"device": device}
+    )
+    entry.add_to_hass(hass)
 
     result = await _async_get_serial_ports(hass_ws_client, hass)
 
     assert [(port["device"], port["present"]) for port in result] == [
         (TTY_USB0, True),
         (ESPHOME_PORT, True),
-        (TTY_USB1, False),
+        (device, False),
     ]
     assert result[2] == {
-        "device": TTY_USB1,
+        "device": device,
         "resolved_device": None,
         "serial_number": None,
         "manufacturer": None,
@@ -284,7 +352,7 @@ async def test_absent_configured_port(
                 "title": "Test USB",
                 "active": False,
                 "domain": "test_usb",
-                "config_entry_id": result[2]["consumers"][0]["config_entry_id"],
+                "config_entry_id": entry.entry_id,
                 "slug": None,
             }
         ],

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -252,6 +252,32 @@ async def test_config_entry_ignored_and_disabled(
 
 
 @pytest.mark.usefixtures("setup_ports")
+@pytest.mark.usefixtures("setup_ports")
+@pytest.mark.parametrize(
+    ("domain", "data"),
+    [
+        pytest.param("alarmdecoder", {"device_path": TTY_USB0}, id="alarmdecoder"),
+        pytest.param("bryant_evolution", {"filename": TTY_USB0}, id="bryant_evolution"),
+        pytest.param("elkm1", {"host": f"serial://{TTY_USB0}:115200"}, id="elkm1"),
+        pytest.param("mysensors", {"device": TTY_USB0}, id="mysensors"),
+    ],
+)
+async def test_non_usb_serial_domains(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    domain: str,
+    data: dict[str, Any],
+) -> None:
+    """Test integrations holding a serial port without a `usb` dependency."""
+    mock_integration(hass, MockModule(domain))
+    MockConfigEntry(domain=domain, title="Test", data=data).add_to_hass(hass)
+
+    result = await _async_get_serial_ports(hass_ws_client, hass)
+
+    assert [len(port["consumers"]) for port in result] == [1, 0]
+
+
+@pytest.mark.usefixtures("setup_ports")
 async def test_config_entry_unknown_integration(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -322,21 +348,26 @@ async def test_remote_port_consumer(
 
 @pytest.mark.usefixtures("setup_ports")
 @pytest.mark.parametrize(
-    "device",
+    ("device", "present"),
     [
-        pytest.param(TTY_USB1, id="local"),
-        pytest.param("esphome-hass://02AB/uart0", id="esphome_proxy"),
-        pytest.param("esphome://ttl-to-serial.local/uart1", id="esphome"),
-        pytest.param("socket://192.0.2.1:1234", id="socket"),
-        pytest.param("rfc2217://192.0.2.1:1234", id="rfc2217"),
+        pytest.param(TTY_USB1, False, id="local"),
+        pytest.param("esphome-hass://02AB/uart0", False, id="esphome_proxy"),
+        pytest.param("esphome://ttl-to-serial.local/uart1", True, id="esphome"),
+        pytest.param("socket://192.0.2.1:1234", True, id="socket"),
+        pytest.param("tcp://192.0.2.1:1234", True, id="tcp"),
+        pytest.param("rfc2217://192.0.2.1:1234", True, id="rfc2217"),
     ],
 )
-async def test_absent_configured_port(
+async def test_configured_port_not_scanned(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device: str,
+    present: bool,
 ) -> None:
-    """Test a configured port that is not currently present."""
+    """Test a configured port that is not in the scan.
+
+    Scannable ports are absent, unscannable URLs are assumed present.
+    """
     mock_integration(hass, MockModule("test_usb", dependencies=["usb"]))
     entry = MockConfigEntry(
         domain="test_usb", title="Test USB", data={"device": device}
@@ -348,7 +379,7 @@ async def test_absent_configured_port(
     assert [(port["device"], port["present"]) for port in result] == [
         (TTY_USB0, True),
         (ESPHOME_PORT, True),
-        (device, False),
+        (device, present),
     ]
     assert result[2] == {
         "device": device,
@@ -359,7 +390,7 @@ async def test_absent_configured_port(
         "interface_description": None,
         "interface_num": None,
         "matching_integrations": [],
-        "present": False,
+        "present": present,
         "discovery_flows": [],
         "consumers": [
             {

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1327,12 +1327,14 @@ async def test_async_scan_serial_ports(hass: HomeAssistant) -> None:
     assert devices == [
         SerialDevice(
             device="/dev/ttyAMA1",
+            resolved_device="/dev/ttyAMA1",
             serial_number=None,
             manufacturer=None,
             description="ttyAMA1",
         ),
         USBDevice(
             device="/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_10B41DE589FC-if00",
+            resolved_device="/dev/ttyACM0",
             vid="303A",
             pid="4001",
             serial_number="10B41DE589FC",
@@ -1693,6 +1695,7 @@ async def test_list_serial_ports(
     mock_ports = [
         USBDevice(
             device="/dev/ttyUSB0",
+            resolved_device="/dev/ttyUSB0",
             vid="10C4",
             pid="EA60",
             serial_number="001234",
@@ -1704,6 +1707,7 @@ async def test_list_serial_ports(
         ),
         USBDevice(
             device="/dev/ttyUSB1",
+            resolved_device="/dev/ttyUSB1",
             vid="DEAD",
             pid="BEEF",
             serial_number=None,
@@ -1712,6 +1716,7 @@ async def test_list_serial_ports(
         ),
         USBDevice(
             device="/dev/ttyUSB2",
+            resolved_device="/dev/ttyUSB2",
             vid="0000",
             pid="0000",
             serial_number=None,
@@ -1720,6 +1725,7 @@ async def test_list_serial_ports(
         ),
         SerialDevice(
             device="/dev/ttyS0",
+            resolved_device="/dev/ttyS0",
             serial_number=None,
             manufacturer=None,
             description="ttyS0",
@@ -1741,6 +1747,7 @@ async def test_list_serial_ports(
     assert response["result"] == [
         {
             "device": "/dev/ttyUSB0",
+            "resolved_device": "/dev/ttyUSB0",
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "001234",
@@ -1754,6 +1761,7 @@ async def test_list_serial_ports(
         },
         {
             "device": "/dev/ttyUSB1",
+            "resolved_device": "/dev/ttyUSB1",
             "vid": "DEAD",
             "pid": "BEEF",
             "serial_number": None,
@@ -1767,6 +1775,7 @@ async def test_list_serial_ports(
         },
         {
             "device": "/dev/ttyUSB2",
+            "resolved_device": "/dev/ttyUSB2",
             "vid": "0000",
             "pid": "0000",
             "serial_number": None,
@@ -1780,6 +1789,7 @@ async def test_list_serial_ports(
         },
         {
             "device": "/dev/ttyS0",
+            "resolved_device": "/dev/ttyS0",
             "serial_number": None,
             "manufacturer": None,
             "description": "ttyS0",

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1750,6 +1750,7 @@ async def test_list_serial_ports(
             "interface_description": "CP2102 USB to UART Bridge",
             "interface_num": 0,
             "matching_integrations": ["homeassistant_sky_connect"],
+            "present": True,
         },
         {
             "device": "/dev/ttyUSB1",
@@ -1762,6 +1763,7 @@ async def test_list_serial_ports(
             "interface_description": None,
             "interface_num": None,
             "matching_integrations": ["custom_component"],
+            "present": True,
         },
         {
             "device": "/dev/ttyUSB2",
@@ -1774,6 +1776,7 @@ async def test_list_serial_ports(
             "interface_description": None,
             "interface_num": None,
             "matching_integrations": [],
+            "present": True,
         },
         {
             "device": "/dev/ttyS0",
@@ -1783,6 +1786,7 @@ async def test_list_serial_ports(
             "interface_description": None,
             "interface_num": None,
             "matching_integrations": [],
+            "present": True,
         },
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a parameter to the existing `usb/list_serial_ports` WebSocket API to list active, inactive, and missing serial ports. This parameter will be used by the frontend to show a serial port panel, identifying what ports are in available, in use, disconnected, etc.

Part of https://github.com/home-assistant/epics/issues/87.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53699

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
