### PR TITLE
Add web session injection in Actron Air

### DIFF
--- a/homeassistant/components/actron_air/__init__.py
+++ b/homeassistant/components/actron_air/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
 from .coordinator import (
@@ -27,7 +28,10 @@ PLATFORMS = [
 async def async_setup_entry(hass: HomeAssistant, entry: ActronAirConfigEntry) -> bool:
     """Set up Actron Air integration from a config entry."""
 
-    api = ActronAirAPI(refresh_token=entry.data[CONF_API_TOKEN])
+    api = ActronAirAPI(
+        refresh_token=entry.data[CONF_API_TOKEN],
+        session=async_get_clientsession(hass),
+    )
     systems: list[ActronAirSystemInfo] = []
 
     try:

--- a/homeassistant/components/actron_air/config_flow.py
+++ b/homeassistant/components/actron_air/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_API_TOKEN
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
 
@@ -37,7 +38,7 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if self._api is None:
             LOGGER.debug("Initiating device authorization")
-            self._api = ActronAirAPI()
+            self._api = ActronAirAPI(session=async_get_clientsession(self.hass))
             try:
                 device_code_response = await self._api.request_device_code()
             except ActronAirAuthError as err:

--- a/homeassistant/components/actron_air/quality_scale.yaml
+++ b/homeassistant/components/actron_air/quality_scale.yaml
@@ -74,5 +74,5 @@ rules:
 
   # Platinum
   async-dependency: done
-  inject-websession: todo
+  inject-websession: done
   strict-typing: done

--- a/tests/components/actron_air/conftest.py
+++ b/tests/components/actron_air/conftest.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_actron_api() -> Generator[AsyncMock]:
+def mock_actron_api_class() -> Generator[MagicMock]:
     """Mock the Actron Air API class."""
     with (
         patch(
@@ -32,6 +32,14 @@ def mock_actron_api() -> Generator[AsyncMock]:
             "homeassistant.components.actron_air.config_flow.ActronAirAPI",
             new=mock_api,
         ),
+    ):
+        yield mock_api
+
+
+@pytest.fixture
+def mock_actron_api(mock_actron_api_class: MagicMock) -> Generator[AsyncMock]:
+    """Mock the Actron Air API instance."""
+    with (
         patch.object(ActronAirACSystem, "set_system_mode", new_callable=AsyncMock),
         patch.object(
             ActronAirUserAirconSettings, "set_away_mode", new_callable=AsyncMock
@@ -54,7 +62,7 @@ def mock_actron_api() -> Generator[AsyncMock]:
             ActronAirUserAirconSettings, "set_fan_mode", new_callable=AsyncMock
         ),
     ):
-        api = mock_api.return_value
+        api = mock_actron_api_class.return_value
 
         # Mock device code request
         api.request_device_code.return_value = ActronAirDeviceCode(

--- a/tests/components/actron_air/test_config_flow.py
+++ b/tests/components/actron_air/test_config_flow.py
@@ -1,7 +1,7 @@
 """Config flow tests for the Actron Air Integration."""
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from actron_neo_api import ActronAirAuthError
 from actron_neo_api.models.auth import ActronAirUserInfo
@@ -12,8 +12,26 @@ from homeassistant.components.actron_air.const import DOMAIN
 from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_actron_api")
+async def test_user_flow_uses_shared_session(
+    hass: HomeAssistant, mock_actron_api_class: MagicMock
+) -> None:
+    """Test the API is created with Home Assistant's shared client session."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert mock_actron_api_class.call_args.kwargs["session"] is async_get_clientsession(
+        hass
+    )
+
+    await hass.async_block_till_done()
+    await hass.config_entries.flow.async_configure(result["flow_id"])
 
 
 @pytest.mark.usefixtures("mock_setup_entry")

--- a/tests/components/actron_air/test_init.py
+++ b/tests/components/actron_air/test_init.py
@@ -10,10 +10,26 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_actron_api")
+async def test_setup_entry_uses_shared_session(
+    hass: HomeAssistant,
+    mock_actron_api_class: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the API is created with Home Assistant's shared client session."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_actron_api_class.call_args.kwargs["session"] is async_get_clientsession(
+        hass
+    )
 
 
 async def test_setup_entry_auth_error(


### PR DESCRIPTION
## Proposed change
Adds web session injection (Platinum integration quality scale) ahead of switching from Cloud Poll to Cloud Push. The library pre-requisite bump was pushed in #179108. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
