### PR TITLE
Add ssl option to the concord232 config flow

### DIFF
--- a/homeassistant/components/concord232/__init__.py
+++ b/homeassistant/components/concord232/__init__.py
@@ -1,6 +1,7 @@
 """The Concord232 integration."""
 
 from concord232 import client as concord232_client
+from yarl import URL
 
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
@@ -12,7 +13,8 @@ PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR]
 
 def build_url(host: str, port: int) -> str:
     """Return the server url for the stored connection settings."""
-    return f"http://{host}:{port}"
+    # URL.build brackets IPv6 hosts correctly
+    return str(URL.build(scheme="http", host=host, port=port))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -> bool:
@@ -22,8 +24,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -
     coordinator = Concord232Coordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: Concord232ConfigEntry
+) -> None:
+    """Reload the entry when its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -> bool:

--- a/homeassistant/components/concord232/__init__.py
+++ b/homeassistant/components/concord232/__init__.py
@@ -2,7 +2,7 @@
 
 from concord232 import client as concord232_client
 
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import Concord232ConfigEntry, Concord232Coordinator
@@ -10,14 +10,17 @@ from .coordinator import Concord232ConfigEntry, Concord232Coordinator
 PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR]
 
 
-def build_url(host: str, port: int) -> str:
+def build_url(host: str, port: int, use_ssl: bool) -> str:
     """Return the server url for the stored connection settings."""
-    return f"http://{host}:{port}"
+    protocol = "https" if use_ssl else "http"
+    return f"{protocol}://{host}:{port}"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -> bool:
     """Set up Concord232 from a config entry."""
-    url = build_url(entry.data[CONF_HOST], entry.data[CONF_PORT])
+    url = build_url(
+        entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data.get(CONF_SSL, False)
+    )
     client = await hass.async_add_executor_job(concord232_client.Client, url)
     coordinator = Concord232Coordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/concord232/__init__.py
+++ b/homeassistant/components/concord232/__init__.py
@@ -1,1 +1,31 @@
-"""The concord232 component."""
+"""The Concord232 integration."""
+
+from concord232 import client as concord232_client
+
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import Concord232ConfigEntry, Concord232Coordinator
+
+PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR]
+
+
+def build_url(host: str, port: int) -> str:
+    """Return the server url for the stored connection settings."""
+    return f"http://{host}:{port}"
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -> bool:
+    """Set up Concord232 from a config entry."""
+    url = build_url(entry.data[CONF_HOST], entry.data[CONF_PORT])
+    client = await hass.async_add_executor_job(concord232_client.Client, url)
+    coordinator = Concord232Coordinator(hass, entry, client)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: Concord232ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -1,5 +1,6 @@
 """Support for Concord232 alarm control panels."""
 
+import asyncio
 import logging
 from typing import override
 
@@ -58,9 +59,14 @@ async def async_setup_platform(
 
 async def _async_import_yaml(hass: HomeAssistant, config: ConfigType) -> None:
     """Start an import flow and create the deprecation repair issue."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
-    )
+    # The alarm and binary sensor platforms set up concurrently and import the
+    # same server; the lock lets the first import create the entry and the
+    # second merge into it.
+    lock = hass.data.setdefault(f"{DOMAIN}_import_lock", asyncio.Lock())
+    async with lock:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
+        )
     if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
         ir.async_create_issue(
             hass,

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import override
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -17,6 +17,7 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
@@ -155,8 +156,7 @@ class Concord232Alarm(
         """Send disarm command."""
         if not self._validate_code(code, AlarmControlPanelState.DISARMED):
             return
-        await self.hass.async_add_executor_job(self.coordinator.client.disarm, code)
-        await self.coordinator.async_request_refresh()
+        await self._async_command(self.coordinator.client.disarm, code)
 
     @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
@@ -164,19 +164,24 @@ class Concord232Alarm(
         if not self._validate_code(code, AlarmControlPanelState.ARMED_HOME):
             return
         if self._mode == MODE_SILENT:
-            await self.hass.async_add_executor_job(
-                self.coordinator.client.arm, "stay", "silent"
-            )
+            await self._async_command(self.coordinator.client.arm, "stay", "silent")
         else:
-            await self.hass.async_add_executor_job(self.coordinator.client.arm, "stay")
-        await self.coordinator.async_request_refresh()
+            await self._async_command(self.coordinator.client.arm, "stay")
 
     @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         if not self._validate_code(code, AlarmControlPanelState.ARMED_AWAY):
             return
-        await self.hass.async_add_executor_job(self.coordinator.client.arm, "away")
+        await self._async_command(self.coordinator.client.arm, "away")
+
+    async def _async_command(self, command: Any, *args: Any) -> None:
+        """Run a panel command and raise when the server rejects it."""
+        if not await self.hass.async_add_executor_job(command, *args):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+            )
         await self.coordinator.async_request_refresh()
 
     def _validate_code(self, code: str | None, state: AlarmControlPanelState) -> bool:

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -1,11 +1,8 @@
 """Support for Concord232 alarm control panels."""
 
-import datetime
 import logging
 from typing import override
 
-from concord232 import client as concord232_client
-import requests
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
@@ -15,20 +12,25 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
     CodeFormat,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEFAULT_MODE, DEFAULT_PORT, DOMAIN, MODE_SILENT
+from .coordinator import Concord232ConfigEntry, Concord232Coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 DEFAULT_HOST = "localhost"
 DEFAULT_NAME = "CONCORD232"
-DEFAULT_PORT = 5007
-DEFAULT_MODE = "audible"
-
-SCAN_INTERVAL = datetime.timedelta(seconds=10)
 
 PLATFORM_SCHEMA = ALARM_CONTROL_PANEL_PLATFORM_SCHEMA.extend(
     {
@@ -41,98 +43,137 @@ PLATFORM_SCHEMA = ALARM_CONTROL_PANEL_PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Concord232 alarm control panel platform."""
-    name: str = config[CONF_NAME]
-    code: str | None = config.get(CONF_CODE)
-    mode: str = config[CONF_MODE]
-    host: str = config[CONF_HOST]
-    port: int = config[CONF_PORT]
-
-    url = f"http://{host}:{port}"
-
-    try:
-        add_entities([Concord232Alarm(url, name, code, mode)], True)
-    except requests.exceptions.ConnectionError as ex:
-        _LOGGER.error("Unable to connect to Concord232: %s", str(ex))
+    """Import the YAML platform configuration and create a config entry."""
+    await _async_import_yaml(hass, config)
 
 
-class Concord232Alarm(AlarmControlPanelEntity):
+async def _async_import_yaml(hass: HomeAssistant, config: ConfigType) -> None:
+    """Start an import flow and create the deprecation repair issue."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
+    )
+    if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_yaml_import_issue_cannot_connect",
+            breaks_in_ha_version="2027.3.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="deprecated_yaml_import_issue_cannot_connect",
+        )
+        return
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2027.3.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Concord232",
+        },
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: Concord232ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Concord232 alarm control panel from a config entry."""
+    async_add_entities([Concord232Alarm(entry)])
+
+
+class Concord232Alarm(
+    CoordinatorEntity[Concord232Coordinator], AlarmControlPanelEntity
+):
     """Representation of the Concord232-based alarm panel."""
 
     _attr_code_format = CodeFormat.NUMBER
+    _attr_has_entity_name = True
+    _attr_name = None
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
 
-    def __init__(self, url: str, name: str, code: str | None, mode: str) -> None:
+    def __init__(self, entry: Concord232ConfigEntry) -> None:
         """Initialize the Concord232 alarm panel."""
-
-        self._attr_name = name
+        super().__init__(entry.runtime_data)
+        self._attr_unique_id = f"{entry.entry_id}_panel"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=entry.title,
+            manufacturer="GE Interlogix",
+            model="Concord",
+        )
+        code: str | None = entry.options.get(CONF_CODE)
         self._code = code
         self._alarm_control_panel_option_default_code = code
-        self._mode = mode
-        self._url = url
-        self._alarm = concord232_client.Client(self._url)
-        self._alarm.partitions = self._alarm.list_partitions()
+        # The panel protocol arms without a code; only require one when the
+        # user configured a code to gate arming locally.
+        self._attr_code_arm_required = code is not None
+        self._mode: str = entry.options.get(CONF_MODE, DEFAULT_MODE)
 
-    def update(self) -> None:
-        """Update values from API."""
-        try:
-            part = self._alarm.list_partitions()[0]
-        except requests.exceptions.ConnectionError as ex:
-            _LOGGER.error(
-                "Unable to connect to %(host)s: %(reason)s",
-                {"host": self._url, "reason": ex},
-            )
-            return
-        except IndexError:
-            _LOGGER.error("Concord232 reports no partitions")
-            return
-
-        if part["arming_level"] == "Off":
-            self._attr_alarm_state = AlarmControlPanelState.DISARMED
-        elif "Home" in part["arming_level"]:
-            self._attr_alarm_state = AlarmControlPanelState.ARMED_HOME
-        else:
-            self._attr_alarm_state = AlarmControlPanelState.ARMED_AWAY
+    @property
+    @override
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        """Return the state of the panel."""
+        partitions = self.coordinator.data.partitions
+        if not partitions:
+            return None
+        arming_level: str = partitions[0]["arming_level"]
+        if arming_level == "Off":
+            return AlarmControlPanelState.DISARMED
+        if "Home" in arming_level:
+            return AlarmControlPanelState.ARMED_HOME
+        return AlarmControlPanelState.ARMED_AWAY
 
     @override
-    def alarm_disarm(self, code: str | None = None) -> None:
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if not self._validate_code(code, AlarmControlPanelState.DISARMED):
             return
-        self._alarm.disarm(code)
+        await self.hass.async_add_executor_job(self.coordinator.client.disarm, code)
+        await self.coordinator.async_request_refresh()
 
     @override
-    def alarm_arm_home(self, code: str | None = None) -> None:
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         if not self._validate_code(code, AlarmControlPanelState.ARMED_HOME):
             return
-        if self._mode == "silent":
-            self._alarm.arm("stay", "silent")
+        if self._mode == MODE_SILENT:
+            await self.hass.async_add_executor_job(
+                self.coordinator.client.arm, "stay", "silent"
+            )
         else:
-            self._alarm.arm("stay")
+            await self.hass.async_add_executor_job(self.coordinator.client.arm, "stay")
+        await self.coordinator.async_request_refresh()
 
     @override
-    def alarm_arm_away(self, code: str | None = None) -> None:
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         if not self._validate_code(code, AlarmControlPanelState.ARMED_AWAY):
             return
-        self._alarm.arm("away")
+        await self.hass.async_add_executor_job(self.coordinator.client.arm, "away")
+        await self.coordinator.async_request_refresh()
 
     def _validate_code(self, code: str | None, state: AlarmControlPanelState) -> bool:
         """Validate given code."""
         if self._code is None:
             return True
-        alarm_code = self._code
-        check = not alarm_code or code == alarm_code
+        check = code == self._code
         if not check:
             _LOGGER.warning("Invalid code given for %s", state)
         return check

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -121,7 +121,8 @@ class Concord232Alarm(
             manufacturer="GE Interlogix",
             model="Concord",
         )
-        code: str | None = entry.options.get(CONF_CODE)
+        # An empty options field means no code is configured
+        code: str | None = entry.options.get(CONF_CODE) or None
         self._code = code
         self._alarm_control_panel_option_default_code = code
         # The panel protocol arms without a code; only require one when the

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -18,7 +18,10 @@ from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -89,7 +92,7 @@ async def _async_import_yaml(hass: HomeAssistant, config: ConfigType) -> None:
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: Concord232ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Concord232 alarm control panel from a config entry."""
     async_add_entities([Concord232Alarm(entry)])

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -1,11 +1,7 @@
-"""Support for exposing Concord232 elements as sensors."""
+"""Support for exposing Concord232 zones as binary sensors."""
 
-import datetime
-import logging
 from typing import Any, override
 
-from concord232 import client as concord232_client
-import requests
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -17,20 +13,22 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt as dt_util
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-_LOGGER = logging.getLogger(__name__)
+from .alarm_control_panel import _async_import_yaml
+from .const import DOMAIN
+from .coordinator import Concord232ConfigEntry, Concord232Coordinator
+
+PARALLEL_UPDATES = 0
 
 CONF_EXCLUDE_ZONES = "exclude_zones"
 CONF_ZONE_TYPES = "zone_types"
 
 DEFAULT_HOST = "localhost"
-DEFAULT_NAME = "Alarm"
 DEFAULT_PORT = 5007
-
-SCAN_INTERVAL = datetime.timedelta(seconds=10)
 
 ZONE_TYPES_SCHEMA = vol.Schema({cv.positive_int: BINARY_SENSOR_DEVICE_CLASSES_SCHEMA})
 
@@ -46,53 +44,18 @@ PLATFORM_SCHEMA = BINARY_SENSOR_PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Concord232 binary sensor platform."""
-
-    host: str = config[CONF_HOST]
-    port: int = config[CONF_PORT]
-    exclude: list[int] = config[CONF_EXCLUDE_ZONES]
-    zone_types: dict[int, BinarySensorDeviceClass] = config[CONF_ZONE_TYPES]
-    sensors = []
-
-    try:
-        _LOGGER.debug("Initializing client")
-        client = concord232_client.Client(f"http://{host}:{port}")
-        client.zones = client.list_zones()
-        client.last_zone_update = dt_util.utcnow()
-
-    except requests.exceptions.ConnectionError as ex:
-        _LOGGER.error("Unable to connect to Concord232: %s", str(ex))
-        return
-
-    # The order of zones returned by client.list_zones() can vary.
-    # When the zones are not named, this can result in the same entity
-    # name mapping to different sensors in an unpredictable way.  Sort
-    # the zones by zone number to prevent this.
-
-    client.zones.sort(key=lambda zone: zone["number"])
-
-    for zone in client.zones:
-        _LOGGER.debug("Loading Zone found: %s", zone["name"])
-        if zone["number"] not in exclude:
-            sensors.append(
-                Concord232ZoneSensor(
-                    client,
-                    zone,
-                    zone_types.get(zone["number"], get_opening_type(zone)),
-                )
-            )
-
-    add_entities(sensors, True)
+    """Import the YAML platform configuration and create a config entry."""
+    await _async_import_yaml(hass, config)
 
 
-def get_opening_type(zone):
-    """Return the result of the type guessing from name."""
+def get_opening_type(zone: dict[str, Any]) -> BinarySensorDeviceClass:
+    """Return the device class guessed from the zone name."""
     if "MOTION" in zone["name"]:
         return BinarySensorDeviceClass.MOTION
     if "KEY" in zone["name"]:
@@ -100,48 +63,61 @@ def get_opening_type(zone):
     if "SMOKE" in zone["name"]:
         return BinarySensorDeviceClass.SMOKE
     if "WATER" in zone["name"]:
-        return "water"
+        return BinarySensorDeviceClass.MOISTURE
     return BinarySensorDeviceClass.OPENING
 
 
-class Concord232ZoneSensor(BinarySensorEntity):
-    """Representation of a Concord232 zone as a sensor."""
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: Concord232ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Concord232 zone binary sensors from a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        Concord232ZoneSensor(entry, zone) for zone in coordinator.data.zones
+    )
 
-    def __init__(
-        self,
-        client: concord232_client.Client,
-        zone: dict[str, Any],
-        zone_type: BinarySensorDeviceClass,
-    ) -> None:
-        """Initialize the Concord232 binary sensor."""
-        self._client = client
-        self._zone = zone
-        self._number = zone["number"]
-        self._attr_device_class = zone_type
+
+class Concord232ZoneSensor(
+    CoordinatorEntity[Concord232Coordinator], BinarySensorEntity
+):
+    """Representation of a Concord232 zone as a binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: Concord232ConfigEntry, zone: dict[str, Any]) -> None:
+        """Initialize the Concord232 zone binary sensor."""
+        super().__init__(entry.runtime_data)
+        self._number: int = zone["number"]
+        self._attr_unique_id = f"{entry.entry_id}_zone_{self._number}"
+        self._attr_name = zone["name"]
+        self._attr_device_class = get_opening_type(zone)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=entry.title,
+        )
+
+    def _zone(self) -> dict[str, Any] | None:
+        """Return this zone's current data."""
+        return next(
+            (
+                zone
+                for zone in self.coordinator.data.zones
+                if zone["number"] == self._number
+            ),
+            None,
+        )
 
     @property
     @override
-    def name(self) -> str:
-        """Return the name of the binary sensor."""
-        return self._zone["name"]
+    def available(self) -> bool:
+        """Return True when the coordinator and the zone are available."""
+        return super().available and self._zone() is not None
 
     @property
     @override
     def is_on(self) -> bool:
-        """Return true if the binary sensor is on."""
-        # True means "faulted" or "open" or "abnormal state"
-        return bool(self._zone["state"] != "Normal")
-
-    def update(self) -> None:
-        """Get updated stats from API."""
-        last_update = dt_util.utcnow() - self._client.last_zone_update
-        _LOGGER.debug("Zone: %s ", self._zone)
-        if last_update > datetime.timedelta(seconds=1):
-            self._client.zones = self._client.list_zones()
-            self._client.last_zone_update = dt_util.utcnow()
-            _LOGGER.debug("Updated from zone: %s", self._zone["name"])
-
-        if hasattr(self._client, "zones"):
-            self._zone = next(
-                x for x in self._client.zones if x["number"] == self._number
-            )
+        """Return true if the zone is faulted (open, tripped or abnormal)."""
+        zone = self._zone()
+        return zone is not None and zone["state"] != "Normal"

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -120,4 +120,10 @@ class Concord232ZoneSensor(
     def is_on(self) -> bool:
         """Return true if the zone is faulted (open, tripped or abnormal)."""
         zone = self._zone()
-        return zone is not None and zone["state"] != "Normal"
+        if zone is None:
+            return False
+        # The original concord232 server reports zone state as a string; the
+        # actively maintained fork reports a list of states. Accept both.
+        state = zone["state"]
+        states = state if isinstance(state, list) else [state]
+        return states != ["Normal"]

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
@@ -93,6 +93,7 @@ class Concord232ZoneSensor(
         """Initialize the Concord232 zone binary sensor."""
         super().__init__(entry.runtime_data)
         self._number: int = zone["number"]
+        self._zone_data = zone
         self._attr_unique_id = f"{entry.entry_id}_zone_{self._number}"
         self._attr_name = zone["name"]
         self._attr_device_class = get_opening_type(zone)
@@ -112,6 +113,14 @@ class Concord232ZoneSensor(
             None,
         )
 
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Cache the zone's data so a missing zone keeps its last state."""
+        if (zone := self._zone()) is not None:
+            self._zone_data = zone
+        super()._handle_coordinator_update()
+
     @property
     @override
     def available(self) -> bool:
@@ -122,11 +131,8 @@ class Concord232ZoneSensor(
     @override
     def is_on(self) -> bool:
         """Return true if the zone is faulted (open, tripped or abnormal)."""
-        zone = self._zone()
-        if zone is None:
-            return False
         # The original concord232 server reports zone state as a string; the
         # actively maintained fork reports a list of states. Accept both.
-        state = zone["state"]
+        state = self._zone_data["state"]
         states = state if isinstance(state, list) else [state]
         return states != ["Normal"]

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -14,7 +14,10 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -70,7 +73,7 @@ def get_opening_type(zone: dict[str, Any]) -> BinarySensorDeviceClass:
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: Concord232ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Concord232 zone binary sensors from a config entry."""
     coordinator = entry.runtime_data

--- a/homeassistant/components/concord232/config_flow.py
+++ b/homeassistant/components/concord232/config_flow.py
@@ -73,9 +73,11 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            self._async_abort_entries_match(
-                {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
+            await self.async_set_unique_id(
+                f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}",
+                raise_on_progress=False,
             )
+            self._abort_if_unique_id_configured()
             url = build_url(user_input[CONF_HOST], user_input[CONF_PORT])
             if await self.hass.async_add_executor_job(_try_connect, url):
                 return self.async_create_entry(
@@ -95,18 +97,28 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_HOST: import_data[CONF_HOST],
             CONF_PORT: import_data[CONF_PORT],
         }
-        self._async_abort_entries_match(
-            {CONF_HOST: data[CONF_HOST], CONF_PORT: data[CONF_PORT]}
-        )
-        url = build_url(data[CONF_HOST], data[CONF_PORT])
-        if not await self.hass.async_add_executor_job(_try_connect, url):
-            return self.async_abort(reason="cannot_connect")
-
         options: dict[str, Any] = {}
         if CONF_CODE in import_data:
             options[CONF_CODE] = import_data[CONF_CODE]
         if CONF_MODE in import_data:
             options[CONF_MODE] = import_data[CONF_MODE]
+
+        # Both platforms import the same YAML server; the unique_id serializes
+        # them. When the other platform's import created the entry first, merge
+        # the alarm-only fields (code, mode) into it instead of dropping them.
+        await self.async_set_unique_id(f"{data[CONF_HOST]}:{data[CONF_PORT]}")
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.unique_id != self.unique_id:
+                continue
+            if options:
+                self.hass.config_entries.async_update_entry(
+                    entry, options={**entry.options, **options}
+                )
+            return self.async_abort(reason="already_configured")
+
+        url = build_url(data[CONF_HOST], data[CONF_PORT])
+        if not await self.hass.async_add_executor_job(_try_connect, url):
+            return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(
             title=import_data.get(CONF_NAME, data[CONF_HOST]),

--- a/homeassistant/components/concord232/config_flow.py
+++ b/homeassistant/components/concord232/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Concord232 integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from concord232 import client as concord232_client
 import requests
@@ -59,12 +59,14 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: Concord232ConfigEntry,
     ) -> Concord232OptionsFlow:
         """Create the options flow."""
         return Concord232OptionsFlow()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/concord232/config_flow.py
+++ b/homeassistant/components/concord232/config_flow.py
@@ -73,11 +73,9 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            await self.async_set_unique_id(
-                f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}",
-                raise_on_progress=False,
+            self._async_abort_entries_match(
+                {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
             )
-            self._abort_if_unique_id_configured()
             url = build_url(user_input[CONF_HOST], user_input[CONF_PORT])
             if await self.hass.async_add_executor_job(_try_connect, url):
                 return self.async_create_entry(
@@ -103,12 +101,15 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
         if CONF_MODE in import_data:
             options[CONF_MODE] = import_data[CONF_MODE]
 
-        # Both platforms import the same YAML server; the unique_id serializes
-        # them. When the other platform's import created the entry first, merge
-        # the alarm-only fields (code, mode) into it instead of dropping them.
-        await self.async_set_unique_id(f"{data[CONF_HOST]}:{data[CONF_PORT]}")
+        # Both platforms import the same YAML server (their setups hold a shared
+        # lock, so the imports run one at a time). When the other platform's
+        # import created the entry first, merge the alarm-only fields (code,
+        # mode) into it instead of dropping them.
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.unique_id != self.unique_id:
+            if (
+                entry.data.get(CONF_HOST) != data[CONF_HOST]
+                or entry.data.get(CONF_PORT) != data[CONF_PORT]
+            ):
                 continue
             if options:
                 self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/concord232/config_flow.py
+++ b/homeassistant/components/concord232/config_flow.py
@@ -8,7 +8,14 @@ import requests
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
-from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_HOST,
+    CONF_MODE,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SSL,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.selector import (
     SelectSelector,
@@ -26,6 +33,7 @@ USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_SSL, default=False): bool,
     }
 )
 
@@ -74,7 +82,9 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match(
                 {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
             )
-            url = build_url(user_input[CONF_HOST], user_input[CONF_PORT])
+            url = build_url(
+                user_input[CONF_HOST], user_input[CONF_PORT], user_input[CONF_SSL]
+            )
             if await self.hass.async_add_executor_job(_try_connect, url):
                 return self.async_create_entry(
                     title=user_input[CONF_HOST], data=user_input
@@ -92,11 +102,12 @@ class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
         data = {
             CONF_HOST: import_data[CONF_HOST],
             CONF_PORT: import_data[CONF_PORT],
+            CONF_SSL: import_data.get(CONF_SSL, False),
         }
         self._async_abort_entries_match(
             {CONF_HOST: data[CONF_HOST], CONF_PORT: data[CONF_PORT]}
         )
-        url = build_url(data[CONF_HOST], data[CONF_PORT])
+        url = build_url(data[CONF_HOST], data[CONF_PORT], data[CONF_SSL])
         if not await self.hass.async_add_executor_job(_try_connect, url):
             return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/concord232/config_flow.py
+++ b/homeassistant/components/concord232/config_flow.py
@@ -1,0 +1,131 @@
+"""Config flow for the Concord232 integration."""
+
+import logging
+from typing import Any
+
+from concord232 import client as concord232_client
+import requests
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from . import build_url
+from .const import DEFAULT_MODE, DEFAULT_PORT, DOMAIN, MODE_AUDIBLE, MODE_SILENT
+from .coordinator import Concord232ConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    }
+)
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CODE): str,
+        vol.Required(CONF_MODE, default=DEFAULT_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=[MODE_AUDIBLE, MODE_SILENT],
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="arm_home_mode",
+            )
+        ),
+    }
+)
+
+
+def _try_connect(url: str) -> bool:
+    """Return True when the Concord232 server answers."""
+    try:
+        concord232_client.Client(url).list_partitions()
+    except requests.exceptions.RequestException:
+        return False
+    return True
+
+
+class Concord232ConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a Concord232 config flow."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: Concord232ConfigEntry,
+    ) -> Concord232OptionsFlow:
+        """Create the options flow."""
+        return Concord232OptionsFlow()
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match(
+                {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
+            )
+            url = build_url(user_input[CONF_HOST], user_input[CONF_PORT])
+            if await self.hass.async_add_executor_job(_try_connect, url):
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+            errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(USER_SCHEMA, user_input),
+            errors=errors,
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import a config entry from YAML platform configuration."""
+        data = {
+            CONF_HOST: import_data[CONF_HOST],
+            CONF_PORT: import_data[CONF_PORT],
+        }
+        self._async_abort_entries_match(
+            {CONF_HOST: data[CONF_HOST], CONF_PORT: data[CONF_PORT]}
+        )
+        url = build_url(data[CONF_HOST], data[CONF_PORT])
+        if not await self.hass.async_add_executor_job(_try_connect, url):
+            return self.async_abort(reason="cannot_connect")
+
+        options: dict[str, Any] = {}
+        if CONF_CODE in import_data:
+            options[CONF_CODE] = import_data[CONF_CODE]
+        if CONF_MODE in import_data:
+            options[CONF_MODE] = import_data[CONF_MODE]
+
+        return self.async_create_entry(
+            title=import_data.get(CONF_NAME, data[CONF_HOST]),
+            data=data,
+            options=options,
+        )
+
+
+class Concord232OptionsFlow(OptionsFlow):
+    """Handle Concord232 options (arm code and arm-home mode)."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SCHEMA, dict(self.config_entry.options)
+            ),
+        )

--- a/homeassistant/components/concord232/const.py
+++ b/homeassistant/components/concord232/const.py
@@ -1,0 +1,14 @@
+"""Constants for the Concord232 integration."""
+
+from datetime import timedelta
+from typing import Final
+
+DOMAIN: Final = "concord232"
+
+DEFAULT_PORT: Final = 5007
+DEFAULT_MODE: Final = "audible"
+
+MODE_AUDIBLE: Final = "audible"
+MODE_SILENT: Final = "silent"
+
+UPDATE_INTERVAL: Final = timedelta(seconds=10)

--- a/homeassistant/components/concord232/coordinator.py
+++ b/homeassistant/components/concord232/coordinator.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from concord232 import client as concord232_client
 import requests
@@ -47,6 +47,7 @@ class Concord232Coordinator(DataUpdateCoordinator[Concord232Data]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> Concord232Data:
         """Fetch partitions and zones."""
         return await self.hass.async_add_executor_job(self._fetch)

--- a/homeassistant/components/concord232/coordinator.py
+++ b/homeassistant/components/concord232/coordinator.py
@@ -1,0 +1,64 @@
+"""Coordinator for the Concord232 integration."""
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from concord232 import client as concord232_client
+import requests
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, UPDATE_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type Concord232ConfigEntry = ConfigEntry[Concord232Coordinator]
+
+
+@dataclass
+class Concord232Data:
+    """Data fetched from the Concord232 server."""
+
+    partitions: list[dict[str, Any]]
+    zones: list[dict[str, Any]]
+
+
+class Concord232Coordinator(DataUpdateCoordinator[Concord232Data]):
+    """Poll partitions and zones from the Concord232 server."""
+
+    config_entry: Concord232ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: Concord232ConfigEntry,
+        client: concord232_client.Client,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> Concord232Data:
+        """Fetch partitions and zones."""
+        return await self.hass.async_add_executor_job(self._fetch)
+
+    def _fetch(self) -> Concord232Data:
+        """Fetch from the blocking client."""
+        try:
+            partitions = self.client.list_partitions()
+            zones = self.client.list_zones()
+        except requests.exceptions.RequestException as err:
+            raise UpdateFailed(f"Unable to reach the Concord232 server: {err}") from err
+        # Zone order can vary between responses; sort so unnamed zones map to
+        # stable entities.
+        zones.sort(key=lambda zone: zone["number"])
+        return Concord232Data(partitions=partitions, zones=zones)

--- a/homeassistant/components/concord232/manifest.json
+++ b/homeassistant/components/concord232/manifest.json
@@ -6,12 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/concord232",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": [
-    "concord232",
-    "stevedore"
-  ],
+  "loggers": ["concord232", "stevedore"],
   "quality_scale": "legacy",
-  "requirements": [
-    "concord232==0.15.1"
-  ]
+  "requirements": ["concord232==0.15.1"]
 }

--- a/homeassistant/components/concord232/manifest.json
+++ b/homeassistant/components/concord232/manifest.json
@@ -2,9 +2,16 @@
   "domain": "concord232",
   "name": "Concord232",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/concord232",
+  "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["concord232", "stevedore"],
+  "loggers": [
+    "concord232",
+    "stevedore"
+  ],
   "quality_scale": "legacy",
-  "requirements": ["concord232==0.15.1"]
+  "requirements": [
+    "concord232==0.15.1"
+  ]
 }

--- a/homeassistant/components/concord232/strings.json
+++ b/homeassistant/components/concord232/strings.json
@@ -4,11 +4,13 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "ssl": "[%key:common::config_flow::data::ssl%]"
         },
         "data_description": {
           "host": "The hostname or IP address of the concord232 server.",
-          "port": "The port the concord232 server listens on."
+          "port": "The port the concord232 server listens on.",
+          "ssl": "Connect to the concord232 server over HTTPS, for example through a TLS proxy in front of it."
         }
       }
     },

--- a/homeassistant/components/concord232/strings.json
+++ b/homeassistant/components/concord232/strings.json
@@ -19,6 +19,11 @@
       }
     }
   },
+  "exceptions": {
+    "command_failed": {
+      "message": "The concord232 server rejected the command"
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_cannot_connect": {
       "description": "Configuring Concord232 using YAML is being removed but the concord232 server could not be reached while importing your existing configuration.\n\nMake sure the server is running, restart Home Assistant to try again, or remove the Concord232 YAML configuration from your configuration.yaml file and add the integration manually.",

--- a/homeassistant/components/concord232/strings.json
+++ b/homeassistant/components/concord232/strings.json
@@ -1,0 +1,50 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of the concord232 server.",
+          "port": "The port the concord232 server listens on."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "code": "Alarm code",
+          "mode": "Arm home mode"
+        },
+        "data_description": {
+          "code": "Code required to arm and disarm the panel from Home Assistant. Leave empty to allow arming and disarming without a code.",
+          "mode": "Whether arming in home mode sounds the exit chime."
+        }
+      }
+    }
+  },
+  "selector": {
+    "arm_home_mode": {
+      "options": {
+        "audible": "Audible",
+        "silent": "Silent"
+      }
+    }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "title": "YAML import failed",
+      "description": "Configuring Concord232 using YAML is being removed but the concord232 server could not be reached while importing your existing configuration.\n\nMake sure the server is running, restart Home Assistant to try again, or remove the Concord232 YAML configuration from your configuration.yaml file and add the integration manually."
+    }
+  }
+}

--- a/homeassistant/components/concord232/strings.json
+++ b/homeassistant/components/concord232/strings.json
@@ -38,7 +38,7 @@
           "mode": "Arm home mode"
         },
         "data_description": {
-          "code": "Code required to arm and disarm the panel from Home Assistant. Leave empty to allow arming and disarming without a code.",
+          "code": "Code stored for the panel: it is sent when disarming, filled in automatically when a command does not provide one, and commands that do provide a code must match it. Leave empty to arm without a code and send no code on disarm.",
           "mode": "Whether arming in home mode sounds the exit chime."
         }
       }

--- a/homeassistant/components/concord232/strings.json
+++ b/homeassistant/components/concord232/strings.json
@@ -1,5 +1,11 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "step": {
       "user": {
         "data": {
@@ -11,12 +17,12 @@
           "port": "The port the concord232 server listens on."
         }
       }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "description": "Configuring Concord232 using YAML is being removed but the concord232 server could not be reached while importing your existing configuration.\n\nMake sure the server is running, restart Home Assistant to try again, or remove the Concord232 YAML configuration from your configuration.yaml file and add the integration manually.",
+      "title": "YAML import failed"
     }
   },
   "options": {
@@ -39,12 +45,6 @@
         "audible": "Audible",
         "silent": "Silent"
       }
-    }
-  },
-  "issues": {
-    "deprecated_yaml_import_issue_cannot_connect": {
-      "title": "YAML import failed",
-      "description": "Configuring Concord232 using YAML is being removed but the concord232 server could not be reached while importing your existing configuration.\n\nMake sure the server is running, restart Home Assistant to try again, or remove the Concord232 YAML configuration from your configuration.yaml file and add the integration manually."
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -139,6 +139,7 @@ FLOWS = {
         "color_extractor",
         "comelit",
         "compit",
+        "concord232",
         "control4",
         "cookidoo",
         "coolmaster",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1154,7 +1154,7 @@
     "concord232": {
       "name": "Concord232",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "coned": {

--- a/tests/components/concord232/conftest.py
+++ b/tests/components/concord232/conftest.py
@@ -53,7 +53,6 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="localhost",
-        unique_id="localhost:5007",
         data={CONF_HOST: "localhost", CONF_PORT: 5007},
     )
 

--- a/tests/components/concord232/conftest.py
+++ b/tests/components/concord232/conftest.py
@@ -1,31 +1,64 @@
 """Fixtures for the Concord232 integration."""
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
+from concord232 import client as concord232_client
 import pytest
+
+from homeassistant.components.concord232.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_concord232_client() -> Generator[MagicMock]:
-    """Mock the concord232 Client for easier testing."""
+def mock_concord232_client_class() -> Generator[MagicMock]:
+    """Mock the concord232 Client class.
+
+    One shared mock is patched into every import path, so constructor
+    calls from setup and the config flow are visible on the yielded
+    class mock.
+    """
+    mock_client_class = create_autospec(concord232_client.Client)
     with (
         patch(
-            "homeassistant.components.concord232.alarm_control_panel.concord232_client.Client",
-            autospec=True,
-        ) as mock_client_class,
+            "homeassistant.components.concord232.concord232_client.Client",
+            new=mock_client_class,
+        ),
         patch(
-            "homeassistant.components.concord232.binary_sensor.concord232_client.Client",
+            "homeassistant.components.concord232.config_flow.concord232_client.Client",
             new=mock_client_class,
         ),
     ):
         mock_instance = mock_client_class.return_value
-
-        # Set up default return values
         mock_instance.list_partitions.return_value = [{"arming_level": "Off"}]
         mock_instance.list_zones.return_value = [
-            {"number": 1, "name": "Zone 1", "state": "Normal"},
-            {"number": 2, "name": "Zone 2", "state": "Normal"},
+            {"number": 1, "name": "FRONT DOOR", "state": "Normal"},
+            {"number": 2, "name": "HALL MOTION", "state": "Normal"},
         ]
+        yield mock_client_class
 
-        yield mock_instance
+
+@pytest.fixture
+def mock_concord232_client(mock_concord232_client_class: MagicMock) -> MagicMock:
+    """Return the mocked concord232 client instance."""
+    return mock_concord232_client_class.return_value
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="localhost",
+        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+    )
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the integration from a config entry."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/concord232/conftest.py
+++ b/tests/components/concord232/conftest.py
@@ -53,6 +53,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="localhost",
+        unique_id="localhost:5007",
         data={CONF_HOST: "localhost", CONF_PORT: 5007},
     )
 

--- a/tests/components/concord232/conftest.py
+++ b/tests/components/concord232/conftest.py
@@ -7,7 +7,7 @@ from concord232 import client as concord232_client
 import pytest
 
 from homeassistant.components.concord232.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -53,7 +53,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="localhost",
-        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+        data={CONF_HOST: "localhost", CONF_PORT: 5007, CONF_SSL: False},
     )
 
 

--- a/tests/components/concord232/test_alarm_control_panel.py
+++ b/tests/components/concord232/test_alarm_control_panel.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import setup_integration
 
@@ -187,3 +188,31 @@ async def test_code_validation(
         blocking=True,
     )
     assert mock_concord232_client.arm.called is arm_called
+
+
+@pytest.mark.parametrize(
+    ("service", "client_method"),
+    [
+        (SERVICE_ALARM_ARM_HOME, "arm"),
+        (SERVICE_ALARM_ARM_AWAY, "arm"),
+        (SERVICE_ALARM_DISARM, "disarm"),
+    ],
+)
+async def test_rejected_command_raises(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    client_method: str,
+) -> None:
+    """Test a rejected panel command surfaces as an error."""
+    await setup_integration(hass, mock_config_entry)
+    getattr(mock_concord232_client, client_method).return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )

--- a/tests/components/concord232/test_alarm_control_panel.py
+++ b/tests/components/concord232/test_alarm_control_panel.py
@@ -13,266 +13,177 @@ from homeassistant.components.alarm_control_panel import (
     SERVICE_ALARM_DISARM,
     AlarmControlPanelState,
 )
+from homeassistant.components.concord232.const import UPDATE_INTERVAL
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
     CONF_CODE,
-    CONF_HOST,
     CONF_MODE,
-    CONF_NAME,
-    CONF_PORT,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from tests.common import async_fire_time_changed
+from .conftest import setup_integration
 
-VALID_CONFIG = {
-    ALARM_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-        CONF_NAME: "Test Alarm",
-    }
-}
+from tests.common import MockConfigEntry, async_fire_time_changed
 
-VALID_CONFIG_WITH_CODE = {
-    ALARM_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-        CONF_NAME: "Test Alarm",
-        CONF_CODE: "1234",
-    }
-}
-
-VALID_CONFIG_SILENT_MODE = {
-    ALARM_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-        CONF_NAME: "Test Alarm",
-        CONF_MODE: "silent",
-    }
-}
-
-
-async def test_setup_platform(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test platform setup."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_alarm")
-    assert state is not None
-    assert state.state == AlarmControlPanelState.DISARMED
-
-
-async def test_setup_platform_connection_error(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test platform setup with connection error."""
-    mock_concord232_client.list_partitions.side_effect = (
-        requests.exceptions.ConnectionError("Connection failed")
-    )
-
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.test_alarm") is None
-
-
-async def test_alarm_disarm(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test disarm service."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        ALARM_DOMAIN,
-        SERVICE_ALARM_DISARM,
-        {ATTR_ENTITY_ID: "alarm_control_panel.test_alarm"},
-        blocking=True,
-    )
-    mock_concord232_client.disarm.assert_called_once_with(None)
-
-
-async def test_alarm_disarm_with_code(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test disarm service with code."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG_WITH_CODE)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        ALARM_DOMAIN,
-        SERVICE_ALARM_DISARM,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_alarm",
-            ATTR_CODE: "1234",
-        },
-        blocking=True,
-    )
-    mock_concord232_client.disarm.assert_called_once_with("1234")
-
-
-async def test_alarm_disarm_invalid_code(
-    hass: HomeAssistant,
-    mock_concord232_client: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test disarm service with invalid code."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG_WITH_CODE)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        ALARM_DOMAIN,
-        SERVICE_ALARM_DISARM,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_alarm",
-            ATTR_CODE: "9999",
-        },
-        blocking=True,
-    )
-    mock_concord232_client.disarm.assert_not_called()
-    assert "Invalid code given" in caplog.text
+ENTITY_ID = "alarm_control_panel.localhost"
 
 
 @pytest.mark.parametrize(
-    ("service", "expected_arm_call"),
+    ("arming_level", "expected"),
     [
-        (SERVICE_ALARM_ARM_HOME, "stay"),
-        (SERVICE_ALARM_ARM_AWAY, "away"),
+        ("Off", AlarmControlPanelState.DISARMED),
+        ("Stay/Home", AlarmControlPanelState.ARMED_HOME),
+        ("Away", AlarmControlPanelState.ARMED_AWAY),
     ],
 )
-async def test_alarm_arm(
+async def test_alarm_state(
     hass: HomeAssistant,
     mock_concord232_client: MagicMock,
-    service: str,
-    expected_arm_call: str,
+    mock_config_entry: MockConfigEntry,
+    arming_level: str,
+    expected: AlarmControlPanelState,
 ) -> None:
-    """Test arm service."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG_WITH_CODE)
+    """Test the panel state maps from the partition arming level."""
+    mock_concord232_client.list_partitions.return_value = [
+        {"arming_level": arming_level}
+    ]
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == expected
+
+
+async def test_state_updates_on_poll(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the panel state follows coordinator updates."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get(ENTITY_ID).state == AlarmControlPanelState.DISARMED
+
+    mock_concord232_client.list_partitions.return_value = [{"arming_level": "Away"}]
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).state == AlarmControlPanelState.ARMED_AWAY
+
+
+async def test_unavailable_on_error(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the panel becomes unavailable when the server stops answering."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_concord232_client.list_partitions.side_effect = (
+        requests.exceptions.ConnectionError("boom")
+    )
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_args"),
+    [
+        (SERVICE_ALARM_ARM_HOME, ("stay",)),
+        (SERVICE_ALARM_ARM_AWAY, ("away",)),
+    ],
+)
+async def test_arm_services(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    expected_args: tuple[str, ...],
+) -> None:
+    """Test arming without a configured code."""
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         ALARM_DOMAIN,
         service,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_alarm",
-            ATTR_CODE: "1234",
-        },
+        {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
-    mock_concord232_client.arm.assert_called_once_with(expected_arm_call)
+    mock_concord232_client.arm.assert_called_once_with(*expected_args)
 
 
-async def test_alarm_arm_home_silent_mode(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
+async def test_arm_home_silent_mode(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test arm home service with silent mode."""
-    config_with_code = VALID_CONFIG_SILENT_MODE.copy()
-    config_with_code[ALARM_DOMAIN][CONF_CODE] = "1234"
-    await async_setup_component(hass, ALARM_DOMAIN, config_with_code)
+    """Test the silent option is passed through when arming home."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={CONF_MODE: "silent"}
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
         ALARM_DOMAIN,
         SERVICE_ALARM_ARM_HOME,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_alarm",
-            ATTR_CODE: "1234",
-        },
+        {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
     mock_concord232_client.arm.assert_called_once_with("stay", "silent")
 
 
-async def test_update_state_disarmed(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
+async def test_disarm(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test update when alarm is disarmed."""
-    mock_concord232_client.list_partitions.return_value = [{"arming_level": "Off"}]
-    mock_concord232_client.list_zones.return_value = [
-        {"number": 1, "name": "Zone 1", "state": "Normal"},
-    ]
+    """Test disarming passes the code to the client."""
+    await setup_integration(hass, mock_config_entry)
 
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_alarm")
-    assert state.state == AlarmControlPanelState.DISARMED
+    await hass.services.async_call(
+        ALARM_DOMAIN,
+        SERVICE_ALARM_DISARM,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_CODE: "1234"},
+        blocking=True,
+    )
+    mock_concord232_client.disarm.assert_called_once_with("1234")
 
 
 @pytest.mark.parametrize(
-    ("arming_level", "expected_state"),
+    ("code", "arm_called"),
     [
-        ("Home", AlarmControlPanelState.ARMED_HOME),
-        ("Away", AlarmControlPanelState.ARMED_AWAY),
+        ("1234", True),
+        ("9999", False),
     ],
 )
-async def test_update_state_armed(
+async def test_code_validation(
     hass: HomeAssistant,
     mock_concord232_client: MagicMock,
-    freezer: FrozenDateTimeFactory,
-    arming_level: str,
-    expected_state: str,
+    mock_config_entry: MockConfigEntry,
+    code: str,
+    arm_called: bool,
 ) -> None:
-    """Test update when alarm is armed."""
-    mock_concord232_client.list_partitions.return_value = [
-        {"arming_level": arming_level}
-    ]
-    mock_concord232_client.partitions = (
-        mock_concord232_client.list_partitions.return_value
+    """Test a configured code gates arming."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={CONF_CODE: "1234"}
     )
-    mock_concord232_client.list_zones.return_value = [
-        {"number": 1, "name": "Zone 1", "state": "Normal"},
-    ]
-
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Trigger update
-    freezer.tick(10)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_alarm")
-    assert state.state == expected_state
-
-
-async def test_update_connection_error(
-    hass: HomeAssistant,
-    mock_concord232_client: MagicMock,
-    freezer: FrozenDateTimeFactory,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test update with connection error."""
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    mock_concord232_client.list_partitions.side_effect = (
-        requests.exceptions.ConnectionError("Connection failed")
+    await hass.services.async_call(
+        ALARM_DOMAIN,
+        SERVICE_ALARM_ARM_AWAY,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_CODE: code},
+        blocking=True,
     )
-
-    freezer.tick(10)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    assert "Unable to connect to" in caplog.text
-
-
-async def test_update_no_partitions(
-    hass: HomeAssistant,
-    mock_concord232_client: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test update when no partitions are available."""
-    mock_concord232_client.list_partitions.return_value = []
-
-    await async_setup_component(hass, ALARM_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    assert "Concord232 reports no partitions" in caplog.text
+    assert mock_concord232_client.arm.called is arm_called

--- a/tests/components/concord232/test_alarm_control_panel.py
+++ b/tests/components/concord232/test_alarm_control_panel.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_CODE,
     CONF_MODE,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -160,7 +161,15 @@ async def test_disarm(
 
 
 @pytest.mark.parametrize(
-    ("code", "arm_called"),
+    ("service", "client_method"),
+    [
+        (SERVICE_ALARM_ARM_HOME, "arm"),
+        (SERVICE_ALARM_ARM_AWAY, "arm"),
+        (SERVICE_ALARM_DISARM, "disarm"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("code", "command_sent"),
     [
         ("1234", True),
         ("9999", False),
@@ -170,10 +179,12 @@ async def test_code_validation(
     hass: HomeAssistant,
     mock_concord232_client: MagicMock,
     mock_config_entry: MockConfigEntry,
+    service: str,
+    client_method: str,
     code: str,
-    arm_called: bool,
+    command_sent: bool,
 ) -> None:
-    """Test a configured code gates arming."""
+    """Test a configured code gates every command."""
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry, options={CONF_CODE: "1234"}
@@ -183,11 +194,25 @@ async def test_code_validation(
 
     await hass.services.async_call(
         ALARM_DOMAIN,
-        SERVICE_ALARM_ARM_AWAY,
+        service,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_CODE: code},
         blocking=True,
     )
-    assert mock_concord232_client.arm.called is arm_called
+    assert getattr(mock_concord232_client, client_method).called is command_sent
+
+
+async def test_no_partitions_reports_unknown(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the panel state is unknown when the server reports no partitions."""
+    mock_concord232_client.list_partitions.return_value = []
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/components/concord232/test_alarm_control_panel.py
+++ b/tests/components/concord232/test_alarm_control_panel.py
@@ -1,5 +1,6 @@
 """Tests for the Concord232 alarm control panel platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -69,7 +70,7 @@ async def test_state_updates_on_poll(
     assert hass.states.get(ENTITY_ID).state == AlarmControlPanelState.DISARMED
 
     mock_concord232_client.list_partitions.return_value = [{"arming_level": "Away"}]
-    freezer.tick(UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -88,7 +89,7 @@ async def test_unavailable_on_error(
     mock_concord232_client.list_partitions.side_effect = (
         requests.exceptions.ConnectionError("boom")
     )
-    freezer.tick(UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/concord232/test_binary_sensor.py
+++ b/tests/components/concord232/test_binary_sensor.py
@@ -1,199 +1,99 @@
 """Tests for the Concord232 binary sensor platform."""
 
-import datetime
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-import requests
 
-from homeassistant.components.binary_sensor import (
-    DOMAIN as BINARY_SENSOR_DOMAIN,
-    BinarySensorDeviceClass,
-)
-from homeassistant.components.concord232.binary_sensor import (
-    CONF_EXCLUDE_ZONES,
-    CONF_ZONE_TYPES,
-)
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.concord232.const import UPDATE_INTERVAL
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from tests.common import async_fire_time_changed
+from .conftest import setup_integration
 
-VALID_CONFIG = {
-    BINARY_SENSOR_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-    }
-}
-
-VALID_CONFIG_WITH_EXCLUDE = {
-    BINARY_SENSOR_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-        CONF_EXCLUDE_ZONES: [2],
-    }
-}
-
-VALID_CONFIG_WITH_ZONE_TYPES = {
-    BINARY_SENSOR_DOMAIN: {
-        "platform": "concord232",
-        CONF_HOST: "localhost",
-        CONF_PORT: 5007,
-        CONF_ZONE_TYPES: {1: "door", 2: "window"},
-    }
-}
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_setup_platform(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test platform setup."""
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    state1 = hass.states.get("binary_sensor.zone_1")
-    state2 = hass.states.get("binary_sensor.zone_2")
-    assert state1 is not None
-    assert state2 is not None
-    assert state1.state == "off"
-    assert state2.state == "off"
-
-
-async def test_setup_platform_connection_error(
+async def test_zone_sensors_created(
     hass: HomeAssistant,
     mock_concord232_client: MagicMock,
-    caplog: pytest.LogCaptureFixture,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test platform setup with connection error."""
-    mock_concord232_client.list_zones.side_effect = requests.exceptions.ConnectionError(
-        "Connection failed"
-    )
+    """Test one binary sensor is created per zone."""
+    await setup_integration(hass, mock_config_entry)
 
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
+    front_door = hass.states.get("binary_sensor.localhost_front_door")
+    assert front_door is not None
+    assert front_door.state == STATE_OFF
+    assert front_door.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.OPENING
 
-    assert "Unable to connect to Concord232" in caplog.text
-    assert hass.states.get("binary_sensor.zone_1") is None
-
-
-async def test_setup_with_exclude_zones(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test platform setup with excluded zones."""
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG_WITH_EXCLUDE)
-    await hass.async_block_till_done()
-
-    state1 = hass.states.get("binary_sensor.zone_1")
-    state2 = hass.states.get("binary_sensor.zone_2")
-    assert state1 is not None
-    assert state2 is None  # Zone 2 should be excluded
-
-
-async def test_setup_with_zone_types(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test platform setup with custom zone types."""
-    await async_setup_component(
-        hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG_WITH_ZONE_TYPES
-    )
-    await hass.async_block_till_done()
-
-    state1 = hass.states.get("binary_sensor.zone_1")
-    state2 = hass.states.get("binary_sensor.zone_2")
-    assert state1 is not None
-    assert state2 is not None
-    # Check device class is set correctly
-    assert state1.attributes.get("device_class") == BinarySensorDeviceClass.DOOR
-    assert state2.attributes.get("device_class") == BinarySensorDeviceClass.WINDOW
-
-
-async def test_zone_state_faulted(
-    hass: HomeAssistant, mock_concord232_client: MagicMock
-) -> None:
-    """Test zone state when faulted."""
-    mock_concord232_client.list_zones.return_value = [
-        {"number": 1, "name": "Zone 1", "state": "Faulted"},
-    ]
-    mock_concord232_client.zones = mock_concord232_client.list_zones.return_value
-
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.zone_1")
-    assert state.state == "on"  # Faulted state means on (faulted)
-
-
-@pytest.mark.freeze_time("2023-10-21")
-async def test_zone_update_refresh(
-    hass: HomeAssistant,
-    mock_concord232_client: MagicMock,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test that zone updates refresh the client data."""
-    mock_concord232_client.list_zones.return_value = [
-        {"number": 1, "name": "Zone 1", "state": "Normal"},
-    ]
-    mock_concord232_client.zones = mock_concord232_client.list_zones.return_value
-
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("binary_sensor.zone_1").state == "off"
-
-    # Update zone state - need to update both return_value and zones attribute
-    new_zones = [
-        {"number": 1, "name": "Zone 1", "state": "Faulted"},
-    ]
-    mock_concord232_client.list_zones.return_value = new_zones
-    mock_concord232_client.zones = new_zones
-
-    freezer.tick(datetime.timedelta(seconds=10))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    freezer.tick(datetime.timedelta(seconds=10))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.zone_1")
-    assert state.state == "on"
+    motion = hass.states.get("binary_sensor.localhost_hall_motion")
+    assert motion is not None
+    assert motion.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOTION
 
 
 @pytest.mark.parametrize(
-    ("sensor_name", "entity_id", "expected_device_class"),
+    ("zone_name", "expected_class"),
     [
-        (
-            "MOTION Sensor",
-            "binary_sensor.motion_sensor",
-            BinarySensorDeviceClass.MOTION,
-        ),
-        ("SMOKE Sensor", "binary_sensor.smoke_sensor", BinarySensorDeviceClass.SMOKE),
-        (
-            "Unknown Sensor",
-            "binary_sensor.unknown_sensor",
-            BinarySensorDeviceClass.OPENING,
-        ),
+        ("SIDE MOTION", BinarySensorDeviceClass.MOTION),
+        ("FIRE KEY", BinarySensorDeviceClass.SAFETY),
+        ("HALL SMOKE", BinarySensorDeviceClass.SMOKE),
+        ("SINK WATER", BinarySensorDeviceClass.MOISTURE),
+        ("FRONT DOOR", BinarySensorDeviceClass.OPENING),
     ],
 )
-async def test_device_class(
+async def test_device_class_guessing(
     hass: HomeAssistant,
     mock_concord232_client: MagicMock,
-    sensor_name: str,
-    entity_id: str,
-    expected_device_class: BinarySensorDeviceClass,
+    mock_config_entry: MockConfigEntry,
+    zone_name: str,
+    expected_class: BinarySensorDeviceClass,
 ) -> None:
-    """Test zone type detection for motion sensor."""
+    """Test the device class is guessed from the zone name."""
     mock_concord232_client.list_zones.return_value = [
-        {"number": 1, "name": sensor_name, "state": "Normal"},
+        {"number": 1, "name": zone_name, "state": "Normal"}
     ]
-    mock_concord232_client.zones = mock_concord232_client.list_zones.return_value
+    await setup_integration(hass, mock_config_entry)
 
-    await async_setup_component(hass, BINARY_SENSOR_DOMAIN, VALID_CONFIG)
+    entity_id = f"binary_sensor.localhost_{zone_name.lower().replace(' ', '_')}"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_DEVICE_CLASS] == expected_class
+
+
+async def test_zone_state_updates(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a tripped zone turns the sensor on at the next poll."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_OFF
+
+    mock_concord232_client.list_zones.return_value = [
+        {"number": 1, "name": "FRONT DOOR", "state": "Tripped"},
+        {"number": 2, "name": "HALL MOTION", "state": "Normal"},
+    ]
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity_id)
-    assert state.attributes.get("device_class") == expected_device_class
+    assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_ON
+
+
+async def test_unsorted_zones_map_to_stable_entities(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zones are sorted by number regardless of server order."""
+    mock_concord232_client.list_zones.return_value = [
+        {"number": 2, "name": "HALL MOTION", "state": "Normal"},
+        {"number": 1, "name": "FRONT DOOR", "state": "Tripped"},
+    ]
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_ON
+    assert hass.states.get("binary_sensor.localhost_hall_motion").state == STATE_OFF

--- a/tests/components/concord232/test_binary_sensor.py
+++ b/tests/components/concord232/test_binary_sensor.py
@@ -97,3 +97,31 @@ async def test_unsorted_zones_map_to_stable_entities(
 
     assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_ON
     assert hass.states.get("binary_sensor.localhost_hall_motion").state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("zone_state", "expected"),
+    [
+        # The original concord232 server reports a plain string.
+        ("Normal", STATE_OFF),
+        ("Tripped", STATE_ON),
+        # The actively maintained fork reports a list of states.
+        (["Normal"], STATE_OFF),
+        (["Tripped"], STATE_ON),
+        (["Tripped", "Trouble"], STATE_ON),
+    ],
+)
+async def test_zone_state_shapes(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    zone_state: str | list[str],
+    expected: str,
+) -> None:
+    """Test both server variants' zone state shapes are understood."""
+    mock_concord232_client.list_zones.return_value = [
+        {"number": 1, "name": "FRONT DOOR", "state": zone_state}
+    ]
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("binary_sensor.localhost_front_door").state == expected

--- a/tests/components/concord232/test_binary_sensor.py
+++ b/tests/components/concord232/test_binary_sensor.py
@@ -7,7 +7,12 @@ import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.concord232.const import UPDATE_INTERVAL
-from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 
 from .conftest import setup_integration
@@ -125,3 +130,35 @@ async def test_zone_state_shapes(
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("binary_sensor.localhost_front_door").state == expected
+
+
+async def test_zone_missing_from_update_goes_unavailable(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a zone that disappears from a poll goes unavailable and returns."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_OFF
+
+    mock_concord232_client.list_zones.return_value = [
+        {"number": 2, "name": "HALL MOTION", "state": "Normal"}
+    ]
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.localhost_front_door").state == STATE_UNAVAILABLE
+    )
+
+    mock_concord232_client.list_zones.return_value = [
+        {"number": 1, "name": "FRONT DOOR", "state": "Tripped"},
+        {"number": 2, "name": "HALL MOTION", "state": "Normal"},
+    ]
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.localhost_front_door").state == STATE_ON

--- a/tests/components/concord232/test_binary_sensor.py
+++ b/tests/components/concord232/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Concord232 binary sensor platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -81,7 +82,7 @@ async def test_zone_state_updates(
         {"number": 1, "name": "FRONT DOOR", "state": "Tripped"},
         {"number": 2, "name": "HALL MOTION", "state": "Normal"},
     ]
-    freezer.tick(UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -145,7 +146,7 @@ async def test_zone_missing_from_update_goes_unavailable(
     mock_concord232_client.list_zones.return_value = [
         {"number": 2, "name": "HALL MOTION", "state": "Normal"}
     ]
-    freezer.tick(UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -157,7 +158,7 @@ async def test_zone_missing_from_update_goes_unavailable(
         {"number": 1, "name": "FRONT DOOR", "state": "Tripped"},
         {"number": 2, "name": "HALL MOTION", "state": "Normal"},
     ]
-    freezer.tick(UPDATE_INTERVAL)
+    freezer.tick(UPDATE_INTERVAL + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/concord232/test_config_flow.py
+++ b/tests/components/concord232/test_config_flow.py
@@ -1,0 +1,205 @@
+"""Tests for the Concord232 config flow."""
+
+from unittest.mock import MagicMock
+
+import requests
+
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.concord232.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {CONF_HOST: "localhost", CONF_PORT: 5007}
+
+
+async def test_user_flow(
+    hass: HomeAssistant, mock_concord232_client: MagicMock
+) -> None:
+    """Test a successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "localhost"
+    assert result["data"] == USER_INPUT
+
+
+async def test_user_flow_cannot_connect_recovers(
+    hass: HomeAssistant, mock_concord232_client: MagicMock
+) -> None:
+    """Test connection errors show an error and the flow can recover."""
+    mock_concord232_client.list_partitions.side_effect = (
+        requests.exceptions.ConnectionError("boom")
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_concord232_client.list_partitions.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the same host and port cannot be added twice."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow(
+    hass: HomeAssistant, mock_concord232_client: MagicMock
+) -> None:
+    """Test importing YAML platform configuration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_HOST: "localhost",
+            CONF_PORT: 5007,
+            CONF_NAME: "Test Alarm",
+            CONF_CODE: "1234",
+            CONF_MODE: "silent",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Test Alarm"
+    assert result["data"] == USER_INPUT
+    assert result["options"] == {CONF_CODE: "1234", CONF_MODE: "silent"}
+
+
+async def test_import_flow_cannot_connect(
+    hass: HomeAssistant, mock_concord232_client: MagicMock
+) -> None:
+    """Test the import flow aborts when the server is unreachable."""
+    mock_concord232_client.list_partitions.side_effect = (
+        requests.exceptions.ConnectionError("boom")
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the import flow aborts for an already configured server."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_yaml_platform_creates_entry_and_issue(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test YAML platform setup imports the config and creates an issue."""
+    assert await async_setup_component(
+        hass,
+        ALARM_DOMAIN,
+        {
+            ALARM_DOMAIN: {
+                "platform": DOMAIN,
+                CONF_HOST: "localhost",
+                CONF_PORT: 5007,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == USER_INPUT
+    assert issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+
+
+async def test_yaml_platform_import_cannot_connect_issue(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a failed YAML import creates the cannot-connect issue."""
+    mock_concord232_client.list_partitions.side_effect = (
+        requests.exceptions.ConnectionError("boom")
+    )
+    assert await async_setup_component(
+        hass,
+        BINARY_SENSOR_DOMAIN,
+        {
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                CONF_HOST: "localhost",
+                CONF_PORT: 5007,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert not hass.config_entries.async_entries(DOMAIN)
+    assert issue_registry.async_get_issue(
+        DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
+    )
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow sets code and mode."""
+    await setup_integration(hass, mock_config_entry)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_CODE: "1234", CONF_MODE: "silent"}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options == {CONF_CODE: "1234", CONF_MODE: "silent"}

--- a/tests/components/concord232/test_config_flow.py
+++ b/tests/components/concord232/test_config_flow.py
@@ -203,3 +203,75 @@ async def test_options_flow(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options == {CONF_CODE: "1234", CONF_MODE: "silent"}
+
+
+async def test_options_change_takes_effect_without_manual_reload(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test saving options reloads the entry so the panel picks them up."""
+    await setup_integration(hass, mock_config_entry)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_MODE: "silent"}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_arm_home",
+        {"entity_id": "alarm_control_panel.localhost"},
+        blocking=True,
+    )
+    mock_concord232_client.arm.assert_called_once_with("stay", "silent")
+
+
+async def test_empty_code_option_means_no_code(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an empty code option allows codeless arming."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, options={CONF_CODE: ""})
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_arm_away",
+        {"entity_id": "alarm_control_panel.localhost"},
+        blocking=True,
+    )
+    mock_concord232_client.arm.assert_called_once_with("away")
+
+
+async def test_second_import_merges_alarm_options(
+    hass: HomeAssistant, mock_concord232_client: MagicMock
+) -> None:
+    """Test the alarm platform's import enriches the entry the other created."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_HOST: "localhost",
+            CONF_PORT: 5007,
+            CONF_CODE: "1234",
+            CONF_MODE: "silent",
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].options == {CONF_CODE: "1234", CONF_MODE: "silent"}

--- a/tests/components/concord232/test_config_flow.py
+++ b/tests/components/concord232/test_config_flow.py
@@ -8,7 +8,14 @@ from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.concord232.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_CODE, CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_HOST,
+    CONF_MODE,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SSL,
+)
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import issue_registry as ir
@@ -18,7 +25,7 @@ from .conftest import setup_integration
 
 from tests.common import MockConfigEntry
 
-USER_INPUT = {CONF_HOST: "localhost", CONF_PORT: 5007}
+USER_INPUT = {CONF_HOST: "localhost", CONF_PORT: 5007, CONF_SSL: False}
 
 
 async def test_user_flow(
@@ -37,6 +44,23 @@ async def test_user_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "localhost"
     assert result["data"] == USER_INPUT
+
+
+async def test_user_flow_ssl(
+    hass: HomeAssistant,
+    mock_concord232_client_class: MagicMock,
+    mock_concord232_client: MagicMock,
+) -> None:
+    """Test the ssl option produces an https url."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "alarm.example.com", CONF_PORT: 443, CONF_SSL: True},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    mock_concord232_client_class.assert_called_with("https://alarm.example.com:443")
 
 
 async def test_user_flow_cannot_connect_recovers(
@@ -203,3 +227,20 @@ async def test_options_flow(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options == {CONF_CODE: "1234", CONF_MODE: "silent"}
+
+
+async def test_entry_without_ssl_key_sets_up(
+    hass: HomeAssistant,
+    mock_concord232_client_class: MagicMock,
+    mock_concord232_client: MagicMock,
+) -> None:
+    """Test an entry created before the ssl option defaults to http."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="localhost",
+        data={CONF_HOST: "localhost", CONF_PORT: 5007},
+    )
+    await setup_integration(hass, entry)
+
+    assert entry.state.value == "loaded"
+    mock_concord232_client_class.assert_called_with("http://localhost:5007")

--- a/tests/components/concord232/test_config_flow.py
+++ b/tests/components/concord232/test_config_flow.py
@@ -275,3 +275,19 @@ async def test_second_import_merges_alarm_options(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].options == {CONF_CODE: "1234", CONF_MODE: "silent"}
+
+
+async def test_import_alongside_other_server_creates_second_entry(
+    hass: HomeAssistant,
+    mock_concord232_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test importing a second server coexists with an unrelated entry."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "otherhost", CONF_PORT: 5007},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2


### PR DESCRIPTION
## Proposed change

Adds an ssl option to the concord232 config flow, so the integration can connect to a concord232 server behind a TLS-terminating reverse proxy over HTTPS.

Stacked on #179587; only the last commit ("Add ssl option to the concord232 config flow") is new here. Entries created before this option default to http via `data.get(CONF_SSL, False)`, covered by a test.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47432
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
