### PR TITLE
Forward service call context to entity in assist_satellite.ask_question

### DIFF
--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -131,6 +131,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 f"Invalid Assist satellite entity id: {satellite_entity_id}"
             )
 
+        satellite_entity.async_set_context(call.context)
+
         ask_question_args = {
             "question": call.data.get("question"),
             "question_media_id": call.data.get("question_media_id"),

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Generator
 from dataclasses import asdict
-from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -917,6 +916,7 @@ async def test_ask_question(
     """Test asking a question on a device and matching an answer."""
     entity_id = "assist_satellite.test_entity"
     question_text = "What kind of music would you like to listen to?"
+    context = Context()
 
     await async_update_pipeline(
         hass, async_get_pipeline(hass), stt_engine="test-stt-engine", stt_language="en"
@@ -983,37 +983,11 @@ async def test_ask_question(
             {"entity_id": entity_id, "question": question_text, **service_data},
             blocking=True,
             return_response=True,
+            context=context,
         )
         assert entity.state == AssistSatelliteState.IDLE
         assert response == asdict(expected_answer)
-
-
-async def test_ask_question_sets_context(
-    hass: HomeAssistant,
-    init_components: ConfigEntry,
-    entity: MockAssistSatellite,
-) -> None:
-    """Test that ask_question forwards the service call context to the entity."""
-    context = Context()
-    captured: list[Context | None] = []
-
-    async def async_internal_ask_question(**kwargs: Any) -> AssistSatelliteAnswer:
-        captured.append(entity._context)
-        return AssistSatelliteAnswer(id=None, sentence="yes")
-
-    with patch.object(
-        entity, "async_internal_ask_question", new=async_internal_ask_question
-    ):
-        await hass.services.async_call(
-            DOMAIN,
-            "ask_question",
-            {"entity_id": ENTITY_ID, "question": "are you there?"},
-            blocking=True,
-            return_response=True,
-            context=context,
-        )
-
-    assert captured == [context]
+        assert hass.states.get(entity_id).context is context
 
 
 async def test_ask_question_requires_entity_permission(

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Generator
 from dataclasses import asdict
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -985,6 +986,34 @@ async def test_ask_question(
         )
         assert entity.state == AssistSatelliteState.IDLE
         assert response == asdict(expected_answer)
+
+
+async def test_ask_question_sets_context(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+) -> None:
+    """Test that ask_question forwards the service call context to the entity."""
+    context = Context()
+    captured: list[Context | None] = []
+
+    async def async_internal_ask_question(**kwargs: Any) -> AssistSatelliteAnswer:
+        captured.append(entity._context)
+        return AssistSatelliteAnswer(id=None, sentence="yes")
+
+    with patch.object(
+        entity, "async_internal_ask_question", new=async_internal_ask_question
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "ask_question",
+            {"entity_id": ENTITY_ID, "question": "are you there?"},
+            blocking=True,
+            return_response=True,
+            context=context,
+        )
+
+    assert captured == [context]
 
 
 async def test_ask_question_requires_entity_permission(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`assist_satellite.ask_question` is registered with `hass.services.async_register` (`__init__.py:150`) rather than as an entity service, because it does its own permission check and returns a flat response. As a result nothing ever called `async_set_context` on the satellite entity, so the state changes the service causes (`RESPONDING` while the question plays, back to `IDLE` afterwards) were attributed to whatever context the entity happened to be holding from an earlier `announce` or `start_conversation`, or to nothing at all.

The handler already resolves the entity and already reads `call.context` for its permission check, so this just forwards it before acting:

```python
satellite_entity.async_set_context(call.context)
```

Entity services get this for free from `_async_handle_entity_calls` (`helpers/service.py:771-822`); hand-rolled service handlers have to do it themselves. Converting `ask_question` to an entity service would be the better fix, but it returns `asdict(answer)` directly while entity services key their response by entity id, so that would be a breaking change to the service's response shape.

Found while auditing the codebase for services that act on entities without forwarding the service call context. Separate PRs cover the other integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQdoLT4SC1w5LUgDQA3vEq)_