### PR TITLE
Bump bleak-esphome to 4.0.0

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -522,7 +522,9 @@ class RuntimeEntryData:
         """
         self.available = False
         if self.bluetooth_device:
-            self.bluetooth_device.available = False
+            # Fails pending BLE slot waiters and clears the dead
+            # session's allocations in addition to closing the gate.
+            self.bluetooth_device.async_set_unavailable()
         # Make a copy since calling the disconnect callbacks
         # may also try to discard/remove themselves.
         for disconnect_cb in self.disconnect_callbacks.copy():

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aioesphomeapi==45.12.0",
     "esphome-dashboard-api==1.4.0",
-    "bleak-esphome==3.9.7"
+    "bleak-esphome==4.0.0"
   ],
   "zeroconf": ["_esphomelib._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -657,7 +657,7 @@ beautifulsoup4==4.13.3
 bizkaibus==0.1.1
 
 # homeassistant.components.esphome
-bleak-esphome==3.9.7
+bleak-esphome==4.0.0
 
 # homeassistant.components.bluetooth
 bleak-retry-connector==4.6.3

--- a/tests/components/esphome/test_bluetooth.py
+++ b/tests/components/esphome/test_bluetooth.py
@@ -1,5 +1,6 @@
 """Test the ESPHome bluetooth integration."""
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from aioesphomeapi import (
     BluetoothScannerState,
     BluetoothScannerStateResponse,
 )
+import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import BluetoothScanningMode
@@ -343,3 +345,22 @@ async def test_scanning_mode_default_pinned_before_register(
     # habluetooth auto-mode worker is spawned at registration time.
     set_mode_mock.assert_called_once_with(BluetoothScannerMode.PASSIVE)
     assert requested_at_register == [BluetoothScanningMode.AUTO]
+
+
+async def test_bluetooth_disconnect_fails_parked_slot_waiter(
+    hass: HomeAssistant, mock_bluetooth_entry_with_raw_adv: MockESPHomeDevice
+) -> None:
+    """Test a parked BLE slot waiter fails fast when the entry disconnects."""
+    entry_data = mock_bluetooth_entry_with_raw_adv.entry.runtime_data
+    bluetooth_device = entry_data.bluetooth_device
+    assert bluetooth_device is not None
+    task = hass.async_create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    await mock_bluetooth_entry_with_raw_adv.mock_disconnect(True)
+    await hass.async_block_till_done()
+
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
+        await task
+    assert bluetooth_device.available is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump bleak-esphome from 3.9.7 to 4.0.0.

The 4.0.0 major requires callers to use the new `ESPHomeBluetoothDevice.async_set_unavailable()` on ESP disconnect instead of setting `bluetooth_device.available = False`; this PR makes that swap in `entry_data.async_on_disconnect`, which also fails any BLE connect attempt parked waiting for a free connection slot on the disconnected proxy and clears the dead session's allocation snapshot. A new test covers the parked slot waiter failing fast on disconnect.

- PyPI: https://pypi.org/project/bleak-esphome/4.0.0/
- Changelog: https://github.com/bluetooth-devices/bleak-esphome/releases/tag/v4.0.0
- Diff: https://github.com/bluetooth-devices/bleak-esphome/compare/v3.9.7...v4.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176516
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
