### PR TITLE
Guard against creating diagnostics for unsupported devices

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -311,6 +311,16 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
         if (device := dev_reg.async_get(sub_id)) is None:
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
+        # A composite device spans multiple config entries and has no single
+        # owner; not supported.
+        if dev_reg.async_is_composite_device_id(sub_id):
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+
+        # Reject a device not owned by this config entry; without this a foreign
+        # (possibly child) device would be handed to the integration's handler.
+        if device.config_entry_id != config_entry.entry_id:
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+
         filename += f"-{device.name}-{device.id}"
 
         if info.device_diagnostics is None:

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -308,12 +308,11 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
         if sub_id is None:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
-        if (device := dev_reg.async_get(sub_id)) is None:
-            return web.Response(status=HTTPStatus.NOT_FOUND)
-
-        # A composite device spans multiple config entries and has no single
-        # owner; not supported.
-        if dev_reg.async_is_composite_device_id(sub_id):
+        # Reject unknown and composite device which spans multiple config entries and
+        # has no single owner; not supported.
+        if (
+            device := dev_reg.async_get(sub_id, include_composite_devices=False)
+        ) is None:
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
         # Reject a device not owned by this config entry; without this a foreign

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -460,7 +460,11 @@ async def test_download_diagnostics_composite_device_rejected(
     device_registry.devices[device_2.id] = attr.evolve(
         device_2, composite_device_id=composite_id
     )
-    assert device_registry.async_is_composite_device_id(composite_id) is True
+    # Check the device is a composite device id, which is not supported for diagnostics
+    assert device_registry.async_get(composite_id) is not None
+    assert (
+        device_registry.async_get(composite_id, include_composite_devices=False) is None
+    )
 
     handler = (
         hass.data[_DIAGNOSTICS_DATA].platforms["fake_integration"].device_diagnostics

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock, patch
 
+import attr
 from freezegun import freeze_time
 import pytest
 
-from homeassistant.components.diagnostics import DOMAIN
+from homeassistant.components.diagnostics import _DIAGNOSTICS_DATA, DOMAIN
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
@@ -384,3 +385,90 @@ async def test_failure_scenarios(
         f"/api/diagnostics/config_entry/{config_entry.entry_id}/device/fake_id"
     )
     assert response.status == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    "device_key",
+    [
+        pytest.param("parent", id="main_device"),
+        pytest.param("child", id="child_device"),
+    ],
+)
+async def test_download_diagnostics_device_not_owned_by_config_entry(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
+    device_key: str,
+) -> None:
+    """Test requesting device diagnostics via a config entry that doesn't own it.
+
+    A device (main or child) belonging to another config entry must be rejected
+    with a not-found response, never handed to the URL entry's integration.
+    """
+    owner_entry = MockConfigEntry(domain="fake_integration")
+    owner_entry.add_to_hass(hass)
+    other_entry = MockConfigEntry(domain="fake_integration")
+    other_entry.add_to_hass(hass)
+
+    parent = device_registry.async_get_or_create(
+        config_entry_id=owner_entry.entry_id,
+        identifiers={("test", "strip")},
+        name="Power strip",
+    )
+    child = device_registry.async_get_or_create_child(
+        config_entry_id=owner_entry.entry_id,
+        identifiers={("test", "strip_outlet_1")},
+        parent_device_id=parent.id,
+        name="Outlet 1",
+    )
+    devices = {"parent": parent, "child": child}
+
+    client = await hass_client()
+    response = await client.get(
+        f"/api/diagnostics/config_entry/{other_entry.entry_id}"
+        f"/device/{devices[device_key].id}"
+    )
+    assert response.status == HTTPStatus.NOT_FOUND
+
+
+async def test_download_diagnostics_composite_device_rejected(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test requesting device diagnostics for a pre-migration composite device.
+
+    A composite device id spans multiple config entries and has no single owner,
+    so it must be rejected with a not-found response and never handed to the
+    integration's device diagnostics handler.
+    """
+    entry_1 = MockConfigEntry(domain="fake_integration")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="fake_integration")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "1")}
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "2")}
+    )
+    composite_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=composite_id
+    )
+    device_registry.devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=composite_id
+    )
+    assert device_registry.async_is_composite_device_id(composite_id) is True
+
+    handler = (
+        hass.data[_DIAGNOSTICS_DATA].platforms["fake_integration"].device_diagnostics
+    )
+
+    client = await hass_client()
+    response = await client.get(
+        f"/api/diagnostics/config_entry/{entry_1.entry_id}/device/{composite_id}"
+    )
+    assert response.status == HTTPStatus.NOT_FOUND
+    handler.assert_not_called()

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -454,10 +454,10 @@ async def test_download_diagnostics_composite_device_rejected(
     )
     composite_id = "composite00000000000000000000ab"
     # Simulate a migration split: both devices carry the pre-migration composite id
-    device_registry.devices[device_1.id] = attr.evolve(
+    device_registry._devices[device_1.id] = attr.evolve(
         device_1, composite_device_id=composite_id
     )
-    device_registry.devices[device_2.id] = attr.evolve(
+    device_registry._devices[device_2.id] = attr.evolve(
         device_2, composite_device_id=composite_id
     )
     # Check the device is a composite device id, which is not supported for diagnostics


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Guard against creating diagnostics for unsupported devices:
- A removed composite device replaced by one device per config entry
- A device owned by another config entry

Spotted by the bot when working on https://github.com/home-assistant/core/pull/178666

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
