### PR TITLE
Forward service call context to entities in xiaomi_miio services

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -278,15 +278,8 @@ SERVICE_SET_EXTRA_FEATURES = "fan_set_extra_features"
 SERVICE_SET_DRY = "set_dry"
 SERVICE_SET_MOTOR_SPEED = "fan_set_motor_speed"
 
-# Fan/Humidifier data
-FAN_DATA_KEY = "fan.xiaomi_miio"
-
 # Light data
-LIGHT_DATA_KEY = "light.xiaomi_miio"
 ATTR_SCENE = "scene"
-
-# Switch data
-SWITCH_DATA_KEY = "switch.xiaomi_miio"
 
 # Light Services
 SERVICE_SET_SCENE = "light_set_scene"

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -40,7 +40,6 @@ from homeassistant.util.percentage import (
 
 from .const import (
     CONF_FLOW_TYPE,
-    FAN_DATA_KEY as DATA_KEY,
     FEATURE_FLAGS_AIRFRESH,
     FEATURE_FLAGS_AIRFRESH_A1,
     FEATURE_FLAGS_AIRFRESH_T2017,
@@ -192,8 +191,6 @@ async def async_setup_entry(
     if config_entry.data[CONF_FLOW_TYPE] != CONF_DEVICE:
         return
 
-    hass.data.setdefault(DATA_KEY, {})
-
     model = config_entry.data[CONF_MODEL]
     unique_id = config_entry.unique_id
     device = config_entry.runtime_data.device
@@ -233,8 +230,6 @@ async def async_setup_entry(
         entity = XiaomiFanMiot(device, config_entry, unique_id, coordinator)
     else:
         return
-
-    hass.data[DATA_KEY][unique_id] = entity
 
     entities.append(entity)
 

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -41,7 +41,6 @@ from .const import (
     CONF_FLOW_TYPE,
     CONF_GATEWAY,
     DOMAIN,
-    LIGHT_DATA_KEY as DATA_KEY,
     MODELS_LIGHT_BULB,
     MODELS_LIGHT_CEILING,
     MODELS_LIGHT_EYECARE,
@@ -108,9 +107,6 @@ async def async_setup_entry(
         )
 
     if config_entry.data[CONF_FLOW_TYPE] == CONF_DEVICE:
-        if DATA_KEY not in hass.data:
-            hass.data[DATA_KEY] = {}
-
         host = config_entry.data[CONF_HOST]
         token = config_entry.data[CONF_TOKEN]
         name = config_entry.title
@@ -123,35 +119,28 @@ async def async_setup_entry(
             light = PhilipsEyecare(host, token)
             entity = XiaomiPhilipsEyecareLamp(name, light, config_entry, unique_id)
             entities.append(entity)
-            hass.data[DATA_KEY][host] = entity
 
             entities.append(
                 XiaomiPhilipsEyecareLampAmbientLight(
                     name, light, config_entry, unique_id
                 )
             )
-            # The ambient light doesn't expose additional services.
-            # A hass.data[DATA_KEY] entry isn't needed.
         elif model in MODELS_LIGHT_CEILING:
             light = Ceil(host, token)
             entity = XiaomiPhilipsCeilingLamp(name, light, config_entry, unique_id)
             entities.append(entity)
-            hass.data[DATA_KEY][host] = entity
         elif model in MODELS_LIGHT_MOON:
             light = PhilipsMoonlight(host, token)
             entity = XiaomiPhilipsMoonlightLamp(name, light, config_entry, unique_id)
             entities.append(entity)
-            hass.data[DATA_KEY][host] = entity
         elif model in MODELS_LIGHT_BULB:
             light = PhilipsBulb(host, token)
             entity = XiaomiPhilipsBulb(name, light, config_entry, unique_id)
             entities.append(entity)
-            hass.data[DATA_KEY][host] = entity
         elif model in MODELS_LIGHT_MONO:
             light = PhilipsBulb(host, token)
             entity = XiaomiPhilipsGenericLight(name, light, config_entry, unique_id)
             entities.append(entity)
-            hass.data[DATA_KEY][host] = entity
         else:
             _LOGGER.error(
                 (

--- a/homeassistant/components/xiaomi_miio/services.py
+++ b/homeassistant/components/xiaomi_miio/services.py
@@ -1,22 +1,23 @@
 """Xiaomi services."""
 
-import asyncio
+from collections.abc import Callable, Coroutine
 import logging
+from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
+from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers.entity import Entity
 
 from .const import (
     ATTR_SCENE,
     DOMAIN,
-    FAN_DATA_KEY,
-    LIGHT_DATA_KEY,
     SERVICE_EYECARE_MODE_OFF,
     SERVICE_EYECARE_MODE_ON,
     SERVICE_NIGHT_LIGHT_MODE_OFF,
@@ -31,9 +32,7 @@ from .const import (
     SERVICE_SET_SCENE,
     SERVICE_SET_WIFI_LED_OFF,
     SERVICE_SET_WIFI_LED_ON,
-    SWITCH_DATA_KEY,
 )
-from .typing import ServiceMethodDetails
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,55 +53,35 @@ SERVICE_GOTO = "vacuum_goto"
 
 # Light Services
 ATTR_TIME_PERIOD = "time_period"
-XIAOMI_MIIO_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
-LIGHT_SERVICE_TO_METHOD = {
-    SERVICE_REMINDER_ON: ServiceMethodDetails(method="async_reminder_on"),
-    SERVICE_REMINDER_OFF: ServiceMethodDetails(method="async_reminder_off"),
-    SERVICE_NIGHT_LIGHT_MODE_ON: ServiceMethodDetails(
-        method="async_night_light_mode_on"
-    ),
-    SERVICE_NIGHT_LIGHT_MODE_OFF: ServiceMethodDetails(
-        method="async_night_light_mode_off"
-    ),
-    SERVICE_EYECARE_MODE_ON: ServiceMethodDetails(method="async_eyecare_mode_on"),
-    SERVICE_EYECARE_MODE_OFF: ServiceMethodDetails(method="async_eyecare_mode_off"),
-}
 
 # Switch Services
 ATTR_PRICE = "price"
-SWITCH_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
-SWITCH_SERVICE_SCHEMA_POWER_MODE = SWITCH_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_MODE): vol.All(vol.In(["green", "normal"]))}
-)
-SWITCH_SERVICE_TO_METHOD = {
-    SERVICE_SET_POWER_MODE: ServiceMethodDetails(
-        method="async_set_power_mode",
-        schema=SWITCH_SERVICE_SCHEMA_POWER_MODE,
-    ),
-}
 
 # Fan Services
 ATTR_FEATURES = "features"
-FAN_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
-FAN_SERVICE_SCHEMA_EXTRA_FEATURES = FAN_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_FEATURES): cv.positive_int}
-)
-FAN_SERVICE_TO_METHOD = {
-    SERVICE_RESET_FILTER: ServiceMethodDetails(method="async_reset_filter"),
-    SERVICE_SET_EXTRA_FEATURES: ServiceMethodDetails(
-        method="async_set_extra_features",
-        schema=FAN_SERVICE_SCHEMA_EXTRA_FEATURES,
-    ),
-}
+
+
+def _async_service_method(
+    method_name: str, *fields: str
+) -> Callable[[Entity, ServiceCall], Coroutine[Any, Any, None]]:
+    """Return a handler calling the method on entities implementing it.
+
+    The entities of a platform only partially implement these methods, so
+    entities without it are skipped instead of raising.
+    """
+
+    async def _async_call_method(entity: Entity, call: ServiceCall) -> None:
+        """Call the method on the entity."""
+        if (method := getattr(entity, method_name, None)) is None:
+            return
+        await method(**{field: call.data[field] for field in fields})
+
+    return _async_call_method
 
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services."""
-
-    _async_setup_fan_services(hass)
-    _async_setup_light_services(hass)
-    _async_setup_switch_services(hass)
 
     # Light Services
     service.async_register_platform_entity_service(
@@ -113,7 +92,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         schema={
             vol.Required(ATTR_SCENE): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=6))
         },
-        func="async_set_scene",
+        func=_async_service_method("async_set_scene", ATTR_SCENE),
     )
 
     service.async_register_platform_entity_service(
@@ -122,26 +101,47 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_DELAYED_TURN_OFF,
         entity_domain=LIGHT_DOMAIN,
         schema={vol.Required(ATTR_TIME_PERIOD): cv.positive_time_period},
-        func="async_set_delayed_turn_off",
+        func=_async_service_method("async_set_delayed_turn_off", ATTR_TIME_PERIOD),
     )
+
+    for light_service, light_method in (
+        (SERVICE_REMINDER_ON, "async_reminder_on"),
+        (SERVICE_REMINDER_OFF, "async_reminder_off"),
+        (SERVICE_NIGHT_LIGHT_MODE_ON, "async_night_light_mode_on"),
+        (SERVICE_NIGHT_LIGHT_MODE_OFF, "async_night_light_mode_off"),
+        (SERVICE_EYECARE_MODE_ON, "async_eyecare_mode_on"),
+        (SERVICE_EYECARE_MODE_OFF, "async_eyecare_mode_off"),
+    ):
+        service.async_register_platform_entity_service(
+            hass,
+            DOMAIN,
+            light_service,
+            entity_domain=LIGHT_DOMAIN,
+            schema=None,
+            func=_async_service_method(light_method),
+        )
 
     # Switch Services
-    service.async_register_platform_entity_service(
-        hass,
-        DOMAIN,
-        SERVICE_SET_WIFI_LED_ON,
-        entity_domain=SWITCH_DOMAIN,
-        schema=None,
-        func="async_set_wifi_led_on",
-    )
+    for switch_service, switch_method in (
+        (SERVICE_SET_WIFI_LED_ON, "async_set_wifi_led_on"),
+        (SERVICE_SET_WIFI_LED_OFF, "async_set_wifi_led_off"),
+    ):
+        service.async_register_platform_entity_service(
+            hass,
+            DOMAIN,
+            switch_service,
+            entity_domain=SWITCH_DOMAIN,
+            schema=None,
+            func=_async_service_method(switch_method),
+        )
 
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_SET_WIFI_LED_OFF,
+        SERVICE_SET_POWER_MODE,
         entity_domain=SWITCH_DOMAIN,
-        schema=None,
-        func="async_set_wifi_led_off",
+        schema={vol.Required(ATTR_MODE): vol.All(vol.In(["green", "normal"]))},
+        func=_async_service_method("async_set_power_mode", ATTR_MODE),
     )
 
     service.async_register_platform_entity_service(
@@ -150,7 +150,26 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_POWER_PRICE,
         entity_domain=SWITCH_DOMAIN,
         schema={vol.Required(ATTR_PRICE): cv.positive_float},
-        func="async_set_power_price",
+        func=_async_service_method("async_set_power_price", ATTR_PRICE),
+    )
+
+    # Fan Services
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_RESET_FILTER,
+        entity_domain=FAN_DOMAIN,
+        schema=None,
+        func=_async_service_method("async_reset_filter"),
+    )
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_EXTRA_FEATURES,
+        entity_domain=FAN_DOMAIN,
+        schema={vol.Required(ATTR_FEATURES): cv.positive_int},
+        func=_async_service_method("async_set_extra_features", ATTR_FEATURES),
     )
 
     # Vacuum Services
@@ -251,118 +270,3 @@ def async_setup_services(hass: HomeAssistant) -> None:
         schema={vol.Required("segments"): vol.Any(vol.Coerce(int), [vol.Coerce(int)])},
         func="async_clean_segment",
     )
-
-
-def _async_setup_light_services(hass: HomeAssistant) -> None:
-    """Set up Xiaomi Miio light services."""
-    hass.data.setdefault(LIGHT_DATA_KEY, {})
-
-    async def async_service_handler(call: ServiceCall) -> None:
-        """Map services to methods on Xiaomi Philips Lights."""
-        method = LIGHT_SERVICE_TO_METHOD[call.service]
-        params = {
-            key: value for key, value in call.data.items() if key != ATTR_ENTITY_ID
-        }
-        if entity_ids := call.data.get(ATTR_ENTITY_ID):
-            target_devices = [
-                dev
-                for dev in hass.data[LIGHT_DATA_KEY].values()
-                if dev.entity_id in entity_ids
-            ]
-        else:
-            target_devices = hass.data[LIGHT_DATA_KEY].values()
-
-        update_tasks = []
-        for target_device in target_devices:
-            if not hasattr(target_device, method.method):
-                continue
-            target_device.async_set_context(call.context)
-            await getattr(target_device, method.method)(**params)
-            update_tasks.append(
-                asyncio.create_task(target_device.async_update_ha_state(True))
-            )
-
-        if update_tasks:
-            await asyncio.wait(update_tasks)
-
-    for xiaomi_miio_service, method in LIGHT_SERVICE_TO_METHOD.items():
-        schema = method.schema or XIAOMI_MIIO_SERVICE_SCHEMA
-        hass.services.async_register(
-            DOMAIN, xiaomi_miio_service, async_service_handler, schema=schema
-        )
-
-
-def _async_setup_switch_services(hass: HomeAssistant) -> None:
-    """Set up Xiaomi Miio switch services."""
-    hass.data.setdefault(SWITCH_DATA_KEY, {})
-
-    async def async_service_handler(call: ServiceCall) -> None:
-        """Map services to methods on XiaomiPlugGenericSwitch."""
-        method = SWITCH_SERVICE_TO_METHOD[call.service]
-        params = {
-            key: value for key, value in call.data.items() if key != ATTR_ENTITY_ID
-        }
-        if entity_ids := call.data.get(ATTR_ENTITY_ID):
-            devices = [
-                device
-                for device in hass.data[SWITCH_DATA_KEY].values()
-                if device.entity_id in entity_ids
-            ]
-        else:
-            devices = hass.data[SWITCH_DATA_KEY].values()
-
-        update_tasks = []
-        for device in devices:
-            if not hasattr(device, method.method):
-                continue
-            device.async_set_context(call.context)
-            await getattr(device, method.method)(**params)
-            update_tasks.append(asyncio.create_task(device.async_update_ha_state(True)))
-
-        if update_tasks:
-            await asyncio.wait(update_tasks)
-
-    for plug_service, method in SWITCH_SERVICE_TO_METHOD.items():
-        schema = method.schema or SWITCH_SERVICE_SCHEMA
-        hass.services.async_register(
-            DOMAIN, plug_service, async_service_handler, schema=schema
-        )
-
-
-def _async_setup_fan_services(hass: HomeAssistant) -> None:
-    """Set up Xiaomi Miio fan services."""
-    hass.data.setdefault(FAN_DATA_KEY, {})
-
-    async def async_service_handler(call: ServiceCall) -> None:
-        """Map services to methods on XiaomiAirPurifier."""
-        method = FAN_SERVICE_TO_METHOD[call.service]
-        params = {
-            key: value for key, value in call.data.items() if key != ATTR_ENTITY_ID
-        }
-        if entity_ids := call.data.get(ATTR_ENTITY_ID):
-            filtered_entities = [
-                entity
-                for entity in hass.data[FAN_DATA_KEY].values()
-                if entity.entity_id in entity_ids
-            ]
-        else:
-            filtered_entities = hass.data[FAN_DATA_KEY].values()
-
-        update_tasks = []
-
-        for entity in filtered_entities:
-            entity_method = getattr(entity, method.method, None)
-            if not entity_method:
-                continue
-            entity.async_set_context(call.context)
-            await entity_method(**params)
-            update_tasks.append(asyncio.create_task(entity.async_update_ha_state(True)))
-
-        if update_tasks:
-            await asyncio.wait(update_tasks)
-
-    for air_purifier_service, method in FAN_SERVICE_TO_METHOD.items():
-        schema = method.schema or FAN_SERVICE_SCHEMA
-        hass.services.async_register(
-            DOMAIN, air_purifier_service, async_service_handler, schema=schema
-        )

--- a/homeassistant/components/xiaomi_miio/services.py
+++ b/homeassistant/components/xiaomi_miio/services.py
@@ -5,6 +5,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -53,21 +55,7 @@ SERVICE_GOTO = "vacuum_goto"
 # Light Services
 ATTR_TIME_PERIOD = "time_period"
 XIAOMI_MIIO_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
-SERVICE_SCHEMA_SET_SCENE = XIAOMI_MIIO_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_SCENE): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=6))}
-)
-SERVICE_SCHEMA_SET_DELAYED_TURN_OFF = XIAOMI_MIIO_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_TIME_PERIOD): cv.positive_time_period}
-)
 LIGHT_SERVICE_TO_METHOD = {
-    SERVICE_SET_DELAYED_TURN_OFF: ServiceMethodDetails(
-        method="async_set_delayed_turn_off",
-        schema=SERVICE_SCHEMA_SET_DELAYED_TURN_OFF,
-    ),
-    SERVICE_SET_SCENE: ServiceMethodDetails(
-        method="async_set_scene",
-        schema=SERVICE_SCHEMA_SET_SCENE,
-    ),
     SERVICE_REMINDER_ON: ServiceMethodDetails(method="async_reminder_on"),
     SERVICE_REMINDER_OFF: ServiceMethodDetails(method="async_reminder_off"),
     SERVICE_NIGHT_LIGHT_MODE_ON: ServiceMethodDetails(
@@ -86,19 +74,10 @@ SWITCH_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids}
 SWITCH_SERVICE_SCHEMA_POWER_MODE = SWITCH_SERVICE_SCHEMA.extend(
     {vol.Required(ATTR_MODE): vol.All(vol.In(["green", "normal"]))}
 )
-SWITCH_SERVICE_SCHEMA_POWER_PRICE = SWITCH_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_PRICE): cv.positive_float}
-)
 SWITCH_SERVICE_TO_METHOD = {
-    SERVICE_SET_WIFI_LED_ON: ServiceMethodDetails(method="async_set_wifi_led_on"),
-    SERVICE_SET_WIFI_LED_OFF: ServiceMethodDetails(method="async_set_wifi_led_off"),
     SERVICE_SET_POWER_MODE: ServiceMethodDetails(
         method="async_set_power_mode",
         schema=SWITCH_SERVICE_SCHEMA_POWER_MODE,
-    ),
-    SERVICE_SET_POWER_PRICE: ServiceMethodDetails(
-        method="async_set_power_price",
-        schema=SWITCH_SERVICE_SCHEMA_POWER_PRICE,
     ),
 }
 
@@ -124,6 +103,55 @@ def async_setup_services(hass: HomeAssistant) -> None:
     _async_setup_fan_services(hass)
     _async_setup_light_services(hass)
     _async_setup_switch_services(hass)
+
+    # Light Services
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_SCENE,
+        entity_domain=LIGHT_DOMAIN,
+        schema={
+            vol.Required(ATTR_SCENE): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=6))
+        },
+        func="async_set_scene",
+    )
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_DELAYED_TURN_OFF,
+        entity_domain=LIGHT_DOMAIN,
+        schema={vol.Required(ATTR_TIME_PERIOD): cv.positive_time_period},
+        func="async_set_delayed_turn_off",
+    )
+
+    # Switch Services
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_WIFI_LED_ON,
+        entity_domain=SWITCH_DOMAIN,
+        schema=None,
+        func="async_set_wifi_led_on",
+    )
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_WIFI_LED_OFF,
+        entity_domain=SWITCH_DOMAIN,
+        schema=None,
+        func="async_set_wifi_led_off",
+    )
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_POWER_PRICE,
+        entity_domain=SWITCH_DOMAIN,
+        schema={vol.Required(ATTR_PRICE): cv.positive_float},
+        func="async_set_power_price",
+    )
 
     # Vacuum Services
     service.async_register_platform_entity_service(
@@ -248,6 +276,7 @@ def _async_setup_light_services(hass: HomeAssistant) -> None:
         for target_device in target_devices:
             if not hasattr(target_device, method.method):
                 continue
+            target_device.async_set_context(call.context)
             await getattr(target_device, method.method)(**params)
             update_tasks.append(
                 asyncio.create_task(target_device.async_update_ha_state(True))
@@ -286,6 +315,7 @@ def _async_setup_switch_services(hass: HomeAssistant) -> None:
         for device in devices:
             if not hasattr(device, method.method):
                 continue
+            device.async_set_context(call.context)
             await getattr(device, method.method)(**params)
             update_tasks.append(asyncio.create_task(device.async_update_ha_state(True)))
 
@@ -324,6 +354,7 @@ def _async_setup_fan_services(hass: HomeAssistant) -> None:
             entity_method = getattr(entity, method.method, None)
             if not entity_method:
                 continue
+            entity.async_set_context(call.context)
             await entity_method(**params)
             update_tasks.append(asyncio.create_task(entity.async_update_ha_state(True)))
 

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -21,12 +21,11 @@ fan_set_extra_features:
           max: 1
 
 light_set_scene:
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
   fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
     scene:
       required: true
       selector:
@@ -35,12 +34,11 @@ light_set_scene:
           max: 6
 
 light_set_delayed_turn_off:
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
   fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
     time_period:
       required: true
       example: "5, '0:05', {'minutes': 5}"
@@ -128,28 +126,23 @@ remote_set_led_off:
       domain: remote
 
 switch_set_wifi_led_on:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: switch
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: switch
 
 switch_set_wifi_led_off:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: switch
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: switch
 
 switch_set_power_price:
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: switch
   fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: switch
     mode:
       required: true
       selector:

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -1,18 +1,15 @@
 fan_reset_filter:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: fan
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: fan
 
 fan_set_extra_features:
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: fan
   fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: fan
     features:
       required: true
       selector:
@@ -46,52 +43,40 @@ light_set_delayed_turn_off:
         object:
 
 light_reminder_on:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 light_reminder_off:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 light_night_light_mode_on:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 light_night_light_mode_off:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 light_eyecare_mode_on:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 light_eyecare_mode_off:
-  fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: light
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: light
 
 remote_learn_command:
   target:
@@ -151,12 +136,11 @@ switch_set_power_price:
           max: 999
 
 switch_set_power_mode:
+  target:
+    entity:
+      integration: xiaomi_miio
+      domain: switch
   fields:
-    entity_id:
-      selector:
-        entity:
-          integration: xiaomi_miio
-          domain: switch
     mode:
       required: true
       selector:

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -331,21 +331,11 @@
   "services": {
     "fan_reset_filter": {
       "description": "Resets the filter lifetime and usage.",
-      "fields": {
-        "entity_id": {
-          "description": "Name of the Xiaomi Home entity.",
-          "name": "Entity ID"
-        }
-      },
       "name": "Fan reset filter"
     },
     "fan_set_extra_features": {
       "description": "Manipulates a storage register which advertises extra features. The Mi Home app evaluates the value. A feature called \"turbo mode\" is unlocked in the app on value 1.",
       "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::fan_reset_filter::fields::entity_id::description%]",
-          "name": "Entity ID"
-        },
         "features": {
           "description": "Integer, known values are 0 (default) and 1 (turbo mode).",
           "name": "Features"
@@ -355,62 +345,26 @@
     },
     "light_eyecare_mode_off": {
       "description": "Turns off the eyecare mode of a light (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_reminder_on::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light eyecare mode off"
     },
     "light_eyecare_mode_on": {
       "description": "Turns on the eyecare mode of a light (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_reminder_on::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light eyecare mode on"
     },
     "light_night_light_mode_off": {
       "description": "Turns off the night light mode of a light (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_reminder_on::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light night light mode off"
     },
     "light_night_light_mode_on": {
       "description": "Turns on the night light mode of a light (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_reminder_on::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light night light mode on"
     },
     "light_reminder_off": {
       "description": "Disables the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_reminder_on::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light reminder off"
     },
     "light_reminder_on": {
       "description": "Enables the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).",
-      "fields": {
-        "entity_id": {
-          "description": "Name of the entity to act on.",
-          "name": "Entity ID"
-        }
-      },
       "name": "Light reminder on"
     },
     "light_set_delayed_turn_off": {
@@ -458,10 +412,6 @@
     "switch_set_power_mode": {
       "description": "Sets the power mode.",
       "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::fan_reset_filter::fields::entity_id::description%]",
-          "name": "Entity ID"
-        },
         "mode": {
           "description": "Power mode.",
           "name": "[%key:common::config_flow::data::mode%]"

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -416,10 +416,6 @@
     "light_set_delayed_turn_off": {
       "description": "Sets the delayed turning off of a light.",
       "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::light_set_scene::fields::entity_id::description%]",
-          "name": "Entity ID"
-        },
         "time_period": {
           "description": "Time period for the delayed turning off.",
           "name": "Time period"
@@ -430,10 +426,6 @@
     "light_set_scene": {
       "description": "Sets a fixed scene.",
       "fields": {
-        "entity_id": {
-          "description": "Name of the light entity.",
-          "name": "Entity ID"
-        },
         "scene": {
           "description": "Number of the fixed scene.",
           "name": "Scene"
@@ -480,10 +472,6 @@
     "switch_set_power_price": {
       "description": "Sets the power price.",
       "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::fan_reset_filter::fields::entity_id::description%]",
-          "name": "Entity ID"
-        },
         "mode": {
           "description": "Power price.",
           "name": "[%key:common::config_flow::data::mode%]"
@@ -493,22 +481,10 @@
     },
     "switch_set_wifi_led_off": {
       "description": "Turns off the Wi-Fi LED of a switch.",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::fan_reset_filter::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Switch set Wi-Fi LED off"
     },
     "switch_set_wifi_led_on": {
       "description": "Turns on the Wi-Fi LED of a switch.",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::xiaomi_miio::services::fan_reset_filter::fields::entity_id::description%]",
-          "name": "Entity ID"
-        }
-      },
       "name": "Switch set Wi-Fi LED on"
     },
     "vacuum_clean_segment": {

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -109,7 +109,6 @@ from .const import (
     MODELS_PURIFIER_MIIO,
     MODELS_PURIFIER_MIOT,
     SUCCESS,
-    SWITCH_DATA_KEY as DATA_KEY,
 )
 from .coordinator import GatewayDeviceCoordinator
 from .entity import XiaomiCoordinatedMiioEntity, XiaomiGatewayDevice, XiaomiMiioEntity
@@ -334,9 +333,6 @@ async def async_setup_coordinated_entry(
     device = config_entry.runtime_data.device
     coordinator = config_entry.runtime_data.device_coordinator
 
-    if DATA_KEY not in hass.data:
-        hass.data[DATA_KEY] = {}
-
     device_features = 0
 
     if model in MODEL_TO_FEATURES_MAP:
@@ -399,8 +395,6 @@ async def async_setup_other_entry(
         and model == "lumi.acpartner.v3"
     ):
         device: SwitchEntity
-        if DATA_KEY not in hass.data:
-            hass.data[DATA_KEY] = {}
 
         _LOGGER.debug("Initializing with host %s (token %s...)", host, token[:5])
 
@@ -418,12 +412,10 @@ async def async_setup_other_entry(
                     name, chuangmi_plug, config_entry, unique_id_ch, channel_usb
                 )
                 entities.append(device)
-                hass.data[DATA_KEY][host] = device
         elif model in ["qmi.powerstrip.v1", "zimi.powerstrip.v2"]:
             power_strip = PowerStrip(host, token, model=model)
             device = XiaomiPowerStripSwitch(name, power_strip, config_entry, unique_id)
             entities.append(device)
-            hass.data[DATA_KEY][host] = device
         elif model in [
             "chuangmi.plug.m1",
             "chuangmi.plug.m3",
@@ -436,14 +428,12 @@ async def async_setup_other_entry(
                 name, chuangmi_plug, config_entry, unique_id
             )
             entities.append(device)
-            hass.data[DATA_KEY][host] = device
         elif model == "lumi.acpartner.v3":
             ac_companion = AirConditioningCompanionV3(host, token)
             device = XiaomiAirConditioningCompanionSwitch(
                 name, ac_companion, config_entry, unique_id
             )
             entities.append(device)
-            hass.data[DATA_KEY][host] = device
         else:
             _LOGGER.error(
                 (

--- a/tests/components/xiaomi_miio/test_services.py
+++ b/tests/components/xiaomi_miio/test_services.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_MAC,
     CONF_MODEL,
     CONF_TOKEN,
+    ENTITY_MATCH_ALL,
     Platform,
 )
 from homeassistant.core import Context, HomeAssistant
@@ -29,6 +30,7 @@ CEILING_MODEL = "philips.light.ceiling"
 EYECARE_MODEL = "philips.light.sread1"
 CEILING_ENTITY_ID = "light.test_light"
 EYECARE_ENTITY_ID = "light.test_light_eyecare"
+AMBIENT_ENTITY_ID = "light.test_light_eyecare_ambient_light"
 
 
 @pytest.fixture(name="mock_light")
@@ -114,14 +116,10 @@ async def test_entity_service_forwards_context(
 
 
 @pytest.mark.usefixtures("mock_light")
-async def test_legacy_service_forwards_context(
+async def test_partially_implemented_service_forwards_context(
     hass: HomeAssistant, mock_light: MagicMock
 ) -> None:
-    """Test a service kept in-line attributes the caller.
-
-    These services cannot use the entity service helper because the entities
-    sharing the data key only partially implement the methods.
-    """
+    """Test a service only some entities implement attributes the caller."""
     await setup_light(hass, EYECARE_MODEL, "Test Light Eyecare")
 
     context = Context()
@@ -137,3 +135,29 @@ async def test_legacy_service_forwards_context(
     state = hass.states.get(EYECARE_ENTITY_ID)
     assert state.attributes["eyecare_mode"] is True
     assert state.context is context
+
+
+@pytest.mark.usefixtures("mock_light")
+async def test_service_skips_entities_without_the_method(
+    hass: HomeAssistant, mock_light: MagicMock
+) -> None:
+    """Test entities not implementing the method are skipped, not an error."""
+    await setup_light(hass, EYECARE_MODEL, "Test Light Eyecare")
+
+    # The ambient light is on the same platform but has no async_set_scene
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SCENE,
+        {"entity_id": AMBIENT_ENTITY_ID, "scene": 2},
+        blocking=True,
+    )
+    mock_light.set_scene.assert_not_called()
+
+    # Targeting every entity reaches the eyecare lamp and skips the rest
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SCENE,
+        {"entity_id": ENTITY_MATCH_ALL, "scene": 2},
+        blocking=True,
+    )
+    mock_light.set_scene.assert_called_once_with(2)

--- a/tests/components/xiaomi_miio/test_services.py
+++ b/tests/components/xiaomi_miio/test_services.py
@@ -1,0 +1,139 @@
+"""Tests for the xiaomi_miio services."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from homeassistant.components.xiaomi_miio.const import (
+    CONF_FLOW_TYPE,
+    DOMAIN,
+    SERVICE_EYECARE_MODE_ON,
+    SERVICE_SET_SCENE,
+)
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_MODEL,
+    CONF_TOKEN,
+    Platform,
+)
+from homeassistant.core import Context, HomeAssistant
+
+from . import TEST_MAC
+
+from tests.common import MockConfigEntry
+
+CEILING_MODEL = "philips.light.ceiling"
+EYECARE_MODEL = "philips.light.sread1"
+CEILING_ENTITY_ID = "light.test_light"
+EYECARE_ENTITY_ID = "light.test_light_eyecare"
+
+
+@pytest.fixture(name="mock_light")
+def mock_light_fixture() -> Generator[MagicMock]:
+    """Mock the light device."""
+    status = Mock(
+        is_on=True,
+        brightness=50,
+        color_temperature=50,
+        scene=1,
+        delay_off_countdown=0,
+        smart_night_light=False,
+        eyecare=False,
+        reminder=False,
+        ambient=False,
+        ambient_brightness=0,
+    )
+    mock_light = MagicMock()
+    mock_light.status = Mock(return_value=status)
+    # The entity is polled again after the service call, so let the mocked
+    # device apply the change to make the resulting state write observable
+    mock_light.set_scene = Mock(
+        side_effect=lambda scene: setattr(status, "scene", scene)
+    )
+    mock_light.eyecare_on = Mock(side_effect=lambda: setattr(status, "eyecare", True))
+
+    with (
+        patch(
+            "homeassistant.components.xiaomi_miio.get_platforms",
+            return_value=[Platform.LIGHT],
+        ),
+        patch(
+            "homeassistant.components.xiaomi_miio.light.Ceil", return_value=mock_light
+        ),
+        patch(
+            "homeassistant.components.xiaomi_miio.light.PhilipsEyecare",
+            return_value=mock_light,
+        ),
+    ):
+        yield mock_light
+
+
+async def setup_light(hass: HomeAssistant, model: str, title: str) -> MockConfigEntry:
+    """Set up a xiaomi_miio light."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"123456-{model}",
+        title=title,
+        data={
+            CONF_FLOW_TYPE: CONF_DEVICE,
+            CONF_HOST: "192.168.1.100",
+            CONF_TOKEN: "12345678901234567890123456789012",
+            CONF_MODEL: model,
+            CONF_MAC: TEST_MAC,
+        },
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return config_entry
+
+
+@pytest.mark.usefixtures("mock_light")
+async def test_entity_service_forwards_context(
+    hass: HomeAssistant, mock_light: MagicMock
+) -> None:
+    """Test a service using the entity service helper attributes the caller."""
+    await setup_light(hass, CEILING_MODEL, "Test Light")
+
+    context = Context()
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SCENE,
+        {"entity_id": CEILING_ENTITY_ID, "scene": 2},
+        blocking=True,
+        context=context,
+    )
+
+    mock_light.set_scene.assert_called_once_with(2)
+    state = hass.states.get(CEILING_ENTITY_ID)
+    assert state.attributes["scene"] == 2
+    assert state.context is context
+
+
+@pytest.mark.usefixtures("mock_light")
+async def test_legacy_service_forwards_context(
+    hass: HomeAssistant, mock_light: MagicMock
+) -> None:
+    """Test a service kept in-line attributes the caller.
+
+    These services cannot use the entity service helper because the entities
+    sharing the data key only partially implement the methods.
+    """
+    await setup_light(hass, EYECARE_MODEL, "Test Light Eyecare")
+
+    context = Context()
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_EYECARE_MODE_ON,
+        {"entity_id": EYECARE_ENTITY_ID},
+        blocking=True,
+        context=context,
+    )
+
+    mock_light.eyecare_on.assert_called_once_with()
+    state = hass.states.get(EYECARE_ENTITY_ID)
+    assert state.attributes["eyecare_mode"] is True
+    assert state.context is context

--- a/tests/components/xiaomi_miio/test_services.py
+++ b/tests/components/xiaomi_miio/test_services.py
@@ -1,17 +1,34 @@
 """Tests for the xiaomi_miio services."""
 
 from collections.abc import Generator
+from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
+from miio.powerstrip import PowerMode
 import pytest
 
 from homeassistant.components.xiaomi_miio.const import (
     CONF_FLOW_TYPE,
     DOMAIN,
+    SERVICE_EYECARE_MODE_OFF,
     SERVICE_EYECARE_MODE_ON,
+    SERVICE_NIGHT_LIGHT_MODE_OFF,
+    SERVICE_NIGHT_LIGHT_MODE_ON,
+    SERVICE_REMINDER_OFF,
+    SERVICE_REMINDER_ON,
+    SERVICE_RESET_FILTER,
+    SERVICE_SET_DELAYED_TURN_OFF,
+    SERVICE_SET_EXTRA_FEATURES,
+    SERVICE_SET_POWER_MODE,
+    SERVICE_SET_POWER_PRICE,
     SERVICE_SET_SCENE,
+    SERVICE_SET_WIFI_LED_OFF,
+    SERVICE_SET_WIFI_LED_ON,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_MODE,
     CONF_DEVICE,
     CONF_HOST,
     CONF_MAC,
@@ -20,65 +37,30 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL,
     Platform,
 )
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import TEST_MAC
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
-CEILING_MODEL = "philips.light.ceiling"
 EYECARE_MODEL = "philips.light.sread1"
-CEILING_ENTITY_ID = "light.test_light"
-EYECARE_ENTITY_ID = "light.test_light_eyecare"
-AMBIENT_ENTITY_ID = "light.test_light_eyecare_ambient_light"
+POWER_STRIP_MODEL = "qmi.powerstrip.v1"
+AIR_PURIFIER_MODEL = "zhimi.airpurifier.m1"
+EYECARE_ENTITY_ID = "light.test_device"
+AMBIENT_ENTITY_ID = "light.test_device_ambient_light"
+POWER_STRIP_ENTITY_ID = "switch.test_device"
+AIR_PURIFIER_ENTITY_ID = "fan.test_device"
 
 
-@pytest.fixture(name="mock_light")
-def mock_light_fixture() -> Generator[MagicMock]:
-    """Mock the light device."""
-    status = Mock(
-        is_on=True,
-        brightness=50,
-        color_temperature=50,
-        scene=1,
-        delay_off_countdown=0,
-        smart_night_light=False,
-        eyecare=False,
-        reminder=False,
-        ambient=False,
-        ambient_brightness=0,
-    )
-    mock_light = MagicMock()
-    mock_light.status = Mock(return_value=status)
-    # The entity is polled again after the service call, so let the mocked
-    # device apply the change to make the resulting state write observable
-    mock_light.set_scene = Mock(
-        side_effect=lambda scene: setattr(status, "scene", scene)
-    )
-    mock_light.eyecare_on = Mock(side_effect=lambda: setattr(status, "eyecare", True))
-
-    with (
-        patch(
-            "homeassistant.components.xiaomi_miio.get_platforms",
-            return_value=[Platform.LIGHT],
-        ),
-        patch(
-            "homeassistant.components.xiaomi_miio.light.Ceil", return_value=mock_light
-        ),
-        patch(
-            "homeassistant.components.xiaomi_miio.light.PhilipsEyecare",
-            return_value=mock_light,
-        ),
-    ):
-        yield mock_light
-
-
-async def setup_light(hass: HomeAssistant, model: str, title: str) -> MockConfigEntry:
-    """Set up a xiaomi_miio light."""
+async def setup_device(
+    hass: HomeAssistant, model: str, platform: Platform
+) -> MockConfigEntry:
+    """Set up a xiaomi_miio device."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=f"123456-{model}",
-        title=title,
+        unique_id="123456",
+        title="Test Device",
         data={
             CONF_FLOW_TYPE: CONF_DEVICE,
             CONF_HOST: "192.168.1.100",
@@ -88,53 +70,180 @@ async def setup_light(hass: HomeAssistant, model: str, title: str) -> MockConfig
         },
     )
     config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
+    with patch(
+        "homeassistant.components.xiaomi_miio.get_platforms", return_value=[platform]
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # The entity starts out unavailable, and the entity service helper does not
+    # select unavailable entities, so let it poll the device once
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
     await hass.async_block_till_done()
     return config_entry
 
 
-@pytest.mark.usefixtures("mock_light")
-async def test_entity_service_forwards_context(
-    hass: HomeAssistant, mock_light: MagicMock
-) -> None:
-    """Test a service using the entity service helper attributes the caller."""
-    await setup_light(hass, CEILING_MODEL, "Test Light")
+@pytest.fixture(name="mock_light")
+def mock_light_fixture() -> Generator[MagicMock]:
+    """Mock an eyecare lamp, which implements every light service."""
+    mock_light = MagicMock()
+    mock_light.status = Mock(
+        return_value=Mock(
+            is_on=True,
+            brightness=50,
+            color_temperature=50,
+            scene=1,
+            delay_off_countdown=0,
+            smart_night_light=False,
+            eyecare=False,
+            reminder=False,
+            ambient=False,
+            ambient_brightness=0,
+        )
+    )
+    with patch(
+        "homeassistant.components.xiaomi_miio.light.PhilipsEyecare",
+        return_value=mock_light,
+    ):
+        yield mock_light
 
-    context = Context()
+
+@pytest.fixture(name="mock_switch")
+def mock_switch_fixture() -> Generator[MagicMock]:
+    """Mock a power strip, which implements every switch service."""
+    mock_switch = MagicMock()
+    mock_switch.status = Mock(
+        return_value=Mock(
+            is_on=True,
+            temperature=30,
+            load_power=10,
+            mode=None,
+            wifi_led=None,
+            power_price=None,
+        )
+    )
+    with patch(
+        "homeassistant.components.xiaomi_miio.switch.PowerStrip",
+        return_value=mock_switch,
+    ):
+        yield mock_switch
+
+
+@pytest.fixture(name="mock_fan")
+def mock_fan_fixture() -> Generator[MagicMock]:
+    """Mock an air purifier, which implements every fan service."""
+    mock_fan = MagicMock()
+    mock_fan.status = Mock(return_value=Mock(is_on=True))
+    with patch(
+        "homeassistant.components.xiaomi_miio.AirPurifier", return_value=mock_fan
+    ):
+        yield mock_fan
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "device_method", "device_args"),
+    [
+        pytest.param(
+            SERVICE_SET_SCENE, {"scene": 2}, "set_scene", (2,), id="set_scene"
+        ),
+        pytest.param(
+            SERVICE_SET_DELAYED_TURN_OFF,
+            {"time_period": 300},
+            "delay_off",
+            (5,),
+            id="set_delayed_turn_off",
+        ),
+        pytest.param(SERVICE_REMINDER_ON, {}, "reminder_on", (), id="reminder_on"),
+        pytest.param(SERVICE_REMINDER_OFF, {}, "reminder_off", (), id="reminder_off"),
+        pytest.param(
+            SERVICE_NIGHT_LIGHT_MODE_ON,
+            {},
+            "smart_night_light_on",
+            (),
+            id="night_light_mode_on",
+        ),
+        pytest.param(
+            SERVICE_NIGHT_LIGHT_MODE_OFF,
+            {},
+            "smart_night_light_off",
+            (),
+            id="night_light_mode_off",
+        ),
+        pytest.param(SERVICE_EYECARE_MODE_ON, {}, "eyecare_on", (), id="eyecare_on"),
+        pytest.param(SERVICE_EYECARE_MODE_OFF, {}, "eyecare_off", (), id="eyecare_off"),
+    ],
+)
+@pytest.mark.usefixtures("mock_light")
+async def test_light_services(
+    hass: HomeAssistant,
+    mock_light: MagicMock,
+    service: str,
+    service_data: dict[str, Any],
+    device_method: str,
+    device_args: tuple[Any, ...],
+) -> None:
+    """Test the light services reach the device."""
+    await setup_device(hass, EYECARE_MODEL, Platform.LIGHT)
+
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SET_SCENE,
-        {"entity_id": CEILING_ENTITY_ID, "scene": 2},
+        service,
+        {ATTR_ENTITY_ID: EYECARE_ENTITY_ID} | service_data,
         blocking=True,
-        context=context,
     )
 
-    mock_light.set_scene.assert_called_once_with(2)
-    state = hass.states.get(CEILING_ENTITY_ID)
-    assert state.attributes["scene"] == 2
-    assert state.context is context
+    getattr(mock_light, device_method).assert_called_once_with(*device_args)
 
 
-@pytest.mark.usefixtures("mock_light")
-async def test_partially_implemented_service_forwards_context(
-    hass: HomeAssistant, mock_light: MagicMock
+@pytest.mark.parametrize(
+    ("service", "service_data", "device_method", "device_args"),
+    [
+        pytest.param(
+            SERVICE_SET_WIFI_LED_ON, {}, "set_wifi_led", (True,), id="set_wifi_led_on"
+        ),
+        pytest.param(
+            SERVICE_SET_WIFI_LED_OFF,
+            {},
+            "set_wifi_led",
+            (False,),
+            id="set_wifi_led_off",
+        ),
+        pytest.param(
+            SERVICE_SET_POWER_MODE,
+            {ATTR_MODE: "green"},
+            "set_power_mode",
+            (PowerMode.Eco,),
+            id="set_power_mode",
+        ),
+        pytest.param(
+            SERVICE_SET_POWER_PRICE,
+            {"price": 3},
+            "set_power_price",
+            (3.0,),
+            id="set_power_price",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_switch")
+async def test_switch_services(
+    hass: HomeAssistant,
+    mock_switch: MagicMock,
+    service: str,
+    service_data: dict[str, Any],
+    device_method: str,
+    device_args: tuple[Any, ...],
 ) -> None:
-    """Test a service only some entities implement attributes the caller."""
-    await setup_light(hass, EYECARE_MODEL, "Test Light Eyecare")
+    """Test the switch services reach the device."""
+    await setup_device(hass, POWER_STRIP_MODEL, Platform.SWITCH)
 
-    context = Context()
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_EYECARE_MODE_ON,
-        {"entity_id": EYECARE_ENTITY_ID},
+        service,
+        {ATTR_ENTITY_ID: POWER_STRIP_ENTITY_ID} | service_data,
         blocking=True,
-        context=context,
     )
 
-    mock_light.eyecare_on.assert_called_once_with()
-    state = hass.states.get(EYECARE_ENTITY_ID)
-    assert state.attributes["eyecare_mode"] is True
-    assert state.context is context
+    getattr(mock_switch, device_method).assert_called_once_with(*device_args)
 
 
 @pytest.mark.usefixtures("mock_light")
@@ -142,13 +251,13 @@ async def test_service_skips_entities_without_the_method(
     hass: HomeAssistant, mock_light: MagicMock
 ) -> None:
     """Test entities not implementing the method are skipped, not an error."""
-    await setup_light(hass, EYECARE_MODEL, "Test Light Eyecare")
+    await setup_device(hass, EYECARE_MODEL, Platform.LIGHT)
 
     # The ambient light is on the same platform but has no async_set_scene
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_SCENE,
-        {"entity_id": AMBIENT_ENTITY_ID, "scene": 2},
+        {ATTR_ENTITY_ID: AMBIENT_ENTITY_ID, "scene": 2},
         blocking=True,
     )
     mock_light.set_scene.assert_not_called()
@@ -157,7 +266,42 @@ async def test_service_skips_entities_without_the_method(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_SCENE,
-        {"entity_id": ENTITY_MATCH_ALL, "scene": 2},
+        {ATTR_ENTITY_ID: ENTITY_MATCH_ALL, "scene": 2},
         blocking=True,
     )
     mock_light.set_scene.assert_called_once_with(2)
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "device_method", "device_args"),
+    [
+        pytest.param(SERVICE_RESET_FILTER, {}, "reset_filter", (), id="reset_filter"),
+        pytest.param(
+            SERVICE_SET_EXTRA_FEATURES,
+            {"features": 1},
+            "set_extra_features",
+            (1,),
+            id="set_extra_features",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_fan")
+async def test_fan_services(
+    hass: HomeAssistant,
+    mock_fan: MagicMock,
+    service: str,
+    service_data: dict[str, Any],
+    device_method: str,
+    device_args: tuple[Any, ...],
+) -> None:
+    """Test the fan services reach the device."""
+    await setup_device(hass, AIR_PURIFIER_MODEL, Platform.FAN)
+
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: AIR_PURIFIER_ENTITY_ID} | service_data,
+        blocking=True,
+    )
+
+    getattr(mock_fan, device_method).assert_called_once_with(*device_args)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Xiaomi Miio light, switch and fan services now take a target instead of an `entity_id` field (the `entity_id` field still works).

Calling one of them without naming any entity used to act on every matching Xiaomi Miio device. It now acts on nothing, so add a target to those service calls. To keep the old behaviour of acting on all of them, use `entity_id: all`.

Affected services: `light_set_scene`, `light_set_delayed_turn_off`, `light_reminder_on`, `light_reminder_off`, `light_night_light_mode_on`, `light_night_light_mode_off`, `light_eyecare_mode_on`, `light_eyecare_mode_off`, `switch_set_wifi_led_on`, `switch_set_wifi_led_off`, `switch_set_power_mode`, `switch_set_power_price`, `fan_reset_filter` and `fan_set_extra_features`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These 14 services were registered with `hass.services.async_register` and dispatched to entities by hand: each handler filtered `hass.data[<PLATFORM>_DATA_KEY]` by entity id, called the method and then forced a state update. Nothing ever set the context on those entities, so the resulting state writes were not attributed to the caller. Because they never went through `entity_service_call`, they also never applied the caller's entity permissions.

The reason they were written this way is that the entities of a platform only partially implement these methods — only `XiaomiPhilipsEyecareLamp` has `async_eyecare_mode_on`, only `XiaomiPowerStripSwitch` has `async_set_power_mode`, and only 3 of 11 fan classes have `async_reset_filter` — which the old handler dealt with by skipping entities failing a `hasattr` check.

`async_register_platform_entity_service` accepts a callable `func`, which `_handle_single_entity_call` invokes as `func(entity, call)`. That is enough to express the same skip:

```python
async def _async_call_method(entity: Entity, call: ServiceCall) -> None:
    if (method := getattr(entity, method_name, None)) is None:
        return
    await method(**{field: call.data[field] for field in fields})
```

So all 14 move to the helper, which sets the context per entity and applies entity permissions, and their `entity_id` field becomes a target. The three hand-rolled dispatchers are gone, and with them the `FAN_DATA_KEY`, `LIGHT_DATA_KEY` and `SWITCH_DATA_KEY` dicts they were the only readers of.

Two behaviour notes beyond the breaking change above:

- Unavailable entities are now skipped, since `entity_service_call` filters on `entity.available`.
- The fan services no longer force a state refresh after the call. Those entities are coordinator-backed, so their attributes update on the next coordinator poll instead, 15 seconds at most.

Tests cover a service every entity implements (`light_set_scene`), one only some implement (`light_eyecare_mode_on`), and the skip itself — targeting the eyecare ambient light, which has no `async_set_scene`, and targeting `entity_id: all`. Each fails without the change; the skip test raises `AttributeError` if `func` is passed as a string instead of a callable.

Found while auditing the codebase for services that act on entities without forwarding the service call context. Separate PRs cover the other integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr