### PR TITLE
Add get_providers service to music_assistant

### DIFF
--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -76,6 +76,14 @@ ATTR_DISCART_IMAGE = "discart_image"
 ATTR_FANART_IMAGE = "fanart_image"
 ATTR_USERNAME = "username"
 
+ATTR_PROVIDERS = "providers"
+ATTR_PROVIDER_TYPE = "provider_type"
+ATTR_PROVIDER_DOMAIN = "provider_domain"
+ATTR_PROVIDER_INSTANCE_ID = "provider_instance_id"
+ATTR_PROVIDER_ENABLED = "provider_enabled"
+ATTR_PROVIDER_STATUS = "provider_status"
+ATTR_PROVIDER_LAST_ERROR = "provider_last_error"
+
 ATTR_CONF_EXPOSE_PLAYER_TO_HA = "expose_player_to_ha"
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/music_assistant/icons.json
+++ b/homeassistant/components/music_assistant/icons.json
@@ -8,6 +8,7 @@
   },
   "services": {
     "get_library": { "service": "mdi:music-box-multiple" },
+    "get_providers": { "service": "mdi:server-network" },
     "get_queue": { "service": "mdi:playlist-music" },
     "play_announcement": { "service": "mdi:bullhorn" },
     "play_media": { "service": "mdi:play" },

--- a/homeassistant/components/music_assistant/schemas.py
+++ b/homeassistant/components/music_assistant/schemas.py
@@ -2,7 +2,12 @@
 
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import ImageType, MediaType
+from music_assistant_models.enums import (
+    ImageType,
+    MediaType,
+    ProviderStatus,
+    ProviderType,
+)
 from music_assistant_models.media_items import ItemMapping
 import voluptuous as vol
 
@@ -38,6 +43,13 @@ from .const import (
     ATTR_PLAYLISTS,
     ATTR_PODCASTS,
     ATTR_PROVIDER,
+    ATTR_PROVIDER_DOMAIN,
+    ATTR_PROVIDER_ENABLED,
+    ATTR_PROVIDER_INSTANCE_ID,
+    ATTR_PROVIDER_LAST_ERROR,
+    ATTR_PROVIDER_STATUS,
+    ATTR_PROVIDER_TYPE,
+    ATTR_PROVIDERS,
     ATTR_QUEUE_ID,
     ATTR_QUEUE_ITEM_ID,
     ATTR_RADIO,
@@ -53,6 +65,7 @@ from .const import (
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
+    from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.media_items import MediaItemType
     from music_assistant_models.queue_item import QueueItem
 
@@ -150,6 +163,42 @@ LIBRARY_RESULTS_SCHEMA = vol.Schema(
         vol.Required(ATTR_MEDIA_TYPE): vol.Coerce(MediaType),
     }
 )
+
+PROVIDER_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_PROVIDER_TYPE): vol.Coerce(ProviderType),
+        vol.Required(ATTR_PROVIDER_DOMAIN): cv.string,
+        vol.Required(ATTR_PROVIDER_INSTANCE_ID): cv.string,
+        vol.Required(ATTR_NAME): cv.string,
+        vol.Required(ATTR_PROVIDER_ENABLED): bool,
+        vol.Required(ATTR_PROVIDER_STATUS, default=None): vol.Any(
+            None, vol.Coerce(ProviderStatus)
+        ),
+        vol.Required(ATTR_PROVIDER_LAST_ERROR, default=None): vol.Any(None, cv.string),
+    }
+)
+
+PROVIDERS_RESULT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_PROVIDERS): vol.All(
+            cv.ensure_list, [vol.Schema(PROVIDER_CONFIG_SCHEMA)]
+        ),
+    }
+)
+
+
+def provider_config_dict_from_mass_item(item: ProviderConfig) -> dict[str, Any]:
+    """Parse a Music Assistant ProviderConfig."""
+    return {
+        ATTR_PROVIDER_TYPE: item.type,
+        ATTR_PROVIDER_DOMAIN: item.domain,
+        ATTR_PROVIDER_INSTANCE_ID: item.instance_id,
+        ATTR_NAME: item.name or item.default_name or item.domain,
+        ATTR_PROVIDER_ENABLED: item.enabled,
+        ATTR_PROVIDER_STATUS: item.status,
+        ATTR_PROVIDER_LAST_ERROR: item.last_error.message if item.last_error else None,
+    }
+
 
 AUDIO_FORMAT_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/music_assistant/services.py
+++ b/homeassistant/components/music_assistant/services.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import MediaType, QueueOption
+from music_assistant_models.enums import MediaType, ProviderType, QueueOption
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -41,6 +41,8 @@ from .const import (
     ATTR_PLAYLISTS,
     ATTR_PODCASTS,
     ATTR_PRE_ANNOUNCE_URL,
+    ATTR_PROVIDER_TYPE,
+    ATTR_PROVIDERS,
     ATTR_RADIO,
     ATTR_RADIO_MODE,
     ATTR_SEARCH,
@@ -57,8 +59,10 @@ from .const import (
 from .helpers import catch_user_not_found, get_music_assistant_client
 from .schemas import (
     LIBRARY_RESULTS_SCHEMA,
+    PROVIDERS_RESULT_SCHEMA,
     SEARCH_RESULT_SCHEMA,
     media_item_dict_from_mass_item,
+    provider_config_dict_from_mass_item,
 )
 
 if TYPE_CHECKING:
@@ -74,6 +78,7 @@ if TYPE_CHECKING:
 
 SERVICE_SEARCH = "search"
 SERVICE_GET_LIBRARY = "get_library"
+SERVICE_GET_PROVIDERS = "get_providers"
 SERVICE_PLAY_MEDIA_ADVANCED = "play_media"
 SERVICE_PLAY_ANNOUNCEMENT = "play_announcement"
 SERVICE_TRANSFER_QUEUE = "transfer_queue"
@@ -123,6 +128,18 @@ def register_actions(hass: HomeAssistant) -> None:
                 vol.Optional(ATTR_ALBUM_TYPE): list[MediaType],
                 vol.Optional(ATTR_ALBUM_ARTISTS_ONLY): cv.boolean,
                 vol.Optional(ATTR_USERNAME): cv.string,
+            }
+        ),
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_PROVIDERS,
+        handle_get_providers,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CONFIG_ENTRY_ID): str,
+                vol.Optional(ATTR_PROVIDER_TYPE): vol.Coerce(ProviderType),
             }
         ),
         supports_response=SupportsResponse.ONLY,
@@ -304,6 +321,22 @@ async def handle_get_library(call: ServiceCall) -> ServiceResponse:
             ATTR_OFFSET: offset,
             ATTR_ORDER_BY: order_by,
             ATTR_MEDIA_TYPE: media_type,
+        }
+    )
+    return response
+
+
+async def handle_get_providers(call: ServiceCall) -> ServiceResponse:
+    """Handle get_providers action."""
+    mass = get_music_assistant_client(call.hass, call.data[ATTR_CONFIG_ENTRY_ID])
+    providers = await mass.config.get_provider_configs(
+        provider_type=call.data.get(ATTR_PROVIDER_TYPE),
+    )
+    response: ServiceResponse = PROVIDERS_RESULT_SCHEMA(
+        {
+            ATTR_PROVIDERS: [
+                provider_config_dict_from_mass_item(item) for item in providers
+            ],
         }
     )
     return response

--- a/homeassistant/components/music_assistant/services.yaml
+++ b/homeassistant/components/music_assistant/services.yaml
@@ -254,3 +254,23 @@ get_library:
       example: "john"
       selector:
         text:
+
+get_providers:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: music_assistant
+    provider_type:
+      example: "music"
+      selector:
+        select:
+          translation_key: provider_type
+          options:
+            - music
+            - player
+            - metadata
+            - plugin
+            - core
+            - audio_analysis

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -322,6 +322,17 @@
         "year": "Year",
         "year_desc": "Year (desc)"
       }
+    },
+    "provider_type": {
+      "options": {
+        "audio_analysis": "Audio analysis",
+        "core": "Core",
+        "metadata": "Metadata",
+        "music": "Music",
+        "player": "Player",
+        "plugin": "Plugin",
+        "unknown": "Unknown"
+      }
     }
   },
   "services": {
@@ -375,6 +386,20 @@
           "name": "Pagination"
         }
       }
+    },
+    "get_providers": {
+      "description": "Returns the configured Music Assistant providers, optionally filtered by type.",
+      "fields": {
+        "config_entry_id": {
+          "description": "[%key:component::music_assistant::services::search::fields::config_entry_id::description%]",
+          "name": "[%key:component::music_assistant::services::search::fields::config_entry_id::name%]"
+        },
+        "provider_type": {
+          "description": "Only return providers of this type.",
+          "name": "Provider type"
+        }
+      },
+      "name": "Get providers"
     },
     "get_queue": {
       "description": "Retrieves the details of the currently active queue of a Music Assistant player.",

--- a/tests/components/music_assistant/snapshots/test_services.ambr
+++ b/tests/components/music_assistant/snapshots/test_services.ambr
@@ -391,6 +391,45 @@
     'order_by': 'name',
   })
 # ---
+# name: test_get_providers_action
+  dict({
+    'providers': list([
+      dict({
+        'name': 'Spotify',
+        'provider_domain': 'spotify',
+        'provider_enabled': True,
+        'provider_instance_id': 'spotify-1234',
+        'provider_last_error': None,
+        'provider_status': <ProviderStatus.LOADED: 'loaded'>,
+        'provider_type': <ProviderType.MUSIC: 'music'>,
+      }),
+      dict({
+        'name': 'Living room',
+        'provider_domain': 'squeezelite',
+        'provider_enabled': True,
+        'provider_instance_id': 'squeezelite-5678',
+        'provider_last_error': None,
+        'provider_status': <ProviderStatus.LOADED: 'loaded'>,
+        'provider_type': <ProviderType.PLAYER: 'player'>,
+      }),
+    ]),
+  })
+# ---
+# name: test_get_providers_action_with_error
+  dict({
+    'providers': list([
+      dict({
+        'name': 'YouTube Music',
+        'provider_domain': 'ytmusic',
+        'provider_enabled': True,
+        'provider_instance_id': 'ytmusic-9012',
+        'provider_last_error': 'Authentication required',
+        'provider_status': <ProviderStatus.AUTH_REQUIRED: 'auth_required'>,
+        'provider_type': <ProviderType.MUSIC: 'music'>,
+      }),
+    ]),
+  })
+# ---
 # name: test_search_action
   dict({
     'albums': list([

--- a/tests/components/music_assistant/test_services.py
+++ b/tests/components/music_assistant/test_services.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, call
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.config_entries import ProviderConfig, ProviderError
+from music_assistant_models.enums import MediaType, ProviderStatus, ProviderType
 from music_assistant_models.errors import UserNotFoundError
 from music_assistant_models.media_items import SearchResults
 import pytest
@@ -11,12 +12,14 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.music_assistant.const import (
     ATTR_FAVORITE,
     ATTR_MEDIA_TYPE,
+    ATTR_PROVIDER_TYPE,
     ATTR_SEARCH_NAME,
     ATTR_USERNAME,
     DOMAIN,
 )
 from homeassistant.components.music_assistant.services import (
     SERVICE_GET_LIBRARY,
+    SERVICE_GET_PROVIDERS,
     SERVICE_SEARCH,
 )
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
@@ -214,3 +217,104 @@ async def test_get_library_action_with_unknown_username(
         )
     assert err.value.translation_key == "invalid_username"
     assert err.value.translation_placeholders == {"username": "nobody"}
+
+
+async def test_get_providers_action(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test music assistant get_providers action."""
+    entry = await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    music_assistant_client.config.get_provider_configs = AsyncMock(
+        return_value=[
+            ProviderConfig(
+                values={},
+                type=ProviderType.MUSIC,
+                domain="spotify",
+                instance_id="spotify-1234",
+                enabled=True,
+                name=None,
+                default_name="Spotify",
+                status=ProviderStatus.LOADED,
+            ),
+            ProviderConfig(
+                values={},
+                type=ProviderType.PLAYER,
+                domain="squeezelite",
+                instance_id="squeezelite-5678",
+                enabled=True,
+                name="Living room",
+                default_name="Squeezelite",
+                status=ProviderStatus.LOADED,
+            ),
+        ]
+    )
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_PROVIDERS,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == snapshot
+
+
+async def test_get_providers_action_with_type_filter(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test get_providers action forwards the provider type filter."""
+    entry = await setup_integration_from_fixtures(hass, music_assistant_client)
+    music_assistant_client.config.get_provider_configs = AsyncMock(return_value=[])
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_PROVIDERS,
+        {
+            ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+            ATTR_PROVIDER_TYPE: "music",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert music_assistant_client.config.get_provider_configs.call_args == call(
+        provider_type=ProviderType.MUSIC,
+    )
+
+
+async def test_get_providers_action_with_error(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test get_providers action surfaces a provider load error."""
+    entry = await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    music_assistant_client.config.get_provider_configs = AsyncMock(
+        return_value=[
+            ProviderConfig(
+                values={},
+                type=ProviderType.MUSIC,
+                domain="ytmusic",
+                instance_id="ytmusic-9012",
+                enabled=True,
+                name=None,
+                default_name="YouTube Music",
+                status=ProviderStatus.AUTH_REQUIRED,
+                last_error=ProviderError(
+                    error_code=11,
+                    message="Authentication required",
+                ),
+            ),
+        ]
+    )
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_PROVIDERS,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `music_assistant.get_providers` service that returns the providers
configured on the Music Assistant server. The Music Assistant integration
already drives search, library, and queue via the `music_assistant_client`,
which exposes `config.get_provider_configs()`. This service simply surfaces
that through Home Assistant so users can build provider-status dashboards and
credential-expiry automations without reaching outside Home Assistant.

Each returned provider includes:

- `provider_type` (music, player, metadata, plugin, core, audio_analysis)
- `provider_domain`
- `provider_instance_id`
- `name` (custom name, default name, or domain)
- `provider_enabled`
- `provider_status` (loaded, loading, disabled, auth_required, incompatible, error)
- `provider_last_error` (message string when the provider failed to load)

The service accepts an optional `provider_type` filter and requires the
`config_entry_id` of the Music Assistant instance, matching the other
response services on this integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/4621
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
