### PR TITLE
Dedup Z-Wave JS ESPHome placeholder discovery against a home ID

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1650,6 +1650,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         if not is_hassio(self.hass):
             return self.async_abort(reason="not_hassio")
 
+        # The adapter may first be discovered without a home ID and get the
+        # placeholder unique id below, then report a home ID on a later
+        # discovery. Track the placeholder id so such a discovery can be
+        # deduplicated against a pending prompt or an ignored entry.
+        placeholder_unique_id = f"esphome_{discovery_info.name}"
         if discovery_info.zwave_home_id:
             existing_entry: ConfigEntry | None = None
             if (
@@ -1697,6 +1702,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     return self.async_abort(reason="already_configured")
 
+            if any(
+                flow["context"].get("unique_id") == placeholder_unique_id
+                for flow in self._async_in_progress()
+            ):
+                return self.async_abort(reason="already_in_progress")
             # We are not aborting if home ID configured
             # here, we just want to make sure that it's set
             # We will update a USB based config entry
@@ -1710,10 +1720,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             # also when the adapter doesn't report a home ID yet.
             # It is replaced with the home ID before an entry is created.
             self._unique_id_is_placeholder = True
-            await self.async_set_unique_id(f"esphome_{discovery_info.name}")
+            await self.async_set_unique_id(placeholder_unique_id)
 
         if any(
-            entry.source == SOURCE_IGNORE and entry.unique_id == self.unique_id
+            entry.source == SOURCE_IGNORE
+            and entry.unique_id in (self.unique_id, placeholder_unique_id)
             for entry in self._async_current_entries(include_ignore=True)
         ):
             return self.async_abort(reason="already_configured")

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.components.hassio import (
 )
 from homeassistant.config_entries import (
     SOURCE_ESPHOME,
+    SOURCE_IGNORE,
     SOURCE_USB,
     SOURCE_ZEROCONF,
     ConfigEntry,
@@ -235,6 +236,9 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         self._recommended_install = False
         self._rf_region: str | None = None
         self._entry_unloaded_by_flow = False
+        # Set if the flow unique id is a placeholder that must be replaced
+        # with the home ID before a config entry is created.
+        self._unique_id_is_placeholder = False
 
     async def async_step_install_addon(
         self, user_input: dict[str, Any] | None = None
@@ -1015,7 +1019,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info = await self._async_get_addon_discovery_info()
             self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
 
-        if not self.unique_id or self.source == SOURCE_USB:
+        if (
+            not self.unique_id
+            or self.source == SOURCE_USB
+            or self._unique_id_is_placeholder
+        ):
             if not self.version_info:
                 try:
                     self.version_info = await async_get_version_info(
@@ -1027,6 +1035,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(
                 str(self.version_info.home_id), raise_on_progress=False
             )
+            self._unique_id_is_placeholder = False
 
         if (
             existing_entry := next(
@@ -1696,6 +1705,18 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(
                 str(discovery_info.zwave_home_id), raise_on_progress=False
             )
+        else:
+            # Set a placeholder unique id so the discovery can be ignored
+            # also when the adapter doesn't report a home ID yet.
+            # It is replaced with the home ID before an entry is created.
+            self._unique_id_is_placeholder = True
+            await self.async_set_unique_id(f"esphome_{discovery_info.name}")
+
+        if any(
+            entry.source == SOURCE_IGNORE and entry.unique_id == self.unique_id
+            for entry in self._async_current_entries(include_ignore=True)
+        ):
+            return self.async_abort(reason="already_configured")
 
         self.socket_path = discovery_info.socket_path
         home_id_display = format_home_id_for_display(discovery_info.zwave_home_id)

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1695,6 +1695,66 @@ async def test_esphome_discovery_migration(
     assert entry.data["use_addon"] is True
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running")
+async def test_esphome_discovery_placeholder_then_home_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test a home ID discovery dedups against a pending placeholder prompt."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=ESPHOME_DISCOVERY_INFO_CLEAN,
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
+
+    # The same adapter now reports a home ID while its prompt is open.
+    home_id_info = ESPHomeServiceInfo(
+        name=ESPHOME_DISCOVERY_INFO_CLEAN.name,
+        zwave_home_id=1234,
+        ip_address=ESPHOME_DISCOVERY_INFO_CLEAN.ip_address,
+        port=ESPHOME_DISCOVERY_INFO_CLEAN.port,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=home_id_info,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+
+
+@pytest.mark.usefixtures("supervisor", "addon_running")
+async def test_esphome_discovery_placeholder_ignored_then_home_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test a home ID discovery honors a placeholder-based ignore."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=config_entries.SOURCE_IGNORE,
+        unique_id="esphome_mock-name",
+    )
+    entry.add_to_hass(hass)
+
+    # The adapter that was ignored without a home ID now reports one.
+    home_id_info = ESPHomeServiceInfo(
+        name="mock-name",
+        zwave_home_id=1234,
+        ip_address="192.168.1.100",
+        port=6053,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=home_id_info,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 @pytest.mark.usefixtures("supervisor", "addon_running", "addon_info")
 async def test_esphome_discovery_same_socket_no_reload(
     hass: HomeAssistant,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1738,6 +1738,78 @@ async def test_esphome_discovery_same_socket_no_reload(
     }
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running")
+@pytest.mark.parametrize(
+    ("esphome_discovery_info", "ignored_unique_id"),
+    [
+        pytest.param(ESPHOME_DISCOVERY_INFO, "1234", id="home_id"),
+        pytest.param(
+            ESPHOME_DISCOVERY_INFO_CLEAN, "esphome_mock-name", id="no_home_id"
+        ),
+    ],
+)
+async def test_esphome_discovery_ignored(
+    hass: HomeAssistant,
+    esphome_discovery_info: ESPHomeServiceInfo,
+    ignored_unique_id: str,
+) -> None:
+    """Test ESPHome discovery aborts when the discovery was ignored."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=config_entries.SOURCE_IGNORE,
+        unique_id=ignored_unique_id,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=esphome_discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("supervisor", "addon_running")
+async def test_esphome_discovery_without_home_id_can_be_ignored(
+    hass: HomeAssistant,
+) -> None:
+    """Test a discovery without a home ID gets a unique id for ignoring."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=ESPHOME_DISCOVERY_INFO_CLEAN,
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
+
+    flows = hass.config_entries.flow.async_progress_by_handler(
+        DOMAIN, match_context={"source": config_entries.SOURCE_ESPHOME}
+    )
+    assert len(flows) == 1
+    assert flows[0]["context"]["unique_id"] == "esphome_mock-name"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IGNORE},
+        data={"unique_id": "esphome_mock-name", "title": "ZWA-2 proxy"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # The discovery prompt is gone and rediscovery aborts.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ESPHOME},
+        data=ESPHOME_DISCOVERY_INFO_CLEAN,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 @pytest.mark.usefixtures("supervisor", "addon_running", "addon_info")
 async def test_esphome_discovery_already_configured_unmanaged_addon(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An ESPHome adapter first discovered without a home ID gets a placeholder unique id (#179595). When it later reports a home ID, deduplicate that discovery against the pending placeholder prompt and against a placeholder-based ignored entry, instead of presenting a second prompt. Builds on #179595.

Extracted from #176135.

cc @AlCalzone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
