### PR TITLE
Fix flaky google calendar coordinator tests

### DIFF
--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -388,10 +388,7 @@ async def test_update_error(
 
     with patch("homeassistant.util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
-        # Ensure coordinator update completes
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     # Entity is marked uanvailable due to API failure
     state = hass.states.get(TEST_ENTITY)
@@ -420,10 +417,7 @@ async def test_update_error(
 
     with patch("homeassistant.util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
-        # Ensure coordinator update completes
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     # State updated with new API response
     state = hass.states.get(TEST_ENTITY)
@@ -671,10 +665,7 @@ async def test_future_event_update_behavior(
     now += datetime.timedelta(minutes=60)
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
-    await hass.async_block_till_done()
-    # Ensure coordinator update completes
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Event has started
     state = hass.states.get(TEST_ENTITY)
@@ -711,10 +702,7 @@ async def test_future_event_offset_update_behavior(
     now += datetime.timedelta(minutes=45)
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
-    await hass.async_block_till_done()
-    # Ensure coordinator update completes
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Event has not started, but the offset was reached
     state = hass.states.get(TEST_ENTITY)


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A

## Proposed change

Fixes a flaky `tests/components/google/test_calendar.py::test_update_error`, seen failing in CI with `AssertionError: assert 'unavailable' == 'off'` ([failed job log](https://github.com/home-assistant/core/actions/runs/32348210228/job/96361931038)).

`DataUpdateCoordinator` runs its scheduled refresh via `async_create_background_task`, and `hass.async_block_till_done()` does not await background tasks by default. The tests worked around this by calling it three times in a row, which merely gave the refresh enough event loop iterations to usually finish. Under CI load it did not — the log shows the coordinator recovery landing in the teardown phase, after the assertion had already run.

Replaced the three-call blocks with a single `await hass.async_block_till_done(wait_background_tasks=True)`. Four sites in the file had the identical pattern, so all four are fixed.

Verification: reducing the three calls to one `wait_background_tasks=False` call reproduces the CI failure deterministically; the same single call with `wait_background_tasks=True` passes. The two differ only by that argument, isolating the cause. The suite was then run 8x under random ordering and 3x under CI's env (`PYTHONASYNCIODEBUG=1`, `HASS_CI=1`, `SQLALCHEMY_WARN_20=1`), 137 passed each time.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgEizT1oPK17YCyumT1XGu)_