### PR TITLE
Add repairs for upcoming bumps of minimum supported db engine versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -479,10 +479,12 @@ jobs:
       contents: read
     needs:
       - info
-    # Only run on push to the dev branch; this job reaches out to endoflife.date, and
-    # we do not want a new MariaDB/MySQL release to fail CI on PR runs or the rc/master
-    # branches.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    # Run on push to the dev branch and on pull requests targeting dev; this job
+    # reaches out to endoflife.date, and we do not want a new MariaDB/MySQL release
+    # to fail CI on the rc/master branches.
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev')
+      || (github.event_name == 'pull_request' && github.base_ref == 'dev')
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -479,12 +479,10 @@ jobs:
       contents: read
     needs:
       - info
-    # Run on push to the dev branch and on pull requests targeting dev; this job
-    # reaches out to endoflife.date, and we do not want a new MariaDB/MySQL release
-    # to fail CI on the rc/master branches.
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev')
-      || (github.event_name == 'pull_request' && github.base_ref == 'dev')
+    # Only run on push to the dev branch; this job reaches out to endoflife.date, and
+    # we do not want a new MariaDB/MySQL release to fail CI on PR runs or the rc/master
+    # branches.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -472,6 +472,32 @@ jobs:
         run: |
           uv run --no-project python -m script.gen_copilot_instructions validate
 
+  gen-recorder-db-versions:
+    name: Check recorder database versions
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs:
+      - info
+    # Only run on push to the dev branch; this job reaches out to endoflife.date, and
+    # we do not want a new MariaDB/MySQL release to fail CI on PR runs or the rc/master
+    # branches.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        id: python
+        uses: ./.github/actions/setup-uv-python
+        with:
+          uv-version: ${{ needs.info.outputs.uv_version }}
+          python-version: ${{ needs.info.outputs.default_python }}
+      - name: Check MariaDB and MySQL versions are up to date
+        run: |
+          uv run --no-project python -m script.gen_recorder_db_versions validate
+
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-24.04

--- a/homeassistant/components/recorder/strings.json
+++ b/homeassistant/components/recorder/strings.json
@@ -4,6 +4,10 @@
       "description": "The database backup stated at {start_time} failed due to lack of resources. The backup cannot be trusted and must be restarted. This can happen if the database is too large or if the system is under heavy load. Consider upgrading the system hardware or reducing the size of the database by decreasing the number of history days to keep or creating a filter.",
       "title": "Database backup failed due to lack of resources"
     },
+    "database_engine_not_supported_lts": {
+      "description": "Version {server_version} of {database_engine} is not a supported long-term support (LTS) release. Short-term releases and end-of-life LTS releases are no longer supported; please upgrade to one of the supported LTS versions ({lts_versions}) to continue using the recorder.",
+      "title": "Update {database_engine} to a supported LTS version to continue using the recorder"
+    },
     "database_engine_too_old": {
       "description": "Support for version {server_version} of {database_engine} is ending; the minimum supported version is {min_version}. Please upgrade your database software.",
       "title": "Update {database_engine} to {min_version} or later to continue using the recorder"

--- a/homeassistant/components/recorder/strings.json
+++ b/homeassistant/components/recorder/strings.json
@@ -5,11 +5,11 @@
       "title": "Database backup failed due to lack of resources"
     },
     "database_engine_not_supported_lts": {
-      "description": "Version {server_version} of {database_engine} is not a supported long-term support (LTS) release. Short-term releases and end-of-life LTS releases are no longer supported; please upgrade to one of the supported LTS versions ({lts_versions}) to continue using the recorder.",
+      "description": "Version {server_version} of {database_engine} is not a supported long-term support (LTS) release. Support for short-term releases and end-of-life LTS releases will be removed; please upgrade to one of the supported LTS versions ({lts_versions}) and restart Home Assistant to continue using the recorder.",
       "title": "Update {database_engine} to a supported LTS version to continue using the recorder"
     },
     "database_engine_too_old": {
-      "description": "Support for version {server_version} of {database_engine} is ending; the minimum supported version is {min_version}. Please upgrade your database software.",
+      "description": "Support for version {server_version} of {database_engine} is ending; the minimum supported version will be {min_version}. Please upgrade your database software and restart Home Assistant.",
       "title": "Update {database_engine} to {min_version} or later to continue using the recorder"
     },
     "maria_db_range_index_regression": {

--- a/homeassistant/components/recorder/strings.json
+++ b/homeassistant/components/recorder/strings.json
@@ -4,6 +4,10 @@
       "description": "The database backup stated at {start_time} failed due to lack of resources. The backup cannot be trusted and must be restarted. This can happen if the database is too large or if the system is under heavy load. Consider upgrading the system hardware or reducing the size of the database by decreasing the number of history days to keep or creating a filter.",
       "title": "Database backup failed due to lack of resources"
     },
+    "database_engine_too_old": {
+      "description": "Support for version {server_version} of {database_engine} is ending; the minimum supported version is {min_version}. Please upgrade your database software.",
+      "title": "Update {database_engine} to {min_version} or later to continue using the recorder"
+    },
     "maria_db_range_index_regression": {
       "description": "Older versions of MariaDB suffer from a significant performance regression when retrieving history data or purging the database. Update to MariaDB version {min_version} or later and restart Home Assistant. If you are using the MariaDB Core app, make sure to update it to the latest version.",
       "title": "Update MariaDB to {min_version} or later resolve a significant performance issue"

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -89,6 +89,12 @@ MIN_VERSION_MYSQL = _simple_version("8.0.0")
 MIN_VERSION_PGSQL = _simple_version("12.0")
 MIN_VERSION_SQLITE = _simple_version("3.40.1")
 
+# Upcoming minimum versions we warn about ahead of raising the hard minimum,
+# as (version, breaks_in_ha_version).
+UPCOMING_MIN_VERSION_MARIA_DB = (_simple_version("10.11.0"), "2027.3.0")
+UPCOMING_MIN_VERSION_MYSQL = (_simple_version("8.4.0"), "2027.3.0")
+UPCOMING_MIN_VERSION_PGSQL = (_simple_version("15.0"), "2027.3.0")
+
 
 # This is the maximum time after the recorder ends the session
 # before we no longer consider startup to be a "restart" and we
@@ -346,6 +352,58 @@ def _raise_if_version_unsupported(
     raise UnsupportedDialect
 
 
+@callback
+def _async_delete_issue_deprecated_version(hass: HomeAssistant) -> None:
+    """Delete the issue about upcoming unsupported database version."""
+    ir.async_delete_issue(hass, DOMAIN, "database_engine_too_old")
+
+
+@callback
+def _async_create_issue_deprecated_version(
+    hass: HomeAssistant,
+    server_version: AwesomeVersion,
+    database_engine: str,
+    min_version: AwesomeVersion,
+    breaks_in_ha_version: str,
+) -> None:
+    """Warn about upcoming unsupported database version."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "database_engine_too_old",
+        is_fixable=False,
+        severity=ir.IssueSeverity.CRITICAL,
+        translation_key="database_engine_too_old",
+        translation_placeholders={
+            "database_engine": database_engine,
+            "server_version": str(server_version),
+            "min_version": str(min_version),
+        },
+        breaks_in_ha_version=breaks_in_ha_version,
+    )
+
+
+def _check_deprecated_version(
+    hass: HomeAssistant,
+    server_version: AwesomeVersion,
+    database_engine: str,
+    upcoming_min_version: tuple[AwesomeVersion, str],
+) -> None:
+    """Create or remove the issue about an upcoming unsupported database version."""
+    min_version, breaks_in_ha_version = upcoming_min_version
+    if server_version < min_version:
+        hass.add_job(
+            _async_create_issue_deprecated_version,
+            hass,
+            server_version,
+            database_engine,
+            min_version,
+            breaks_in_ha_version,
+        )
+    else:
+        hass.add_job(_async_delete_issue_deprecated_version, hass)
+
+
 def _extract_version_from_server_response_or_raise(
     server_response: str,
 ) -> AwesomeVersion:
@@ -490,6 +548,9 @@ def setup_connection_for_dialect(
                     _raise_if_version_unsupported(
                         version or version_string, "MariaDB", MIN_VERSION_MARIA_DB
                     )
+                _check_deprecated_version(
+                    instance.hass, version, "MariaDB", UPCOMING_MIN_VERSION_MARIA_DB
+                )
                 if version and (
                     (version < RECOMMENDED_MIN_VERSION_MARIA_DB)
                     or (MARIA_DB_106 <= version < RECOMMENDED_MIN_VERSION_MARIA_DB_106)
@@ -516,6 +577,9 @@ def setup_connection_for_dialect(
                 # MySQL
                 # https://github.com/home-assistant/core/issues/137178
                 slow_dependent_subquery = True
+                _check_deprecated_version(
+                    instance.hass, version, "MySQL", UPCOMING_MIN_VERSION_MYSQL
+                )
 
         # Ensure all times are using UTC to avoid issues with daylight savings
         execute_on_connection(dbapi_connection, "SET time_zone = '+00:00'")
@@ -535,6 +599,9 @@ def setup_connection_for_dialect(
                 _raise_if_version_unsupported(
                     version or version_string, "PostgreSQL", MIN_VERSION_PGSQL
                 )
+            _check_deprecated_version(
+                instance.hass, version, "PostgreSQL", UPCOMING_MIN_VERSION_PGSQL
+            )
 
     else:
         _fail_unsupported_dialect(dialect_name)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -8,7 +8,7 @@ import functools
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, Concatenate, NoReturn
+from typing import TYPE_CHECKING, Any, Concatenate, NamedTuple, NoReturn
 
 from awesomeversion import (
     AwesomeVersion,
@@ -27,6 +27,9 @@ import voluptuous as vol
 
 from homeassistant.const import WEEKDAYS
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.generated.recorder_database_versions import (
+    SUPPORTED_DATABASE_VERSIONS,
+)
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.recorder import (  # noqa: F401
     DATA_INSTANCE,
@@ -89,11 +92,46 @@ MIN_VERSION_MYSQL = _simple_version("8.0.0")
 MIN_VERSION_PGSQL = _simple_version("12.0")
 MIN_VERSION_SQLITE = _simple_version("3.40.1")
 
-# Upcoming minimum versions we warn about ahead of raising the hard minimum,
-# as (version, breaks_in_ha_version).
-UPCOMING_MIN_VERSION_MARIA_DB = (_simple_version("10.11.0"), "2027.3.0")
-UPCOMING_MIN_VERSION_MYSQL = (_simple_version("8.4.0"), "2027.3.0")
+# PostgreSQL has no LTS/short-term split, so we warn once the version drops
+# below this upcoming minimum, as (version, breaks_in_ha_version).
 UPCOMING_MIN_VERSION_PGSQL = (_simple_version("15.0"), "2027.3.0")
+
+
+# MariaDB and MySQL ship both long-term support (LTS) releases, supported for
+# years, and short-term/innovation releases, supported only until the next
+# release (~3 months). We allow versions on a currently-supported (non-EoL) LTS
+# series and warn against all others (short-term releases and end-of-life LTS
+# series).
+# Versions newer than the latest known non-LTS release are assumed supported
+# so we don't warn about releases we don't know about yet.
+class _LTSVersionSupport(NamedTuple):
+    """Supported LTS policy for an engine that ships LTS + short-term releases."""
+
+    supported_series: frozenset[tuple[int, int]]
+    latest_non_lts_series: tuple[int, int]
+    breaks_in_ha_version: str
+
+
+def _parse_db_series(cycle: str) -> tuple[int, int]:
+    """Parse a "<major>.<minor>" release series into a tuple."""
+    major, _, minor = cycle.partition(".")
+    return int(major), int(minor)
+
+
+def _lts_support(engine: str, breaks_in_ha_version: str) -> _LTSVersionSupport:
+    """Build the LTS support policy for an engine from the generated version file."""
+    versions = SUPPORTED_DATABASE_VERSIONS[engine]
+    return _LTSVersionSupport(
+        supported_series=frozenset(
+            _parse_db_series(cycle) for cycle in versions["supported_lts"]
+        ),
+        latest_non_lts_series=_parse_db_series(versions["latest_non_lts"]),
+        breaks_in_ha_version=breaks_in_ha_version,
+    )
+
+
+SUPPORTED_MARIA_DB_LTS = _lts_support("mariadb", "2027.3.0")
+SUPPORTED_MYSQL_LTS = _lts_support("mysql", "2027.3.0")
 
 
 # This is the maximum time after the recorder ends the session
@@ -353,9 +391,9 @@ def _raise_if_version_unsupported(
 
 
 @callback
-def _async_delete_issue_deprecated_version(hass: HomeAssistant) -> None:
-    """Delete the issue about upcoming unsupported database version."""
-    ir.async_delete_issue(hass, DOMAIN, "database_engine_too_old")
+def _async_delete_issue_deprecated_version(hass: HomeAssistant, issue_id: str) -> None:
+    """Delete a deprecated database version repair issue."""
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 @callback
@@ -383,6 +421,31 @@ def _async_create_issue_deprecated_version(
     )
 
 
+@callback
+def _async_create_issue_not_supported_lts(
+    hass: HomeAssistant,
+    server_version: AwesomeVersion,
+    database_engine: str,
+    lts_versions: str,
+    breaks_in_ha_version: str,
+) -> None:
+    """Warn about a database version that is not a supported LTS release."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "database_engine_not_supported_lts",
+        is_fixable=False,
+        severity=ir.IssueSeverity.CRITICAL,
+        translation_key="database_engine_not_supported_lts",
+        translation_placeholders={
+            "database_engine": database_engine,
+            "server_version": str(server_version),
+            "lts_versions": lts_versions,
+        },
+        breaks_in_ha_version=breaks_in_ha_version,
+    )
+
+
 def _check_deprecated_version(
     hass: HomeAssistant,
     server_version: AwesomeVersion,
@@ -401,7 +464,46 @@ def _check_deprecated_version(
             breaks_in_ha_version,
         )
     else:
-        hass.add_job(_async_delete_issue_deprecated_version, hass)
+        hass.add_job(
+            _async_delete_issue_deprecated_version, hass, "database_engine_too_old"
+        )
+
+
+def _check_lts_version(
+    hass: HomeAssistant,
+    server_version: AwesomeVersion,
+    database_engine: str,
+    lts_support: _LTSVersionSupport,
+) -> None:
+    """Warn unless the version is on a supported LTS series or newer than we know.
+
+    MariaDB and MySQL only support long-term support (LTS) releases for years;
+    short-term releases and end-of-life LTS series are deprecated. Versions newer
+    than the latest known non-LTS release are assumed supported to avoid warning
+    about releases we don't know about yet.
+    """
+    series = (server_version.section(0), server_version.section(1))
+    if (
+        series in lts_support.supported_series
+        or series > lts_support.latest_non_lts_series
+    ):
+        hass.add_job(
+            _async_delete_issue_deprecated_version,
+            hass,
+            "database_engine_not_supported_lts",
+        )
+    else:
+        lts_versions = ", ".join(
+            f"{major}.{minor}" for major, minor in sorted(lts_support.supported_series)
+        )
+        hass.add_job(
+            _async_create_issue_not_supported_lts,
+            hass,
+            server_version,
+            database_engine,
+            lts_versions,
+            lts_support.breaks_in_ha_version,
+        )
 
 
 def _extract_version_from_server_response_or_raise(
@@ -548,8 +650,9 @@ def setup_connection_for_dialect(
                     _raise_if_version_unsupported(
                         version or version_string, "MariaDB", MIN_VERSION_MARIA_DB
                     )
-                _check_deprecated_version(
-                    instance.hass, version, "MariaDB", UPCOMING_MIN_VERSION_MARIA_DB
+                # No elif here since _raise_if_version_unsupported raises
+                _check_lts_version(
+                    instance.hass, version, "MariaDB", SUPPORTED_MARIA_DB_LTS
                 )
                 if version and (
                     (version < RECOMMENDED_MIN_VERSION_MARIA_DB)
@@ -577,9 +680,7 @@ def setup_connection_for_dialect(
                 # MySQL
                 # https://github.com/home-assistant/core/issues/137178
                 slow_dependent_subquery = True
-                _check_deprecated_version(
-                    instance.hass, version, "MySQL", UPCOMING_MIN_VERSION_MYSQL
-                )
+                _check_lts_version(instance.hass, version, "MySQL", SUPPORTED_MYSQL_LTS)
 
         # Ensure all times are using UTC to avoid issues with daylight savings
         execute_on_connection(dbapi_connection, "SET time_zone = '+00:00'")
@@ -599,6 +700,7 @@ def setup_connection_for_dialect(
                 _raise_if_version_unsupported(
                     version or version_string, "PostgreSQL", MIN_VERSION_PGSQL
                 )
+            # No elif here since _raise_if_version_unsupported raises
             _check_deprecated_version(
                 instance.hass, version, "PostgreSQL", UPCOMING_MIN_VERSION_PGSQL
             )

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -410,7 +410,7 @@ def _async_create_issue_deprecated_version(
         DOMAIN,
         "database_engine_too_old",
         is_fixable=False,
-        severity=ir.IssueSeverity.CRITICAL,
+        severity=ir.IssueSeverity.WARNING,
         translation_key="database_engine_too_old",
         translation_placeholders={
             "database_engine": database_engine,
@@ -435,7 +435,7 @@ def _async_create_issue_not_supported_lts(
         DOMAIN,
         "database_engine_not_supported_lts",
         is_fixable=False,
-        severity=ir.IssueSeverity.CRITICAL,
+        severity=ir.IssueSeverity.WARNING,
         translation_key="database_engine_not_supported_lts",
         translation_placeholders={
             "database_engine": database_engine,

--- a/homeassistant/generated/recorder_database_versions.py
+++ b/homeassistant/generated/recorder_database_versions.py
@@ -1,0 +1,30 @@
+"""Automatically generated file.
+
+To update, run python3 -m script.gen_recorder_db_versions
+
+This file is generated from https://endoflife.date. For each of MariaDB and
+MySQL, ``supported_lts`` lists the currently supported (non-end-of-life)
+long-term support release series, and ``latest_non_lts`` is the newest known
+short-term/innovation release series. Both are ``"<major>.<minor>"`` strings.
+"""
+
+from typing import TypedDict
+
+
+class DatabaseVersions(TypedDict):
+    """Supported release series for a database engine."""
+
+    supported_lts: list[str]
+    latest_non_lts: str
+
+
+SUPPORTED_DATABASE_VERSIONS: dict[str, DatabaseVersions] = {
+    "mariadb": {
+        "supported_lts": ["10.11", "11.4", "11.8", "12.3"],
+        "latest_non_lts": "12.2",
+    },
+    "mysql": {
+        "supported_lts": ["8.4", "9.7"],
+        "latest_non_lts": "9.6",
+    },
+}

--- a/script/gen_recorder_db_versions.py
+++ b/script/gen_recorder_db_versions.py
@@ -1,0 +1,140 @@
+"""Generate the recorder's supported database versions file from endoflife.date.
+
+Usage:
+    python3 -m script.gen_recorder_db_versions            # regenerate the file
+    python3 -m script.gen_recorder_db_versions validate   # fail if out of date
+
+For MariaDB and MySQL we track the currently supported (non-end-of-life) LTS
+release series and the newest known short-term/innovation release series. A CI
+job on the dev branch runs the ``validate`` mode, so it fails whenever a new
+(non-patch) MariaDB or MySQL release means the committed file is out of date.
+
+Accessing the network here is a deliberate exception to the general policy of
+not doing so in tests/CI; only this maintenance job talks to endoflife.date, and
+the recorder itself only reads the committed file.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import urllib.request
+
+SOURCES = {
+    "mariadb": "https://endoflife.date/api/mariadb.json",
+    "mysql": "https://endoflife.date/api/mysql.json",
+}
+OUTPUT_FILE = (
+    Path(__file__).parent.parent
+    / "homeassistant"
+    / "generated"
+    / "recorder_database_versions.py"
+)
+HEADER = '''"""Automatically generated file.
+
+To update, run python3 -m script.gen_recorder_db_versions
+
+This file is generated from https://endoflife.date. For each of MariaDB and
+MySQL, ``supported_lts`` lists the currently supported (non-end-of-life)
+long-term support release series, and ``latest_non_lts`` is the newest known
+short-term/innovation release series. Both are ``"<major>.<minor>"`` strings.
+"""
+
+from typing import TypedDict
+
+
+class DatabaseVersions(TypedDict):
+    """Supported release series for a database engine."""
+
+    supported_lts: list[str]
+    latest_non_lts: str
+
+
+SUPPORTED_DATABASE_VERSIONS: dict[str, DatabaseVersions] = {'''
+
+
+def _series_key(cycle: str) -> tuple[int, int]:
+    """Return a sortable (major, minor) key for a "<major>.<minor>" cycle."""
+    major, _, minor = cycle.partition(".")
+    return int(major), int(minor)
+
+
+def _eol(cycle: dict) -> date:
+    """Return the end-of-life date for a cycle (date.max when none is set)."""
+    eol = cycle["eol"]
+    return date.max if isinstance(eol, bool) else date.fromisoformat(eol)
+
+
+def _engine_versions(cycles: list[dict]) -> dict:
+    """Compute the supported LTS series and latest non-LTS series for an engine."""
+    today = datetime.now(UTC).date()
+    supported_lts = sorted(
+        (
+            cycle["cycle"]
+            for cycle in cycles
+            if cycle.get("lts") and _eol(cycle) > today
+        ),
+        key=_series_key,
+    )
+    latest_non_lts = max(
+        (cycle["cycle"] for cycle in cycles if not cycle.get("lts")),
+        key=_series_key,
+    )
+    return {"supported_lts": supported_lts, "latest_non_lts": latest_non_lts}
+
+
+def fetch_versions() -> dict:
+    """Fetch and compute the supported version data for all engines."""
+    versions = {}
+    for engine, url in SOURCES.items():
+        with urllib.request.urlopen(url) as response:
+            cycles = json.load(response)
+        versions[engine] = _engine_versions(cycles)
+    return versions
+
+
+def render(versions: dict) -> str:
+    """Render the generated database_versions.py content."""
+    lines = [HEADER]
+    for engine, data in versions.items():
+        supported = ", ".join(f'"{cycle}"' for cycle in data["supported_lts"])
+        lines.append(f'    "{engine}": {{')
+        lines.append(f'        "supported_lts": [{supported}],')
+        lines.append(f'        "latest_non_lts": "{data["latest_non_lts"]}",')
+        lines.append("    },")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def load_committed() -> dict:
+    """Load the committed SUPPORTED_DATABASE_VERSIONS without importing recorder."""
+    spec = importlib.util.spec_from_file_location("_database_versions", OUTPUT_FILE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    committed: dict = module.SUPPORTED_DATABASE_VERSIONS
+    return committed
+
+
+def main() -> int:
+    """Generate the file or validate that the committed one is up to date."""
+    validate = len(sys.argv) > 1 and sys.argv[1] == "validate"
+    versions = fetch_versions()
+    if validate:
+        if versions != load_committed():
+            print(
+                "homeassistant/components/recorder/database_versions.py is out of "
+                "date with a new MariaDB or MySQL release.\n"
+                "Run: python3 -m script.gen_recorder_db_versions"
+            )
+            return 1
+        return 0
+    OUTPUT_FILE.write_text(render(versions))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/gen_recorder_db_versions.py
+++ b/script/gen_recorder_db_versions.py
@@ -5,13 +5,16 @@ Usage:
     python3 -m script.gen_recorder_db_versions validate   # fail if out of date
 
 For MariaDB and MySQL we track the currently supported (non-end-of-life) LTS
-release series and the newest known short-term/innovation release series. A CI
-job on the dev branch runs the ``validate`` mode, so it fails whenever a new
+release series and the newest known short-term/innovation release series.
+
+A CI job on the dev branch runs the ``validate`` mode, so it fails whenever a new
 (non-patch) MariaDB or MySQL release means the committed file is out of date.
 
 Accessing the network here is a deliberate exception to the general policy of
 not doing so in tests/CI; only this maintenance job talks to endoflife.date, and
-the recorder itself only reads the committed file.
+the recorder itself only reads the committed file. ``validate`` skips (instead of
+failing) when endoflife.date cannot be reached, so an outage does not fail
+unrelated pull requests.
 """
 
 from __future__ import annotations
@@ -21,12 +24,19 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
+import time
+import urllib.error
 import urllib.request
 
 SOURCES = {
     "mariadb": "https://endoflife.date/api/mariadb.json",
     "mysql": "https://endoflife.date/api/mysql.json",
 }
+FETCH_TIMEOUT = 30
+FETCH_RETRIES = 3
+FETCH_RETRY_WAIT = 2
+# Errors that mean we could not get usable data from endoflife.date
+FETCH_ERRORS = (urllib.error.URLError, TimeoutError, json.JSONDecodeError)
 OUTPUT_FILE = (
     Path(__file__).parent.parent
     / "homeassistant"
@@ -68,9 +78,8 @@ def _eol(cycle: dict) -> date:
     return date.max if isinstance(eol, bool) else date.fromisoformat(eol)
 
 
-def _engine_versions(cycles: list[dict]) -> dict:
+def _engine_versions(cycles: list[dict], today: date) -> dict:
     """Compute the supported LTS series and latest non-LTS series for an engine."""
-    today = datetime.now(UTC).date()
     supported_lts = sorted(
         (
             cycle["cycle"]
@@ -86,18 +95,30 @@ def _engine_versions(cycles: list[dict]) -> dict:
     return {"supported_lts": supported_lts, "latest_non_lts": latest_non_lts}
 
 
+def _fetch(url: str) -> list[dict]:
+    """Fetch and parse an endoflife.date API response, retrying transient errors."""
+    for attempt in range(FETCH_RETRIES):
+        try:
+            with urllib.request.urlopen(url, timeout=FETCH_TIMEOUT) as response:
+                cycles: list[dict] = json.load(response)
+                return cycles
+        except FETCH_ERRORS:
+            if attempt == FETCH_RETRIES - 1:
+                raise
+            time.sleep(FETCH_RETRY_WAIT)
+    raise RuntimeError  # pragma: no cover
+
+
 def fetch_versions() -> dict:
     """Fetch and compute the supported version data for all engines."""
-    versions = {}
-    for engine, url in SOURCES.items():
-        with urllib.request.urlopen(url) as response:
-            cycles = json.load(response)
-        versions[engine] = _engine_versions(cycles)
-    return versions
+    today = datetime.now(UTC).date()
+    return {
+        engine: _engine_versions(_fetch(url), today) for engine, url in SOURCES.items()
+    }
 
 
 def render(versions: dict) -> str:
-    """Render the generated database_versions.py content."""
+    """Render the generated recorder_database_versions.py content."""
     lines = [HEADER]
     for engine, data in versions.items():
         supported = ", ".join(f'"{cycle}"' for cycle in data["supported_lts"])
@@ -121,18 +142,23 @@ def load_committed() -> dict:
 
 def main() -> int:
     """Generate the file or validate that the committed one is up to date."""
-    validate = len(sys.argv) > 1 and sys.argv[1] == "validate"
-    versions = fetch_versions()
-    if validate:
+    if len(sys.argv) > 1 and sys.argv[1] == "validate":
+        try:
+            versions = fetch_versions()
+        except FETCH_ERRORS as err:
+            print(f"Skipping validation, could not reach endoflife.date: {err}")
+            return 0
         if versions != load_committed():
+            relative_path = OUTPUT_FILE.relative_to(Path(__file__).parent.parent)
             print(
-                "homeassistant/components/recorder/database_versions.py is out of "
-                "date with a new MariaDB or MySQL release.\n"
+                f"{relative_path} is out of date with the latest MariaDB or MySQL "
+                "release data from endoflife.date (a new release or an LTS series "
+                "reaching end of life).\n"
                 "Run: python3 -m script.gen_recorder_db_versions"
             )
             return 1
         return 0
-    OUTPUT_FILE.write_text(render(versions))
+    OUTPUT_FILE.write_text(render(fetch_versions()))
     return 0
 
 

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -749,58 +749,102 @@ async def test_no_issue_for_mariadb_with_MDEV_25020(
     assert database_engine.optimizer.slow_dependent_subquery is False
 
 
+async def test_issue_for_deprecated_pgsql_version(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test we create and delete an issue for a PostgreSQL version below the minimum."""
+    instance_mock = MagicMock()
+    instance_mock.hass = hass
+    execute_args = []
+    close_mock = MagicMock()
+    reported_version = "13.2"
+
+    def execute_mock(statement):
+        nonlocal execute_args
+        execute_args.append(statement)
+
+    def fetchall_mock():
+        nonlocal execute_args
+        if execute_args[-1] == "SHOW server_version":
+            return [[reported_version]]
+        return None
+
+    def _make_cursor_mock(*_):
+        return MagicMock(execute=execute_mock, close=close_mock, fetchall=fetchall_mock)
+
+    dbapi_connection = MagicMock(cursor=_make_cursor_mock)
+
+    database_engine = await hass.async_add_executor_job(
+        util.setup_connection_for_dialect,
+        instance_mock,
+        "postgresql",
+        dbapi_connection,
+        True,
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "database_engine_too_old")
+    assert issue is not None
+    assert issue.breaks_in_ha_version == "2027.3.0"
+    assert issue.translation_placeholders == {
+        "database_engine": "PostgreSQL",
+        "server_version": "13.2",
+        "min_version": "15.0",
+    }
+    assert database_engine is not None
+
+    reported_version = "15.2"
+    database_engine = await hass.async_add_executor_job(
+        util.setup_connection_for_dialect,
+        instance_mock,
+        "postgresql",
+        dbapi_connection,
+        True,
+    )
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, "database_engine_too_old") is None
+    assert database_engine is not None
+
+
 @pytest.mark.parametrize(
     (
-        "dialect",
-        "version_query",
         "server_version",
         "extracted_version",
         "engine_name",
-        "min_version",
+        "lts_versions",
         "supported_version",
     ),
     [
         (
-            "mysql",
-            "SELECT VERSION()",
             "10.6.0-MariaDB",
             "10.6.0",
             "MariaDB",
-            "10.11.0",
-            "10.11.0-MariaDB",
+            "10.11, 11.4, 11.8, 12.3",
+            "11.8.1-MariaDB",
         ),
         (
-            "mysql",
-            "SELECT VERSION()",
-            "8.0.0",
-            "8.0.0",
-            "MySQL",
-            "8.4.0",
-            "8.4.0",
+            "11.5.0-MariaDB",
+            "11.5.0",
+            "MariaDB",
+            "10.11, 11.4, 11.8, 12.3",
+            "11.8.1-MariaDB",
         ),
-        (
-            "postgresql",
-            "SHOW server_version",
-            "13.2",
-            "13.2",
-            "PostgreSQL",
-            "15.0",
-            "15.2",
-        ),
+        ("8.0.0", "8.0.0", "MySQL", "8.4, 9.7", "8.4.0"),
+        ("8.2.0", "8.2.0", "MySQL", "8.4, 9.7", "9.7.0"),
     ],
 )
-async def test_issue_for_deprecated_database_version(
+async def test_issue_for_not_supported_lts_version(
     hass: HomeAssistant,
-    dialect: str,
-    version_query: str,
     server_version: str,
     extracted_version: str,
     engine_name: str,
-    min_version: str,
+    lts_versions: str,
     supported_version: str,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test we create and delete an issue for end-of-life database versions."""
+    """Test we warn about MariaDB/MySQL versions that are not a supported LTS release."""
     instance_mock = MagicMock()
     instance_mock.hass = hass
     execute_args = []
@@ -813,7 +857,7 @@ async def test_issue_for_deprecated_database_version(
 
     def fetchall_mock():
         nonlocal execute_args
-        if execute_args[-1] == version_query:
+        if execute_args[-1] == "SELECT VERSION()":
             return [[reported_version]]
         return None
 
@@ -825,19 +869,19 @@ async def test_issue_for_deprecated_database_version(
     database_engine = await hass.async_add_executor_job(
         util.setup_connection_for_dialect,
         instance_mock,
-        dialect,
+        "mysql",
         dbapi_connection,
         True,
     )
     await hass.async_block_till_done()
 
-    issue = issue_registry.async_get_issue(DOMAIN, "database_engine_too_old")
+    issue = issue_registry.async_get_issue(DOMAIN, "database_engine_not_supported_lts")
     assert issue is not None
     assert issue.breaks_in_ha_version == "2027.3.0"
     assert issue.translation_placeholders == {
         "database_engine": engine_name,
         "server_version": extracted_version,
-        "min_version": min_version,
+        "lts_versions": lts_versions,
     }
     assert database_engine is not None
 
@@ -845,13 +889,67 @@ async def test_issue_for_deprecated_database_version(
     database_engine = await hass.async_add_executor_job(
         util.setup_connection_for_dialect,
         instance_mock,
-        dialect,
+        "mysql",
         dbapi_connection,
         True,
     )
     await hass.async_block_till_done()
 
-    assert issue_registry.async_get_issue(DOMAIN, "database_engine_too_old") is None
+    assert (
+        issue_registry.async_get_issue(DOMAIN, "database_engine_not_supported_lts")
+        is None
+    )
+    assert database_engine is not None
+
+
+@pytest.mark.parametrize(
+    "server_version",
+    [
+        "12.4.0-MariaDB",  # non-LTS MariaDB release newer than we know about
+        "13.4.0-MariaDB",  # LTS MariaDB release newer than we know about
+        "9.8.0",  # non-LTS MySQL release newer than we know about
+        "10.4.0",  # LTS MySQL release newer than we know about
+    ],
+)
+async def test_no_issue_for_future_database_version(
+    hass: HomeAssistant,
+    server_version: str,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test we assume versions newer than the latest known non-LTS release are supported."""
+    instance_mock = MagicMock()
+    instance_mock.hass = hass
+    execute_args = []
+    close_mock = MagicMock()
+
+    def execute_mock(statement):
+        nonlocal execute_args
+        execute_args.append(statement)
+
+    def fetchall_mock():
+        nonlocal execute_args
+        if execute_args[-1] == "SELECT VERSION()":
+            return [[server_version]]
+        return None
+
+    def _make_cursor_mock(*_):
+        return MagicMock(execute=execute_mock, close=close_mock, fetchall=fetchall_mock)
+
+    dbapi_connection = MagicMock(cursor=_make_cursor_mock)
+
+    database_engine = await hass.async_add_executor_job(
+        util.setup_connection_for_dialect,
+        instance_mock,
+        "mysql",
+        dbapi_connection,
+        True,
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, "database_engine_not_supported_lts")
+        is None
+    )
     assert database_engine is not None
 
 

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -749,6 +749,112 @@ async def test_no_issue_for_mariadb_with_MDEV_25020(
     assert database_engine.optimizer.slow_dependent_subquery is False
 
 
+@pytest.mark.parametrize(
+    (
+        "dialect",
+        "version_query",
+        "server_version",
+        "extracted_version",
+        "engine_name",
+        "min_version",
+        "supported_version",
+    ),
+    [
+        (
+            "mysql",
+            "SELECT VERSION()",
+            "10.6.0-MariaDB",
+            "10.6.0",
+            "MariaDB",
+            "10.11.0",
+            "10.11.0-MariaDB",
+        ),
+        (
+            "mysql",
+            "SELECT VERSION()",
+            "8.0.0",
+            "8.0.0",
+            "MySQL",
+            "8.4.0",
+            "8.4.0",
+        ),
+        (
+            "postgresql",
+            "SHOW server_version",
+            "13.2",
+            "13.2",
+            "PostgreSQL",
+            "15.0",
+            "15.2",
+        ),
+    ],
+)
+async def test_issue_for_deprecated_database_version(
+    hass: HomeAssistant,
+    dialect: str,
+    version_query: str,
+    server_version: str,
+    extracted_version: str,
+    engine_name: str,
+    min_version: str,
+    supported_version: str,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test we create and delete an issue for end-of-life database versions."""
+    instance_mock = MagicMock()
+    instance_mock.hass = hass
+    execute_args = []
+    close_mock = MagicMock()
+    reported_version = server_version
+
+    def execute_mock(statement):
+        nonlocal execute_args
+        execute_args.append(statement)
+
+    def fetchall_mock():
+        nonlocal execute_args
+        if execute_args[-1] == version_query:
+            return [[reported_version]]
+        return None
+
+    def _make_cursor_mock(*_):
+        return MagicMock(execute=execute_mock, close=close_mock, fetchall=fetchall_mock)
+
+    dbapi_connection = MagicMock(cursor=_make_cursor_mock)
+
+    database_engine = await hass.async_add_executor_job(
+        util.setup_connection_for_dialect,
+        instance_mock,
+        dialect,
+        dbapi_connection,
+        True,
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "database_engine_too_old")
+    assert issue is not None
+    assert issue.breaks_in_ha_version == "2027.3.0"
+    assert issue.translation_placeholders == {
+        "database_engine": engine_name,
+        "server_version": extracted_version,
+        "min_version": min_version,
+    }
+    assert database_engine is not None
+
+    reported_version = supported_version
+    database_engine = await hass.async_add_executor_job(
+        util.setup_connection_for_dialect,
+        instance_mock,
+        dialect,
+        dbapi_connection,
+        True,
+    )
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, "database_engine_too_old") is None
+    assert database_engine is not None
+
+
 @pytest.mark.skip_on_db_engine(["mysql", "postgresql"])
 @pytest.mark.usefixtures("skip_by_db_engine")
 async def test_basic_sanity_check(

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -146,9 +146,14 @@ def disable_mariadb_issue() -> None:
 
 @pytest.fixture(autouse=True)
 def disable_deprecated_database_version_issue() -> None:
-    """Disable creating issue about deprecated database versions."""
-    with patch(
-        "homeassistant.components.recorder.util._async_create_issue_deprecated_version"
+    """Disable creating issues about deprecated database versions."""
+    with (
+        patch(
+            "homeassistant.components.recorder.util._async_create_issue_deprecated_version"
+        ),
+        patch(
+            "homeassistant.components.recorder.util._async_create_issue_not_supported_lts"
+        ),
     ):
         yield
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -144,6 +144,15 @@ def disable_mariadb_issue() -> None:
         yield
 
 
+@pytest.fixture(autouse=True)
+def disable_deprecated_database_version_issue() -> None:
+    """Disable creating issue about deprecated database versions."""
+    with patch(
+        "homeassistant.components.recorder.util._async_create_issue_deprecated_version"
+    ):
+        yield
+
+
 async def async_list_statistic_ids(
     hass: HomeAssistant,
     statistic_ids: set[str] | None = None,

--- a/tests/script/test_gen_recorder_db_versions.py
+++ b/tests/script/test_gen_recorder_db_versions.py
@@ -1,0 +1,88 @@
+"""Tests for the gen_recorder_db_versions script."""
+
+from datetime import date
+import sys
+from unittest.mock import patch
+import urllib.error
+
+import pytest
+
+from script import gen_recorder_db_versions as gen
+
+# endoflife.date exposes `lts` as a boolean for most cycles, but as the date the
+# cycle became LTS for some (e.g. MySQL 8.0), and `eol` as a date string or, when
+# no end of life is announced yet, the boolean false.
+MARIADB_CYCLES = [
+    {"cycle": "12.3", "lts": True, "eol": "2029-06-12"},  # supported LTS
+    {"cycle": "12.2", "lts": False, "eol": "2026-05-28"},  # newest non-LTS
+    {"cycle": "11.8", "lts": True, "eol": "2028-06-04"},  # supported LTS
+    {"cycle": "10.6", "lts": True, "eol": "2026-07-06"},  # LTS past end of life
+    {"cycle": "10.3", "lts": False, "eol": "2023-05-25"},  # old non-LTS
+]
+MYSQL_CYCLES = [
+    {"cycle": "9.7", "lts": True, "eol": "2034-04-21"},  # supported LTS (bool)
+    {"cycle": "9.6", "lts": False, "eol": "2026-04-21"},  # newest non-LTS
+    {"cycle": "8.4", "lts": True, "eol": "2032-04-30"},  # supported LTS (bool)
+    {"cycle": "8.0", "lts": "2023-07-18", "eol": "2026-04-30"},  # LTS-as-date, past EOL
+]
+
+
+@pytest.mark.parametrize(
+    ("cycles", "expected"),
+    [
+        (MARIADB_CYCLES, {"supported_lts": ["11.8", "12.3"], "latest_non_lts": "12.2"}),
+        (MYSQL_CYCLES, {"supported_lts": ["8.4", "9.7"], "latest_non_lts": "9.6"}),
+    ],
+    ids=["mariadb", "mysql"],
+)
+def test_engine_versions(cycles: list[dict], expected: dict) -> None:
+    """Test end-of-life filtering, LTS bool/date handling, and series ordering."""
+    assert gen._engine_versions(cycles, date(2026, 8, 20)) == expected
+
+
+def test_eol_handles_missing_and_date() -> None:
+    """Test a missing end-of-life date maps to date.max and a date string is parsed."""
+    assert gen._eol({"eol": False}) == date.max
+    assert gen._eol({"eol": "2028-02-16"}) == date(2028, 2, 16)
+
+
+def test_render_matches_committed() -> None:
+    """Test the committed file is exactly what render() produces."""
+    assert gen.render(gen.load_committed()) == gen.OUTPUT_FILE.read_text()
+
+
+def test_main_validate_up_to_date() -> None:
+    """Test validate succeeds when the committed file matches the fetched data."""
+    with (
+        patch.object(gen, "fetch_versions", return_value=gen.load_committed()),
+        patch.object(sys, "argv", ["prog", "validate"]),
+    ):
+        assert gen.main() == 0
+
+
+def test_main_validate_out_of_date(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test validate fails and reports the generated file path when out of date."""
+    stale = {
+        "mariadb": {"supported_lts": ["0.0"], "latest_non_lts": "0.0"},
+        "mysql": {"supported_lts": ["0.0"], "latest_non_lts": "0.0"},
+    }
+    with (
+        patch.object(gen, "fetch_versions", return_value=stale),
+        patch.object(sys, "argv", ["prog", "validate"]),
+    ):
+        assert gen.main() == 1
+    output = capsys.readouterr().out
+    assert "homeassistant/generated/recorder_database_versions.py" in output
+    assert "components/recorder/database_versions.py" not in output
+
+
+def test_main_validate_skips_on_network_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test validate skips (instead of failing) when endoflife.date is unreachable."""
+    with (
+        patch.object(gen, "fetch_versions", side_effect=urllib.error.URLError("boom")),
+        patch.object(sys, "argv", ["prog", "validate"]),
+    ):
+        assert gen.main() == 0
+    assert "Skipping validation" in capsys.readouterr().out


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for outdated versions of the PostgreSQL, MariaDB and MySQL database
engines is being deprecated; the recorder creates a repair issue asking the user
to upgrade. Support is planned to be dropped in a future release (`2027.3`,
~6 months out), after which the recorder will refuse to start on those versions.

- **PostgreSQL** (no LTS/short-term split): versions below **15** are deprecated.
- **MariaDB** and **MySQL** ship both long-term support (LTS) releases (supported
  for years) and short-term/innovation releases (supported only ~3 months). Only
  versions on a currently-supported LTS series are allowed; short-term releases
  and end-of-life LTS releases are deprecated.
  - Supported MariaDB LTS series: **10.11, 11.4, 11.8, 12.3**.
  - Supported MySQL LTS series: **8.4, 9.7**.

The LTS MariaDB and MySQL LTS releases do not follow any well-defined pattern, so we add a CI job which runs on merge to dev, which checks that the recorder knows about the latest supported LTS versions.

No repairs are raised for unknown future versions to avoid false positives.

#### Details on the version support:

MariaDB: https://endoflife.date/mariadb
MySQL: https://endoflife.date/mysql
PostgreSQL: https://endoflife.date/postgresql

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
