### PR TITLE
Fix some Matter bridged devices being merged into their bridge

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -213,8 +213,15 @@ class MatterAdapter:
         serial_number: str | None = None
         # if available, we also add the serialnumber as identifier
         if (
-            basic_info_serial_number := basic_info.serialNumber
-        ) and "test" not in basic_info_serial_number.lower():
+            (basic_info_serial_number := basic_info.serialNumber)
+            and "test" not in basic_info_serial_number.lower()
+            # some bridges report their own serialnumber for the devices they bridge,
+            # which would make the identifier resolve to the bridge's device
+            and not (
+                isinstance(basic_info, clusters.BridgedDeviceBasicInformation)
+                and basic_info_serial_number == endpoint.node.device_info.serialNumber
+            )
+        ):
             # prefix identifier with 'serial_' to be able to filter it
             identifiers.add((DOMAIN, f"{ID_TYPE_SERIAL}_{basic_info_serial_number}"))
             serial_number = basic_info_serial_number

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -212,11 +212,11 @@ class MatterAdapter:
         node_device_identifier = (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")
         identifiers = {node_device_identifier}
         serial_number: str | None = None
-        # if available, we also add the serialnumber as identifier
+        # if available, we also add the serial number as identifier
         if (
             (basic_info_serial_number := basic_info.serialNumber)
             and "test" not in basic_info_serial_number.lower()
-            # some bridges report their own serialnumber for the devices they bridge,
+            # some bridges report their own serial number for the devices they bridge,
             # which would make the identifier resolve to the bridge's device
             and not (
                 isinstance(basic_info, clusters.BridgedDeviceBasicInformation)

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -209,7 +209,24 @@ class MatterAdapter:
             server_info,
             endpoint,
         )
-        identifiers = {(DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")}
+        node_device_identifier = (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")
+        # a bridged device that was merged into the bridge's device by a shared serial
+        # number keeps resolving to it through the identifier it left behind there
+        if (
+            via_device_id is not UNDEFINED
+            and (
+                merged_device := device_registry.async_get_device_by_identifier(
+                    node_device_identifier, self.config_entry.entry_id
+                )
+            )
+            and merged_device.id == via_device_id
+        ):
+            device_registry.async_update_device(
+                merged_device.id,
+                new_identifiers=merged_device.identifiers - {node_device_identifier},
+            )
+
+        identifiers = {node_device_identifier}
         serial_number: str | None = None
         # if available, we also add the serialnumber as identifier
         if (

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -210,22 +210,6 @@ class MatterAdapter:
             endpoint,
         )
         node_device_identifier = (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")
-        # a bridged device that was merged into the bridge's device by a shared serial
-        # number keeps resolving to it through the identifier it left behind there
-        if (
-            via_device_id is not UNDEFINED
-            and (
-                merged_device := device_registry.async_get_device_by_identifier(
-                    node_device_identifier, self.config_entry.entry_id
-                )
-            )
-            and merged_device.id == via_device_id
-        ):
-            device_registry.async_update_device(
-                merged_device.id,
-                new_identifiers=merged_device.identifiers - {node_device_identifier},
-            )
-
         identifiers = {node_device_identifier}
         serial_number: str | None = None
         # if available, we also add the serialnumber as identifier
@@ -242,6 +226,18 @@ class MatterAdapter:
             # prefix identifier with 'serial_' to be able to filter it
             identifiers.add((DOMAIN, f"{ID_TYPE_SERIAL}_{basic_info_serial_number}"))
             serial_number = basic_info_serial_number
+
+        # the bridge's device entry keeps every identifier that was ever merged onto
+        # it, so a bridged device can still resolve to it through one left behind
+        if (
+            via_device_id is not UNDEFINED
+            and (via_device := device_registry.async_get(via_device_id))
+            and (stale_identifiers := via_device.identifiers & identifiers)
+        ):
+            device_registry.async_update_device(
+                via_device.id,
+                new_identifiers=via_device.identifiers - stale_identifiers,
+            )
 
         # Model name is the human readable name of the model/product name
         model_name = (

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -10,7 +10,7 @@ from homeassistant.components.matter.adapter import get_clean_name
 from homeassistant.components.matter.const import DOMAIN, ID_TYPE_DEVICE_ID
 from homeassistant.components.matter.helpers import get_device_id
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import create_node_from_fixture
 
@@ -359,6 +359,67 @@ async def test_device_registry_bridged_device_with_bridge_serial_number(
     assert bridged_entry.via_device_id == bridge_entry.id
     assert (DOMAIN, "serial_glg5mxh") not in bridged_entry.identifiers
     assert bridged_entry.serial_number is None
+
+
+async def test_device_registry_bridged_device_merged_into_bridge(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a bridged device that was merged into the bridge's device is split off.
+
+    A bridged device reporting the serial number of the bridge used to be merged
+    into the bridge's device entry, which keeps resolving to it through the
+    identifier that is left behind there.
+    """
+    node = create_node_from_fixture("atios_knx_bridge", {"29/57/15": "glg5mxh"})
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "ws://localhost:5580/ws"}
+    )
+    config_entry.add_to_hass(hass)
+
+    merged_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"),
+            (DOMAIN, "serial_glg5mxh"),
+        },
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "00000000000004D2-000000000000003E-29-29-ElectricalPowerMeasurementWatt-144-8",
+        config_entry=config_entry,
+        device_id=merged_entry.id,
+        suggested_object_id="electricity_monitor_ac_power",
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+        config_entry.entry_id,
+    )
+    assert bridge_entry is not None
+    assert bridge_entry.id == merged_entry.id
+    assert (DOMAIN, "serial_glg5mxh") in bridge_entry.identifiers
+
+    bridged_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"), config_entry.entry_id
+    )
+    assert bridged_entry is not None
+    assert bridged_entry.id != bridge_entry.id
+    assert bridged_entry.via_device_id == bridge_entry.id
+    assert hass.states.get("sensor.electricity_monitor_ac_power")
+
+    # the entities of the bridged device move to the device it is split off into
+    assert (
+        entity_registry.async_get(entity_entry.entity_id).device_id == bridged_entry.id
+    )
 
 
 @pytest.mark.usefixtures("matter_node")

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -330,6 +330,38 @@ async def test_composed_bridged_device_endpoint_removed(
 
 
 @pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["atios_knx_bridge"])
+@pytest.mark.parametrize(
+    "attributes", [{"29/57/15": "glg5mxh"}], ids=["bridge_serial_number"]
+)
+async def test_device_registry_bridged_device_with_bridge_serial_number(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a bridged device reporting the serial number of the bridge itself.
+
+    The serial number identifier must be skipped, as it would otherwise resolve
+    to the bridge's own device entry.
+    """
+    entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+        entry_id,
+    )
+    assert bridge_entry is not None
+    assert (DOMAIN, "serial_glg5mxh") in bridge_entry.identifiers
+
+    bridged_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"), entry_id
+    )
+    assert bridged_entry is not None
+    assert bridged_entry.id != bridge_entry.id
+    assert bridged_entry.via_device_id == bridge_entry.id
+    assert (DOMAIN, "serial_glg5mxh") not in bridged_entry.identifiers
+    assert bridged_entry.serial_number is None
+
+
+@pytest.mark.usefixtures("matter_node")
 @pytest.mark.parametrize("node_fixture", ["mock_air_purifier"])
 async def test_device_registry_single_node_composed_device(
     hass: HomeAssistant,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -470,9 +470,10 @@ async def test_bad_node_not_crash_integration(
     assert "Error setting up node" in caplog.text
 
 
-@pytest.mark.usefixtures("matter_node")
 @pytest.mark.parametrize("node_fixture", ["mock_composed_bridge"])
-@pytest.mark.parametrize("attributes", [{"2/57/15": "MB-1234"}], ids=["bridge_serial"])
+@pytest.mark.parametrize(
+    "attributes", [{"2/57/15": "MB-1234"}], ids=["bridge_serial_number"]
+)
 async def test_composed_bridged_device_with_bridge_serial_number(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -468,3 +468,31 @@ async def test_bad_node_not_crash_integration(
     assert hass.states.get("light.mock_onoff_light") is not None
     assert len(hass.states.async_all("light")) == 1
     assert "Error setting up node" in caplog.text
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["mock_composed_bridge"])
+@pytest.mark.parametrize("attributes", [{"2/57/15": "MB-1234"}], ids=["bridge_serial"])
+async def test_composed_bridged_device_with_bridge_serial_number(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test a composed bridged device reporting the serial number of the bridge."""
+    entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        identifier_for(matter_client, matter_node, 0), entry_id
+    )
+    assert bridge_entry is not None
+
+    # the part endpoints 3 and 4 are represented by the device of their compose parent
+    identifier = identifier_for(matter_client, matter_node, 2)
+    assert identifier_for(matter_client, matter_node, 3) == identifier
+    assert identifier_for(matter_client, matter_node, 4) == identifier
+
+    device_entry = device_registry.async_get_device_by_identifier(identifier, entry_id)
+    assert device_entry is not None
+    assert device_entry.id != bridge_entry.id
+    assert device_entry.via_device_id == bridge_entry.id
+    assert (DOMAIN, "serial_MB-1234") not in device_entry.identifiers

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -496,3 +496,107 @@ async def test_composed_bridged_device_with_bridge_serial_number(
     assert device_entry.id != bridge_entry.id
     assert device_entry.via_device_id == bridge_entry.id
     assert (DOMAIN, "serial_MB-1234") not in device_entry.identifiers
+
+
+async def test_device_registry_bridged_device_merged_with_changed_bridge_serial(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test splitting off a merged bridged device after the bridge's serial changed.
+
+    The bridge's device entry keeps the shared serial number identifier, so the
+    bridged device has to be split off from it by all of its identifiers, not just
+    its device ID, or it resolves to the bridge again through that serial number.
+    """
+    node = create_node_from_fixture(
+        "atios_knx_bridge", {"0/40/15": "b7hcpwo", "29/57/15": "glg5mxh"}
+    )
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "ws://localhost:5580/ws"}
+    )
+    config_entry.add_to_hass(hass)
+
+    merged_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"),
+            (DOMAIN, "serial_glg5mxh"),
+        },
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+        config_entry.entry_id,
+    )
+    assert bridge_entry is not None
+    assert bridge_entry.id == merged_entry.id
+    # the bridge keeps its own serial number, the stale one goes to the bridged device
+    assert (DOMAIN, "serial_b7hcpwo") in bridge_entry.identifiers
+    assert (DOMAIN, "serial_glg5mxh") not in bridge_entry.identifiers
+
+    bridged_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"), config_entry.entry_id
+    )
+    assert bridged_entry is not None
+    assert bridged_entry.id != bridge_entry.id
+    assert bridged_entry.via_device_id == bridge_entry.id
+    assert (DOMAIN, "serial_glg5mxh") in bridged_entry.identifiers
+
+
+async def test_device_registry_bridged_device_split_off_with_changed_bridge_serial(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a bridged device that already has its own entry when the serial changes.
+
+    The bridge's device entry still holds the serial number it shared with the
+    bridged device, so that identifier has to be taken from it once the bridged
+    device reports it as its own again.
+    """
+    node = create_node_from_fixture(
+        "atios_knx_bridge", {"0/40/15": "b7hcpwo", "29/57/15": "glg5mxh"}
+    )
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "ws://localhost:5580/ws"}
+    )
+    config_entry.add_to_hass(hass)
+
+    bridge = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+            (DOMAIN, "serial_glg5mxh"),
+        },
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "deviceid_00000000000004D2-000000000000003E-29")},
+        via_device_id=bridge.id,
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice"),
+        config_entry.entry_id,
+    )
+    assert bridge_entry is not None
+    assert (DOMAIN, "serial_b7hcpwo") in bridge_entry.identifiers
+    assert (DOMAIN, "serial_glg5mxh") not in bridge_entry.identifiers
+
+    bridged_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000003E-29"), config_entry.entry_id
+    )
+    assert bridged_entry is not None
+    assert bridged_entry.id != bridge_entry.id
+    assert bridged_entry.via_device_id == bridge_entry.id
+    assert (DOMAIN, "serial_glg5mxh") in bridged_entry.identifiers


### PR DESCRIPTION
## "Breaking change"?

Technically, this could be considered a breaking change, as the device entry changes for affected devices. But so far, we've only seen this for the Aqara Matter hub. And even there, only for the "air conditioner" endpoint from [the issue](https://github.com/home-assistant/core/issues/178698), which may very well be an IR-controlled air conditioner, so even the Aqara hub is only *sometimes* exposing an incorrect serial number, leading to this issue. As it's currently just exposed in a very broken way, I wouldn't classify this as a breaking change really. The entities (and entity IDs) are unchanged.


## Proposed change

This PR fixes an issue where a Matter bridge and one of the devices it bridges end up as a single device in HA, so that the bridge's own device page is gone and its "via device" links to itself. This happens when a bridge reports its own serial number for a bridged device, as the Aqara Hub M3 does for its "Air Conditioner" endpoint, since the serial number is used as a device registry identifier.

Device registry entries that were already merged this way are split up again, so existing installs recover as well.

### Difference to reported issue on `dev`

On current `dev`, with #178194 merged, such a self-referencing "via device" raises and aborts the setup of the whole node, which leaves most of the bridge's devices and entities missing entirely.

So even if Aqara later fixes the incorrect serial number with a firmware update, we IMO still need to guard against this in HA Core now, as the next HA Core version includes a breaking change that would literally break this device entirely.


## Detailed LLM-generated PR description

<details><summary>AI summary of changes and issue  (<b>CLICK TO EXPAND</b>)</summary>
<p>

### The problem

Some bridges report their own serial number in the `BridgedDeviceBasicInformation` cluster of the devices they bridge. In #178698 the Aqara Hub M3 does this for its "Air Conditioner" endpoint, which appears to be the hub's own IR functionality rather than a separate physical device — plausibly why it ends up reporting the hub's own identity: it reports the hub's `SerialNumber` and `UniqueID` verbatim (HA does not use the `UniqueID` here), while the three actually bridged devices of that hub report their own.

Aqara has since confirmed in that issue that they will change the serial number and unique ID of the air conditioner and the hub in a firmware update, expected in September, after which the hub has to be re-added to HA. That fixes the cause at the source for this one hub, but it does not remove the need for this PR: nothing stops another bridge from doing the same, and until an affected user has that firmware installed, the self-referencing via device makes the whole node fail to set up on a Core version that includes #178194.

### Cause

Since the serial number is added as a second device registry identifier, and identifiers identify a device within a config entry, such a bridged device resolves to the bridge's own device entry: it is merged into the bridge, takes over its name and hides the bridge's own device page, and its via device resolves to that same entry, so the device links to itself. Clicking "Connected via <bridge>" leads back to the same page.

### What breaks

Since #178194, a device is no longer allowed to be its own via device, so this now raises during setup. The exception is caught by `_setup_node()`, which means every endpoint from the offending one onwards is skipped: for the hub in #178698, four of its five devices and 14 of its 16 enabled entities are gone, leaving only the bridge itself.

That raise is not part of any 2026.8 release, so on 2026.8 the merge and the self-link happen silently — that is the state reported in #178698 — while the setup failure is new on dev.

### The fix

The `SerialNumber` attribute is optional and the specification does not require it to be unique, so it cannot be relied on to identify a bridged device. This PR skips the serial number identifier (and the `serial_number` device registry field, since the value belongs to a different device) for a bridged device that reports the serial number of the bridge it sits behind. The device ID identifier is unaffected and is always unique, so no device loses its identity.

### Installs that are already affected

The second commit deals with installs that are already affected. Registering an existing device entry again only merges identifiers onto it, so the identifier of the bridged device stays on the bridge's entry: the bridged device keeps resolving to the bridge through that leftover identifier even though the serial number identifier is no longer added, and setup keeps failing. The identifiers a bridged device is about to be registered with are therefore taken from the bridge's device entry whenever it still holds any of them, so the bridged device gets its own entry again.

The fourth commit generalizes that, and supersedes the narrower condition the second commit used. The bridge's entry keeps the shared serial number as well, so removing only the device ID identifier is not enough once the bridge starts reporting a different serial number than before: the bridged device then no longer matches the check that skips the shared serial number and is registered with it again while the bridge still holds a copy. Depending on whether the two are still merged at that point, the via device of the bridged device resolves to itself again, or its identifiers end up spread over two device entries, and the node fails to set up either way. The serial number of the bridge itself is never taken from it, since it is skipped for a bridged device that reports it.

This does not touch anything else and only matches when the bridge's device entry holds an identifier the bridged device is registered with, so it is a no-op for every unaffected install.

Note that the bridged device gets a new device registry entry when it is split off, so a custom name or area that was set on the merged entry stays with the bridge. Its entities are moved to the new entry automatically.

### Tests

The first two commits are covered by tests using the existing `atios_knx_bridge` fixture with the serial number of the bridged device overridden to the bridge's own. The third commit adds a test for a composed bridged device that reports the bridge's serial number, using the `mock_composed_bridge` fixture from #179118: the part endpoints of a composed device inherit the `BridgedDeviceBasicInformation` of their compose parent, so they are covered by the same check. The fourth commit adds two more tests, one per registry state a bridge whose serial number changed can be in: with the bridged device still merged into it, and with the two already split apart. The tests in the first, second and fourth commits fail without the change in the commit they belong to. The composed device test is confirmatory: it covers a case the first commit's check already handles, so it passes on its own.

Verified in addition against the device diagnostics attached to #178698: with this PR, the hub in that issue is set up completely again, with all five devices and all 16 enabled entities, both for a fresh setup and with the device registry entry an affected user already has. Its Temp/Humidity Sensor is a composed bridged device, which needed #179118 (merged in the meantime) to get its via device back as well.

### Known limitation

Left out on purpose to keep the condition unambiguous: two bridged devices of the same bridge that report the same serial number as each other are still merged into one device. Only a bridged device that reports the serial number of its own bridge is handled, since that is the case where it is clear which device the entry belongs to.

A device entry can also keep a serial number identifier that nothing claims any more, if both the bridge and the bridged device end up reporting a different serial number than the one they once shared. That leftover is harmless, as it no longer collides with anything, and removing stale identifiers in general is out of scope here.

## Breaking change?

Technically, this could be considered a breaking change, but it should affect very few installs: it only applies if a Matter bridge reports its own serial number for one of the devices it bridges, which so far is only known for the Aqara Hub M3 and its "Air Conditioner" endpoint.

On such an install, the bridged device is currently merged into the bridge and shows up as a single device. It is now split off into its own device again, which means it gets a new device entry: a custom name, area, or label that was set on the merged device stays with the bridge and has to be set again on the split-off device. Its entities keep their entity IDs and are moved over automatically, so automations and dashboards that reference entities keep working. Automations that reference the *device* instead still point at the bridge and need to be updated.

Aqara has confirmed in #178698 that a firmware update changing the serial number of the hub and its air conditioner is planned. That firmware still has to be released and installed, and the hub has to be re-added to HA for it to take effect, so this is not something we can wait for: with #178194 an affected install would otherwise be considerably worse off on the next Core release than it is today, as the whole node fails to set up instead of just showing one merged device.

</p>
</details>

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178698
- This PR is related to issue: #179026, fixed by #179118
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr