### PR TITLE
Add 'charged' to NUT battery charger status options

### DIFF
--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -39,6 +39,7 @@ AMBIENT_SENSORS = {
     "ambient.temperature.status",
 }
 BATTERY_CHARGER_STATUS_OPTIONS = [
+    "charged",
     "charging",
     "discharging",
     "floating",

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -140,6 +140,7 @@
       "battery_charger_status": {
         "name": "Charging status",
         "state": {
+          "charged": "Charged",
           "charging": "[%key:common::state::charging%]",
           "disabled": "[%key:common::state::disabled%]",
           "discharging": "[%key:common::state::discharging%]",

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -211,6 +211,37 @@ async def test_unknown_state_sensors(hass: HomeAssistant) -> None:
         assert state2.state == "OQ"
 
 
+async def test_battery_charger_status_charged(hass: HomeAssistant) -> None:
+    """Test the battery charger status sensor accepts a 'charged' state.
+
+    Some UPS drivers (e.g. Tripp Lite units) report "charged" for
+    battery.charger.status, which isn't one of the four values documented in
+    the NUT variable list (charging/discharging/floating/resting) but is a
+    real value seen in the wild, same as the already-supported
+    disabled/off/unknown values.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "mock", CONF_PORT: "mock"},
+    )
+    entry.add_to_hass(hass)
+
+    mock_pynut = _get_mock_nutclient(
+        list_ups={"ups1": "UPS 1"},
+        list_vars={"battery.charger.status": "charged"},
+    )
+
+    with patch(
+        "homeassistant.components.nut.AIONUTClient",
+        return_value=mock_pynut,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.ups1_charging_status")
+        assert state.state == "charged"
+
+
 async def test_stale_options(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
 The NUT integration’s “Charging status” sensor only accepts a fixed list of values: charging, discharging, floating, resting, unknown, disabled, off. Some UPS units (Tripp Lite, per the linked issue) report “charged” instead, which isn’t on that list. Home Assistant’s sensor validation raises an error for any value outside the declared options, so the entity becomes permanently unavailable and logs an error on every poll. This adds “charged” to the accepted options in sensor.py and its display string in strings.json, plus a regression test. Note: I wasn’t able to get a fully clean local pytest run — there’s a pre-existing, unrelated translation-loading issue in this environment that also breaks other existing tests on an unmodified checkout, not something this change caused — but the test run’s own debug log confirmed the entity correctly accepts “charged” with no error.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This PR fixes or closes issue: fixes #179442

 
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
