### PR TITLE
Migrate bluetooth_le_tracker to config entry architecture

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/__init__.py
+++ b/homeassistant/components/bluetooth_le_tracker/__init__.py
@@ -1,1 +1,23 @@
 """The bluetooth_le_tracker component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = ["device_tracker"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> bool:
+    """Set up Bluetooth LE Tracker from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bluetooth_le_tracker/config_flow.py
+++ b/homeassistant/components/bluetooth_le_tracker/config_flow.py
@@ -1,0 +1,27 @@
+"""Config flow for Bluetooth LE Tracker."""
+
+from typing import override
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+
+from .const import DOMAIN
+
+
+class BluetoothLETrackerConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Bluetooth LE Tracker."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title="Bluetooth LE Tracker",
+                data={},
+            )
+
+        return self.async_show_form(step_id="user")

--- a/homeassistant/components/bluetooth_le_tracker/const.py
+++ b/homeassistant/components/bluetooth_le_tracker/const.py
@@ -1,0 +1,3 @@
+"""Constants for Bluetooth LE Tracker."""
+
+DOMAIN = "bluetooth_le_tracker"

--- a/homeassistant/components/bluetooth_le_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_le_tracker/manifest.json
@@ -2,8 +2,10 @@
   "domain": "bluetooth_le_tracker",
   "name": "Bluetooth LE Tracker",
   "codeowners": [],
+  "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/bluetooth_le_tracker",
+  "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "legacy"
 }

--- a/homeassistant/components/bluetooth_le_tracker/strings.json
+++ b/homeassistant/components/bluetooth_le_tracker/strings.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "step": {
+      "user": {
+        "description": "Set up Bluetooth LE Tracker"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -107,6 +107,7 @@ FLOWS = {
         "bluemaestro",
         "bluesound",
         "bluetooth",
+        "bluetooth_le_tracker",
         "bond",
         "bosch_alarm",
         "bosch_shc",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -806,8 +806,8 @@
     },
     "bluetooth_le_tracker": {
       "name": "Bluetooth LE Tracker",
-      "integration_type": "hub",
-      "config_flow": false,
+      "integration_type": "device",
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "bond": {

--- a/tests/components/bluetooth_le_tracker/__init__.py
+++ b/tests/components/bluetooth_le_tracker/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the Bluetooth LE tracker component."""
+"""Tests for bluetooth_le_tracker."""

--- a/tests/components/bluetooth_le_tracker/test_config_flow.py
+++ b/tests/components/bluetooth_le_tracker/test_config_flow.py
@@ -1,0 +1,36 @@
+"""Tests for Bluetooth LE Tracker config flow."""
+
+from homeassistant.components.bluetooth_le_tracker.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
+    """Test user flow creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Bluetooth LE Tracker"
+    assert result2["data"] == {}
+
+
+async def test_single_instance_allowed(hass: HomeAssistant) -> None:
+    """Test that only one config entry is allowed."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/bluetooth_le_tracker/test_init.py
+++ b/tests/components/bluetooth_le_tracker/test_init.py
@@ -1,0 +1,35 @@
+"""Tests for Bluetooth LE Tracker __init__."""
+
+from unittest.mock import patch
+
+from homeassistant.components.bluetooth_le_tracker.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(hass: HomeAssistant) -> None:
+    """Test setup of a config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.bluetooth_le_tracker.device_tracker"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test unloading a config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.bluetooth_le_tracker.device_tracker"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
## Description
Migrates the `bluetooth_le_tracker` integration from the legacy 
`async_setup_scanner` pattern to the modern config entry architecture.

## Changes
- Added `config_flow.py` with `BluetoothLETrackerConfigFlow`
- Added `const.py` with domain constant  
- Updated `manifest.json` to declare `config_flow: true` and `integration_type: device`
- Added `async_setup_entry` and `async_unload_entry` to `__init__.py`
- Added translations for config flow

## Testing
- All pre-commit hooks pass (ruff, mypy, pylint, hassfest)
- hassfest validates 0 invalid integrations