### PR TITLE
Fix OTBR creating duplicate config entry on add-on restart

### DIFF
--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.homeassistant_yellow import hardware as yellow_har
 from homeassistant.components.thread import async_get_preferred_dataset
 from homeassistant.config_entries import (
     SOURCE_HASSIO,
+    ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
@@ -186,6 +187,22 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
+    @callback
+    def _async_find_legacy_entry_by_host(self, host: str) -> ConfigEntry | None:
+        """Return an entry created by the first version of the integration.
+
+        Those entries have no unique id, they can only be matched by host.
+        This can be removed in HA Core 2027.3.
+        """
+        for entry in self._async_current_entries():
+            if (
+                entry.source == SOURCE_HASSIO
+                and entry.unique_id is None
+                and yarl.URL(entry.data["url"]).host == host
+            ):
+                return entry
+        return None
+
     @override
     async def async_step_hassio(
         self, discovery_info: HassioServiceInfo
@@ -195,48 +212,30 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
         url = f"http://{config['host']}:{config['port']}"
         config_entry_data = {"url": url}
 
-        # Entries created by the first version of the integration have no unique id
-        # and are matched by host below, unless another entry already claims the uuid
-        # This can be removed in HA Core 2027.3
-        entry_with_uuid = self.hass.config_entries.async_entry_for_domain_unique_id(
+        matching_entry = self.hass.config_entries.async_entry_for_domain_unique_id(
             DOMAIN, discovery_info.uuid
         )
+        if matching_entry is None:
+            # Entries created by the first version of the integration have no unique
+            # id and can only be matched to this discovery by host
+            # This fallback can be removed in HA Core 2027.3
+            matching_entry = self._async_find_legacy_entry_by_host(config["host"])
 
-        if current_entries := self._async_current_entries():
-            for current_entry in current_entries:
-                if current_entry.source != SOURCE_HASSIO:
-                    continue
-                current_url = yarl.URL(current_entry.data["url"])
-                if not (unique_id := current_entry.unique_id):
-                    # The first version did not set a unique_id
-                    # so if the entry does not have a unique_id
-                    # we have to assume it's the first version, which can only be
-                    # matched to this discovery by host
-                    # This check can be removed in HA Core 2027.3
-                    if (
-                        entry_with_uuid is not None
-                        or current_url.host != config["host"]
-                    ):
-                        continue
-                    unique_id = discovery_info.uuid
+        if matching_entry is not None:
+            # Update the URL in case the add-on moved, and set the unique id of
+            # entries created by the first version
+            # Remove the unique_id update in HA Core 2027.3
+            updated = self.hass.config_entries.async_update_entry(
+                matching_entry,
+                data=config_entry_data,
+                unique_id=discovery_info.uuid,
+            )
+            if not updated and matching_entry.state is ConfigEntryState.LOADED:
+                # Reload the entry since OTBR has restarted, an entry which was
+                # updated is reloaded by its update listener
+                await self.hass.config_entries.async_reload(matching_entry.entry_id)
 
-                if unique_id != discovery_info.uuid:
-                    continue
-
-                # The entry is updated in place when the add-on has moved, the
-                # unique_id is only missing for entries created by the first version
-                # Remove the unique_id update in HA Core 2027.3
-                updated = self.hass.config_entries.async_update_entry(
-                    current_entry,
-                    data=config_entry_data,
-                    unique_id=unique_id,
-                )
-                if not updated and current_entry.state is ConfigEntryState.LOADED:
-                    # Reload the entry since OTBR has restarted, an entry which was
-                    # updated is reloaded by its update listener
-                    await self.hass.config_entries.async_reload(current_entry.entry_id)
-
-                return self.async_abort(reason="already_configured")
+            return self.async_abort(reason="already_configured")
 
         try:
             await self._connect_and_configure_router(url)

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -195,6 +195,13 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
         url = f"http://{config['host']}:{config['port']}"
         config_entry_data = {"url": url}
 
+        # Entries created by the first version of the integration have no unique id
+        # and are matched by host below, unless another entry already claims the uuid
+        # This can be removed in HA Core 2027.3
+        entry_with_uuid = self.hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, discovery_info.uuid
+        )
+
         if current_entries := self._async_current_entries():
             for current_entry in current_entries:
                 if current_entry.source != SOURCE_HASSIO:
@@ -206,7 +213,10 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     # we have to assume it's the first version, which can only be
                     # matched to this discovery by host
                     # This check can be removed in HA Core 2027.3
-                    if current_url.host != config["host"]:
+                    if (
+                        entry_with_uuid is not None
+                        or current_url.host != config["host"]
+                    ):
                         continue
                     unique_id = discovery_info.uuid
 

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -213,18 +213,17 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                 if unique_id != discovery_info.uuid:
                     continue
 
-                if (
-                    current_url.host != config["host"]
-                    or current_url.port != config["port"]
-                ):
-                    # Update URL with the new host and port
-                    self.hass.config_entries.async_update_entry(
-                        current_entry,
-                        data=config_entry_data,
-                        unique_id=unique_id,  # Remove in HA Core 2025.9
-                    )
-                elif current_entry.state is ConfigEntryState.LOADED:
-                    # Reload the entry since OTBR has restarted
+                # The entry is updated in place when the add-on has moved, the
+                # unique_id is only missing for entries created by the first version
+                # Remove the unique_id update in HA Core 2025.9
+                updated = self.hass.config_entries.async_update_entry(
+                    current_entry,
+                    data=config_entry_data,
+                    unique_id=unique_id,
+                )
+                if not updated and current_entry.state is ConfigEntryState.LOADED:
+                    # Reload the entry since OTBR has restarted, an entry which was
+                    # updated is reloaded by its update listener
                     await self.hass.config_entries.async_reload(current_entry.entry_id)
 
                 return self.async_abort(reason="already_configured")

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -205,7 +205,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     # so if the entry does not have a unique_id
                     # we have to assume it's the first version, which can only be
                     # matched to this discovery by host
-                    # This check can be removed in HA Core 2025.9
+                    # This check can be removed in HA Core 2027.3
                     if current_url.host != config["host"]:
                         continue
                     unique_id = discovery_info.uuid
@@ -215,7 +215,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # The entry is updated in place when the add-on has moved, the
                 # unique_id is only missing for entries created by the first version
-                # Remove the unique_id update in HA Core 2025.9
+                # Remove the unique_id update in HA Core 2027.3
                 updated = self.hass.config_entries.async_update_entry(
                     current_entry,
                     data=config_entry_data,

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -230,7 +230,11 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                 data=config_entry_data,
                 unique_id=discovery_info.uuid,
             )
-            if not updated and matching_entry.state is ConfigEntryState.LOADED:
+            if matching_entry.state is ConfigEntryState.SETUP_RETRY:
+                # The discovery means the add-on is back, don't wait for the
+                # setup retry backoff to expire
+                self.hass.config_entries.async_schedule_reload(matching_entry.entry_id)
+            elif not updated and matching_entry.state is ConfigEntryState.LOADED:
                 # Reload the entry since OTBR has restarted, an entry which was
                 # updated is reloaded by its update listener
                 await self.hass.config_entries.async_reload(matching_entry.entry_id)

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -203,8 +203,11 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                 if not (unique_id := current_entry.unique_id):
                     # The first version did not set a unique_id
                     # so if the entry does not have a unique_id
-                    # we have to assume it's the first version
+                    # we have to assume it's the first version, which can only be
+                    # matched to this discovery by host
                     # This check can be removed in HA Core 2025.9
+                    if current_url.host != config["host"]:
+                        continue
                     unique_id = discovery_info.uuid
 
                 if unique_id != discovery_info.uuid:
@@ -212,23 +215,18 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 if (
                     current_url.host != config["host"]
-                    or current_url.port == config["port"]
+                    or current_url.port != config["port"]
                 ):
+                    # Update URL with the new host and port
+                    self.hass.config_entries.async_update_entry(
+                        current_entry,
+                        data=config_entry_data,
+                        unique_id=unique_id,  # Remove in HA Core 2025.9
+                    )
+                elif current_entry.state is ConfigEntryState.LOADED:
                     # Reload the entry since OTBR has restarted
-                    if current_entry.state is ConfigEntryState.LOADED:
-                        assert current_entry.unique_id is not None
-                        await self.hass.config_entries.async_reload(
-                            current_entry.entry_id
-                        )
+                    await self.hass.config_entries.async_reload(current_entry.entry_id)
 
-                    continue
-
-                # Update URL with the new port
-                self.hass.config_entries.async_update_entry(
-                    current_entry,
-                    data=config_entry_data,
-                    unique_id=unique_id,  # Remove in HA Core 2025.9
-                )
                 return self.async_abort(reason="already_configured")
 
         try:

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     FirmwareInfo,
     OwningAddon,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
@@ -993,6 +994,84 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
     }
     config_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert config_entry.data == expected_data
+
+
+@pytest.mark.usefixtures("get_border_agent_id")
+async def test_hassio_discovery_flow_new_host(hass: HomeAssistant) -> None:
+    """Test the host can be updated."""
+    mock_integration(hass, MockModule("hassio"))
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={
+            "url": f"http://core-silabs-multiprotocol_old:{HASSIO_DATA.config['port']}"
+        },
+        domain=otbr.DOMAIN,
+        options={},
+        source="hassio",
+        title="Open Thread Border Router",
+        unique_id=HASSIO_DATA.uuid,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    expected_data = {
+        "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+    }
+    assert hass.config_entries.async_entries(otbr.DOMAIN) == [config_entry]
+    assert config_entry.data == expected_data
+
+
+@pytest.mark.parametrize(
+    "entry_state",
+    [
+        ConfigEntryState.NOT_LOADED,
+        ConfigEntryState.SETUP_RETRY,
+    ],
+)
+@pytest.mark.usefixtures(
+    "otbr_addon_info",
+    "get_active_dataset_tlvs",
+    "get_border_agent_id",
+    "get_extended_address",
+)
+async def test_hassio_discovery_flow_addon_restarted_entry_not_loaded(
+    hass: HomeAssistant, entry_state: ConfigEntryState
+) -> None:
+    """Test no duplicate entry is created when the add-on restarts while unloaded.
+
+    The config entry is unloaded while the ZBT-1 or ZBT-2 firmware is updated, and
+    the add-on is restarted before the entry is set up again.
+    """
+    mock_integration(hass, MockModule("hassio"))
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={
+            "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}"
+        },
+        domain=otbr.DOMAIN,
+        options={},
+        source="hassio",
+        title="Open Thread Border Router",
+        unique_id=HASSIO_DATA.uuid,
+    )
+    config_entry.add_to_hass(hass)
+    config_entry.mock_state(hass, entry_state)
+
+    result = await hass.config_entries.flow.async_init(
+        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert hass.config_entries.async_entries(otbr.DOMAIN) == [config_entry]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from http import HTTPStatus
 import re
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import aiohttp
 import pytest
@@ -1049,10 +1049,10 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
 
 
 @pytest.mark.parametrize(
-    "entry_state",
+    ("entry_state", "expected_reloads"),
     [
-        ConfigEntryState.NOT_LOADED,
-        ConfigEntryState.SETUP_RETRY,
+        (ConfigEntryState.NOT_LOADED, 0),
+        (ConfigEntryState.SETUP_RETRY, 1),
     ],
 )
 @pytest.mark.usefixtures(
@@ -1062,12 +1062,13 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
     "get_extended_address",
 )
 async def test_hassio_discovery_flow_addon_restarted_entry_not_loaded(
-    hass: HomeAssistant, entry_state: ConfigEntryState
+    hass: HomeAssistant, entry_state: ConfigEntryState, expected_reloads: int
 ) -> None:
     """Test no duplicate entry is created when the add-on restarts while unloaded.
 
     The config entry is unloaded while the ZBT-1 or ZBT-2 firmware is updated, and
-    the add-on is restarted before the entry is set up again.
+    the add-on is restarted before the entry is set up again. An entry which is
+    retrying its setup is reloaded, the discovery means the add-on is back.
     """
     mock_integration(hass, MockModule("hassio"))
 
@@ -1085,13 +1086,20 @@ async def test_hassio_discovery_flow_addon_restarted_entry_not_loaded(
     config_entry.add_to_hass(hass)
     config_entry.mock_state(hass, entry_state)
 
-    result = await hass.config_entries.flow.async_init(
-        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
-    )
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_schedule_reload:
+        result = await hass.config_entries.flow.async_init(
+            otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(otbr.DOMAIN) == [config_entry]
+    assert (
+        mock_schedule_reload.mock_calls
+        == [call(config_entry.entry_id)] * expected_reloads
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -891,33 +891,46 @@ async def test_hassio_discovery_flow_404(
 
 
 @pytest.mark.parametrize(
-    ("entry_url", "entry_unique_id"),
+    ("entry_url", "entry_unique_id", "entry_state"),
     [
         pytest.param(
             f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}",
             HASSIO_DATA.uuid,
+            ConfigEntryState.NOT_LOADED,
             id="new_port",
         ),
         pytest.param(
             f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}",
             None,
+            ConfigEntryState.NOT_LOADED,
             id="new_port_missing_unique_id",
         ),
         pytest.param(
             f"http://core-silabs-multiprotocol-old:{HASSIO_DATA.config['port']}",
             HASSIO_DATA.uuid,
+            ConfigEntryState.NOT_LOADED,
             id="new_host",
         ),
         pytest.param(
             f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
             None,
+            ConfigEntryState.NOT_LOADED,
             id="same_url_missing_unique_id",
+        ),
+        pytest.param(
+            f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+            None,
+            ConfigEntryState.LOADED,
+            id="same_url_missing_unique_id_loaded",
         ),
     ],
 )
 @pytest.mark.usefixtures("get_border_agent_id")
 async def test_hassio_discovery_flow_updates_entry(
-    hass: HomeAssistant, entry_url: str, entry_unique_id: str | None
+    hass: HomeAssistant,
+    entry_url: str,
+    entry_unique_id: str | None,
+    entry_state: ConfigEntryState,
 ) -> None:
     """Test the URL and the unique id of the existing entry are updated."""
     mock_integration(hass, MockModule("hassio"))
@@ -932,6 +945,7 @@ async def test_hassio_discovery_flow_updates_entry(
         unique_id=entry_unique_id,
     )
     config_entry.add_to_hass(hass)
+    config_entry.mock_state(hass, entry_state)
 
     result = await hass.config_entries.flow.async_init(
         otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -890,24 +890,46 @@ async def test_hassio_discovery_flow_404(
     assert result["reason"] == "unknown"
 
 
+@pytest.mark.parametrize(
+    ("entry_url", "entry_unique_id"),
+    [
+        pytest.param(
+            f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}",
+            HASSIO_DATA.uuid,
+            id="new_port",
+        ),
+        pytest.param(
+            f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}",
+            None,
+            id="new_port_missing_unique_id",
+        ),
+        pytest.param(
+            f"http://core-silabs-multiprotocol-old:{HASSIO_DATA.config['port']}",
+            HASSIO_DATA.uuid,
+            id="new_host",
+        ),
+        pytest.param(
+            f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+            None,
+            id="same_url_missing_unique_id",
+        ),
+    ],
+)
 @pytest.mark.usefixtures("get_border_agent_id")
-async def test_hassio_discovery_flow_new_port_missing_unique_id(
-    hass: HomeAssistant,
+async def test_hassio_discovery_flow_updates_entry(
+    hass: HomeAssistant, entry_url: str, entry_unique_id: str | None
 ) -> None:
-    """Test the port can be updated when the unique id is missing."""
+    """Test the URL and the unique id of the existing entry are updated."""
     mock_integration(hass, MockModule("hassio"))
 
     # Setup the config entry
     config_entry = MockConfigEntry(
-        data={
-            "url": (
-                f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}"
-            )
-        },
+        data={"url": entry_url},
         domain=otbr.DOMAIN,
         options={},
         source="hassio",
         title="Open Thread Border Router",
+        unique_id=entry_unique_id,
     )
     config_entry.add_to_hass(hass)
 
@@ -921,42 +943,9 @@ async def test_hassio_discovery_flow_new_port_missing_unique_id(
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
     }
-    config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
+    assert hass.config_entries.async_entries(otbr.DOMAIN) == [config_entry]
     assert config_entry.data == expected_data
-
-
-@pytest.mark.usefixtures("get_border_agent_id")
-async def test_hassio_discovery_flow_new_port(hass: HomeAssistant) -> None:
-    """Test the port can be updated."""
-    mock_integration(hass, MockModule("hassio"))
-
-    # Setup the config entry
-    config_entry = MockConfigEntry(
-        data={
-            "url": (
-                f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port'] + 1}"
-            )
-        },
-        domain=otbr.DOMAIN,
-        options={},
-        source="hassio",
-        title="Open Thread Border Router",
-        unique_id=HASSIO_DATA.uuid,
-    )
-    config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-    expected_data = {
-        "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-    }
-    config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
-    assert config_entry.data == expected_data
+    assert config_entry.unique_id == HASSIO_DATA.uuid
 
 
 @pytest.mark.usefixtures(
@@ -993,38 +982,6 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
         "url": f"http://openthread_border_router:{HASSIO_DATA.config['port'] + 1}",
     }
     config_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
-    assert config_entry.data == expected_data
-
-
-@pytest.mark.usefixtures("get_border_agent_id")
-async def test_hassio_discovery_flow_new_host(hass: HomeAssistant) -> None:
-    """Test the host can be updated."""
-    mock_integration(hass, MockModule("hassio"))
-
-    # Setup the config entry
-    config_entry = MockConfigEntry(
-        data={
-            "url": f"http://core-silabs-multiprotocol_old:{HASSIO_DATA.config['port']}"
-        },
-        domain=otbr.DOMAIN,
-        options={},
-        source="hassio",
-        title="Open Thread Border Router",
-        unique_id=HASSIO_DATA.uuid,
-    )
-    config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-    expected_data = {
-        "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-    }
-    assert hass.config_entries.async_entries(otbr.DOMAIN) == [config_entry]
     assert config_entry.data == expected_data
 
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -968,6 +968,55 @@ async def test_hassio_discovery_flow_updates_entry(
     "get_border_agent_id",
     "get_extended_address",
 )
+async def test_hassio_discovery_flow_entry_without_unique_id_kept(
+    hass: HomeAssistant,
+) -> None:
+    """Test an entry without a unique id is left alone when the uuid is taken.
+
+    An entry created by the first version of the integration next to a newer entry
+    for the same add-on is the state older versions could leave behind.
+    """
+    mock_integration(hass, MockModule("hassio"))
+
+    url = f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}"
+    legacy_entry = MockConfigEntry(
+        data={"url": url},
+        domain=otbr.DOMAIN,
+        options={},
+        source="hassio",
+        title="Open Thread Border Router",
+        unique_id=None,
+    )
+    legacy_entry.add_to_hass(hass)
+    config_entry = MockConfigEntry(
+        data={"url": url},
+        domain=otbr.DOMAIN,
+        options={},
+        source="hassio",
+        title="Open Thread Border Router",
+        unique_id=HASSIO_DATA.uuid,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert legacy_entry.unique_id is None
+    assert hass.config_entries.async_entries(otbr.DOMAIN) == [
+        legacy_entry,
+        config_entry,
+    ]
+
+
+@pytest.mark.usefixtures(
+    "otbr_addon_info",
+    "get_active_dataset_tlvs",
+    "get_border_agent_id",
+    "get_extended_address",
+)
 async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -> None:
     """Test the port is not updated if we get data for another addon hosting OTBR."""
     mock_integration(hass, MockModule("hassio"))


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where a warning is logged when the OTBR add-on is rediscovered:
- "Detected that integration 'otbr' creates a config entry when another entry with the same unique ID exists"

This usually happens when updating ZBT-1/ZBT-2/Yellow firmware, because we still fell through to `async_create_entry` with the `continue`, even though we had already found the matching config entry.

The config entry is unloaded while the add-on restarts, so the border agent ID check that normally catches this does not see it either. We now update or reload the entry as needed and correctly abort the hassio discovery with `already_configured`. (cc @puddly)

### Why aborting is correct

Per comment in [`config_entries.py`](https://github.com/home-assistant/core/blob/281bec203b8eb137cb099878341031e8b0adf005/homeassistant/config_entries.py#L1784-L1799) and the [config flow unique ID dev blog post](https://developers.home-assistant.io/blog/2025/03/01/config-flow-unique-id/), the new behavior is correct: a non-user visible flow should (optionally) update the existing entry before aborting.

But note that we can't use `_abort_if_unique_id_configured()` here, since earlier-created entries have no unique ID to match on. That method also only reloads a **loaded** entry when its data changed, yet the add-on restarting with the same URL needs a reload without any data change. We do follow its other rule and reload an entry which is in `SETUP_RETRY`, keeping similar current behavior, where this is essentially done when the config entry is replaced.

### Broken unique ID migration

This PR also fixes an issue where adding the unique ID to a legacy config entry did not actually work. Before, it only ever worked if the host is the same but the port changed. Now it also works when the URL is unchanged. (Entries that already have a unique ID additionally get their URL updated when only the host changed, which did not work before either.)

Unfortunately, instances with two OTBR config entries for the same host already exist now, so we can't just migrate all by host. We leave the older one untouched with this PR to keep that behavior as is and not end up with two config entries sharing the same unique ID. (So that part works similarly to current `dev` but we fix the UID migration for other entries.)

The "remove in HA Core 2025.9" markers on that legacy fallback move to 2027.3, since the migration effectively only starts working with this PR.

For a possible follow-up PR, we may want to either spawn a repair to delete the old broken config entries, or rather just delete those entries automatically outside of the discovery flow.



## Detailed AI-generated PR description

There's a way more detailed PR description below. It might be useful to at least skim it to understand the issue(s)/fix better.

<details><summary>LLM-generated PR description (<b>CLICK TO EXPAND</b>)</summary>
<p>

Fixes the long standing `Detected that integration 'otbr' creates a config entry when another entry with the same unique ID exists` warning. Reporters typically see it right after updating the firmware of a Connect ZBT-1/ZBT-2 or a Yellow, or after an OTBR add-on update.

### The bug

`async_step_hassio` looped over the existing hassio config entries, and the loop had exactly one exit:

| Existing hassio entry vs. the discovery | What the loop did |
| --- | --- |
| Same host, **new port** | update the URL, `return` abort — the only exit |
| Same host, **same port** | reload it (only when loaded), `continue` |
| **Different host** | reload it (only when loaded), `continue` |
| Different UUID | `continue` — correct, this is a second add-on |

Those rows are for an entry that has a unique ID. An entry created by the first version of the integration has none, and is covered further down.

Every `continue` eventually ran the loop out, and the code after the loop creates an entry. So everything except "the add-on moved to a new port" ran past the loop into `async_create_entry()`, including the most ordinary event in the integration's life: the add-on restarting on an unchanged URL.

When that really did create the duplicate — the next section covers when it did not — what it left behind depends on the entry:

| Existing entry | Result |
| --- | --- |
| Has a unique ID | core unloads it and replaces it with the new one, so a single entry survives, but under a new entry ID |
| No unique ID (first version) | core has nothing to match it against, so it is not replaced and the install ends up with **two** OTBR entries, without even the warning |

### Why it usually goes unnoticed

The duplicate was normally caught one step later: `_connect_and_configure_router()` raises `AlreadyConfigured` when another entry's OTBR reports the same border agent ID. But `_is_border_agent_id_configured()` reads `runtime_data`, so it can only iterate *loaded* entries. If the matching entry is not loaded, nothing catches the duplicate.

### Why a firmware update triggers it

A firmware update is exactly that situation. `homeassistant_hardware`'s `async_firmware_flashing_context()` unloads the OTBR config entry and stops the OTBR add-on for the duration of the flash, and on the way out it restarts the add-on *before* setting the config entry back up. The add-on restart triggers a hassio discovery while the entry is still unloaded, and the flow runs all the way into `async_create_entry()`.

### The fix

The flow now looks the entry up instead of scanning, and always aborts with `already_configured` once it has one, instead of falling through:

- `async_entry_for_domain_unique_id()` gives the entry owning the discovery's UUID. Only when nothing owns it does the flow fall back to matching an entry created by the very first version of the integration, which has no unique ID, by host. The fallback can therefore never claim a discovery another entry owns.
- The entry is updated in place. This covers the previous "the add-on is now on a different port" case, and it also backfills the unique ID of those first-version entries.
- An entry in `SETUP_RETRY` is reloaded straight away, since the discovery proves the add-on is back and there is no point waiting out the retry backoff. This is what `_abort_if_unique_id_configured()` does for discovery flows, and it has to happen regardless of whether the update changed anything, because an entry which is retrying setup has no update listener registered yet.
- Otherwise the entry is only reloaded explicitly when the update changed nothing, which is the "the add-on restarted on the same URL" case. An entry that *was* changed is already reloaded by the integration's own update listener, which exists while the entry is loaded, so this avoids reloading it twice.

Reloading a `NOT_LOADED` entry is deliberately avoided. That state is recoverable, so reloading it would *set it up* behind the update flow's back, and that flow's own closing `async_setup()` would then raise `OperationNotAllowed`.

### Other changes in the same loop

- The "an entry created by the first version has no unique ID" fallback now only claims a discovery whose host matches the entry's URL. Such an entry used to match *any* OTBR discovery. That stayed harmless while such an entry was unloaded, because the loop fell through afterwards and the other add-on ended up with its own entry (a loaded one raised the `assert` below instead), but now that the loop always aborts on a match, the guard is what keeps a legacy entry for one add-on from claiming the discovery of a different one.
- Because the fallback only runs when nothing owns the discovery's UUID, it can no longer adopt an entry while another one holds that UUID. An install that hit the second row of the table above has exactly that pair of entries, and backfilling a unique ID that is already in use makes core log an error.
- The older entry therefore keeps no unique ID for as long as the newer one exists, and is never matched. Nothing is orphaned, since an OTBR entry owns no devices or entities, and deleting the newer entry makes the next discovery adopt and migrate the older one. Removing the leftover entry is out of scope here — doing it from inside a discovery flow is the wrong place for it — but a repair issue offering to clean up the pair would be a reasonable follow-up.
- An `assert current_entry.unique_id is not None` in the reload branch is dropped. A loaded legacy entry reached it, and since those have no unique ID by definition, it raised inside the flow.

### The removal marker moves to HA Core 2027.3

The `unique_id` backfill sat in the update branch, so it only ever ran on the one path that reached it:

| Entry created by the first version (no unique ID) | What happened |
| --- | --- |
| Same host, new port | backfilled — the only path that migrated an entry |
| Same URL, entry loaded | `assert current_entry.unique_id is not None` raised inside the flow |
| Same URL, entry not loaded | a duplicate was created next to it — core cannot match an entry that has no unique ID, so the install was left with two entries and this one was never migrated |
| Different host | loaded: the same `assert` raised. Not loaded: the other add-on's discovery fell through and correctly created its own entry. Either way this entry stayed unmigrated |

Entries without a unique ID can therefore still exist, and the migration effectively starts with this PR rather than having run since 2025.9. The backfill now happens on every match, so for most of them the first discovery after this lands is what migrates them.

### Tests

- The two nearly identical "the entry URL is updated" tests are merged into a single parametrized test, which also covers a changed host and asserts the resulting unique ID.
- Its cases include a legacy entry seeing an unchanged URL, loaded and unloaded, the two paths where the unique ID was not being backfilled.
- A regression test covers a discovery arriving while the entry is `NOT_LOADED` or `SETUP_RETRY`. Without the fix it reproduces the reported warning and creates the duplicate entry.
- Another covers the entry pair an affected install can already have. Without the fix, the older entry ends up holding a unique ID that is already in use, which core logs as an error.

### Known gaps and possible follow-ups

None of these are caused or worsened by this PR, they are listed so they are not lost:

- The leftover entry on an install that already has two could be cleaned up, either by a repair issue offering to remove it or during entry setup.
- When the legacy fallback is removed in HA Core 2027.3, note that entries which were never matched because another entry owns their UUID still have no unique ID, so that change cannot assume every entry has been migrated by then.

</p>
</details>


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #142313
- This PR is related to issue: #151906
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
