### PR TITLE
Deprecate default_ members in DeviceInfo

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -265,10 +265,10 @@ def _validate_device_info(
 # Deprecated `async_get_or_create` parameters, mapped to the HA Core version they are
 # removed in.
 _DEPRECATED_DEVICE_INFO_PARAMETERS = {
-    "default_manufacturer": "2027.9.0",
-    "default_model": "2027.9.0",
-    "default_name": "2027.9.0",
-    "via_device": "2027.8.0",
+    "default_manufacturer": ("2027.9.0", "manufacturer"),
+    "default_model": ("2027.9.0", "model"),
+    "default_name": ("2027.9.0", "name"),
+    "via_device": ("2027.8.0", "via_device_id"),
 }
 
 
@@ -2176,12 +2176,13 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             "default_name": default_name,
             "via_device": via_device,
         }
-        for parameter, version in _DEPRECATED_DEVICE_INFO_PARAMETERS.items():
+        for parameter, deprecation in _DEPRECATED_DEVICE_INFO_PARAMETERS.items():
             if deprecated_values[parameter] is UNDEFINED:
                 continue
+            version, replacement = deprecation
             report_usage(
                 "calls `device_registry.async_get_or_create` with a deprecated "
-                f"`{parameter}` parameter",
+                f"`{parameter}` parameter; use `{replacement}` instead",
                 core_behavior=ReportBehavior.ERROR,
                 core_integration_behavior=ReportBehavior.ERROR,
                 breaks_in_ha_version=version,

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -131,9 +131,6 @@ class DeviceInfo(TypedDict, total=False):
     configuration_url: str | URL | None
     connections: set[tuple[str, str]]
     created_at: str
-    default_manufacturer: str
-    default_model: str
-    default_name: str
     entry_type: DeviceEntryType | None
     identifiers: set[tuple[str, str]]
     manufacturer: str | None
@@ -263,6 +260,16 @@ def _validate_device_info(
                 device_info,
                 f"passing both `{field}` and `default_{field}` is not allowed",
             )
+
+
+# Deprecated `async_get_or_create` parameters, mapped to the HA Core version they are
+# removed in.
+_DEPRECATED_DEVICE_INFO_PARAMETERS = {
+    "default_manufacturer": "2027.9.0",
+    "default_model": "2027.9.0",
+    "default_name": "2027.9.0",
+    "via_device": "2027.8.0",
+}
 
 
 class _ValidatedDeviceInfoFields(TypedDict):
@@ -2093,9 +2100,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         configuration_url: str | URL | UndefinedType | None = UNDEFINED,
         connections: set[tuple[str, str]] | UndefinedType | None = UNDEFINED,
         created_at: str | datetime | UndefinedType = UNDEFINED,  # will be ignored
-        default_manufacturer: str | UndefinedType | None = UNDEFINED,
-        default_model: str | UndefinedType | None = UNDEFINED,
-        default_name: str | UndefinedType | None = UNDEFINED,
         # To disable a device if it gets created, does not affect existing devices
         disabled_by: DeviceEntryDisabler | UndefinedType | None = UNDEFINED,
         entry_type: DeviceEntryType | UndefinedType | None = UNDEFINED,
@@ -2111,10 +2115,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         sw_version: str | UndefinedType | None = UNDEFINED,
         translation_key: str | None = None,
         translation_placeholders: Mapping[str, str] | None = None,
-        # via_device is deprecated and will be removed in HA Core 2027.8, use
-        # via_device_id instead
-        via_device: tuple[str, str] | UndefinedType | None = UNDEFINED,
         via_device_id: str | UndefinedType | None = UNDEFINED,
+        **kwargs: Any,
     ) -> DeviceEntry:
         """Get device. Create if it doesn't exist.
 
@@ -2122,6 +2124,18 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         If identifiers overlap with a child device, the method raises.
         """
+        # Extract deprecated parameters, and reject any other unexpected keyword
+        # argument.
+        default_manufacturer = kwargs.pop("default_manufacturer", UNDEFINED)
+        default_model = kwargs.pop("default_model", UNDEFINED)
+        default_name = kwargs.pop("default_name", UNDEFINED)
+        via_device = kwargs.pop("via_device", UNDEFINED)
+        if kwargs:
+            raise TypeError(
+                "async_get_or_create() got unexpected keyword arguments "
+                f"{', '.join(map(repr, kwargs))}"
+            )
+
         default_manufacturer = _validate_str(
             "default_manufacturer", default_manufacturer
         )
@@ -2155,15 +2169,22 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 "Passing both `via_device` and `via_device_id` is not allowed; "
                 "`via_device` is deprecated, pass `via_device_id` only"
             )
-        # Report the deprecated `via_device` here, before any registry mutation.
-        if via_device is not UNDEFINED:
+        # Report the deprecated parameters here, before any registry mutation.
+        deprecated_values = {
+            "default_manufacturer": default_manufacturer,
+            "default_model": default_model,
+            "default_name": default_name,
+            "via_device": via_device,
+        }
+        for parameter, version in _DEPRECATED_DEVICE_INFO_PARAMETERS.items():
+            if deprecated_values[parameter] is UNDEFINED:
+                continue
             report_usage(
-                "calls `device_registry.async_get_or_create` with a `via_device`, "
-                "which is deprecated because device identifiers are no longer unique; "
-                "pass `via_device_id` instead",
+                "calls `device_registry.async_get_or_create` with a deprecated "
+                f"`{parameter}` parameter",
                 core_behavior=ReportBehavior.ERROR,
                 core_integration_behavior=ReportBehavior.ERROR,
-                breaks_in_ha_version="2027.8.0",
+                breaks_in_ha_version=version,
             )
         if (
             config_subentry_id is not UNDEFINED

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4235,9 +4235,13 @@ async def test_async_get_device_deprecated(
 
 
 @pytest.mark.parametrize(
-    "via_device",
-    [("some_domain", "via_id"), None],
-    ids=["value", "none"],
+    ("parameter", "value"),
+    [
+        ("default_manufacturer", "manufacturer"),
+        ("default_model", "model"),
+        ("default_name", "name"),
+        ("via_device", ("some_domain", "via_id")),
+    ],
 )
 @pytest.mark.parametrize(
     ("integration_frame_path", "expectation", "expected_log"),
@@ -4260,17 +4264,18 @@ async def test_async_get_device_deprecated(
     ],
 )
 @pytest.mark.usefixtures("mock_integration_frame")
-async def test_async_get_or_create_via_device_deprecated(
+async def test_async_get_or_create_deprecated_parameters(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
-    via_device: tuple[str, str] | None,
+    parameter: str,
+    value: Any,
     expectation: AbstractContextManager,
     expected_log: int,
 ) -> None:
-    """Test passing via_device to async_get_or_create is deprecated.
+    """Test passing deprecated parameters to async_get_or_create.
 
-    It logs for custom integrations and raises for core and core integrations.
+    They log for custom integrations and raise for core and core integrations.
     """
     config_entry = MockConfigEntry()
     config_entry.add_to_hass(hass)
@@ -4278,23 +4283,37 @@ async def test_async_get_or_create_via_device_deprecated(
         config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
     )
 
-    what = "calls `device_registry.async_get_or_create` with a `via_device`"
+    what = (
+        "calls `device_registry.async_get_or_create` with a deprecated "
+        f"`{parameter}` parameter"
+    )
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers={("some_domain", "some_id")},
-            via_device=via_device,
+            **{parameter: value},
         )
 
     assert caplog.text.count(what) == expected_log
 
 
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("default_manufacturer", "manufacturer"),
+        ("default_model", "model"),
+        ("default_name", "name"),
+        ("via_device", ("some_domain", "via_id")),
+    ],
+)
 @pytest.mark.usefixtures("mock_integration_frame")
-async def test_async_get_or_create_via_device_reported_before_mutation(
+async def test_async_get_or_create_deprecated_parameter_reported_before_mutation(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    parameter: str,
+    value: Any,
 ) -> None:
-    """The via_device deprecation is reported before the registry is mutated.
+    """A deprecated parameter is reported before the registry is mutated.
 
     The default frame is a core integration, so the report raises; the new device must
     not be left partially created.
@@ -4309,7 +4328,7 @@ async def test_async_get_or_create_via_device_reported_before_mutation(
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers={("some_domain", "new_device")},
-            via_device=("some_domain", "via_id"),
+            **{parameter: value},
         )
 
     # The report raised before insertion, so no partial device was left behind.
@@ -4319,6 +4338,25 @@ async def test_async_get_or_create_via_device_reported_before_mutation(
         )
         is None
     )
+
+
+async def test_async_get_or_create_unexpected_keyword_argument(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test passing an unexpected keyword argument to async_get_or_create raises."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+
+    with pytest.raises(
+        TypeError,
+        match="got unexpected keyword arguments 'unexpected'",
+    ):
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("some_domain", "some_id")},
+            unexpected="value",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4235,12 +4235,12 @@ async def test_async_get_device_deprecated(
 
 
 @pytest.mark.parametrize(
-    ("parameter", "value"),
+    ("parameter", "value", "replacement"),
     [
-        ("default_manufacturer", "manufacturer"),
-        ("default_model", "model"),
-        ("default_name", "name"),
-        ("via_device", ("some_domain", "via_id")),
+        ("default_manufacturer", "manufacturer", "manufacturer"),
+        ("default_model", "model", "model"),
+        ("default_name", "name", "name"),
+        ("via_device", ("some_domain", "via_id"), "via_device_id"),
     ],
 )
 @pytest.mark.parametrize(
@@ -4270,6 +4270,7 @@ async def test_async_get_or_create_deprecated_parameters(
     caplog: pytest.LogCaptureFixture,
     parameter: str,
     value: Any,
+    replacement: str,
     expectation: AbstractContextManager,
     expected_log: int,
 ) -> None:
@@ -4285,7 +4286,7 @@ async def test_async_get_or_create_deprecated_parameters(
 
     what = (
         "calls `device_registry.async_get_or_create` with a deprecated "
-        f"`{parameter}` parameter"
+        f"`{parameter}` parameter; use `{replacement}` instead"
     )
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
         device_registry.async_get_or_create(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1531,7 +1531,7 @@ async def test_device_info_called(
 async def test_device_info_not_overrides(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
-    """Test device info is forwarded correctly."""
+    """Test re-registering a device does not override existing values."""
     config_entry = MockConfigEntry(entry_id="super-mock-id")
     config_entry.add_to_hass(hass)
     device = device_registry.async_get_or_create(
@@ -1556,9 +1556,6 @@ async def test_device_info_not_overrides(
                     unique_id="qwer",
                     device_info={
                         "connections": {(dr.CONNECTION_NETWORK_MAC, "abcd")},
-                        "default_name": "default name 1",
-                        "default_model": "default model 1",
-                        "default_manufacturer": "default manufacturer 1",
                     },
                 )
             ]
@@ -2734,8 +2731,8 @@ async def test_device_name_defaulting_config_entry(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     config_entry_title: str,
-    entity_device_name: str,
-    entity_device_default_name: str,
+    entity_device_name: str | None,
+    entity_device_default_name: str | None,
     expected_device_name: str,
 ) -> None:
     """Test setting the device name based on input info."""
@@ -2767,8 +2764,11 @@ async def test_device_name_defaulting_config_entry(
         hass, platform_name=config_entry.domain, platform=platform
     )
 
-    assert await entity_platform.async_setup_entry(config_entry)
-    await hass.async_block_till_done()
+    # `default_name` is deprecated in the device registry; suppress the deprecation
+    # report so it does not raise when the entity is added.
+    with patch.object(dr, "report_usage"):
+        assert await entity_platform.async_setup_entry(config_entry)
+        await hass.async_block_till_done()
 
     device = device_registry.async_get_device_by_connection(
         (dr.CONNECTION_NETWORK_MAC, "1234"), config_entry.entry_id
@@ -2783,7 +2783,6 @@ async def test_device_name_defaulting_config_entry(
         # No identifiers
         ({}, 1),  # Empty device info does not prevent the entity from being created
         ({"name": "bla"}, 0),
-        ({"default_name": "bla"}, 0),
     ],
 )
 async def test_device_type_error_checking(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `default_manufacturer`, `default_model` and `default_name` members in DeviceInfo

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
