### PR TITLE
Share one Modbus connection between the integrations on a device

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
+from .connection import async_get_unit  # noqa: F401
 from .const import DOMAIN
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
 from .schemas import CONFIG_SCHEMA  # noqa: F401

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -9,10 +9,20 @@ from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
-from .connection import async_get_unit  # noqa: F401
+from .connection import async_get_unit
 from .const import DOMAIN
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
-from .schemas import CONFIG_SCHEMA  # noqa: F401
+from .schemas import CONFIG_SCHEMA
+
+# What other integrations may rely on. `async_get_unit` hands out a unit over a
+# connection shared with whoever else asked for the same device; `get_hub` and
+# `ModbusHub` reach a hub the user configured in YAML.
+__all__ = [
+    "CONFIG_SCHEMA",
+    "ModbusHub",
+    "async_get_unit",
+    "get_hub",
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -14,9 +14,6 @@ from .const import DOMAIN
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
 from .schemas import CONFIG_SCHEMA
 
-# What other integrations may rely on. `async_get_unit` hands out a unit over a
-# connection shared with whoever else asked for the same device; `get_hub` and
-# `ModbusHub` reach a hub the user configured in YAML.
 __all__ = [
     "CONFIG_SCHEMA",
     "ModbusHub",

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -1,0 +1,83 @@
+"""Hand out Modbus units over connections shared between integrations."""
+
+from dataclasses import dataclass
+import logging
+
+from modbus_connection import (
+    ModbusSerialParams,
+    ModbusTcpParams,
+    ModbusTlsParams,
+    ModbusUdpParams,
+    ModbusUnit,
+)
+from modbus_connection.tmodbus import ModbusConnection
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.hass_dict import HassKey
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+type ModbusParams = (
+    ModbusTcpParams | ModbusUdpParams | ModbusTlsParams | ModbusSerialParams
+)
+type ModbusEndpoint = tuple[str, str, int] | tuple[str, str]
+
+DATA_MODBUS_CONNECTIONS: HassKey[dict[ModbusEndpoint, _SharedConnection]] = HassKey(
+    f"{DOMAIN}_connections"
+)
+
+
+@dataclass
+class _SharedConnection:
+    """A connection and how many units are held on it."""
+
+    params: ModbusParams
+    connection: ModbusConnection
+    consumers: int = 0
+
+
+@callback
+def async_get_unit(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    params: ModbusParams,
+    unit_id: int,
+) -> ModbusUnit:
+    """Return a unit on the connection these credentials describe.
+
+    Consumers of one device share a connection, so their requests serialize
+    behind its lock. It is closed when the last config entry holding a unit on
+    it unloads.
+
+    Raises `HomeAssistantError` if the device is already in use over different
+    link settings, which cannot both be honoured on one connection.
+    """
+    endpoint = params.endpoint
+    connections = hass.data.setdefault(DATA_MODBUS_CONNECTIONS, {})
+    if (shared := connections.get(endpoint)) is None:
+        shared = connections[endpoint] = _SharedConnection(
+            params, ModbusConnection(params)
+        )
+    elif shared.params != params:
+        raise HomeAssistantError(
+            f"Modbus device {endpoint} is already in use with different link "
+            f"settings: {shared.params} against {params}"
+        )
+
+    shared.consumers += 1
+
+    async def _release() -> None:
+        """Give up this hold, closing behind the last one."""
+        shared.consumers -= 1
+        if shared.consumers or connections.get(endpoint) is not shared:
+            return
+        del connections[endpoint]
+        _LOGGER.debug("Closing the Modbus connection to %s", endpoint)
+        await shared.connection.close()
+
+    entry.async_on_unload(_release)
+    return shared.connection.for_unit(unit_id)

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],
-  "requirements": ["pymodbus==3.13.1"]
+  "requirements": ["pymodbus==3.13.1", "modbus-connection[tmodbus]==4.8.0"]
 }

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],
-  "requirements": ["pymodbus==3.13.1", "modbus-connection[tmodbus]==4.8.0"]
+  "requirements": ["pymodbus==3.13.1", "modbus-connection[tmodbus]==4.8.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1609,6 +1609,9 @@ mitsubishi-comfort==0.5.2
 # homeassistant.components.moat
 moat-ble==0.1.1
 
+# homeassistant.components.modbus
+modbus-connection[tmodbus]==4.8.0
+
 # homeassistant.components.moehlenhoff_alpha2
 moehlenhoff-alpha2==1.4.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1610,7 +1610,7 @@ mitsubishi-comfort==0.5.2
 moat-ble==0.1.1
 
 # homeassistant.components.modbus
-modbus-connection[tmodbus]==4.8.0
+modbus-connection[tmodbus]==4.8.1
 
 # homeassistant.components.moehlenhoff_alpha2
 moehlenhoff-alpha2==1.4.0

--- a/tests/components/modbus/test_connection.py
+++ b/tests/components/modbus/test_connection.py
@@ -1,0 +1,190 @@
+"""Test handing out Modbus units over shared connections."""
+
+from collections.abc import Callable, Generator
+from unittest.mock import AsyncMock, patch
+
+from modbus_connection import ModbusSerialParams, ModbusTcpParams
+import pytest
+
+from homeassistant.components.modbus.connection import (
+    DATA_MODBUS_CONNECTIONS,
+    async_get_unit,
+)
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+type ConsumerFactory = Callable[[], MockConfigEntry]
+
+
+class MockFlow(ConfigFlow):
+    """A config flow for the integration standing in for a consumer."""
+
+
+@pytest.fixture(name="consumer")
+def consumer_fixture(hass: HomeAssistant) -> Generator[ConsumerFactory]:
+    """Return a factory for config entries that can be set up and unloaded."""
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=AsyncMock(return_value=True),
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "test.config_flow")
+
+    def _consumer() -> MockConfigEntry:
+        entry = MockConfigEntry(domain="test")
+        entry.add_to_hass(hass)
+        return entry
+
+    with mock_config_flow("test", MockFlow):
+        yield _consumer
+
+
+async def test_equal_credentials_share_one_connection(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """Two consumers of one device queue behind one link, not two.
+
+    A device answering one conversation cannot be asked a second question
+    halfway through it.
+    """
+    one = consumer()
+    await hass.config_entries.async_setup(one.entry_id)
+    two = consumer()
+    await hass.config_entries.async_setup(two.entry_id)
+
+    async_get_unit(hass, one, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    async_get_unit(hass, two, ModbusTcpParams(host="1.2.3.4", port=502), 2)
+
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+    assert shared.consumers == 2
+
+
+async def test_different_credentials_get_their_own_connection(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """A different host, port or transport is a different device."""
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=503), 1)
+    async_get_unit(hass, entry, ModbusSerialParams(device="/dev/ttyUSB0"), 1)
+
+    assert len(hass.data[DATA_MODBUS_CONNECTIONS]) == 3
+
+
+async def test_the_same_device_reached_by_a_different_name_still_shares(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """Hostnames are case-insensitive, so the case must not split the link."""
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    async_get_unit(hass, entry, ModbusTcpParams(host="Device.local", port=502), 1)
+    async_get_unit(hass, entry, ModbusTcpParams(host="device.local", port=502), 2)
+
+    assert len(hass.data[DATA_MODBUS_CONNECTIONS]) == 1
+
+
+async def test_one_device_cannot_be_used_with_two_link_settings(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """One connection can only be framed one way, so the clash has to be said.
+
+    Silently keeping the first would leave the second consumer reading a device
+    over settings it did not ask for.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+
+    with pytest.raises(HomeAssistantError, match="different link settings"):
+        async_get_unit(
+            hass, entry, ModbusTcpParams(host="1.2.3.4", port=502, framer="rtu"), 2
+        )
+
+
+async def test_the_last_consumer_closes_the_connection(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """A connection lives exactly as long as somebody holds a unit on it."""
+    one = consumer()
+    await hass.config_entries.async_setup(one.entry_id)
+    two = consumer()
+    await hass.config_entries.async_setup(two.entry_id)
+
+    async_get_unit(hass, one, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    async_get_unit(hass, two, ModbusTcpParams(host="1.2.3.4", port=502), 2)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    with patch.object(shared.connection, "close") as close:
+        await hass.config_entries.async_unload(one.entry_id)
+        await hass.async_block_till_done()
+
+        # One consumer left, so the link it is still using stays up.
+        assert not close.called
+        assert hass.data[DATA_MODBUS_CONNECTIONS]
+
+        await hass.config_entries.async_unload(two.entry_id)
+        await hass.async_block_till_done()
+
+    assert close.called
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_one_entry_holding_twice_releases_twice(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """An entry with two devices on one link holds it twice.
+
+    Counting entries rather than units would close the link under the second
+    device the moment the entry unloaded once.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 2)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+    assert shared.consumers == 2
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_reloading_an_entry_reopens_the_connection(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """Nothing is held across a reload, so the entry gets a fresh connection.
+
+    There is no grace period; that is what lets a stale connection be recovered.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    [first] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+    [second] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    assert second.connection is not first.connection


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implementation of Modbus Connection https://github.com/home-assistant/architecture/discussions/1418#discussioncomment-17920417

An integration collects its own connection credentials and asks the Modbus integration for a unit. Two integrations that ask with equal credentials get units over the same connection, so their requests serialize behind its lock instead of contending for the device. Connections are provided by [modbus-connection](https://github.com/home-assistant-libs/modbus-connection) Python package.

Nothing is persisted: a connection exists only while somebody holds a unit on it, and closes when the last consumer's config entry unloads. Handing out a unit performs no I/O, so a device that is powered down does not stop the integration asking for it from setting up.

The YAML integration keeps running on pymodbus untouched, so the component carries both dependencies for now. Consumers only ever see the backend-neutral ModbusUnit protocol.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to the source repository of the new requirement: https://github.com/home-assistant-libs/modbus-connection
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3308/changes
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

