### PR TITLE
Fix flaky statistics_meta duplicate tests on PostgreSQL

### DIFF
--- a/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
+++ b/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
@@ -183,7 +183,11 @@ async def test_delete_metadata_duplicates(
 
     def get_statistics_meta(hass: HomeAssistant) -> list:
         with session_scope(hass=hass, read_only=True) as session:
-            return list(session.query(recorder.db_schema.StatisticsMeta).all())
+            return list(
+                session.query(recorder.db_schema.StatisticsMeta)
+                .order_by(recorder.db_schema.StatisticsMeta.id)
+                .all()
+            )
 
     # Create some duplicated statistics_meta with schema version 28
     with (
@@ -308,7 +312,11 @@ async def test_delete_metadata_duplicates_many(
 
     def get_statistics_meta(hass: HomeAssistant) -> list:
         with session_scope(hass=hass, read_only=True) as session:
-            return list(session.query(recorder.db_schema.StatisticsMeta).all())
+            return list(
+                session.query(recorder.db_schema.StatisticsMeta)
+                .order_by(recorder.db_schema.StatisticsMeta.id)
+                .all()
+            )
 
     # Create some duplicated statistics with schema version 28
     with (


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Fix a flaky recorder test on PostgreSQL. `get_statistics_meta()` queried `statistics_meta` without `ORDER BY` but the test indexes the result positionally, and PostgreSQL gives no order guarantee.

After the schema 28 migration deletes 1102 of 1105 rows, the `unit_class` migration runs `UPDATE statistics_meta SET unit_class=...` on the kWh rows. PostgreSQL writes new tuple versions into the freed pages, so the untouched `%` row is returned first and `assert tmp[0].id == 1101` fails with `assert 1105 == 1101`.

Adding `.order_by(StatisticsMeta.id)` makes the order deterministic. The same helper in `test_delete_metadata_duplicates` had the same latent problem and is fixed too.

Observed in https://github.com/home-assistant/core/actions/runs/32229702027/job/95997332530 (`Run postgres:15.2 tests Python 3.14.5`).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_015MpbDgJhCmPBKg1qNi91aN)_