### PR TITLE
Fix the Lyngdorf volume range

### DIFF
--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -59,7 +59,7 @@ async def async_get_config_entry_diagnostics(
 
     state: dict[str, Any] = {
         "connected": receiver.connected,
-        "model": receiver.model.name if receiver.model else None,
+        "model": receiver.model.name,
         "power_on": receiver.power_on,
         "volume": receiver.volume,
         "max_volume": receiver.max_volume,

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -1,8 +1,9 @@
 """Media player platform for Lyngdorf integration."""
 
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from lyngdorf.device import Receiver
+from lyngdorf.models.base import NumericRange
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -18,10 +19,6 @@ from .entity import LyngdorfEntity
 from .models import LyngdorfConfigEntry
 
 PARALLEL_UPDATES = 1
-
-MAX_VOLUME_DB = 18.0
-MIN_VOLUME_DB = -80.0
-VOLUME_RANGE = MAX_VOLUME_DB - MIN_VOLUME_DB
 
 FEATURES_ZONE_B = (
     MediaPlayerEntityFeature.VOLUME_STEP
@@ -66,16 +63,17 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-def _to_ha_volume(volume_db: float) -> float:
+def _to_ha_volume(volume_db: float, volume_range: NumericRange) -> float:
     """Convert Lyngdorf dB volume to HA 0..1 scale, clamped to 0..1."""
-    volume = (volume_db - MIN_VOLUME_DB) / VOLUME_RANGE
-    return max(0.0, min(volume, 1.0))
+    span = volume_range.max - volume_range.min
+    return max(0.0, min((volume_db - volume_range.min) / span, 1.0))
 
 
-def _to_lyngdorf_volume(volume: float) -> float:
+def _to_lyngdorf_volume(volume: float, volume_range: NumericRange) -> float:
     """Convert HA 0..1 volume to Lyngdorf dB scale, clamped to min and max."""
-    volume_db = volume * VOLUME_RANGE + MIN_VOLUME_DB
-    return max(MIN_VOLUME_DB, min(volume_db, MAX_VOLUME_DB))
+    span = volume_range.max - volume_range.min
+    volume_db = volume * span + volume_range.min
+    return max(volume_range.min, min(volume_db, volume_range.max))
 
 
 class LyngdorfDevice(LyngdorfEntity, MediaPlayerEntity):
@@ -133,13 +131,22 @@ class LyngdorfZoneBDevice(LyngdorfDevice):
         """Return boolean if volume is currently muted."""
         return self._receiver.zone_b_mute_enabled
 
+    @property
+    def _volume_range(self) -> NumericRange:
+        """Return the model's documented Zone B volume range."""
+        volume_range = self._receiver.zone_b_volume_range
+        # This entity is only created for models that have a Zone B.
+        if TYPE_CHECKING:
+            assert volume_range is not None
+        return volume_range
+
     @override
     @property
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
-        if not isinstance(self._receiver.zone_b_volume, float):
+        if (volume := self._receiver.zone_b_volume) is None:
             return None
-        return _to_ha_volume(self._receiver.zone_b_volume)
+        return _to_ha_volume(volume, self._volume_range)
 
     @override
     async def async_turn_on(self) -> None:
@@ -164,7 +171,9 @@ class LyngdorfZoneBDevice(LyngdorfDevice):
     @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self._receiver.zone_b_volume = _to_lyngdorf_volume(volume)
+        self._receiver.set_zone_b_volume(
+            _to_lyngdorf_volume(volume, self._volume_range)
+        )
 
     @override
     async def async_mute_volume(self, mute: bool) -> None:
@@ -234,13 +243,22 @@ class LyngdorfMainDevice(LyngdorfDevice):
         """Return boolean if volume is currently muted."""
         return self._receiver.mute_enabled
 
+    @property
+    def _volume_range(self) -> NumericRange:
+        """Return the model's documented main-zone volume range."""
+        volume_range = self._receiver.volume_range
+        # Every supported model documents a main-zone volume range.
+        if TYPE_CHECKING:
+            assert volume_range is not None
+        return volume_range
+
     @override
     @property
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
-        if not isinstance(self._receiver.volume, float):
+        if (volume := self._receiver.volume) is None:
             return None
-        return _to_ha_volume(self._receiver.volume)
+        return _to_ha_volume(volume, self._volume_range)
 
     @override
     @property
@@ -277,7 +295,7 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self._receiver.volume = _to_lyngdorf_volume(volume)
+        self._receiver.set_volume(_to_lyngdorf_volume(volume, self._volume_range))
 
     @override
     async def async_mute_volume(self, mute: bool) -> None:

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -81,6 +81,9 @@ def mock_receiver() -> Generator[MagicMock]:
             setattr(receiver, f"trim_{_t}", None)
             setattr(receiver, f"trim_{_t}_range", NumericRange(-10.0, 10.0, 0.1))
 
+        receiver.volume_range = NumericRange(-99.9, 24.0, 0.1)
+        receiver.zone_b_volume_range = NumericRange(-99.9, 24.0, 0.1)
+
         receiver.power_on = False
         receiver.volume = -40.0
         receiver.mute_enabled = False

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -131,11 +131,11 @@ async def test_volume_step(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "level", "attr", "expected_db"),
+    ("entity_id", "level", "method", "expected_db"),
     [
-        (MAIN_ZONE, 0.5, "volume", -31.0),
-        (MAIN_ZONE, 1.0, "volume", 18.0),
-        (ZONE_B, 0.3, "zone_b_volume", -50.6),
+        (MAIN_ZONE, 0.5, "set_volume", -37.95),
+        (MAIN_ZONE, 1.0, "set_volume", 24.0),
+        (ZONE_B, 0.3, "set_zone_b_volume", -62.73),
     ],
 )
 async def test_volume_set(
@@ -144,7 +144,7 @@ async def test_volume_set(
     mock_receiver: MagicMock,
     entity_id: str,
     level: float,
-    attr: str,
+    method: str,
     expected_db: float,
 ) -> None:
     """Test setting and clamping volume on both zones."""
@@ -154,7 +154,7 @@ async def test_volume_set(
         {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_VOLUME_LEVEL: level},
         blocking=True,
     )
-    assert getattr(mock_receiver, attr) == pytest.approx(expected_db)
+    getattr(mock_receiver, method).assert_called_once_with(pytest.approx(expected_db))
 
 
 @pytest.mark.parametrize(
@@ -273,7 +273,7 @@ async def test_main_zone_state_properties(
 
     state = hass.states.get(MAIN_ZONE)
     assert state.state == MediaPlayerState.ON
-    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(0.408, abs=0.01)
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(0.484, abs=0.01)
     assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is False
     assert state.attributes[ATTR_INPUT_SOURCE] == "HDMI"
     assert state.attributes[ATTR_SOUND_MODE] == "Movie"
@@ -317,14 +317,7 @@ async def test_zone_b_state_properties(
 
     state = hass.states.get(ZONE_B)
     assert state.state == MediaPlayerState.ON
-    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(0.510, abs=0.01)
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(0.564, abs=0.01)
     assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is True
     assert state.attributes[ATTR_INPUT_SOURCE] == "Optical"
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HDMI", "Optical"]
-
-    mock_receiver.zone_b_volume = "invalid"
-    for cb in callbacks:
-        cb()
-    await hass.async_block_till_done()
-    state = hass.states.get(ZONE_B)
-    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) is None


### PR DESCRIPTION
## Proposed change

The media player mapped Home Assistant's 0..1 volume onto hardcoded bounds of `-80.0 … 18.0 dB`. Those numbers are not the device's — the documented range is `-99.9 … +24.0 dB` on the MP and P families and `-99.9 … +12.0 dB` on the TDAI family, so the mapping was wrong on both ends for every supported model. On an MP-60 a reading of `-40 dB` showed as 41% when it is really 48%, and a full slider sent `+18` rather than `+24`.

The library now exposes the documented range per model, so each zone takes its bounds from `volume_range` / `zone_b_volume_range` instead.

Two guards go with it. `volume_level` tested `isinstance(..., float)`, but the library only ever assigns these from `convert_decibel()`, which returns a float, and they are declared `float | None` — so the only value that could reach the guard was one a test invented. Diagnostics guarded `receiver.model` the same way, though it is declared non-optional and set in the constructor.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
