### PR TITLE
Feature/rest command config entries

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -100,6 +100,19 @@ CALL_ENDPOINT_SCHEMA = vol.Schema(
     }
 )
 
+CALL_ENDPOINT_SERVICE_DESCRIPTION = {
+    "fields": {
+        ATTR_CONFIG_ENTRY_ID: {
+            "required": True,
+            "selector": {"config_entry": {"integration": DOMAIN}},
+        },
+        CONF_PAYLOAD: {
+            "example": '{"message": "The event occurred"}',
+            "selector": {"text": {"multiline": True}},
+        },
+    }
+}
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the REST command component."""
@@ -125,6 +138,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             async_call_endpoint_handler,
             schema=CALL_ENDPOINT_SCHEMA,
             supports_response=SupportsResponse.OPTIONAL,
+        )
+        service.async_set_service_schema(
+            hass,
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            CALL_ENDPOINT_SERVICE_DESCRIPTION,
         )
 
     async def reload_service_handler(call: ServiceCall) -> None:
@@ -183,6 +202,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             async_service_handler,
             supports_response=SupportsResponse.OPTIONAL,
         )
+        if name == SERVICE_CALL_ENDPOINT:
+            service.async_set_service_schema(hass, DOMAIN, name, {})
 
     async_register_call_endpoint()
     for name, command_config in config.get(DOMAIN, {}).items():

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -68,7 +68,7 @@ COMMAND_SCHEMA = vol.Schema(
     }
 )
 
-RESERVED_ACTIONS = {SERVICE_RELOAD, SERVICE_CALL_ENDPOINT}
+RESERVED_ACTIONS = {SERVICE_RELOAD}
 
 
 def _validate_yaml_action_names(
@@ -104,6 +104,29 @@ CALL_ENDPOINT_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the REST command component."""
 
+    async def async_call_endpoint_handler(call: ServiceCall) -> ServiceResponse:
+        """Send a request using a UI-managed endpoint."""
+        entry: RestCommandConfigEntry = service.async_get_config_entry(
+            hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+        )
+        return await entry.runtime_data.async_call(
+            entry.data[CONF_URL],
+            call.data.get(CONF_PAYLOAD, entry.data.get(CONF_PAYLOAD)),
+            {},
+            call.return_response,
+        )
+
+    @callback
+    def async_register_call_endpoint() -> None:
+        """Register the action for UI-managed endpoints."""
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            async_call_endpoint_handler,
+            schema=CALL_ENDPOINT_SCHEMA,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
+
     async def reload_service_handler(call: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
         conf = await async_integration_yaml_config(hass, DOMAIN)
@@ -119,6 +142,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 continue
             hass.services.async_remove(DOMAIN, existing_service)
 
+        async_register_call_endpoint()
         for name, command_config in commands.items():
             async_register_rest_command(name, command_config)
 
@@ -160,28 +184,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             supports_response=SupportsResponse.OPTIONAL,
         )
 
+    async_register_call_endpoint()
     for name, command_config in config.get(DOMAIN, {}).items():
         async_register_rest_command(name, command_config)
-
-    async def async_call_endpoint_handler(call: ServiceCall) -> ServiceResponse:
-        """Send a request using a UI-managed endpoint."""
-        entry: RestCommandConfigEntry = service.async_get_config_entry(
-            hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
-        )
-        return await entry.runtime_data.async_call(
-            entry.data[CONF_URL],
-            call.data.get(CONF_PAYLOAD, entry.data.get(CONF_PAYLOAD)),
-            {},
-            call.return_response,
-        )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CALL_ENDPOINT,
-        async_call_endpoint_handler,
-        schema=CALL_ENDPOINT_SCHEMA,
-        supports_response=SupportsResponse.OPTIONAL,
-    )
 
     hass.services.async_register(
         DOMAIN, SERVICE_RELOAD, reload_service_handler, schema=vol.Schema({})

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -1,16 +1,12 @@
-"""Support for exposing regular REST commands as services."""
+"""Support for exposing regular REST commands as actions."""
 
-from http import HTTPStatus
-from json.decoder import JSONDecodeError
-import logging
 from typing import Any
 
-import aiohttp
-from aiohttp import hdrs
 import voluptuous as vol
-from yarl import URL
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
     CONF_AUTHENTICATION,
     CONF_HEADERS,
     CONF_METHOD,
@@ -31,32 +27,31 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.reload import async_integration_yaml_config
+from homeassistant.helpers.selector import ConfigEntrySelector
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.ssl import SSLCipherList
 
-DOMAIN = "rest_command"
+from .const import (
+    CONF_CONTENT_TYPE,
+    CONF_INSECURE_CIPHER,
+    CONF_SKIP_URL_ENCODING,
+    DEFAULT_METHOD,
+    DEFAULT_TIMEOUT,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    SERVICE_CALL_ENDPOINT,
+    SUPPORTED_REST_METHODS,
+)
+from .http import RestCommandRequest
 
-_LOGGER = logging.getLogger(__name__)
-
-DEFAULT_TIMEOUT = 10
-DEFAULT_METHOD = "get"
-DEFAULT_VERIFY_SSL = True
-
-SUPPORT_REST_METHODS = ["get", "patch", "post", "put", "delete"]
-
-CONF_CONTENT_TYPE = "content_type"
-CONF_INSECURE_CIPHER = "insecure_cipher"
-CONF_SKIP_URL_ENCODING = "skip_url_encoding"
+type RestCommandConfigEntry = ConfigEntry[RestCommandRequest]
 
 COMMAND_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_URL): cv.template,
         vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.All(
-            vol.Lower, vol.In(SUPPORT_REST_METHODS)
+            vol.Lower, vol.In(SUPPORTED_REST_METHODS)
         ),
         vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.template}),
         vol.Optional(CONF_AUTHENTICATION): vol.In(
@@ -73,15 +68,43 @@ COMMAND_SCHEMA = vol.Schema(
     }
 )
 
+RESERVED_ACTIONS = {SERVICE_RELOAD, SERVICE_CALL_ENDPOINT}
+
+
+def _validate_yaml_action_names(
+    commands: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Reject YAML names owned by integration actions."""
+    if reserved_names := RESERVED_ACTIONS.intersection(commands):
+        reserved_name = min(reserved_names)
+        raise vol.Invalid(
+            f'The RESTful Command action name "{reserved_name}" is reserved'
+        )
+    return commands
+
+
+YAML_COMMANDS_SCHEMA = vol.All(
+    _validate_yaml_action_names, cv.schema_with_slug_keys(COMMAND_SCHEMA)
+)
+
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: cv.schema_with_slug_keys(COMMAND_SCHEMA)}, extra=vol.ALLOW_EXTRA
+    {vol.Optional(DOMAIN, default={}): YAML_COMMANDS_SCHEMA}, extra=vol.ALLOW_EXTRA
+)
+
+CALL_ENDPOINT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): ConfigEntrySelector(
+            {"integration": DOMAIN}
+        ),
+        vol.Optional(CONF_PAYLOAD): cv.string,
+    }
 )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the REST command component."""
 
-    async def reload_service_handler(service: ServiceCall) -> None:
+    async def reload_service_handler(call: ServiceCall) -> None:
         """Remove all rest_commands and load new ones from config."""
         conf = await async_integration_yaml_config(hass, DOMAIN)
 
@@ -89,177 +112,45 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if conf is None:
             return
 
+        commands = _validate_yaml_action_names(conf[DOMAIN])
         existing = hass.services.async_services_for_domain(DOMAIN)
         for existing_service in existing:
-            if existing_service == SERVICE_RELOAD:
+            if existing_service in RESERVED_ACTIONS:
                 continue
             hass.services.async_remove(DOMAIN, existing_service)
 
-        for name, command_config in conf[DOMAIN].items():
+        for name, command_config in commands.items():
             async_register_rest_command(name, command_config)
 
     @callback
     def async_register_rest_command(name: str, command_config: dict[str, Any]) -> None:
         """Create service for rest command."""
-        websession = async_get_clientsession(
-            hass,
-            command_config[CONF_VERIFY_SSL],
-            ssl_cipher=(
-                SSLCipherList.INSECURE
-                if command_config[CONF_INSECURE_CIPHER]
-                else SSLCipherList.PYTHON_DEFAULT
-            ),
-        )
-        timeout = command_config[CONF_TIMEOUT]
-        method = command_config[CONF_METHOD]
-
+        request = RestCommandRequest(hass, command_config)
         template_url = command_config[CONF_URL]
-        skip_url_encoding = command_config[CONF_SKIP_URL_ENCODING]
-
-        auth = None
-        digest_auth: tuple[str, str] | None = None
-        if CONF_USERNAME in command_config:
-            username = command_config[CONF_USERNAME]
-            password = command_config.get(CONF_PASSWORD, "")
-            if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
-                digest_auth = (username, password)
-            else:
-                auth = aiohttp.BasicAuth(username, password=password)
-
-        template_payload = None
-        if CONF_PAYLOAD in command_config:
-            template_payload = command_config[CONF_PAYLOAD]
-
+        template_payload = command_config.get(CONF_PAYLOAD)
         template_headers = command_config.get(CONF_HEADERS, {})
 
-        content_type = command_config.get(CONF_CONTENT_TYPE)
-
-        async def async_service_handler(service: ServiceCall) -> ServiceResponse:
-            """Execute a shell command service."""
+        async def async_service_handler(call: ServiceCall) -> ServiceResponse:
+            """Execute a RESTful Command action."""
             payload = None
             if template_payload:
-                payload = bytes(
-                    template_payload.async_render(
-                        variables=service.data, parse_result=False
-                    ),
-                    "utf-8",
+                payload = template_payload.async_render(
+                    variables=call.data, parse_result=False
                 )
 
             request_url = template_url.async_render(
-                variables=service.data, parse_result=False
+                variables=call.data, parse_result=False
             )
 
             headers = {}
             for header_name, template_header in template_headers.items():
                 headers[header_name] = template_header.async_render(
-                    variables=service.data, parse_result=False
+                    variables=call.data, parse_result=False
                 )
 
-            if content_type:
-                headers[hdrs.CONTENT_TYPE] = content_type
-
-            _LOGGER.debug(
-                "Calling %s %s with headers: %s and payload: %s",
-                method,
-                request_url,
-                headers,
-                payload,
+            return await request.async_call(
+                request_url, payload, headers, call.return_response
             )
-
-            try:
-                # Prepare request kwargs
-                request_kwargs = {
-                    "data": payload,
-                    "headers": headers or None,
-                    "timeout": timeout,
-                }
-
-                # Add authentication
-                if auth is not None:
-                    request_kwargs["auth"] = auth
-                elif digest_auth is not None:
-                    request_kwargs["middlewares"] = (
-                        aiohttp.DigestAuthMiddleware(*digest_auth),
-                    )
-
-                async with getattr(websession, method)(
-                    URL(request_url, encoded=skip_url_encoding),
-                    **request_kwargs,
-                ) as response:
-                    if response.status < HTTPStatus.BAD_REQUEST:
-                        _LOGGER.debug(
-                            "Success. Url: %s. Status code: %d. Payload: %s",
-                            response.url,
-                            response.status,
-                            payload,
-                        )
-                    else:
-                        _LOGGER.warning(
-                            "Error. Url: %s. Status code %d. Payload: %s",
-                            response.url,
-                            response.status,
-                            payload,
-                        )
-
-                    if not service.return_response:
-                        # always read the response to avoid closing
-                        # the connection before the server has
-                        # finished sending it, while avoiding
-                        # excessive memory usage
-                        async for _ in response.content.iter_chunked(1024):
-                            pass
-
-                        return None
-
-                    _content = None
-                    try:
-                        if response.content_type == "application/json":
-                            _content = await response.json()
-                        else:
-                            _content = await response.text()
-                    except (JSONDecodeError, AttributeError) as err:
-                        raise HomeAssistantError(
-                            translation_domain=DOMAIN,
-                            translation_key="decoding_error",
-                            translation_placeholders={
-                                "request_url": request_url,
-                                "decoding_type": "JSON",
-                            },
-                        ) from err
-
-                    except UnicodeDecodeError as err:
-                        raise HomeAssistantError(
-                            translation_domain=DOMAIN,
-                            translation_key="decoding_error",
-                            translation_placeholders={
-                                "request_url": request_url,
-                                "decoding_type": "text",
-                            },
-                        ) from err
-                    return {
-                        "content": _content,
-                        "status": response.status,
-                        "headers": {
-                            key: values[0] if len(values) == 1 else values
-                            for key in response.headers
-                            if (values := response.headers.getall(key))
-                        },
-                    }
-
-            except TimeoutError as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="timeout",
-                    translation_placeholders={"request_url": request_url},
-                ) from err
-
-            except aiohttp.ClientError as err:
-                _LOGGER.error("Error fetching data: %s", err)
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="client_error",
-                    translation_placeholders={"request_url": request_url},
-                ) from err
 
         # register services
         hass.services.async_register(
@@ -269,11 +160,52 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             supports_response=SupportsResponse.OPTIONAL,
         )
 
-    for name, command_config in config[DOMAIN].items():
+    for name, command_config in config.get(DOMAIN, {}).items():
         async_register_rest_command(name, command_config)
+
+    async def async_call_endpoint_handler(call: ServiceCall) -> ServiceResponse:
+        """Send a request using a UI-managed endpoint."""
+        entry: RestCommandConfigEntry = service.async_get_config_entry(
+            hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+        )
+        return await entry.runtime_data.async_call(
+            entry.data[CONF_URL],
+            call.data.get(CONF_PAYLOAD, entry.data.get(CONF_PAYLOAD)),
+            {},
+            call.return_response,
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CALL_ENDPOINT,
+        async_call_endpoint_handler,
+        schema=CALL_ENDPOINT_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
 
     hass.services.async_register(
         DOMAIN, SERVICE_RELOAD, reload_service_handler, schema=vol.Schema({})
     )
 
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: RestCommandConfigEntry) -> bool:
+    """Set up a UI-managed RESTful Command endpoint."""
+    entry.runtime_data = RestCommandRequest(hass, dict(entry.data))
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+    return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: RestCommandConfigEntry
+) -> None:
+    """Reload an updated endpoint."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RestCommandConfigEntry
+) -> bool:
+    """Unload a UI-managed RESTful Command endpoint."""
     return True

--- a/homeassistant/components/rest_command/config_flow.py
+++ b/homeassistant/components/rest_command/config_flow.py
@@ -1,0 +1,228 @@
+"""Config flow for RESTful Command."""
+
+from typing import Any, override
+from uuid import uuid4
+
+import voluptuous as vol
+from yarl import URL
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_METHOD,
+    CONF_PASSWORD,
+    CONF_PAYLOAD,
+    CONF_TIMEOUT,
+    CONF_TOKEN,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    CONTENT_TYPE_JSON,
+    HTTP_BASIC_AUTHENTICATION,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import (
+    AUTHENTICATION_BEARER,
+    AUTHENTICATION_NONE,
+    CONF_CONTENT_TYPE,
+    CONF_ENDPOINT_NAME,
+    CONF_INSECURE_CIPHER,
+    CONF_SKIP_URL_ENCODING,
+    DEFAULT_METHOD,
+    DEFAULT_PAYLOAD,
+    DEFAULT_TIMEOUT,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    SUPPORTED_REST_METHODS,
+)
+
+AUTHENTICATION_METHODS = [
+    AUTHENTICATION_NONE,
+    HTTP_BASIC_AUTHENTICATION,
+    HTTP_DIGEST_AUTHENTICATION,
+    AUTHENTICATION_BEARER,
+]
+
+ENDPOINT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENDPOINT_NAME): TextSelector(),
+        vol.Required(CONF_URL): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.URL)
+        ),
+        vol.Required(CONF_METHOD, default=DEFAULT_METHOD): SelectSelector(
+            SelectSelectorConfig(
+                options=SUPPORTED_REST_METHODS,
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="method",
+            )
+        ),
+        vol.Required(CONF_AUTHENTICATION, default=AUTHENTICATION_NONE): SelectSelector(
+            SelectSelectorConfig(
+                options=AUTHENTICATION_METHODS,
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key="authentication",
+            )
+        ),
+        vol.Optional(CONF_USERNAME): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT, autocomplete="username")
+        ),
+        vol.Optional(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
+        vol.Optional(CONF_TOKEN): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
+        vol.Optional(CONF_PAYLOAD, default=DEFAULT_PAYLOAD): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT, multiline=True)
+        ),
+        vol.Optional(CONF_CONTENT_TYPE, default=CONTENT_TYPE_JSON): TextSelector(),
+        vol.Required(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): NumberSelector(
+            NumberSelectorConfig(min=1, step=1, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Required(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): BooleanSelector(),
+        vol.Required(CONF_INSECURE_CIPHER, default=False): BooleanSelector(),
+        vol.Required(CONF_SKIP_URL_ENCODING, default=False): BooleanSelector(),
+    }
+)
+
+
+def _validated_data(
+    user_input: dict[str, Any], previous_data: dict[str, Any] | None = None
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Validate and normalize endpoint data."""
+    errors: dict[str, str] = {}
+    data = user_input.copy()
+    data[CONF_ENDPOINT_NAME] = data[CONF_ENDPOINT_NAME].strip()
+    if not data[CONF_ENDPOINT_NAME]:
+        errors[CONF_ENDPOINT_NAME] = "required"
+
+    try:
+        parsed_url = URL(data[CONF_URL])
+        port = parsed_url.port
+        valid_url = (
+            parsed_url.scheme in ("http", "https")
+            and parsed_url.host is not None
+            and (port is None or port <= 65535)
+        )
+    except TypeError, ValueError:
+        valid_url = False
+    if not valid_url:
+        errors[CONF_URL] = "invalid_url"
+    elif parsed_url.user is not None or parsed_url.password is not None:
+        errors[CONF_URL] = "userinfo_not_allowed"
+
+    authentication = data[CONF_AUTHENTICATION]
+    if authentication in (
+        HTTP_BASIC_AUTHENTICATION,
+        HTTP_DIGEST_AUTHENTICATION,
+    ):
+        data.pop(CONF_TOKEN, None)
+        if not data.get(CONF_USERNAME):
+            errors[CONF_USERNAME] = "required"
+        if not data.get(CONF_PASSWORD) and previous_data is not None:
+            data[CONF_PASSWORD] = previous_data.get(CONF_PASSWORD, "")
+        if not data.get(CONF_PASSWORD):
+            errors[CONF_PASSWORD] = "required"
+    elif authentication == AUTHENTICATION_BEARER:
+        data.pop(CONF_USERNAME, None)
+        data.pop(CONF_PASSWORD, None)
+        if not data.get(CONF_TOKEN) and previous_data is not None:
+            data[CONF_TOKEN] = previous_data.get(CONF_TOKEN, "")
+        if not data.get(CONF_TOKEN):
+            errors[CONF_TOKEN] = "required"
+    else:
+        data.pop(CONF_USERNAME, None)
+        data.pop(CONF_PASSWORD, None)
+        data.pop(CONF_TOKEN, None)
+
+    data[CONF_TIMEOUT] = int(data[CONF_TIMEOUT])
+    return data, errors
+
+
+def _suggested_values(data: dict[str, Any]) -> dict[str, Any]:
+    """Return form values without stored credentials."""
+    suggested = dict(data)
+    suggested.pop(CONF_PASSWORD, None)
+    suggested.pop(CONF_TOKEN, None)
+    return suggested
+
+
+class RestCommandConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for RESTful Command."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Set up a UI-managed endpoint."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            data, errors = _validated_data(user_input)
+            if not errors:
+                self._async_abort_entries_match(
+                    {
+                        CONF_URL: data[CONF_URL],
+                        CONF_METHOD: data[CONF_METHOD],
+                    }
+                )
+                await self.async_set_unique_id(uuid4().hex)
+                return self.async_create_entry(
+                    title=data[CONF_ENDPOINT_NAME],
+                    data=data,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                ENDPOINT_SCHEMA, user_input or {}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Reconfigure an endpoint."""
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            data, errors = _validated_data(user_input, dict(entry.data))
+            if not errors:
+                self._async_abort_entries_match(
+                    {
+                        CONF_URL: data[CONF_URL],
+                        CONF_METHOD: data[CONF_METHOD],
+                    }
+                )
+                return self.async_update_and_abort(
+                    entry,
+                    data=data,
+                    title=data[CONF_ENDPOINT_NAME],
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                ENDPOINT_SCHEMA,
+                user_input or _suggested_values(dict(entry.data)),
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/rest_command/config_flow.py
+++ b/homeassistant/components/rest_command/config_flow.py
@@ -38,7 +38,6 @@ from .const import (
     AUTHENTICATION_BEARER,
     AUTHENTICATION_NONE,
     CONF_CONTENT_TYPE,
-    CONF_ENDPOINT_NAME,
     CONF_INSECURE_CIPHER,
     CONF_SKIP_URL_ENCODING,
     DEFAULT_METHOD,
@@ -58,7 +57,6 @@ AUTHENTICATION_METHODS = [
 
 ENDPOINT_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENDPOINT_NAME): TextSelector(),
         vol.Required(CONF_URL): TextSelector(
             TextSelectorConfig(type=TextSelectorType.URL)
         ),
@@ -108,9 +106,6 @@ def _validated_data(
     """Validate and normalize endpoint data."""
     errors: dict[str, str] = {}
     data = user_input.copy()
-    data[CONF_ENDPOINT_NAME] = data[CONF_ENDPOINT_NAME].strip()
-    if not data[CONF_ENDPOINT_NAME]:
-        errors[CONF_ENDPOINT_NAME] = "required"
 
     try:
         parsed_url = URL(data[CONF_URL])
@@ -184,8 +179,10 @@ class RestCommandConfigFlow(ConfigFlow, domain=DOMAIN):
                     }
                 )
                 await self.async_set_unique_id(uuid4().hex)
+                title = URL(data[CONF_URL]).host
+                assert title is not None
                 return self.async_create_entry(
-                    title=data[CONF_ENDPOINT_NAME],
+                    title=title,
                     data=data,
                 )
 
@@ -215,7 +212,6 @@ class RestCommandConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_and_abort(
                     entry,
                     data=data,
-                    title=data[CONF_ENDPOINT_NAME],
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/rest_command/const.py
+++ b/homeassistant/components/rest_command/const.py
@@ -1,0 +1,21 @@
+"""Constants for the RESTful Command integration."""
+
+from typing import Final
+
+DOMAIN: Final = "rest_command"
+
+AUTHENTICATION_BEARER: Final = "bearer"
+AUTHENTICATION_NONE: Final = "none"
+
+CONF_CONTENT_TYPE: Final = "content_type"
+CONF_ENDPOINT_NAME: Final = "endpoint_name"
+CONF_INSECURE_CIPHER: Final = "insecure_cipher"
+CONF_SKIP_URL_ENCODING: Final = "skip_url_encoding"
+SERVICE_CALL_ENDPOINT: Final = "call_endpoint"
+
+DEFAULT_METHOD: Final = "get"
+DEFAULT_PAYLOAD: Final = '{\n  "message": "The event occurred"\n}'
+DEFAULT_TIMEOUT: Final = 10
+DEFAULT_VERIFY_SSL: Final = True
+
+SUPPORTED_REST_METHODS: Final = ["get", "patch", "post", "put", "delete"]

--- a/homeassistant/components/rest_command/const.py
+++ b/homeassistant/components/rest_command/const.py
@@ -8,7 +8,6 @@ AUTHENTICATION_BEARER: Final = "bearer"
 AUTHENTICATION_NONE: Final = "none"
 
 CONF_CONTENT_TYPE: Final = "content_type"
-CONF_ENDPOINT_NAME: Final = "endpoint_name"
 CONF_INSECURE_CIPHER: Final = "insecure_cipher"
 CONF_SKIP_URL_ENCODING: Final = "skip_url_encoding"
 SERVICE_CALL_ENDPOINT: Final = "call_endpoint"

--- a/homeassistant/components/rest_command/http.py
+++ b/homeassistant/components/rest_command/http.py
@@ -1,0 +1,147 @@
+"""HTTP request handling for RESTful Command."""
+
+from http import HTTPStatus
+from json.decoder import JSONDecodeError
+import logging
+from typing import Any
+
+import aiohttp
+from aiohttp import hdrs
+from yarl import URL
+
+from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_METHOD,
+    CONF_PASSWORD,
+    CONF_TIMEOUT,
+    CONF_TOKEN,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.core import HomeAssistant, ServiceResponse
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import SSLCipherList
+
+from .const import (
+    AUTHENTICATION_BEARER,
+    CONF_CONTENT_TYPE,
+    CONF_INSECURE_CIPHER,
+    CONF_SKIP_URL_ENCODING,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RestCommandRequest:
+    """Execute a configured RESTful Command request."""
+
+    def __init__(self, hass: HomeAssistant, config: dict[str, Any]) -> None:
+        """Initialize the request."""
+        self._config = config
+        self._websession = async_get_clientsession(
+            hass,
+            config[CONF_VERIFY_SSL],
+            ssl_cipher=(
+                SSLCipherList.INSECURE
+                if config[CONF_INSECURE_CIPHER]
+                else SSLCipherList.PYTHON_DEFAULT
+            ),
+        )
+
+    async def async_call(
+        self,
+        request_url: str,
+        payload: str | None,
+        headers: dict[str, str],
+        return_response: bool,
+    ) -> ServiceResponse:
+        """Send the configured request."""
+        method = self._config[CONF_METHOD]
+        if content_type := self._config.get(CONF_CONTENT_TYPE):
+            headers[hdrs.CONTENT_TYPE] = content_type
+        if self._config.get(CONF_AUTHENTICATION) == AUTHENTICATION_BEARER:
+            headers[hdrs.AUTHORIZATION] = f"Bearer {self._config[CONF_TOKEN]}"
+
+        request_kwargs: dict[str, Any] = {
+            "data": payload.encode() if payload is not None else None,
+            "headers": headers or None,
+            "timeout": self._config[CONF_TIMEOUT],
+        }
+
+        if CONF_USERNAME in self._config:
+            username = self._config[CONF_USERNAME]
+            password = self._config.get(CONF_PASSWORD, "")
+            if self._config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
+                request_kwargs["middlewares"] = (
+                    aiohttp.DigestAuthMiddleware(username, password),
+                )
+            else:
+                request_kwargs["auth"] = aiohttp.BasicAuth(username, password)
+
+        _LOGGER.debug("Calling RESTful Command endpoint with method %s", method)
+        try:
+            async with getattr(self._websession, method)(
+                URL(
+                    request_url,
+                    encoded=self._config[CONF_SKIP_URL_ENCODING],
+                ),
+                **request_kwargs,
+            ) as response:
+                if response.status < HTTPStatus.BAD_REQUEST:
+                    _LOGGER.debug(
+                        "RESTful Command request succeeded with status code %d",
+                        response.status,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "RESTful Command request failed with status code %d",
+                        response.status,
+                    )
+
+                if not return_response:
+                    async for _ in response.content.iter_chunked(1024):
+                        pass
+                    return None
+
+                content = None
+                try:
+                    if response.content_type == "application/json":
+                        content = await response.json()
+                    else:
+                        content = await response.text()
+                except JSONDecodeError, AttributeError:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="decoding_error",
+                        translation_placeholders={"decoding_type": "JSON"},
+                    ) from None
+                except UnicodeDecodeError:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="decoding_error",
+                        translation_placeholders={"decoding_type": "text"},
+                    ) from None
+
+                return {
+                    "content": content,
+                    "status": response.status,
+                    "headers": {
+                        key: values[0] if len(values) == 1 else values
+                        for key in response.headers
+                        if (values := response.headers.getall(key))
+                    },
+                }
+        except TimeoutError:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="timeout",
+            ) from None
+        except aiohttp.ClientError, ValueError:
+            _LOGGER.error("Error fetching RESTful Command endpoint")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="client_error",
+            ) from None

--- a/homeassistant/components/rest_command/icons.json
+++ b/homeassistant/components/rest_command/icons.json
@@ -1,5 +1,8 @@
 {
   "services": {
+    "call_endpoint": {
+      "service": "mdi:webhook"
+    },
     "reload": {
       "service": "mdi:reload"
     }

--- a/homeassistant/components/rest_command/manifest.json
+++ b/homeassistant/components/rest_command/manifest.json
@@ -2,6 +2,8 @@
   "domain": "rest_command",
   "name": "RESTful Command",
   "codeowners": ["@jpbede"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rest_command",
+  "integration_type": "service",
   "iot_class": "local_push"
 }

--- a/homeassistant/components/rest_command/services.yaml
+++ b/homeassistant/components/rest_command/services.yaml
@@ -1,1 +1,14 @@
+call_endpoint:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: rest_command
+    payload:
+      example: '{"message": "The event occurred"}'
+      selector:
+        text:
+          multiline: true
+
 reload:

--- a/homeassistant/components/rest_command/strings.json
+++ b/homeassistant/components/rest_command/strings.json
@@ -14,7 +14,6 @@
         "data": {
           "authentication": "Authentication",
           "content_type": "Content type",
-          "endpoint_name": "Endpoint name",
           "insecure_cipher": "Use legacy TLS ciphers",
           "method": "HTTP method",
           "password": "[%key:common::config_flow::data::password%]",
@@ -29,7 +28,6 @@
         "data_description": {
           "authentication": "Authentication method for requests to this endpoint.",
           "content_type": "Content-Type header sent with each request. New endpoints default to application/json.",
-          "endpoint_name": "Name used to identify this endpoint in actions.",
           "insecure_cipher": "Allow legacy TLS ciphers. Enable only when the endpoint cannot use modern ciphers.",
           "method": "HTTP method used for each request.",
           "password": "Password for Basic or Digest authentication. Leave blank to keep the current password.",
@@ -47,7 +45,6 @@
         "data": {
           "authentication": "Authentication",
           "content_type": "Content type",
-          "endpoint_name": "Endpoint name",
           "insecure_cipher": "Use legacy TLS ciphers",
           "method": "HTTP method",
           "password": "[%key:common::config_flow::data::password%]",
@@ -62,7 +59,6 @@
         "data_description": {
           "authentication": "Authentication method for requests to this endpoint.",
           "content_type": "Content-Type header sent with each request. Defaults to application/json.",
-          "endpoint_name": "Name used to identify this endpoint in actions.",
           "insecure_cipher": "Allow legacy TLS ciphers. Enable only when the endpoint cannot use modern ciphers.",
           "method": "HTTP method used for each request.",
           "password": "Password for Basic or Digest authentication.",

--- a/homeassistant/components/rest_command/strings.json
+++ b/homeassistant/components/rest_command/strings.json
@@ -1,16 +1,129 @@
 {
+  "config": {
+    "abort": {
+      "already_configured": "This endpoint is already configured",
+      "reconfigure_successful": "Endpoint reconfigured successfully"
+    },
+    "error": {
+      "invalid_url": "Enter a valid HTTP or HTTPS URL",
+      "required": "This field is required",
+      "userinfo_not_allowed": "Remove the username and password from the URL and use the authentication fields"
+    },
+    "step": {
+      "reconfigure": {
+        "data": {
+          "authentication": "Authentication",
+          "content_type": "Content type",
+          "endpoint_name": "Endpoint name",
+          "insecure_cipher": "Use legacy TLS ciphers",
+          "method": "HTTP method",
+          "password": "[%key:common::config_flow::data::password%]",
+          "payload": "Default payload",
+          "skip_url_encoding": "Skip URL encoding",
+          "timeout": "Timeout",
+          "token": "Bearer token",
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "authentication": "Authentication method for requests to this endpoint.",
+          "content_type": "Content-Type header sent with each request. New endpoints default to application/json.",
+          "endpoint_name": "Name used to identify this endpoint in actions.",
+          "insecure_cipher": "Allow legacy TLS ciphers. Enable only when the endpoint cannot use modern ciphers.",
+          "method": "HTTP method used for each request.",
+          "password": "Password for Basic or Digest authentication. Leave blank to keep the current password.",
+          "payload": "Request body used when the action does not supply one. Enter valid JSON when Content type is application/json.",
+          "skip_url_encoding": "Send the URL without applying URL encoding.",
+          "timeout": "Maximum number of seconds to wait for the endpoint.",
+          "token": "Token used for Bearer authentication. Leave blank to keep the current token.",
+          "url": "HTTP or HTTPS endpoint URL.",
+          "username": "Username for Basic or Digest authentication.",
+          "verify_ssl": "Verify the endpoint's TLS certificate."
+        },
+        "title": "Reconfigure RESTful Command endpoint"
+      },
+      "user": {
+        "data": {
+          "authentication": "Authentication",
+          "content_type": "Content type",
+          "endpoint_name": "Endpoint name",
+          "insecure_cipher": "Use legacy TLS ciphers",
+          "method": "HTTP method",
+          "password": "[%key:common::config_flow::data::password%]",
+          "payload": "Default payload",
+          "skip_url_encoding": "Skip URL encoding",
+          "timeout": "Timeout",
+          "token": "Bearer token",
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "authentication": "Authentication method for requests to this endpoint.",
+          "content_type": "Content-Type header sent with each request. Defaults to application/json.",
+          "endpoint_name": "Name used to identify this endpoint in actions.",
+          "insecure_cipher": "Allow legacy TLS ciphers. Enable only when the endpoint cannot use modern ciphers.",
+          "method": "HTTP method used for each request.",
+          "password": "Password for Basic or Digest authentication.",
+          "payload": "Request body used when the action does not supply one. The prefilled value is valid JSON; action payloads are strings and override it.",
+          "skip_url_encoding": "Send the URL without applying URL encoding.",
+          "timeout": "Maximum number of seconds to wait for the endpoint.",
+          "token": "Token used for Bearer authentication.",
+          "url": "HTTP or HTTPS endpoint URL.",
+          "username": "Username for Basic or Digest authentication.",
+          "verify_ssl": "Verify the endpoint's TLS certificate."
+        },
+        "description": "Set up an outbound HTTP endpoint. Credentials are stored by Home Assistant and are never included in action data.",
+        "title": "Add RESTful Command endpoint"
+      }
+    }
+  },
   "exceptions": {
     "client_error": {
-      "message": "Client error occurred when calling resource \"{request_url}\""
+      "message": "Client error occurred when calling the RESTful Command endpoint"
     },
     "decoding_error": {
-      "message": "The response of \"{request_url}\" could not be decoded as {decoding_type}"
+      "message": "The RESTful Command response could not be decoded as {decoding_type}"
     },
     "timeout": {
-      "message": "Timeout when calling resource \"{request_url}\""
+      "message": "Timeout when calling the RESTful Command endpoint"
+    }
+  },
+  "selector": {
+    "authentication": {
+      "options": {
+        "basic": "Basic",
+        "bearer": "Bearer token",
+        "digest": "Digest",
+        "none": "None"
+      }
+    },
+    "method": {
+      "options": {
+        "delete": "DELETE",
+        "get": "GET",
+        "patch": "PATCH",
+        "post": "POST",
+        "put": "PUT"
+      }
     }
   },
   "services": {
+    "call_endpoint": {
+      "description": "Sends a request to a UI-managed RESTful Command endpoint.",
+      "fields": {
+        "config_entry_id": {
+          "description": "Endpoint to call.",
+          "name": "Endpoint"
+        },
+        "payload": {
+          "description": "Payload for this request. When omitted, the endpoint's default payload is used.",
+          "name": "Payload"
+        }
+      },
+      "name": "Send request"
+    },
     "reload": {
       "description": "Reloads RESTful commands from the YAML-configuration.",
       "name": "[%key:common::action::reload%]"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -654,6 +654,7 @@ FLOWS = {
         "renault",
         "renson",
         "reolink",
+        "rest_command",
         "rfxtrx",
         "rhasspy",
         "ridwell",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6023,8 +6023,8 @@
     },
     "rest_command": {
       "name": "RESTful Command",
-      "integration_type": "hub",
-      "config_flow": false,
+      "integration_type": "service",
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "rexel": {

--- a/tests/components/rest_command/test_config_flow.py
+++ b/tests/components/rest_command/test_config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.components.rest_command.const import (
     AUTHENTICATION_BEARER,
     AUTHENTICATION_NONE,
     CONF_CONTENT_TYPE,
-    CONF_ENDPOINT_NAME,
     CONF_INSECURE_CIPHER,
     CONF_SKIP_URL_ENCODING,
     DEFAULT_PAYLOAD,
@@ -37,7 +36,6 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 USER_INPUT = {
-    CONF_ENDPOINT_NAME: "Primary webhook",
     CONF_URL: "https://example.com/hooks/notify?key=secret",
     CONF_METHOD: "post",
     CONF_AUTHENTICATION: AUTHENTICATION_BEARER,
@@ -86,7 +84,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Primary webhook"
+    assert result["title"] == "example.com"
     assert result["data"] == USER_INPUT
     assert result["result"].unique_id is not None
 
@@ -99,7 +97,6 @@ async def test_user_flow_json_defaults(hass: HomeAssistant) -> None:
 
     defaults = result["data_schema"](
         {
-            CONF_ENDPOINT_NAME: "Webhook",
             CONF_URL: "https://example.com/hook",
         }
     )
@@ -208,7 +205,7 @@ async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
     """Test reconfiguring without re-entering the stored token."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="example.com",
+        title="Custom endpoint",
         data=USER_INPUT,
         unique_id="endpoint-id",
     )
@@ -219,7 +216,6 @@ async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
 
     new_input = {
         **USER_INPUT,
-        CONF_ENDPOINT_NAME: "Backup webhook",
         CONF_URL: "https://new.example.com/hook",
     }
     new_input.pop(CONF_TOKEN)
@@ -229,8 +225,7 @@ async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.title == "Backup webhook"
-    assert entry.data[CONF_ENDPOINT_NAME] == "Backup webhook"
+    assert entry.title == "Custom endpoint"
     assert entry.data[CONF_TOKEN] == "secret-token"
 
 

--- a/tests/components/rest_command/test_config_flow.py
+++ b/tests/components/rest_command/test_config_flow.py
@@ -1,0 +1,259 @@
+"""Tests for the RESTful Command config flow."""
+
+import json
+from typing import Any
+
+import pytest
+
+from homeassistant.components.rest_command.const import (
+    AUTHENTICATION_BEARER,
+    AUTHENTICATION_NONE,
+    CONF_CONTENT_TYPE,
+    CONF_ENDPOINT_NAME,
+    CONF_INSECURE_CIPHER,
+    CONF_SKIP_URL_ENCODING,
+    DEFAULT_PAYLOAD,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_METHOD,
+    CONF_PASSWORD,
+    CONF_PAYLOAD,
+    CONF_TIMEOUT,
+    CONF_TOKEN,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    CONTENT_TYPE_JSON,
+    HTTP_BASIC_AUTHENTICATION,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {
+    CONF_ENDPOINT_NAME: "Primary webhook",
+    CONF_URL: "https://example.com/hooks/notify?key=secret",
+    CONF_METHOD: "post",
+    CONF_AUTHENTICATION: AUTHENTICATION_BEARER,
+    CONF_TOKEN: "secret-token",
+    CONF_CONTENT_TYPE: "application/json",
+    CONF_PAYLOAD: DEFAULT_PAYLOAD,
+    CONF_TIMEOUT: DEFAULT_TIMEOUT,
+    CONF_VERIFY_SSL: True,
+    CONF_INSECURE_CIPHER: False,
+    CONF_SKIP_URL_ENCODING: False,
+}
+BASIC_INPUT = {
+    **USER_INPUT,
+    CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
+}
+BASIC_INPUT.pop(CONF_TOKEN)
+DIGEST_INPUT = {
+    **USER_INPUT,
+    CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
+}
+DIGEST_INPUT.pop(CONF_TOKEN)
+BEARER_WITHOUT_TOKEN_INPUT = USER_INPUT.copy()
+BEARER_WITHOUT_TOKEN_INPUT.pop(CONF_TOKEN)
+VALID_BASIC_INPUT = {
+    **BASIC_INPUT,
+    CONF_USERNAME: "user",
+    CONF_PASSWORD: "password",
+}
+VALID_DIGEST_INPUT = {
+    **DIGEST_INPUT,
+    CONF_USERNAME: "user",
+    CONF_PASSWORD: "password",
+}
+
+
+async def test_user_flow(hass: HomeAssistant) -> None:
+    """Test setting up a Bearer-authenticated endpoint."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Primary webhook"
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id is not None
+
+
+async def test_user_flow_json_defaults(hass: HomeAssistant) -> None:
+    """Test new endpoints suggest a valid JSON request body."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    defaults = result["data_schema"](
+        {
+            CONF_ENDPOINT_NAME: "Webhook",
+            CONF_URL: "https://example.com/hook",
+        }
+    )
+
+    assert defaults[CONF_CONTENT_TYPE] == CONTENT_TYPE_JSON
+    assert defaults[CONF_PAYLOAD] == DEFAULT_PAYLOAD
+    assert json.loads(defaults[CONF_PAYLOAD]) == {"message": "The event occurred"}
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        pytest.param(VALID_BASIC_INPUT, id="basic"),
+        pytest.param(VALID_DIGEST_INPUT, id="digest"),
+    ],
+)
+async def test_user_flow_username_password_authentication(
+    hass: HomeAssistant, user_input: dict[str, Any]
+) -> None:
+    """Test setting up Basic and Digest authenticated endpoints."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == user_input
+    assert CONF_TOKEN not in result["data"]
+
+
+@pytest.mark.parametrize(
+    ("user_input", "errors"),
+    [
+        pytest.param(
+            {**USER_INPUT, CONF_URL: "file:///tmp/hook"},
+            {CONF_URL: "invalid_url"},
+            id="invalid-url",
+        ),
+        pytest.param(
+            {**USER_INPUT, CONF_URL: "https://[malformed"},
+            {CONF_URL: "invalid_url"},
+            id="malformed-url",
+        ),
+        pytest.param(
+            {**USER_INPUT, CONF_URL: "https://example.com:70000/hook"},
+            {CONF_URL: "invalid_url"},
+            id="out-of-range-port",
+        ),
+        pytest.param(
+            {**USER_INPUT, CONF_URL: "https://user:password@example.com/hook"},
+            {CONF_URL: "userinfo_not_allowed"},
+            id="userinfo-not-allowed",
+        ),
+        pytest.param(
+            BASIC_INPUT,
+            {CONF_USERNAME: "required", CONF_PASSWORD: "required"},
+            id="basic-credentials-required",
+        ),
+        pytest.param(
+            DIGEST_INPUT,
+            {CONF_USERNAME: "required", CONF_PASSWORD: "required"},
+            id="digest-credentials-required",
+        ),
+        pytest.param(
+            BEARER_WITHOUT_TOKEN_INPUT,
+            {CONF_TOKEN: "required"},
+            id="bearer-token-required",
+        ),
+    ],
+)
+async def test_user_flow_errors(
+    hass: HomeAssistant,
+    user_input: dict[str, Any],
+    errors: dict[str, str],
+) -> None:
+    """Test endpoint validation errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == errors
+
+
+async def test_user_flow_duplicate(hass: HomeAssistant) -> None:
+    """Test duplicate method and URL prevention."""
+    MockConfigEntry(domain=DOMAIN, data=USER_INPUT).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
+    """Test reconfiguring without re-entering the stored token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="example.com",
+        data=USER_INPUT,
+        unique_id="endpoint-id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    new_input = {
+        **USER_INPUT,
+        CONF_ENDPOINT_NAME: "Backup webhook",
+        CONF_URL: "https://new.example.com/hook",
+    }
+    new_input.pop(CONF_TOKEN)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], new_input
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.title == "Backup webhook"
+    assert entry.data[CONF_ENDPOINT_NAME] == "Backup webhook"
+    assert entry.data[CONF_TOKEN] == "secret-token"
+
+
+async def test_reconfigure_removes_credentials(hass: HomeAssistant) -> None:
+    """Test changing to unauthenticated requests removes credentials."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="example.com",
+        data=USER_INPUT,
+        unique_id="endpoint-id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            **USER_INPUT,
+            CONF_AUTHENTICATION: AUTHENTICATION_NONE,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert CONF_TOKEN not in entry.data
+    assert CONF_USERNAME not in entry.data
+    assert CONF_PASSWORD not in entry.data

--- a/tests/components/rest_command/test_config_flow.py
+++ b/tests/components/rest_command/test_config_flow.py
@@ -201,12 +201,21 @@ async def test_user_flow_duplicate(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
-    """Test reconfiguring without re-entering the stored token."""
+@pytest.mark.parametrize(
+    ("entry_data", "credential"),
+    [
+        pytest.param(USER_INPUT, CONF_TOKEN, id="bearer-token"),
+        pytest.param(VALID_BASIC_INPUT, CONF_PASSWORD, id="basic-password"),
+    ],
+)
+async def test_reconfigure_preserves_credentials(
+    hass: HomeAssistant, entry_data: dict[str, Any], credential: str
+) -> None:
+    """Test reconfiguring without re-entering the stored credential."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Custom endpoint",
-        data=USER_INPUT,
+        data=entry_data,
         unique_id="endpoint-id",
     )
     entry.add_to_hass(hass)
@@ -215,10 +224,10 @@ async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
 
     new_input = {
-        **USER_INPUT,
+        **entry_data,
         CONF_URL: "https://new.example.com/hook",
     }
-    new_input.pop(CONF_TOKEN)
+    new_input.pop(credential)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], new_input
     )
@@ -226,7 +235,7 @@ async def test_reconfigure_preserves_bearer_token(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert entry.title == "Custom endpoint"
-    assert entry.data[CONF_TOKEN] == "secret-token"
+    assert entry.data[credential] == entry_data[credential]
 
 
 async def test_reconfigure_removes_credentials(hass: HomeAssistant) -> None:

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import service
 
 from .conftest import TEST_URL, ComponentSetup
 
@@ -124,6 +125,8 @@ async def test_yaml_call_endpoint_takes_precedence(
         )
 
     assert mock_post.call_args.kwargs["data"] == b"YAML payload"
+    descriptions = await service.async_get_all_descriptions(hass)
+    assert descriptions[DOMAIN][SERVICE_CALL_ENDPOINT]["fields"] == {}
 
 
 async def test_reload_yaml_call_endpoint_ownership(
@@ -161,6 +164,8 @@ async def test_reload_yaml_call_endpoint_ownership(
 
     assert mock_post.call_args.kwargs["data"] == b"Reloaded YAML payload"
     assert not hass.services.has_service(DOMAIN, "get_test")
+    descriptions = await service.async_get_all_descriptions(hass)
+    assert descriptions[DOMAIN][SERVICE_CALL_ENDPOINT]["fields"] == {}
 
 
 async def test_reload_restores_ui_call_endpoint(
@@ -205,6 +210,10 @@ async def test_reload_restores_ui_call_endpoint(
     )
 
     assert len(aioclient_mock.mock_calls) == 1
+    descriptions = await service.async_get_all_descriptions(hass)
+    fields = descriptions[DOMAIN][SERVICE_CALL_ENDPOINT]["fields"]
+    assert set(fields) == {ATTR_CONFIG_ENTRY_ID, CONF_PAYLOAD}
+    assert fields[ATTR_CONFIG_ENTRY_ID]["required"] is True
 
 
 async def test_setup_tests(

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -101,6 +101,23 @@ async def test_reload(hass: HomeAssistant, setup_component: ComponentSetup) -> N
     assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
 
 
+async def test_reload_preserves_actions_when_config_unavailable(
+    hass: HomeAssistant, setup_component: ComponentSetup
+) -> None:
+    """Test reload preserves actions when YAML configuration is unavailable."""
+    await setup_component()
+    existing_services = set(hass.services.async_services_for_domain(DOMAIN))
+
+    with patch(
+        "homeassistant.components.rest_command.async_integration_yaml_config",
+        autospec=True,
+        return_value=None,
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    assert set(hass.services.async_services_for_domain(DOMAIN)) == existing_services
+
+
 async def test_yaml_call_endpoint_takes_precedence(
     hass: HomeAssistant, setup_component: ComponentSetup
 ) -> None:

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -1,27 +1,81 @@
 """The tests for the rest command platform."""
 
 import base64
+from collections.abc import AsyncIterator
 from http import HTTPStatus
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 import aiohttp
 from multidict import CIMultiDict
 import pytest
+import voluptuous as vol
 from yarl import URL
 
-from homeassistant.components.rest_command import DOMAIN
+from homeassistant.components.rest_command import CONFIG_SCHEMA
+from homeassistant.components.rest_command.const import (
+    AUTHENTICATION_BEARER,
+    AUTHENTICATION_NONE,
+    CONF_ENDPOINT_NAME,
+    CONF_INSECURE_CIPHER,
+    CONF_SKIP_URL_ENCODING,
+    DOMAIN,
+    SERVICE_CALL_ENDPOINT,
+)
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    CONF_AUTHENTICATION,
+    CONF_METHOD,
+    CONF_PASSWORD,
+    CONF_PAYLOAD,
+    CONF_TIMEOUT,
+    CONF_TOKEN,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
     CONTENT_TYPE_JSON,
     CONTENT_TYPE_TEXT_PLAIN,
+    HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
     SERVICE_RELOAD,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .conftest import TEST_URL, ComponentSetup
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+def _configure_mock_response(mock_request: MagicMock, url: str = TEST_URL) -> None:
+    """Configure a mocked aiohttp request context manager."""
+
+    async def async_iter_chunks(self: object, chunk_size: int) -> AsyncIterator[bytes]:
+        yield b"success"
+
+    mock_request.return_value.__aenter__.return_value = type(
+        "MockResponse",
+        (),
+        {
+            "status": 200,
+            "content_type": "text/plain",
+            "headers": {},
+            "url": url,
+            "content": type("MockContent", (), {"iter_chunked": async_iter_chunks})(),
+        },
+    )()
+
+
+@pytest.mark.parametrize("reserved_name", [SERVICE_RELOAD, SERVICE_CALL_ENDPOINT])
+async def test_reserved_yaml_action_name(reserved_name: str) -> None:
+    """Test integration-owned action names are rejected in YAML."""
+    with pytest.raises(
+        vol.Invalid,
+        match=rf'The RESTful Command action name "{reserved_name}" is reserved',
+    ):
+        CONFIG_SCHEMA({DOMAIN: {reserved_name: {CONF_URL: TEST_URL}}})
 
 
 async def test_reload(hass: HomeAssistant, setup_component: ComponentSetup) -> None:
@@ -45,6 +99,30 @@ async def test_reload(hass: HomeAssistant, setup_component: ComponentSetup) -> N
 
     assert hass.services.has_service(DOMAIN, "new_test")
     assert not hass.services.has_service(DOMAIN, "get_test")
+    assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
+
+
+async def test_reload_reserved_action_name(
+    hass: HomeAssistant, setup_component: ComponentSetup
+) -> None:
+    """Test reload cannot replace integration-owned action handlers."""
+    await setup_component()
+    collision_config = {
+        DOMAIN: {SERVICE_CALL_ENDPOINT: {CONF_URL: TEST_URL, CONF_METHOD: "get"}}
+    }
+
+    with (
+        patch(
+            "homeassistant.components.rest_command.async_integration_yaml_config",
+            autospec=True,
+            return_value=collision_config,
+        ),
+        pytest.raises(vol.Invalid, match="is reserved"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    assert hass.services.has_service(DOMAIN, "get_test")
+    assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
 
 
 async def test_setup_tests(
@@ -71,7 +149,7 @@ async def test_rest_command_timeout(
 
     with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(DOMAIN, "get_test", {}, blocking=True)
-    assert str(exc.value) == 'Timeout when calling resource "https://example.com/"'
+    assert str(exc.value) == "Timeout when calling the RESTful Command endpoint"
 
     assert len(aioclient_mock.mock_calls) == 1
 
@@ -91,7 +169,7 @@ async def test_rest_command_aiohttp_error(
 
     assert (
         str(exc.value)
-        == 'Client error occurred when calling resource "https://example.com/"'
+        == "Client error occurred when calling the RESTful Command endpoint"
     )
     assert len(aioclient_mock.mock_calls) == 1
 
@@ -426,10 +504,7 @@ async def test_rest_command_get_response_malformed_json(
         await hass.services.async_call(
             DOMAIN, "get_test", {}, blocking=True, return_response=True
         )
-    assert (
-        str(exc.value)
-        == 'The response of "https://example.com/" could not be decoded as JSON'
-    )
+    assert str(exc.value) == "The RESTful Command response could not be decoded as JSON"
 
 
 async def test_rest_command_get_response_none(
@@ -460,10 +535,7 @@ async def test_rest_command_get_response_none(
         response = await hass.services.async_call(
             DOMAIN, "get_test", {}, blocking=True, return_response=True
         )
-    assert (
-        str(exc.value)
-        == 'The response of "https://example.com/" could not be decoded as text'
-    )
+    assert str(exc.value) == "The RESTful Command response could not be decoded as text"
 
     assert not response
 
@@ -521,3 +593,276 @@ async def test_rest_command_skip_url_encoding(
     assert len(aioclient_mock.mock_calls) == 2
     assert str(aioclient_mock.mock_calls[0][1]) == "0%2C"
     assert str(aioclient_mock.mock_calls[1][1]) == "1,"
+
+
+async def test_ui_managed_bearer_endpoint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test calling a UI-managed endpoint with Bearer authentication."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Example",
+        data={
+            CONF_ENDPOINT_NAME: "Example",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "post",
+            CONF_AUTHENTICATION: AUTHENTICATION_BEARER,
+            CONF_TOKEN: "secret-token",
+            CONF_PAYLOAD: "default payload",
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+        unique_id="endpoint-id",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    aioclient_mock.post(
+        TEST_URL,
+        content=b"success",
+        headers={"content-type": "text/plain"},
+    )
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALL_ENDPOINT,
+        {
+            ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+            CONF_PAYLOAD: "action payload",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {
+        "content": "success",
+        "status": 200,
+        "headers": {"content-type": "text/plain"},
+    }
+    assert aioclient_mock.mock_calls[0][2] == b"action payload"
+    assert aioclient_mock.mock_calls[0][3]["Authorization"] == ("Bearer secret-token")
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALL_ENDPOINT,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+    )
+
+    assert aioclient_mock.mock_calls[1][2] == b"default payload"
+
+
+async def test_ui_managed_basic_endpoint(hass: HomeAssistant) -> None:
+    """Test UI-managed Basic authentication on the wire."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Basic endpoint",
+        data={
+            CONF_ENDPOINT_NAME: "Basic endpoint",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "get",
+            CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
+            CONF_USERNAME: "basic-user",
+            CONF_PASSWORD: "basic-password",
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        _configure_mock_response(mock_get)
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+            blocking=True,
+        )
+
+    auth = mock_get.call_args.kwargs["auth"]
+    assert isinstance(auth, aiohttp.BasicAuth)
+    assert auth.login == "basic-user"
+    assert auth.password == "basic-password"
+
+
+async def test_ui_managed_digest_endpoint(hass: HomeAssistant) -> None:
+    """Test UI-managed Digest authentication on the wire."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Digest endpoint",
+        data={
+            CONF_ENDPOINT_NAME: "Digest endpoint",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "get",
+            CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
+            CONF_USERNAME: "digest-user",
+            CONF_PASSWORD: "digest-password",
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        _configure_mock_response(mock_get)
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+            blocking=True,
+        )
+
+    middleware = mock_get.call_args.kwargs["middlewares"][0]
+    assert isinstance(middleware, aiohttp.DigestAuthMiddleware)
+
+
+async def test_loaded_reconfigure_updates_runtime_data(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test a loaded entry uses reconfigured request data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Original endpoint",
+        data={
+            CONF_ENDPOINT_NAME: "Original endpoint",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "get",
+            CONF_AUTHENTICATION: AUTHENTICATION_NONE,
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+        unique_id="endpoint-id",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    original_runtime_data = entry.runtime_data
+
+    result = await entry.start_reconfigure_flow(hass)
+    new_url = "https://example.org/reconfigured"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENDPOINT_NAME: "Reconfigured endpoint",
+            CONF_URL: new_url,
+            CONF_METHOD: "post",
+            CONF_AUTHENTICATION: AUTHENTICATION_NONE,
+            CONF_TIMEOUT: 15,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.title == "Reconfigured endpoint"
+    assert entry.runtime_data is not original_runtime_data
+
+    aioclient_mock.post(new_url, content=b"success")
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALL_ENDPOINT,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+    )
+
+    assert aioclient_mock.mock_calls[0][0] == "POST"
+    assert str(aioclient_mock.mock_calls[0][1]) == new_url
+
+
+async def test_ui_managed_endpoint_unload(
+    hass: HomeAssistant,
+) -> None:
+    """Test unloading a UI-managed endpoint."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ENDPOINT_NAME: "Example",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "get",
+            CONF_AUTHENTICATION: "none",
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
+
+    with pytest.raises(ServiceValidationError, match="is not loaded"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+            blocking=True,
+        )
+
+
+async def test_request_logging_redacts_secrets(
+    hass: HomeAssistant,
+    setup_component: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test rendered request secrets are not logged or included in errors."""
+    secret_url = "https://example.com/hook?token=url-secret"
+    await setup_component(
+        {
+            "secret_test": {
+                "url": secret_url,
+                "method": "post",
+                "headers": {"Authorization": "Bearer header-secret"},
+                "payload": "payload-secret",
+            }
+        }
+    )
+    aioclient_mock.post(secret_url, status=HTTPStatus.BAD_REQUEST)
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG, logger="homeassistant.components.rest_command"):
+        await hass.services.async_call(DOMAIN, "secret_test", {}, blocking=True)
+
+    assert "url-secret" not in caplog.text
+    assert "header-secret" not in caplog.text
+    assert "payload-secret" not in caplog.text
+
+
+async def test_client_error_redacts_exception(
+    hass: HomeAssistant,
+    setup_component: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test client exception details cannot expose request secrets."""
+    await setup_component()
+    aioclient_mock.get(TEST_URL, exc=aiohttp.ClientError("client-secret"))
+    caplog.clear()
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="homeassistant.components.rest_command"),
+        pytest.raises(HomeAssistantError) as exc,
+    ):
+        await hass.services.async_call(DOMAIN, "get_test", {}, blocking=True)
+
+    assert "client-secret" not in caplog.text
+    assert "client-secret" not in str(exc.value)
+    assert exc.value.__cause__ is None

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -68,14 +68,13 @@ def _configure_mock_response(mock_request: MagicMock, url: str = TEST_URL) -> No
     )()
 
 
-@pytest.mark.parametrize("reserved_name", [SERVICE_RELOAD, SERVICE_CALL_ENDPOINT])
-async def test_reserved_yaml_action_name(reserved_name: str) -> None:
+async def test_reserved_yaml_action_name() -> None:
     """Test integration-owned action names are rejected in YAML."""
     with pytest.raises(
         vol.Invalid,
-        match=rf'The RESTful Command action name "{reserved_name}" is reserved',
+        match=rf'The RESTful Command action name "{SERVICE_RELOAD}" is reserved',
     ):
-        CONFIG_SCHEMA({DOMAIN: {reserved_name: {CONF_URL: TEST_URL}}})
+        CONFIG_SCHEMA({DOMAIN: {SERVICE_RELOAD: {CONF_URL: TEST_URL}}})
 
 
 async def test_reload(hass: HomeAssistant, setup_component: ComponentSetup) -> None:
@@ -102,27 +101,112 @@ async def test_reload(hass: HomeAssistant, setup_component: ComponentSetup) -> N
     assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
 
 
-async def test_reload_reserved_action_name(
+async def test_yaml_call_endpoint_takes_precedence(
     hass: HomeAssistant, setup_component: ComponentSetup
 ) -> None:
-    """Test reload cannot replace integration-owned action handlers."""
-    await setup_component()
-    collision_config = {
-        DOMAIN: {SERVICE_CALL_ENDPOINT: {CONF_URL: TEST_URL, CONF_METHOD: "get"}}
-    }
+    """Test an existing YAML call_endpoint action keeps working."""
+    await setup_component(
+        {
+            SERVICE_CALL_ENDPOINT: {
+                CONF_URL: TEST_URL,
+                CONF_METHOD: "post",
+                CONF_PAYLOAD: "{{ message }}",
+            }
+        }
+    )
 
-    with (
-        patch(
-            "homeassistant.components.rest_command.async_integration_yaml_config",
-            autospec=True,
-            return_value=collision_config,
-        ),
-        pytest.raises(vol.Invalid, match="is reserved"),
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        _configure_mock_response(mock_post)
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            {"message": "YAML payload"},
+            blocking=True,
+        )
+
+    assert mock_post.call_args.kwargs["data"] == b"YAML payload"
+
+
+async def test_reload_yaml_call_endpoint_ownership(
+    hass: HomeAssistant, setup_component: ComponentSetup
+) -> None:
+    """Test reload gives an existing YAML call_endpoint action precedence."""
+    await setup_component()
+    collision_config = CONFIG_SCHEMA(
+        {
+            DOMAIN: {
+                SERVICE_CALL_ENDPOINT: {
+                    CONF_URL: TEST_URL,
+                    CONF_METHOD: "post",
+                    CONF_PAYLOAD: "{{ message }}",
+                }
+            }
+        }
+    )
+
+    with patch(
+        "homeassistant.components.rest_command.async_integration_yaml_config",
+        autospec=True,
+        return_value=collision_config,
     ):
         await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
 
-    assert hass.services.has_service(DOMAIN, "get_test")
-    assert hass.services.has_service(DOMAIN, SERVICE_CALL_ENDPOINT)
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        _configure_mock_response(mock_post)
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CALL_ENDPOINT,
+            {"message": "Reloaded YAML payload"},
+            blocking=True,
+        )
+
+    assert mock_post.call_args.kwargs["data"] == b"Reloaded YAML payload"
+    assert not hass.services.has_service(DOMAIN, "get_test")
+
+
+async def test_reload_restores_ui_call_endpoint(
+    hass: HomeAssistant,
+    setup_component: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test removing the YAML collision restores the UI-managed action."""
+    await setup_component(
+        {SERVICE_CALL_ENDPOINT: {CONF_URL: TEST_URL, CONF_METHOD: "get"}}
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Example",
+        data={
+            CONF_ENDPOINT_NAME: "Example",
+            CONF_URL: TEST_URL,
+            CONF_METHOD: "get",
+            CONF_AUTHENTICATION: AUTHENTICATION_NONE,
+            CONF_TIMEOUT: 10,
+            CONF_VERIFY_SSL: True,
+            CONF_INSECURE_CIPHER: False,
+            CONF_SKIP_URL_ENCODING: False,
+        },
+        unique_id="endpoint-id",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    with patch(
+        "homeassistant.components.rest_command.async_integration_yaml_config",
+        autospec=True,
+        return_value=CONFIG_SCHEMA({DOMAIN: {}}),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    aioclient_mock.get(TEST_URL, content=b"success")
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALL_ENDPOINT,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+    )
+
+    assert len(aioclient_mock.mock_calls) == 1
 
 
 async def test_setup_tests(

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -16,7 +16,6 @@ from homeassistant.components.rest_command import CONFIG_SCHEMA
 from homeassistant.components.rest_command.const import (
     AUTHENTICATION_BEARER,
     AUTHENTICATION_NONE,
-    CONF_ENDPOINT_NAME,
     CONF_INSECURE_CIPHER,
     CONF_SKIP_URL_ENCODING,
     DOMAIN,
@@ -177,7 +176,6 @@ async def test_reload_restores_ui_call_endpoint(
         domain=DOMAIN,
         title="Example",
         data={
-            CONF_ENDPOINT_NAME: "Example",
             CONF_URL: TEST_URL,
             CONF_METHOD: "get",
             CONF_AUTHENTICATION: AUTHENTICATION_NONE,
@@ -688,7 +686,6 @@ async def test_ui_managed_bearer_endpoint(
         domain=DOMAIN,
         title="Example",
         data={
-            CONF_ENDPOINT_NAME: "Example",
             CONF_URL: TEST_URL,
             CONF_METHOD: "post",
             CONF_AUTHENTICATION: AUTHENTICATION_BEARER,
@@ -744,7 +741,6 @@ async def test_ui_managed_basic_endpoint(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="Basic endpoint",
         data={
-            CONF_ENDPOINT_NAME: "Basic endpoint",
             CONF_URL: TEST_URL,
             CONF_METHOD: "get",
             CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
@@ -780,7 +776,6 @@ async def test_ui_managed_digest_endpoint(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="Digest endpoint",
         data={
-            CONF_ENDPOINT_NAME: "Digest endpoint",
             CONF_URL: TEST_URL,
             CONF_METHOD: "get",
             CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
@@ -817,7 +812,6 @@ async def test_loaded_reconfigure_updates_runtime_data(
         domain=DOMAIN,
         title="Original endpoint",
         data={
-            CONF_ENDPOINT_NAME: "Original endpoint",
             CONF_URL: TEST_URL,
             CONF_METHOD: "get",
             CONF_AUTHENTICATION: AUTHENTICATION_NONE,
@@ -837,7 +831,6 @@ async def test_loaded_reconfigure_updates_runtime_data(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_ENDPOINT_NAME: "Reconfigured endpoint",
             CONF_URL: new_url,
             CONF_METHOD: "post",
             CONF_AUTHENTICATION: AUTHENTICATION_NONE,
@@ -851,7 +844,7 @@ async def test_loaded_reconfigure_updates_runtime_data(
 
     assert result["reason"] == "reconfigure_successful"
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.title == "Reconfigured endpoint"
+    assert entry.title == "Original endpoint"
     assert entry.runtime_data is not original_runtime_data
 
     aioclient_mock.post(new_url, content=b"success")
@@ -873,7 +866,6 @@ async def test_ui_managed_endpoint_unload(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_ENDPOINT_NAME: "Example",
             CONF_URL: TEST_URL,
             CONF_METHOD: "get",
             CONF_AUTHENTICATION: "none",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
RESTful Command currently requires YAML configuration, even for static outbound HTTP endpoints. This change adds config-entry support so endpoints can be configured through the Home Assistant UI.

Each config entry represents one endpoint and supports:

- GET, PATCH, POST, PUT, and DELETE requests
- Basic, Digest, and Bearer authentication
- A default payload and content type
- Per-call payload overrides
- Timeout, certificate verification, legacy cipher, and URL-encoding settings
- Optional action responses containing the status, content, and response headers

UI-managed endpoints are called through the `rest_command.call_endpoint` action. YAML-defined commands and YAML reload behavior remain supported.

For backward compatibility, an existing YAML command named `call_endpoint` takes precedence. UI-managed endpoints become available through that action after the conflicting YAML command is renamed and RESTful Command is reloaded.

YAML and UI-managed endpoints share the same HTTP execution path. Request logs and translated errors no longer expose rendered URLs, credentials, payloads, or low-level exception details.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47541
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47548
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
