### PR TITLE
Forward service call context to entity in group.set and group.remove

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -272,6 +272,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.warning("%s:Group '%s' doesn't exist!", service.service, object_id)
             return
 
+        group.async_set_context(service.context)
+
         # update group
         if service.service == SERVICE_SET:
             need_update = False

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -265,6 +265,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 mode=service.data.get(ATTR_ALL),
                 object_id=object_id,
                 order=None,
+                context=service.context,
             )
             return
 

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
+    Context,
     Event,
     EventStateChangedData,
     HomeAssistant,
@@ -231,6 +232,7 @@ class Group(Entity):
         mode: bool | None,
         object_id: str | None,
         order: int | None,
+        context: Context | None = None,
     ) -> Group:
         """Initialize a group.
 
@@ -246,6 +248,9 @@ class Group(Entity):
             object_id=object_id,
             order=order,
         )
+
+        if context is not None:
+            group.async_set_context(context)
 
         # If called before the platform async_setup is called (test cases)
         await async_get_component(hass).async_add_entities([group])

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -232,7 +232,7 @@ class Group(Entity):
         mode: bool | None,
         object_id: str | None,
         order: int | None,
-        context: Context | None = None,
+        context: Context | None,
     ) -> Group:
         """Initialize a group.
 

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -216,6 +216,7 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert await async_setup_component(

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
     EVENT_HOMEASSISTANT_START,
+    EVENT_STATE_CHANGED,
     SERVICE_RELOAD,
     STATE_CLOSED,
     STATE_HOME,
@@ -35,6 +36,7 @@ from tests.common import (
     MockModule,
     MockPlatform,
     assert_setup_component,
+    async_capture_events,
     mock_integration,
     mock_platform,
 )
@@ -1013,6 +1015,8 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
 
     assert hass.services.has_service("group", group.SERVICE_SET)
 
+    create_context = Context()
+    created_events = async_capture_events(hass, EVENT_STATE_CHANGED)
     await hass.services.async_call(
         group.DOMAIN,
         group.SERVICE_SET,
@@ -1021,6 +1025,7 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
             "name": "New Group",
             "entities": ["person.one", "person.two"],
         },
+        context=create_context,
     )
     await hass.async_block_till_done()
 
@@ -1028,6 +1033,16 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
     assert group_state.state == "not_home"
     assert group_state.attributes["friendly_name"] == "New Group"
     assert list(group_state.attributes["entity_id"]) == ["person.one", "person.two"]
+
+    # The group recomputes from its members right after, so assert on the state
+    # written when the entity was added rather than on the current state
+    created_event = next(
+        event
+        for event in created_events
+        if event.data["entity_id"] == "group.new_group"
+        and event.data["old_state"] is None
+    )
+    assert created_event.context is create_context
 
     context = Context()
     await hass.services.async_call(
@@ -1099,11 +1114,22 @@ async def test_service_group_set_group_remove_group(hass: HomeAssistant) -> None
         ["test.entity_bla1", "test.entity_id2"]
     )
 
-    common.async_remove(hass, "user_test_group")
+    removed_events = async_capture_events(hass, EVENT_STATE_CHANGED)
+    context = Context()
+    await hass.services.async_call(
+        group.DOMAIN,
+        group.SERVICE_REMOVE,
+        {"object_id": "user_test_group"},
+        blocking=True,
+        context=context,
+    )
     await hass.async_block_till_done()
 
     group_state = hass.states.get("group.user_test_group")
     assert group_state is None
+    assert removed_events[-1].data["entity_id"] == "group.user_test_group"
+    assert removed_events[-1].data["new_state"] is None
+    assert removed_events[-1].context is context
 
 
 async def test_group_order(hass: HomeAssistant) -> None:

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -161,6 +161,7 @@ async def test_setup_group_with_mixed_groupable_states(hass: HomeAssistant) -> N
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     await hass.async_block_till_done()
@@ -183,6 +184,7 @@ async def test_setup_group_with_a_non_existing_state(hass: HomeAssistant) -> Non
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert grp.state == STATE_ON
@@ -204,6 +206,7 @@ async def test_setup_group_with_non_groupable_states(hass: HomeAssistant) -> Non
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert grp.state is None
@@ -220,6 +223,7 @@ async def test_setup_empty_group(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert grp.state is None
@@ -241,6 +245,7 @@ async def test_monitor_group(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     # Test if group setup in our init mode is ok
@@ -267,6 +272,7 @@ async def test_group_turns_off_if_all_off(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     await hass.async_block_till_done()
@@ -293,6 +299,7 @@ async def test_group_turns_on_if_all_are_off_and_one_turns_on(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     # Turn one on
@@ -321,6 +328,7 @@ async def test_allgroup_stays_off_if_all_are_off_and_one_turns_on(
         mode=True,
         object_id=None,
         order=None,
+        context=None,
     )
 
     # Turn one on
@@ -347,6 +355,7 @@ async def test_allgroup_turn_on_if_last_turns_on(hass: HomeAssistant) -> None:
         mode=True,
         object_id=None,
         order=None,
+        context=None,
     )
 
     # Turn one on
@@ -373,6 +382,7 @@ async def test_expand_entity_ids(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert sorted(["light.ceiling", "light.bowl"]) == sorted(
@@ -398,6 +408,7 @@ async def test_expand_entity_ids_does_not_return_duplicates(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert sorted(
@@ -425,6 +436,7 @@ async def test_expand_entity_ids_recursive(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert sorted(["light.ceiling", "light.bowl"]) == sorted(
@@ -453,6 +465,7 @@ async def test_get_entity_ids(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert sorted(group.get_entity_ids(hass, test_group.entity_id)) == [
@@ -476,6 +489,7 @@ async def test_get_entity_ids_with_domain_filter(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert group.get_entity_ids(
@@ -513,6 +527,7 @@ async def test_group_being_init_before_first_tracked_state_is_set_to_on(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     hass.states.async_set("light.not_there_1", STATE_ON)
@@ -541,6 +556,7 @@ async def test_group_being_init_before_first_tracked_state_is_set_to_off(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     hass.states.async_set("light.not_there_1", STATE_OFF)
@@ -565,6 +581,7 @@ async def test_groups_get_unique_names(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     grp2 = await group.Group.async_create_group(
         hass,
@@ -575,6 +592,7 @@ async def test_groups_get_unique_names(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert grp1.entity_id != grp2.entity_id
@@ -594,6 +612,7 @@ async def test_expand_entity_ids_expands_nested_groups(hass: HomeAssistant) -> N
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await group.Group.async_create_group(
         hass,
@@ -604,6 +623,7 @@ async def test_expand_entity_ids_expands_nested_groups(hass: HomeAssistant) -> N
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await group.Group.async_create_group(
         hass,
@@ -614,6 +634,7 @@ async def test_expand_entity_ids_expands_nested_groups(hass: HomeAssistant) -> N
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     assert sorted(group.expand_entity_ids(hass, ["group.group_of_groups"])) == [
@@ -640,6 +661,7 @@ async def test_set_assumed_state_based_on_tracked(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     state = hass.states.get(test_group.entity_id)
@@ -679,6 +701,7 @@ async def test_group_updated_after_device_tracker_zone_change(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     hass.states.async_set("device_tracker.Adam", "cool_state_not_home")
@@ -705,6 +728,7 @@ async def test_is_on(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.async_block_till_done()
 
@@ -842,6 +866,7 @@ async def test_is_on_and_state_mixed_domains(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.async_block_till_done()
 
@@ -885,6 +910,7 @@ async def test_reloading_groups(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     await hass.async_block_till_done()
@@ -962,6 +988,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await group.Group.async_create_group(
         hass,
@@ -972,6 +999,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.async_block_till_done()
 

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1029,6 +1029,7 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
     assert group_state.attributes["friendly_name"] == "New Group"
     assert list(group_state.attributes["entity_id"]) == ["person.one", "person.two"]
 
+    context = Context()
     await hass.services.async_call(
         group.DOMAIN,
         group.SERVICE_SET,
@@ -1036,11 +1037,13 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
             "object_id": "new_group",
             "add_entities": "person.three",
         },
+        context=context,
     )
     await hass.async_block_till_done()
     group_state = hass.states.get("group.new_group")
     assert group_state.state == "home"
     assert "person.three" in list(group_state.attributes["entity_id"])
+    assert group_state.context is context
 
     await hass.services.async_call(
         group.DOMAIN,
@@ -1054,37 +1057,6 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
     group_state = hass.states.get("group.new_group")
     assert group_state.state == "home"
     assert "person.one" not in list(group_state.attributes["entity_id"])
-
-
-async def test_service_group_set_forwards_context(hass: HomeAssistant) -> None:
-    """Check that group.set attributes the state change to the caller."""
-    hass.states.async_set("person.one", "home")
-
-    assert await async_setup_component(hass, "person", {})
-    with assert_setup_component(0, "group"):
-        await async_setup_component(hass, DOMAIN, {"group": {}})
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        group.DOMAIN,
-        group.SERVICE_SET,
-        {"object_id": "new_group", "entities": ["person.one"]},
-        blocking=True,
-    )
-
-    context = Context()
-    await hass.services.async_call(
-        group.DOMAIN,
-        group.SERVICE_SET,
-        {"object_id": "new_group", "name": "Renamed Group"},
-        blocking=True,
-        context=context,
-    )
-    await hass.async_block_till_done()
-
-    group_state = hass.states.get("group.new_group")
-    assert group_state.attributes["friendly_name"] == "Renamed Group"
-    assert group_state.context is context
 
 
 async def test_service_group_set_group_remove_group(hass: HomeAssistant) -> None:

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import Context, CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -1054,6 +1054,37 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
     group_state = hass.states.get("group.new_group")
     assert group_state.state == "home"
     assert "person.one" not in list(group_state.attributes["entity_id"])
+
+
+async def test_service_group_set_forwards_context(hass: HomeAssistant) -> None:
+    """Check that group.set attributes the state change to the caller."""
+    hass.states.async_set("person.one", "home")
+
+    assert await async_setup_component(hass, "person", {})
+    with assert_setup_component(0, "group"):
+        await async_setup_component(hass, DOMAIN, {"group": {}})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        group.DOMAIN,
+        group.SERVICE_SET,
+        {"object_id": "new_group", "entities": ["person.one"]},
+        blocking=True,
+    )
+
+    context = Context()
+    await hass.services.async_call(
+        group.DOMAIN,
+        group.SERVICE_SET,
+        {"object_id": "new_group", "name": "Renamed Group"},
+        blocking=True,
+        context=context,
+    )
+    await hass.async_block_till_done()
+
+    group_state = hass.states.get("group.new_group")
+    assert group_state.attributes["friendly_name"] == "Renamed Group"
+    assert group_state.context is context
 
 
 async def test_service_group_set_group_remove_group(hass: HomeAssistant) -> None:

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -302,6 +302,7 @@ async def test_set_config_parameter(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.services.async_call(
         DOMAIN,
@@ -800,6 +801,7 @@ async def test_bulk_set_config_parameters(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.services.async_call(
         DOMAIN,
@@ -943,6 +945,7 @@ async def test_refresh_value(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     client.async_send_command.return_value = {"result": 2}
     await hass.services.async_call(
@@ -1075,6 +1078,7 @@ async def test_set_value(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.services.async_call(
         DOMAIN,
@@ -1385,6 +1389,7 @@ async def test_multicast_set_value(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.services.async_call(
         DOMAIN,
@@ -1760,6 +1765,7 @@ async def test_ping(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
     await hass.services.async_call(
         DOMAIN,

--- a/tests/helpers/template/extensions/test_state.py
+++ b/tests/helpers/template/extensions/test_state.py
@@ -740,6 +740,7 @@ async def test_expand(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     info = render_to_info(
@@ -800,6 +801,7 @@ async def test_expand(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     info = render_to_info(
@@ -1301,6 +1303,7 @@ async def test_closest_function_home_vs_group_entity_id(hass: HomeAssistant) -> 
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')
@@ -1338,6 +1341,7 @@ async def test_closest_function_home_vs_group_state(hass: HomeAssistant) -> None
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -719,6 +719,7 @@ async def test_extract_entity_ids(hass: HomeAssistant) -> None:
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     call = ServiceCall(hass, "light", "turn_on", {ATTR_ENTITY_ID: "light.Bowl"})

--- a/tests/helpers/test_target.py
+++ b/tests/helpers/test_target.py
@@ -513,6 +513,7 @@ async def test_extract_referenced_entity_ids(
         mode=None,
         object_id=None,
         order=None,
+        context=None,
     )
 
     target_selection = selection_class(selector_config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`group.set` and `group.remove` are registered with `hass.services.async_register` (`__init__.py:314,333`) rather than as entity services, since they address the group by `object_id` and `group.set` may create an entity that does not exist yet. The handler resolves the existing group entity and mutates it without ever setting the context, so:

- `group.set` renaming a group, changing its icon or its mode calls `group.async_write_ha_state()` (`__init__.py:306`) with no attribution.
- `group.remove` calls `component.async_remove_entity`, which ends at `hass.states.async_remove(self.entity_id, context=self._context)` (`helpers/entity.py:1503`) — so the removal carried whatever stale context the entity still held.

Setting the context once, right after the group is resolved, covers both paths.

Entity services get this for free from `_async_handle_entity_calls` (`helpers/service.py:771-822`); hand-rolled service handlers have to do it themselves.

Found while auditing the codebase for services that act on entities without forwarding the service call context. Separate PRs cover the other integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQdoLT4SC1w5LUgDQA3vEq)_