### PR TITLE
Bump habluetooth to 6.26.7 and bluetooth-data-tools to 1.29.21

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -19,7 +19,7 @@
     "bleak-retry-connector==4.6.3",
     "bluetooth-adapters==2.4.0",
     "bluetooth-auto-recovery==1.6.4",
-    "bluetooth-data-tools==1.29.18",
+    "bluetooth-data-tools==1.29.21",
     "dbus-fast==5.0.22",
     "habluetooth==6.26.7"
   ]

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.6.4",
     "bluetooth-data-tools==1.29.18",
     "dbus-fast==5.0.22",
-    "habluetooth==6.26.5"
+    "habluetooth==6.26.7"
   ]
 }

--- a/homeassistant/components/ld2410_ble/manifest.json
+++ b/homeassistant/components/ld2410_ble/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ld2410_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.18", "ld2410-ble==0.1.1"]
+  "requirements": ["bluetooth-data-tools==1.29.21", "ld2410-ble==0.1.1"]
 }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -36,5 +36,5 @@
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.29.18", "led-ble==1.1.11"]
+  "requirements": ["bluetooth-data-tools==1.29.21", "led-ble==1.1.11"]
 }

--- a/homeassistant/components/private_ble_device/manifest.json
+++ b/homeassistant/components/private_ble_device/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/private_ble_device",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.18"]
+  "requirements": ["bluetooth-data-tools==1.29.21"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -35,7 +35,7 @@ file-read-backwards==2.0.0
 fnv-hash-fast==2.0.3
 go2rtc-client==0.4.0
 ha-ffmpeg==3.2.2
-habluetooth==6.26.5
+habluetooth==6.26.7
 hass-nabucasa==2.2.0
 hassil==3.11.0
 home-assistant-bluetooth==2.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ bleak-retry-connector==4.6.3
 bleak==3.0.2
 bluetooth-adapters==2.4.0
 bluetooth-auto-recovery==1.6.4
-bluetooth-data-tools==1.29.18
+bluetooth-data-tools==1.29.21
 cached-ipaddress==1.1.2
 certifi>=2021.5.30
 ciso8601==2.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bluetooth-auto-recovery==1.6.4
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
 # homeassistant.components.private_ble_device
-bluetooth-data-tools==1.29.18
+bluetooth-data-tools==1.29.21
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1228,7 +1228,7 @@ ha-xthings-cloud==1.0.5
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.26.5
+habluetooth==6.26.7
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -565,6 +565,14 @@ async def test_diagnostics_remote_adapter(
                         "slots": 5,
                         "source": "00:00:00:00:00:01",
                     },
+                    # Registering a connectable scanner seeds a zeroed
+                    # entry (slots=0 means no slot info reported yet).
+                    "esp32": {
+                        "allocated": [],
+                        "free": 0,
+                        "slots": 0,
+                        "source": "esp32",
+                    },
                 },
                 "adapters": {
                     "hci0": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump habluetooth from 6.26.5 to 6.26.7 and bluetooth-data-tools from 1.29.18 to 1.29.21.

habluetooth 6.26.7 dispatches a zeroed allocation snapshot to subscribers when a scanner is unregistered and seeds a zeroed entry when a connectable scanner registers, so allocation views no longer render a removed proxy's stale slots; it also logs an ERROR when a scanner registers with a duplicate source. The diagnostics test gains the seeded entry for a freshly registered remote scanner (`slots=0` means no slot info reported yet).

bluetooth-data-tools moves to 1.29.21 in the four pinning manifests (bluetooth, private_ble_device, led_ble, ld2410_ble) because habluetooth 6.26.7 requires bluetooth-data-tools>=1.29.21.

habluetooth:

- PyPI: https://pypi.org/project/habluetooth/6.26.7/
- Changelog: https://github.com/bluetooth-devices/habluetooth/releases/tag/v6.26.7
- Diff: https://github.com/bluetooth-devices/habluetooth/compare/v6.26.5...v6.26.7

bluetooth-data-tools:

- PyPI: https://pypi.org/project/bluetooth-data-tools/1.29.21/
- Changelog: https://github.com/bdraco/bluetooth-data-tools/releases/tag/v1.29.21
- Diff: https://github.com/bdraco/bluetooth-data-tools/compare/v1.29.18...v1.29.21

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176516
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
