### PR TITLE
Add OpenEVSE switch platform

### DIFF
--- a/homeassistant/components/openevse/__init__.py
+++ b/homeassistant/components/openevse/__init__.py
@@ -16,6 +16,7 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.NUMBER,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/openevse/button.py
+++ b/homeassistant/components/openevse/button.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, override
 
-from openevsehttp.__main__ import OpenEVSE
+from openevsehttp import OpenEVSE
 
 from homeassistant.components.button import (
     ButtonDeviceClass,

--- a/homeassistant/components/openevse/helpers.py
+++ b/homeassistant/components/openevse/helpers.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 from aiohttp import ContentTypeError, ServerTimeoutError
 from openevsehttp.exceptions import (
@@ -20,7 +21,7 @@ from .const import DOMAIN
 
 
 @contextmanager
-def openevse_exception_handler(value: float) -> Iterator[None]:
+def openevse_exception_handler(value: Any = None) -> Iterator[None]:
     """Context manager to handle and translate OpenEVSE exceptions."""
     try:
         yield

--- a/homeassistant/components/openevse/number.py
+++ b/homeassistant/components/openevse/number.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, override
 
-from openevsehttp.__main__ import OpenEVSE
+from openevsehttp import OpenEVSE
 
 from homeassistant.components.number import (
     NumberDeviceClass,

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -207,6 +207,17 @@
       "vehicle_soc": {
         "name": "Vehicle state of charge"
       }
+    },
+    "switch": {
+      "current_shaper": {
+        "name": "Current shaper"
+      },
+      "manual_override": {
+        "name": "Manual override"
+      },
+      "solar_pv_divert": {
+        "name": "Solar PV divert"
+      }
     }
   },
   "exceptions": {

--- a/homeassistant/components/openevse/switch.py
+++ b/homeassistant/components/openevse/switch.py
@@ -1,0 +1,115 @@
+"""Support for OpenEVSE switch entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from openevsehttp.__main__ import OpenEVSE
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_SERIAL_NUMBER
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import OpenEVSEConfigEntry, OpenEVSEDataUpdateCoordinator
+from .helpers import openevse_exception_handler
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenEVSESwitchDescription(SwitchEntityDescription):
+    """Describes an OpenEVSE switch entity."""
+
+    is_on_fn: Callable[[OpenEVSE], bool | None]
+    turn_on_fn: Callable[[OpenEVSE], Awaitable[Any]]
+    turn_off_fn: Callable[[OpenEVSE], Awaitable[Any]]
+
+
+SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
+    OpenEVSESwitchDescription(
+        key="solar_pv_divert",
+        translation_key="solar_pv_divert",
+        is_on_fn=lambda ev: ev.divert_active,
+        turn_on_fn=lambda ev: ev.set_divert_mode("eco"),
+        turn_off_fn=lambda ev: ev.set_divert_mode("fast"),
+    ),
+    OpenEVSESwitchDescription(
+        key="current_shaper",
+        translation_key="current_shaper",
+        is_on_fn=lambda ev: ev.shaper_active,
+        turn_on_fn=lambda ev: ev.set_shaper(True),
+        turn_off_fn=lambda ev: ev.set_shaper(False),
+    ),
+    OpenEVSESwitchDescription(
+        key="manual_override",
+        translation_key="manual_override",
+        is_on_fn=lambda ev: ev.manual_override,
+        turn_on_fn=lambda ev: ev.toggle_override(),
+        turn_off_fn=lambda ev: ev.toggle_override(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: OpenEVSEConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up OpenEVSE switches based on config entry."""
+    coordinator = entry.runtime_data
+    identifier = entry.unique_id or entry.entry_id
+    async_add_entities(
+        OpenEVSESwitch(coordinator, description, identifier, entry.unique_id)
+        for description in SWITCH_TYPES
+    )
+
+
+class OpenEVSESwitch(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], SwitchEntity):
+    """Implementation of an OpenEVSE switch."""
+
+    _attr_has_entity_name = True
+    entity_description: OpenEVSESwitchDescription
+
+    def __init__(
+        self,
+        coordinator: OpenEVSEDataUpdateCoordinator,
+        description: OpenEVSESwitchDescription,
+        identifier: str,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{identifier}-{description.key}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, identifier)},
+            manufacturer="OpenEVSE",
+        )
+        if unique_id:
+            self._attr_device_info[ATTR_CONNECTIONS] = {
+                (CONNECTION_NETWORK_MAC, unique_id)
+            }
+            self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return True if the switch is on."""
+        return self.entity_description.is_on_fn(self.coordinator.charger)
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        with openevse_exception_handler():
+            await self.entity_description.turn_on_fn(self.coordinator.charger)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        with openevse_exception_handler():
+            await self.entity_description.turn_off_fn(self.coordinator.charger)

--- a/homeassistant/components/openevse/switch.py
+++ b/homeassistant/components/openevse/switch.py
@@ -29,11 +29,25 @@ class OpenEVSESwitchDescription(SwitchEntityDescription):
     turn_off_fn: Callable[[OpenEVSE], Awaitable[Any]]
 
 
+async def _async_turn_on_override(ev: OpenEVSE) -> None:
+    """Turn on manual override."""
+    if not ev.manual_override:
+        await ev.toggle_override()
+
+
+async def _async_turn_off_override(ev: OpenEVSE) -> None:
+    """Turn off manual override."""
+    if ev.manual_override:
+        await ev.toggle_override()
+
+
 SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
     OpenEVSESwitchDescription(
         key="solar_pv_divert",
         translation_key="solar_pv_divert",
-        is_on_fn=lambda ev: ev.divert_active,
+        is_on_fn=lambda ev: (
+            ev.divertmode == "eco" if ev.divertmode is not None else None
+        ),
         turn_on_fn=lambda ev: ev.set_divert_mode("eco"),
         turn_off_fn=lambda ev: ev.set_divert_mode(
             "fast"
@@ -50,8 +64,8 @@ SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
         key="manual_override",
         translation_key="manual_override",
         is_on_fn=lambda ev: ev.manual_override,
-        turn_on_fn=lambda ev: ev.toggle_override(),
-        turn_off_fn=lambda ev: ev.toggle_override(),
+        turn_on_fn=_async_turn_on_override,
+        turn_off_fn=_async_turn_off_override,
     ),
 )
 

--- a/homeassistant/components/openevse/switch.py
+++ b/homeassistant/components/openevse/switch.py
@@ -35,7 +35,9 @@ SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
         translation_key="solar_pv_divert",
         is_on_fn=lambda ev: ev.divert_active,
         turn_on_fn=lambda ev: ev.set_divert_mode("eco"),
-        turn_off_fn=lambda ev: ev.set_divert_mode("fast"),
+        turn_off_fn=lambda ev: ev.set_divert_mode(
+            "fast"
+        ),  # "fast" disables solar divert
     ),
     OpenEVSESwitchDescription(
         key="current_shaper",

--- a/homeassistant/components/openevse/switch.py
+++ b/homeassistant/components/openevse/switch.py
@@ -29,18 +29,6 @@ class OpenEVSESwitchDescription(SwitchEntityDescription):
     turn_off_fn: Callable[[OpenEVSE], Awaitable[Any]]
 
 
-async def _async_turn_on_override(ev: OpenEVSE) -> None:
-    """Turn on manual override."""
-    if not ev.manual_override:
-        await ev.toggle_override()
-
-
-async def _async_turn_off_override(ev: OpenEVSE) -> None:
-    """Turn off manual override."""
-    if ev.manual_override:
-        await ev.toggle_override()
-
-
 SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
     OpenEVSESwitchDescription(
         key="solar_pv_divert",
@@ -64,8 +52,8 @@ SWITCH_TYPES: tuple[OpenEVSESwitchDescription, ...] = (
         key="manual_override",
         translation_key="manual_override",
         is_on_fn=lambda ev: ev.manual_override,
-        turn_on_fn=_async_turn_on_override,
-        turn_off_fn=_async_turn_off_override,
+        turn_on_fn=lambda ev: ev.toggle_override(),
+        turn_off_fn=lambda ev: ev.toggle_override(),
     ),
 )
 

--- a/homeassistant/components/openevse/switch.py
+++ b/homeassistant/components/openevse/switch.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, override
 
-from openevsehttp.__main__ import OpenEVSE
+from openevsehttp import OpenEVSE
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import ATTR_CONNECTIONS, ATTR_SERIAL_NUMBER
@@ -61,9 +61,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up OpenEVSE switches based on config entry."""
     coordinator = entry.runtime_data
-    identifier = entry.unique_id or entry.entry_id
     async_add_entities(
-        OpenEVSESwitch(coordinator, description, identifier, entry.unique_id)
+        OpenEVSESwitch(
+            coordinator,
+            description,
+            entry.unique_id or entry.entry_id,
+            entry.unique_id,
+        )
         for description in SWITCH_TYPES
     )
 
@@ -95,6 +99,15 @@ class OpenEVSESwitch(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], SwitchEnt
                 (CONNECTION_NETWORK_MAC, unique_id)
             }
             self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            super().available
+            and self.entity_description.is_on_fn(self.coordinator.charger) is not None
+        )
 
     @property
     @override

--- a/tests/components/openevse/snapshots/test_switch.ambr
+++ b/tests/components/openevse/snapshots/test_switch.ambr
@@ -1,0 +1,151 @@
+# serializer version: 1
+# name: test_entities[switch.openevse_mock_config_current_shaper-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.openevse_mock_config_current_shaper',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current shaper',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current shaper',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_shaper',
+    'unique_id': 'deadbeeffeed-current_shaper',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.openevse_mock_config_current_shaper-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'openevse_mock_config Current shaper',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.openevse_mock_config_current_shaper',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[switch.openevse_mock_config_manual_override-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.openevse_mock_config_manual_override',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Manual override',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Manual override',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'manual_override',
+    'unique_id': 'deadbeeffeed-manual_override',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.openevse_mock_config_manual_override-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'openevse_mock_config Manual override',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.openevse_mock_config_manual_override',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[switch.openevse_mock_config_solar_pv_divert-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.openevse_mock_config_solar_pv_divert',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Solar PV divert',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Solar PV divert',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'solar_pv_divert',
+    'unique_id': 'deadbeeffeed-solar_pv_divert',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.openevse_mock_config_solar_pv_divert-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'openevse_mock_config Solar PV divert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.openevse_mock_config_solar_pv_divert',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/openevse/test_switch.py
+++ b/tests/components/openevse/test_switch.py
@@ -46,15 +46,13 @@ async def test_entities(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "service", "method_name", "args", "initial_override", "should_call"),
+    ("entity_id", "service", "method_name", "args"),
     [
         pytest.param(
             "switch.openevse_mock_config_solar_pv_divert",
             SERVICE_TURN_ON,
             "set_divert_mode",
             ("eco",),
-            False,
-            True,
             id="solar_pv_divert_on",
         ),
         pytest.param(
@@ -62,8 +60,6 @@ async def test_entities(
             SERVICE_TURN_OFF,
             "set_divert_mode",
             ("fast",),
-            False,
-            True,
             id="solar_pv_divert_off",
         ),
         pytest.param(
@@ -71,8 +67,6 @@ async def test_entities(
             SERVICE_TURN_ON,
             "set_shaper",
             (True,),
-            False,
-            True,
             id="current_shaper_on",
         ),
         pytest.param(
@@ -80,8 +74,6 @@ async def test_entities(
             SERVICE_TURN_OFF,
             "set_shaper",
             (False,),
-            False,
-            True,
             id="current_shaper_off",
         ),
         pytest.param(
@@ -89,36 +81,14 @@ async def test_entities(
             SERVICE_TURN_ON,
             "toggle_override",
             (),
-            False,
-            True,
             id="manual_override_on",
         ),
         pytest.param(
             "switch.openevse_mock_config_manual_override",
-            SERVICE_TURN_ON,
-            "toggle_override",
-            (),
-            True,
-            False,
-            id="manual_override_on_already_on",
-        ),
-        pytest.param(
-            "switch.openevse_mock_config_manual_override",
             SERVICE_TURN_OFF,
             "toggle_override",
             (),
-            True,
-            True,
             id="manual_override_off",
-        ),
-        pytest.param(
-            "switch.openevse_mock_config_manual_override",
-            SERVICE_TURN_OFF,
-            "toggle_override",
-            (),
-            False,
-            False,
-            id="manual_override_off_already_off",
         ),
     ],
 )
@@ -130,11 +100,8 @@ async def test_switch_turn_on_off(
     service: str,
     method_name: str,
     args: tuple[object, ...],
-    initial_override: bool,
-    should_call: bool,
 ) -> None:
     """Test turning on and off the switch entities."""
-    mock_charger.manual_override = initial_override
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -145,10 +112,7 @@ async def test_switch_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    if should_call:
-        getattr(mock_charger, method_name).assert_called_once_with(*args)
-    else:
-        getattr(mock_charger, method_name).assert_not_called()
+    getattr(mock_charger, method_name).assert_called_once_with(*args)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/openevse/test_switch.py
+++ b/tests/components/openevse/test_switch.py
@@ -19,7 +19,11 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -115,6 +119,12 @@ async def test_switch_turn_on_off(
     ("raised", "expected", "translation_key", "translation_placeholders"),
     [
         (
+            ValueError("invalid mode"),
+            ServiceValidationError,
+            "invalid_value",
+            {"value": "None"},
+        ),
+        (
             AuthenticationError("bad creds"),
             ConfigEntryAuthFailed,
             "authentication_error",
@@ -181,3 +191,25 @@ async def test_switch_raises(
     assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_placeholders == translation_placeholders
+
+
+async def test_switch_availability(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test switch entity availability when is_on_fn returns None."""
+    mock_charger.divert_active = None
+    mock_charger.shaper_active = True
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.openevse_mock_config_solar_pv_divert")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    state = hass.states.get("switch.openevse_mock_config_current_shaper")
+    assert state is not None
+    assert state.state == "on"

--- a/tests/components/openevse/test_switch.py
+++ b/tests/components/openevse/test_switch.py
@@ -46,13 +46,15 @@ async def test_entities(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "service", "method_name", "args"),
+    ("entity_id", "service", "method_name", "args", "initial_override", "should_call"),
     [
         pytest.param(
             "switch.openevse_mock_config_solar_pv_divert",
             SERVICE_TURN_ON,
             "set_divert_mode",
             ("eco",),
+            False,
+            True,
             id="solar_pv_divert_on",
         ),
         pytest.param(
@@ -60,6 +62,8 @@ async def test_entities(
             SERVICE_TURN_OFF,
             "set_divert_mode",
             ("fast",),
+            False,
+            True,
             id="solar_pv_divert_off",
         ),
         pytest.param(
@@ -67,6 +71,8 @@ async def test_entities(
             SERVICE_TURN_ON,
             "set_shaper",
             (True,),
+            False,
+            True,
             id="current_shaper_on",
         ),
         pytest.param(
@@ -74,6 +80,8 @@ async def test_entities(
             SERVICE_TURN_OFF,
             "set_shaper",
             (False,),
+            False,
+            True,
             id="current_shaper_off",
         ),
         pytest.param(
@@ -81,14 +89,36 @@ async def test_entities(
             SERVICE_TURN_ON,
             "toggle_override",
             (),
+            False,
+            True,
             id="manual_override_on",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_manual_override",
+            SERVICE_TURN_ON,
+            "toggle_override",
+            (),
+            True,
+            False,
+            id="manual_override_on_already_on",
         ),
         pytest.param(
             "switch.openevse_mock_config_manual_override",
             SERVICE_TURN_OFF,
             "toggle_override",
             (),
+            True,
+            True,
             id="manual_override_off",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_manual_override",
+            SERVICE_TURN_OFF,
+            "toggle_override",
+            (),
+            False,
+            False,
+            id="manual_override_off_already_off",
         ),
     ],
 )
@@ -100,8 +130,11 @@ async def test_switch_turn_on_off(
     service: str,
     method_name: str,
     args: tuple[object, ...],
+    initial_override: bool,
+    should_call: bool,
 ) -> None:
     """Test turning on and off the switch entities."""
+    mock_charger.manual_override = initial_override
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -112,7 +145,10 @@ async def test_switch_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    getattr(mock_charger, method_name).assert_called_once_with(*args)
+    if should_call:
+        getattr(mock_charger, method_name).assert_called_once_with(*args)
+    else:
+        getattr(mock_charger, method_name).assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -206,7 +242,7 @@ async def test_switch_availability(
     mock_charger: MagicMock,
 ) -> None:
     """Test switch entity availability when is_on_fn returns None."""
-    mock_charger.divert_active = None
+    mock_charger.divertmode = None
     mock_charger.shaper_active = True
 
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/openevse/test_switch.py
+++ b/tests/components/openevse/test_switch.py
@@ -1,0 +1,183 @@
+"""Tests for the OpenEVSE switch platform."""
+
+from unittest.mock import MagicMock, patch
+
+from aiohttp import ContentTypeError, ServerTimeoutError
+from openevsehttp.exceptions import (
+    AuthenticationError,
+    ParseJSONError,
+    UnsupportedFeature,
+)
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.openevse.const import DOMAIN
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test the switch entities."""
+    with patch("homeassistant.components.openevse.PLATFORMS", [Platform.SWITCH]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "service", "method_name", "args"),
+    [
+        pytest.param(
+            "switch.openevse_mock_config_solar_pv_divert",
+            SERVICE_TURN_ON,
+            "set_divert_mode",
+            ("eco",),
+            id="solar_pv_divert_on",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_solar_pv_divert",
+            SERVICE_TURN_OFF,
+            "set_divert_mode",
+            ("fast",),
+            id="solar_pv_divert_off",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_current_shaper",
+            SERVICE_TURN_ON,
+            "set_shaper",
+            (True,),
+            id="current_shaper_on",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_current_shaper",
+            SERVICE_TURN_OFF,
+            "set_shaper",
+            (False,),
+            id="current_shaper_off",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_manual_override",
+            SERVICE_TURN_ON,
+            "toggle_override",
+            (),
+            id="manual_override_on",
+        ),
+        pytest.param(
+            "switch.openevse_mock_config_manual_override",
+            SERVICE_TURN_OFF,
+            "toggle_override",
+            (),
+            id="manual_override_off",
+        ),
+    ],
+)
+async def test_switch_turn_on_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+    entity_id: str,
+    service: str,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    """Test turning on and off the switch entities."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    getattr(mock_charger, method_name).assert_called_once_with(*args)
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected", "translation_key", "translation_placeholders"),
+    [
+        (
+            AuthenticationError("bad creds"),
+            ConfigEntryAuthFailed,
+            "authentication_error",
+            None,
+        ),
+        (
+            TimeoutError("timed out"),
+            HomeAssistantError,
+            "communication_error",
+            None,
+        ),
+        (
+            ServerTimeoutError("timed out"),
+            HomeAssistantError,
+            "communication_error",
+            None,
+        ),
+        (
+            ParseJSONError("bad json"),
+            HomeAssistantError,
+            "communication_error",
+            None,
+        ),
+        (
+            UnsupportedFeature("old firmware"),
+            HomeAssistantError,
+            "unsupported_feature",
+            None,
+        ),
+        (
+            ContentTypeError(MagicMock(), (), message="bad content"),
+            HomeAssistantError,
+            "communication_error",
+            None,
+        ),
+    ],
+)
+async def test_switch_raises(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+    raised: Exception,
+    expected: type[Exception],
+    translation_key: str,
+    translation_placeholders: dict[str, str] | None,
+) -> None:
+    """Test that errors from the charger are translated to HA exceptions."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_charger.set_shaper.side_effect = raised
+
+    with pytest.raises(expected) as exc_info:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "switch.openevse_mock_config_current_shaper",
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == translation_key
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_placeholders == translation_placeholders

--- a/tests/components/openevse/test_switch.py
+++ b/tests/components/openevse/test_switch.py
@@ -17,7 +17,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -118,47 +118,54 @@ async def test_switch_turn_on_off(
 @pytest.mark.parametrize(
     ("raised", "expected", "translation_key", "translation_placeholders"),
     [
-        (
+        pytest.param(
             ValueError("invalid mode"),
             ServiceValidationError,
             "invalid_value",
             {"value": "None"},
+            id="value_error",
         ),
-        (
+        pytest.param(
             AuthenticationError("bad creds"),
             ConfigEntryAuthFailed,
             "authentication_error",
             None,
+            id="auth_error",
         ),
-        (
+        pytest.param(
             TimeoutError("timed out"),
             HomeAssistantError,
             "communication_error",
             None,
+            id="timeout_error",
         ),
-        (
+        pytest.param(
             ServerTimeoutError("timed out"),
             HomeAssistantError,
             "communication_error",
             None,
+            id="server_timeout_error",
         ),
-        (
+        pytest.param(
             ParseJSONError("bad json"),
             HomeAssistantError,
             "communication_error",
             None,
+            id="parse_json_error",
         ),
-        (
+        pytest.param(
             UnsupportedFeature("old firmware"),
             HomeAssistantError,
             "unsupported_feature",
             None,
+            id="unsupported_feature",
         ),
-        (
+        pytest.param(
             ContentTypeError(MagicMock(), (), message="bad content"),
             HomeAssistantError,
             "communication_error",
             None,
+            id="content_type_error",
         ),
     ],
 )
@@ -208,8 +215,8 @@ async def test_switch_availability(
 
     state = hass.states.get("switch.openevse_mock_config_solar_pv_divert")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == STATE_UNAVAILABLE
 
     state = hass.states.get("switch.openevse_mock_config_current_shaper")
     assert state is not None
-    assert state.state == "on"
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch platform to the OpenEVSE integration with support for:
- Solar PV divert (`solar_pv_divert`)
- Current shaper (`current_shaper`)
- Manual override (`manual_override`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47530
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
