### PR TITLE
Migrate integration tests to call dr.async_entries_for_config_entry

### DIFF
--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -164,7 +164,7 @@ async def test_dhcp_flow_simple(
     assert gateway_device.manufacturer == "Intergas"
     assert gateway_device.connections == {("mac", "00:04:a3:de:ad:ff")}
 
-    devices = device_registry.devices.get_devices_for_config_entry_id(entry_id)
+    devices = dr.async_entries_for_config_entry(device_registry, entry_id)
     assert len(devices) == 3
     boiler_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, "c0ffeec0ffee"), entry_id
@@ -212,8 +212,8 @@ async def test_dhcp_flow_migrates_existing_entry_without_unique_id(
     assert gateway_device.manufacturer == "Intergas"
     assert gateway_device.connections == {("mac", "00:04:a3:de:ad:ff")}
 
-    devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_config_entry.entry_id
+    devices = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
     )
     assert len(devices) == 3
     boiler_device = device_registry.async_get_device_by_identifier(

--- a/tests/components/incomfort/test_init.py
+++ b/tests/components/incomfort/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.components.incomfort.coordinator import UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceRegistry
 
 from .conftest import MOCK_HEATER_STATUS
@@ -81,8 +81,8 @@ async def test_stale_devices_cleanup(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.LOADED
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    old_entries = device_registry.devices.get_devices_for_config_entry_id(
-        mock_config_entry.entry_id
+    old_entries = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
     )
     assert len(old_entries) == 3
     old_heater = device_registry.async_get_device_by_identifier(
@@ -103,8 +103,8 @@ async def test_stale_devices_cleanup(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    new_entries = device_registry.devices.get_devices_for_config_entry_id(
-        mock_config_entry.entry_id
+    new_entries = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
     )
     assert len(new_entries) == 3
     new_heater = device_registry.async_get_device_by_identifier(

--- a/tests/components/knx/test_interface_device.py
+++ b/tests/components/knx/test_interface_device.py
@@ -124,8 +124,8 @@ async def test_remove_interface_device(
     assert await async_setup_component(hass, "config", {})
     await knx.setup_integration()
     client = await hass_ws_client(hass)
-    knx_devices = device_registry.devices.get_devices_for_config_entry_id(
-        knx.mock_config_entry.entry_id
+    knx_devices = dr.async_entries_for_config_entry(
+        device_registry, knx.mock_config_entry.entry_id
     )
     assert len(knx_devices) == 1
     assert knx_devices[0].name == "KNX Interface"

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -73,8 +73,8 @@ async def test_stale_device(
     await hass.async_block_till_done()
     if mock_roborock_entry._background_tasks:
         await asyncio.gather(*mock_roborock_entry._background_tasks)
-    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    existing_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
     )
     assert {device.name for device in existing_devices} == {
         "Roborock S7 MaxV",
@@ -95,8 +95,8 @@ async def test_stale_device(
     await hass.async_block_till_done()
     if mock_roborock_entry._background_tasks:
         await asyncio.gather(*mock_roborock_entry._background_tasks)
-    new_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    new_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
     )
     assert {device.name for device in new_devices} == {
         "Roborock S7 2",
@@ -120,8 +120,8 @@ async def test_no_stale_device(
     await hass.async_block_till_done()
     if mock_roborock_entry._background_tasks:
         await asyncio.gather(*mock_roborock_entry._background_tasks)
-    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    existing_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
     )
     assert {device.name for device in existing_devices} == {
         "Roborock S7 MaxV",
@@ -138,8 +138,8 @@ async def test_no_stale_device(
     await hass.async_block_till_done()
     if mock_roborock_entry._background_tasks:
         await asyncio.gather(*mock_roborock_entry._background_tasks)
-    new_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    new_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
     )
     assert {device.name for device in new_devices} == {
         "Roborock S7 MaxV",
@@ -700,8 +700,8 @@ async def test_disabled_device_no_coordinator(
     assert all(coord.duid != first_device.duid for coord in coordinators.v1)
 
     # Other devices should still be set up
-    found_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    found_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
     )
     enabled_device_names = {
         device.name for device in found_devices if not device.disabled

--- a/tests/components/wmspro/test_init.py
+++ b/tests/components/wmspro/test_init.py
@@ -91,8 +91,8 @@ async def test_device_setup(
     assert len(mock_hub_configuration.mock_calls) == 1
     assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
-    device_entries = device_registry.devices.get_devices_for_config_entry_id(
-        mock_config_entry.entry_id
+    device_entries = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
     )
     assert len(device_entries) > len(mock_hub_configuration.destinations)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate integration tests to call `dr.async_entries_for_config_entry` instead of calling `DeviceRegistry.devices.get_devices_for_config_entry_id` which is not meant for public use

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
