### PR TITLE
Migrate Envisalink integration to use ConfigFlow

### DIFF
--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -6,55 +6,62 @@ import logging
 from pyenvisalink import EnvisalinkAlarmPanel
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_CODE,
     CONF_HOST,
     CONF_TIMEOUT,
     EVENT_HOMEASSISTANT_STOP,
-    Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    HomeAssistant,
+    ServiceCall,
+    callback,
+)
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.hass_dict import HassKey
+
+from .const import (
+    ATTR_CUSTOM_FUNCTION,
+    ATTR_PARTITION,
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITIONNAME,
+    CONF_PARTITIONS,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONENAME,
+    CONF_ZONES,
+    CONF_ZONETYPE,
+    DEFAULT_EVL_VERSION,
+    DEFAULT_KEEPALIVE,
+    DEFAULT_PANIC,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DEFAULT_ZONEDUMP_INTERVAL,
+    DEFAULT_ZONETYPE,
+    DOMAIN,
+    LOGIN_RESPONSE_TIMEOUT,
+    PANEL_TYPE_DSC,
+    PANEL_TYPE_HONEYWELL,
+    PLATFORMS,
+    SERVICE_CUSTOM_FUNCTION,
+    SIGNAL_KEYPAD_UPDATE,
+    SIGNAL_PARTITION_UPDATE,
+    SIGNAL_ZONE_UPDATE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "envisalink"
-
-DATA_EVL: HassKey[EnvisalinkAlarmPanel] = HassKey(DOMAIN)
-
-CONF_EVL_KEEPALIVE = "keepalive_interval"
-CONF_EVL_PORT = "port"
-CONF_EVL_VERSION = "evl_version"
-CONF_PANEL_TYPE = "panel_type"
-CONF_PANIC = "panic_type"
-CONF_PARTITIONNAME = "name"
-CONF_PARTITIONS = "partitions"
-CONF_PASS = "password"
-CONF_USERNAME = "user_name"
-CONF_ZONEDUMP_INTERVAL = "zonedump_interval"
-CONF_ZONENAME = "name"
-CONF_ZONES = "zones"
-CONF_ZONETYPE = "type"
-
-PANEL_TYPE_HONEYWELL = "HONEYWELL"
-PANEL_TYPE_DSC = "DSC"
-
-DEFAULT_PORT = 4025
-DEFAULT_EVL_VERSION = 3
-DEFAULT_KEEPALIVE = 60
-DEFAULT_ZONEDUMP_INTERVAL = 30
-DEFAULT_ZONETYPE = "opening"
-DEFAULT_PANIC = "Police"
-DEFAULT_TIMEOUT = 10
-
-SIGNAL_ZONE_UPDATE = "envisalink.zones_updated"
-SIGNAL_PARTITION_UPDATE = "envisalink.partition_updated"
-SIGNAL_KEYPAD_UPDATE = "envisalink.keypad_updated"
-SIGNAL_ZONE_BYPASS_UPDATE = "envisalink.zone_bypass_updated"
+type EnvisalinkConfigEntry = ConfigEntry[EnvisalinkAlarmPanel]
 
 ZONE_SCHEMA = vol.Schema(
     {
@@ -83,22 +90,19 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_EVL_VERSION, default=DEFAULT_EVL_VERSION): vol.All(
                     vol.Coerce(int), vol.Range(min=3, max=4)
                 ),
-                vol.Optional(CONF_EVL_KEEPALIVE, default=DEFAULT_KEEPALIVE): vol.All(
+                # keepalive_interval, zonedump_interval and timeout are no longer
+                # user-configurable; accepted here only so existing YAML doesn't
+                # hard-error, and ignored on import.
+                vol.Optional("keepalive_interval"): vol.All(
                     vol.Coerce(int), vol.Range(min=15)
                 ),
-                vol.Optional(
-                    CONF_ZONEDUMP_INTERVAL, default=DEFAULT_ZONEDUMP_INTERVAL
-                ): vol.Coerce(int),
-                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
+                vol.Optional("zonedump_interval"): vol.Coerce(int),
+                vol.Optional(CONF_TIMEOUT): vol.Coerce(int),
             }
         )
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-SERVICE_CUSTOM_FUNCTION = "invoke_custom_function"
-ATTR_CUSTOM_FUNCTION = "pgm"
-ATTR_PARTITION = "partition"
 
 SERVICE_SCHEMA = vol.Schema(
     {
@@ -108,23 +112,74 @@ SERVICE_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up for Envisalink devices."""
-    conf = config[DOMAIN]
+class InvalidAuth(Exception):
+    """Error to indicate the panel rejected our credentials."""
 
-    host = conf.get(CONF_HOST)
-    port = conf.get(CONF_EVL_PORT)
-    code = conf.get(CONF_CODE)
-    panel_type = conf.get(CONF_PANEL_TYPE)
-    panic_type = conf.get(CONF_PANIC)
-    version = conf.get(CONF_EVL_VERSION)
-    user = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASS)
-    keep_alive = conf.get(CONF_EVL_KEEPALIVE)
-    zone_dump = conf.get(CONF_ZONEDUMP_INTERVAL)
-    zones = conf.get(CONF_ZONES)
-    partitions = conf.get(CONF_PARTITIONS)
-    connection_timeout = conf.get(CONF_TIMEOUT)
+
+class LoginTimeout(Exception):
+    """Error to indicate no login response was ever recognized.
+
+    Distinct from pyenvisalink's own tolerate-and-retry timeout (returned as
+    login_succeeded=False, controller left running): this is our outer bound
+    giving up entirely, after which the panel has already been disconnected
+    and cannot self-heal.
+    """
+
+
+def disconnect_panel(controller: EnvisalinkAlarmPanel) -> None:
+    """Force-close a panel connection and cancel any pending reconnect.
+
+    pyenvisalink's own stop() only sets an internal shutdown flag when given
+    an external event loop (always true for us) - it never closes the
+    transport. Worse, a reconnect already scheduled before stop() is called
+    fires anyway once its delay elapses: reconnect() doesn't check that flag
+    before reconnecting. Left alone, a failed/cancelled/timed-out connection
+    attempt (e.g. during config flow validation) keeps a background
+    reconnect loop alive indefinitely. This reaches past stop() to force an
+    immediate, complete teardown instead.
+    """
+    controller.stop()
+    controller._client.disconnect()  # noqa: SLF001
+    if (reconnect_task := controller._client._reconnect_task) is not None:  # noqa: SLF001
+        reconnect_task.cancel()
+
+
+async def async_connect_panel(
+    hass: HomeAssistant,
+    host: str,
+    port: int,
+    panel_type: str,
+    version: int,
+    user: str,
+    password: str,
+    zone_dump: int = DEFAULT_ZONEDUMP_INTERVAL,
+    keep_alive: int = DEFAULT_KEEPALIVE,
+    connection_timeout: int | None = None,
+) -> tuple[EnvisalinkAlarmPanel, bool]:
+    """Start a connection to an Envisalink panel and wait for a login result.
+
+    Returns (controller, login_succeeded). login_succeeded is False when the
+    login attempt timed out at the library level; pyenvisalink keeps
+    retrying in the background in that case, so the controller is still
+    returned running. Raises InvalidAuth if the panel rejects the given
+    credentials.
+
+    pyenvisalink's own connection_timeout only bounds the raw TCP connect: if
+    the panel never sends a response the library recognizes as a login
+    success/failure (e.g. the wrong panel_type was selected, so its parser
+    can't make sense of the panel's replies), none of the login callbacks
+    ever fire and the connection attempt would otherwise hang forever. The
+    asyncio.timeout below bounds the whole wait, on top of that - unlike the
+    library's own timeout, giving up here means the panel is disconnected
+    and can't self-heal, so it's raised as LoginTimeout instead of returned.
+    """
+    # connection_timeout is resolved here rather than defaulted in the
+    # signature so tests can shrink DEFAULT_TIMEOUT via patch() even when
+    # calling through async_setup_entry/_async_test_connection, which don't
+    # expose their own connection_timeout override.
+    if connection_timeout is None:
+        connection_timeout = DEFAULT_TIMEOUT
+
     sync_connect: asyncio.Future[bool] = hass.loop.create_future()
 
     controller = EnvisalinkAlarmPanel(
@@ -140,29 +195,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         connection_timeout,
         False,
     )
-    hass.data[DATA_EVL] = controller
 
     @callback
     def async_login_fail_callback(data):
         """Handle when the evl rejects our login."""
         _LOGGER.error("The Envisalink rejected your credentials")
         if not sync_connect.done():
-            sync_connect.set_result(False)
+            sync_connect.set_exception(InvalidAuth)
 
     @callback
     def async_connection_fail_callback(data):
         """Network failure callback."""
         _LOGGER.error("Could not establish a connection with the Envisalink- retrying")
         if not sync_connect.done():
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
-            sync_connect.set_result(True)
+            sync_connect.set_result(False)
 
     @callback
     def async_connection_success_callback(data):
         """Handle a successful connection."""
         _LOGGER.debug("Established a connection with the Envisalink")
         if not sync_connect.done():
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
             sync_connect.set_result(True)
 
     @callback
@@ -183,66 +235,168 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug("The envisalink sent a partition update event")
         async_dispatcher_send(hass, SIGNAL_PARTITION_UPDATE, data)
 
-    @callback
-    def stop_envisalink(event):
-        """Shutdown envisalink connection and thread on exit."""
-        _LOGGER.debug("Shutting down Envisalink")
-        controller.stop()
-
-    async def handle_custom_function(call: ServiceCall) -> None:
-        """Handle custom/PGM service."""
-        custom_function = call.data.get(ATTR_CUSTOM_FUNCTION)
-        partition = call.data.get(ATTR_PARTITION)
-        controller.command_output(code, partition, custom_function)
-
+    # All callbacks must be wired up before start(), since the panel can send
+    # an initial zone/partition/keypad status dump immediately after login
+    # succeeds, in the same synchronous burst as the login response.
+    controller.callback_login_failure = async_login_fail_callback
+    controller.callback_login_timeout = async_connection_fail_callback
+    controller.callback_login_success = async_connection_success_callback
     controller.callback_zone_timer_dump = async_zones_updated_callback
     controller.callback_zone_state_change = async_zones_updated_callback
     controller.callback_partition_state_change = async_partition_updated_callback
     controller.callback_keypad_update = async_alarm_data_updated_callback
-    controller.callback_login_failure = async_login_fail_callback
-    controller.callback_login_timeout = async_connection_fail_callback
-    controller.callback_login_success = async_connection_success_callback
 
-    _LOGGER.debug("Start envisalink")
-    controller.start()
+    try:
+        _LOGGER.debug("Start envisalink")
+        controller.start()
+        async with asyncio.timeout(connection_timeout + LOGIN_RESPONSE_TIMEOUT):
+            login_succeeded = await sync_connect
+    except asyncio.CancelledError:
+        # If we're cancelled before the connection resolves (e.g. the config
+        # flow using us is aborted mid-connect), disconnect_panel() must
+        # still run, or the connection (and its background reconnect) keeps
+        # running forever on an orphaned, unreferenced panel.
+        disconnect_panel(controller)
+        raise
+    except TimeoutError as err:
+        disconnect_panel(controller)
+        raise LoginTimeout from err
+    except Exception:
+        # Covers InvalidAuth and any other unexpected error - always leave
+        # the panel fully torn down rather than running unreferenced.
+        disconnect_panel(controller)
+        raise
 
-    if not await sync_connect:
-        return False
+    return controller, login_succeeded
 
-    # Load sub-components for Envisalink
-    if partitions:
-        hass.async_create_task(
-            async_load_platform(
-                hass,
-                Platform.ALARM_CONTROL_PANEL,
-                "envisalink",
-                {CONF_PARTITIONS: partitions, CONF_CODE: code, CONF_PANIC: panic_type},
-                config,
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Envisalink component."""
+
+    async def handle_custom_function(call: ServiceCall) -> None:
+        """Handle custom/PGM service."""
+        entry = next(iter(hass.config_entries.async_loaded_entries(DOMAIN)), None)
+        if entry is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_loaded_entry",
             )
-        )
-        hass.async_create_task(
-            async_load_platform(
-                hass,
-                Platform.SENSOR,
-                "envisalink",
-                {CONF_PARTITIONS: partitions, CONF_CODE: code},
-                config,
-            )
-        )
-    if zones:
-        hass.async_create_task(
-            async_load_platform(
-                hass, Platform.BINARY_SENSOR, "envisalink", {CONF_ZONES: zones}, config
-            )
+        custom_function = call.data[ATTR_CUSTOM_FUNCTION]
+        partition = call.data[ATTR_PARTITION]
+        entry.runtime_data.command_output(
+            entry.options.get(CONF_CODE), partition, custom_function
         )
 
-        # Zone bypass switches are not currently created due
-        # to an issue with some panels. These switches will be
-        # re-added in the future after some further refactoring
-        # of the integration.
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_CUSTOM_FUNCTION, handle_custom_function, schema=SERVICE_SCHEMA
+    async_register_admin_service(
+        hass, DOMAIN, SERVICE_CUSTOM_FUNCTION, handle_custom_function, SERVICE_SCHEMA
     )
 
+    if DOMAIN not in config:
+        return True
+
+    hass.async_create_task(_async_import(hass, config[DOMAIN]))
     return True
+
+
+async def _async_import(hass: HomeAssistant, conf: ConfigType) -> None:
+    """Import Envisalink configuration from YAML and surface appropriate issues."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+    )
+
+    if (
+        result.get("type") is FlowResultType.ABORT
+        and result.get("reason") != "single_instance_allowed"
+    ):
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_yaml_import_issue_{result.get('reason')}",
+            breaks_in_ha_version="2027.4.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=IssueSeverity.WARNING,
+            translation_key=f"deprecated_yaml_import_issue_{result.get('reason')}",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "Envisalink",
+                **(result.get("description_placeholders") or {}),
+            },
+        )
+        return
+
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2027.2.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Envisalink",
+        },
+    )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: EnvisalinkConfigEntry) -> bool:
+    """Set up Envisalink from a config entry."""
+    try:
+        controller, _ = await async_connect_panel(
+            hass,
+            entry.data[CONF_HOST],
+            entry.data[CONF_EVL_PORT],
+            entry.data[CONF_PANEL_TYPE],
+            entry.data[CONF_EVL_VERSION],
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASS],
+        )
+    except InvalidAuth:
+        return False
+    except LoginTimeout as err:
+        raise ConfigEntryNotReady(
+            f"Timed out waiting for a login response from {entry.data[CONF_HOST]}"
+        ) from err
+
+    entry.runtime_data = controller
+
+    @callback
+    def stop_envisalink(event) -> None:
+        """Shutdown envisalink connection and thread on exit."""
+        _LOGGER.debug("Shutting down Envisalink")
+        disconnect_panel(controller)
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
+    )
+
+    # Adding/editing a zone or partition subentry doesn't reload the
+    # entry on its own (only reconfiguring the main connection does) -
+    # without this, newly added zones/partitions wouldn't create
+    # entities until restart.
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except asyncio.CancelledError, Exception:
+        # Failed setup does not call async_unload_entry, so disconnect explicitly.
+        disconnect_panel(controller)
+        raise
+
+    return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: EnvisalinkConfigEntry
+) -> None:
+    """Reload the entry when its data, options or subentries change."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: EnvisalinkConfigEntry) -> bool:
+    """Unload an Envisalink config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        disconnect_panel(entry.runtime_data)
+    return unload_ok

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -12,83 +12,56 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
     CodeFormat,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_CODE
-from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import CONF_CODE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import (
+from . import EnvisalinkConfigEntry
+from .const import (
+    ATTR_KEYPRESS,
     CONF_PANIC,
+    CONF_PARTITION_NUMBER,
     CONF_PARTITIONNAME,
-    CONF_PARTITIONS,
-    DATA_EVL,
-    DOMAIN,
-    PARTITION_SCHEMA,
+    DEFAULT_PANIC,
+    SERVICE_ALARM_KEYPRESS,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
+    SUBENTRY_TYPE_PARTITION,
 )
 from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_ALARM_KEYPRESS = "alarm_keypress"
-ATTR_KEYPRESS = "keypress"
-ALARM_KEYPRESS_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Required(ATTR_KEYPRESS): cv.string,
-    }
-)
 
-
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: EnvisalinkConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Perform the setup for Envisalink alarm panels."""
-    if not discovery_info:
-        return
-    configured_partitions: dict[int, dict[str, Any]] = discovery_info[CONF_PARTITIONS]
-    code: str | None = discovery_info[CONF_CODE]
-    panic_type: str = discovery_info[CONF_PANIC]
+    """Set up Envisalink alarm control panels from a config entry."""
+    controller = entry.runtime_data
+    code = entry.options.get(CONF_CODE)
+    panic_type = entry.options.get(CONF_PANIC, DEFAULT_PANIC)
 
-    entities = []
-    for part_num, part_config in configured_partitions.items():
-        entity_config_data = PARTITION_SCHEMA(part_config)
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_PARTITION):
+        partition_number = subentry.data[CONF_PARTITION_NUMBER]
         entity = EnvisalinkAlarm(
-            part_num,
-            entity_config_data[CONF_PARTITIONNAME],
+            partition_number,
+            subentry.data[CONF_PARTITIONNAME],
             code,
             panic_type,
-            hass.data[DATA_EVL].alarm_state["partition"][part_num],
-            hass.data[DATA_EVL],
+            controller.alarm_state["partition"][partition_number],
+            controller,
         )
-        entities.append(entity)
+        async_add_entities([entity], config_subentry_id=subentry.subentry_id)
 
-    async_add_entities(entities)
-
-    @callback
-    def async_alarm_keypress_handler(service: ServiceCall) -> None:
-        """Map services to methods on Alarm."""
-        entity_ids = service.data[ATTR_ENTITY_ID]
-        keypress = service.data[ATTR_KEYPRESS]
-
-        target_entities = [
-            entity for entity in entities if entity.entity_id in entity_ids
-        ]
-
-        for entity in target_entities:
-            entity.async_alarm_keypress(keypress)
-
-    hass.services.async_register(
-        DOMAIN,
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
         SERVICE_ALARM_KEYPRESS,
-        async_alarm_keypress_handler,
-        schema=ALARM_KEYPRESS_SCHEMA,
+        {vol.Required(ATTR_KEYPRESS): cv.string},
+        "async_alarm_keypress",
     )
 
 
@@ -116,6 +89,7 @@ class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
         self._panic_type = panic_type
         self._alarm_control_panel_option_default_code = code
         self._attr_code_format = CodeFormat.NUMBER if not code else None
+        self._attr_code_arm_required = not code
 
         _LOGGER.debug("Setting up alarm: %s", alarm_name)
         super().__init__(alarm_name, info, controller)
@@ -165,32 +139,28 @@ class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
     @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        self.hass.data[DATA_EVL].disarm_partition(code, self._partition_number)
+        self._controller.disarm_partition(code, self._partition_number)
 
     @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        self.hass.data[DATA_EVL].arm_stay_partition(code, self._partition_number)
+        self._controller.arm_stay_partition(code, self._partition_number)
 
     @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        self.hass.data[DATA_EVL].arm_away_partition(code, self._partition_number)
+        self._controller.arm_away_partition(code, self._partition_number)
 
     @override
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Alarm trigger command. Will be used to trigger a panic alarm."""
-        self.hass.data[DATA_EVL].panic_alarm(self._panic_type)
+        self._controller.panic_alarm(self._panic_type)
 
     @override
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        self.hass.data[DATA_EVL].arm_night_partition(code, self._partition_number)
+        self._controller.arm_night_partition(code, self._partition_number)
 
-    @callback
-    def async_alarm_keypress(self, keypress=None):
+    async def async_alarm_keypress(self, keypress: str) -> None:
         """Send custom keypress."""
-        if keypress:
-            self.hass.data[DATA_EVL].keypresses_to_partition(
-                self._partition_number, keypress
-            )
+        self._controller.keypresses_to_partition(self._partition_number, keypress)

--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -13,47 +13,40 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import ATTR_LAST_TRIP_TIME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from . import (
+from . import EnvisalinkConfigEntry
+from .const import (
+    CONF_ZONE_NUMBER,
     CONF_ZONENAME,
-    CONF_ZONES,
     CONF_ZONETYPE,
-    DATA_EVL,
     SIGNAL_ZONE_UPDATE,
-    ZONE_SCHEMA,
+    SUBENTRY_TYPE_ZONE,
 )
 from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: EnvisalinkConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Envisalink binary sensor entities."""
-    if not discovery_info:
-        return
-    configured_zones: dict[int, dict[str, Any]] = discovery_info[CONF_ZONES]
+    """Set up the Envisalink binary sensor entities from a config entry."""
+    controller = entry.runtime_data
 
-    entities = []
-    for zone_num, zone_data in configured_zones.items():
-        entity_config_data = ZONE_SCHEMA(zone_data)
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_ZONE):
+        zone_number = subentry.data[CONF_ZONE_NUMBER]
         entity = EnvisalinkBinarySensor(
-            zone_num,
-            entity_config_data[CONF_ZONENAME],
-            entity_config_data[CONF_ZONETYPE],
-            hass.data[DATA_EVL].alarm_state["zone"][zone_num],
-            hass.data[DATA_EVL],
+            zone_number,
+            subentry.data[CONF_ZONENAME],
+            subentry.data[CONF_ZONETYPE],
+            controller.alarm_state["zone"][zone_number],
+            controller,
         )
-        entities.append(entity)
-
-    async_add_entities(entities)
+        async_add_entities([entity], config_subentry_id=subentry.subentry_id)
 
 
 class EnvisalinkBinarySensor(EnvisalinkEntity, BinarySensorEntity):

--- a/homeassistant/components/envisalink/config_flow.py
+++ b/homeassistant/components/envisalink/config_flow.py
@@ -1,0 +1,450 @@
+"""Config flow for Envisalink."""
+
+import logging
+from typing import Any, override
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    ConfigSubentryData,
+    ConfigSubentryFlow,
+    OptionsFlow,
+    SubentryFlowResult,
+)
+from homeassistant.const import CONF_CODE, CONF_HOST
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, selector
+
+from . import InvalidAuth, LoginTimeout, async_connect_panel, disconnect_panel
+from .const import (
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITION_NUMBER,
+    CONF_PARTITIONNAME,
+    CONF_PARTITIONS,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONE_NUMBER,
+    CONF_ZONENAME,
+    CONF_ZONES,
+    CONF_ZONETYPE,
+    DEFAULT_EVL_VERSION,
+    DEFAULT_PANIC,
+    DEFAULT_PORT,
+    DEFAULT_ZONETYPE,
+    DOMAIN,
+    EVL_VERSIONS,
+    MAX_PARTITIONS,
+    MAX_ZONES_BY_EVL_VERSION,
+    PANEL_TYPE_DSC,
+    PANEL_TYPE_HONEYWELL,
+    PANIC_TYPES,
+    SUBENTRY_TYPE_PARTITION,
+    SUBENTRY_TYPE_ZONE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONNECTION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_EVL_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Required(CONF_PANEL_TYPE): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[
+                    selector.SelectOptionDict(
+                        value=PANEL_TYPE_HONEYWELL, label="Honeywell"
+                    ),
+                    selector.SelectOptionDict(value=PANEL_TYPE_DSC, label="DSC"),
+                ],
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Required(CONF_EVL_VERSION, default=DEFAULT_EVL_VERSION): vol.All(
+            vol.Coerce(str),
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[str(version) for version in EVL_VERSIONS],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="evl_version",
+                )
+            ),
+            vol.Coerce(int),
+        ),
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASS): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+    }
+)
+
+CODE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CODE): cv.string,
+        vol.Optional(CONF_PANIC, default=DEFAULT_PANIC): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=PANIC_TYPES,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+)
+
+ZONE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ZONENAME): cv.string,
+        vol.Required(CONF_ZONETYPE, default=DEFAULT_ZONETYPE): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[cls.value for cls in BinarySensorDeviceClass],
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key="binary_sensor_device_class",
+                sort=True,
+            ),
+        ),
+    }
+)
+
+PARTITION_SCHEMA = vol.Schema({vol.Required(CONF_PARTITIONNAME): cv.string})
+
+
+async def _async_test_connection(
+    hass: HomeAssistant,
+    host: str,
+    port: int,
+    panel_type: str,
+    version: int,
+    user_name: str,
+    password: str,
+) -> str | None:
+    """Attempt a connection to the panel and return an error code, if any."""
+    try:
+        controller, login_succeeded = await async_connect_panel(
+            hass, host, port, panel_type, version, user_name, password
+        )
+    except InvalidAuth:
+        return "invalid_auth"
+    except LoginTimeout:
+        return "cannot_connect"
+    except Exception:
+        _LOGGER.exception("Unexpected error while connecting to %s:%s", host, port)
+        return "unknown"
+
+    disconnect_panel(controller)
+    return None if login_succeeded else "cannot_connect"
+
+
+class EnvisalinkConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Envisalink."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self.connection_data: dict[str, Any] = {}
+
+    @classmethod
+    @callback
+    @override
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return subentries supported by this integration."""
+        return {
+            SUBENTRY_TYPE_ZONE: ZoneSubentryFlowHandler,
+            SUBENTRY_TYPE_PARTITION: PartitionSubentryFlowHandler,
+        }
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> EnvisalinkOptionsFlow:
+        """Create the options flow."""
+        return EnvisalinkOptionsFlow()
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            error = await _async_test_connection(
+                self.hass,
+                user_input[CONF_HOST],
+                user_input[CONF_EVL_PORT],
+                user_input[CONF_PANEL_TYPE],
+                user_input[CONF_EVL_VERSION],
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASS],
+            )
+            if error:
+                errors["base"] = error
+            else:
+                self.connection_data = user_input
+                return await self.async_step_code()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                CONNECTION_SCHEMA, user_input
+            ),
+            errors=errors,
+        )
+
+    async def async_step_code(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the alarm code and panic type step."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.connection_data[CONF_HOST],
+                data=self.connection_data,
+                options=user_input,
+            )
+
+        return self.async_show_form(step_id="code", data_schema=CODE_SCHEMA)
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import Envisalink configuration from configuration.yaml."""
+        port = import_data.get(CONF_EVL_PORT, DEFAULT_PORT)
+        version = import_data.get(CONF_EVL_VERSION, DEFAULT_EVL_VERSION)
+
+        max_zone_number = MAX_ZONES_BY_EVL_VERSION[version]
+        for zone_number in import_data.get(CONF_ZONES, {}):
+            if not 1 <= zone_number <= max_zone_number:
+                return self.async_abort(
+                    reason="invalid_zone_number",
+                    description_placeholders={
+                        "number": str(zone_number),
+                        "max": str(max_zone_number),
+                    },
+                )
+        for partition_number in import_data.get(CONF_PARTITIONS, {}):
+            if not 1 <= partition_number <= MAX_PARTITIONS:
+                return self.async_abort(
+                    reason="invalid_partition_number",
+                    description_placeholders={
+                        "number": str(partition_number),
+                        "max": str(MAX_PARTITIONS),
+                    },
+                )
+
+        error = await _async_test_connection(
+            self.hass,
+            import_data[CONF_HOST],
+            port,
+            import_data[CONF_PANEL_TYPE],
+            version,
+            import_data[CONF_USERNAME],
+            import_data[CONF_PASS],
+        )
+        if error:
+            return self.async_abort(reason=error)
+
+        subentries: list[ConfigSubentryData] = []
+        for zone_number, zone_config in import_data.get(CONF_ZONES, {}).items():
+            zone_name = zone_config[CONF_ZONENAME]
+            subentries.append(
+                {
+                    "subentry_type": SUBENTRY_TYPE_ZONE,
+                    "title": f"{zone_name} ({zone_number})",
+                    "unique_id": f"{SUBENTRY_TYPE_ZONE}_{zone_number}",
+                    "data": {
+                        CONF_ZONE_NUMBER: zone_number,
+                        CONF_ZONENAME: zone_name,
+                        CONF_ZONETYPE: zone_config.get(CONF_ZONETYPE, DEFAULT_ZONETYPE),
+                    },
+                }
+            )
+        for partition_number, partition_config in import_data.get(
+            CONF_PARTITIONS, {}
+        ).items():
+            partition_name = partition_config[CONF_PARTITIONNAME]
+            subentries.append(
+                {
+                    "subentry_type": SUBENTRY_TYPE_PARTITION,
+                    "title": f"{partition_name} ({partition_number})",
+                    "unique_id": f"{SUBENTRY_TYPE_PARTITION}_{partition_number}",
+                    "data": {
+                        CONF_PARTITION_NUMBER: partition_number,
+                        CONF_PARTITIONNAME: partition_name,
+                    },
+                }
+            )
+
+        return self.async_create_entry(
+            title=import_data[CONF_HOST],
+            data={
+                CONF_HOST: import_data[CONF_HOST],
+                CONF_EVL_PORT: port,
+                CONF_PANEL_TYPE: import_data[CONF_PANEL_TYPE],
+                CONF_EVL_VERSION: version,
+                CONF_USERNAME: import_data[CONF_USERNAME],
+                CONF_PASS: import_data[CONF_PASS],
+            },
+            options={
+                CONF_CODE: import_data.get(CONF_CODE),
+                CONF_PANIC: import_data.get(CONF_PANIC, DEFAULT_PANIC),
+            },
+            subentries=subentries,
+        )
+
+
+class EnvisalinkOptionsFlow(OptionsFlow):
+    """Handle an Envisalink options flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                CODE_SCHEMA, self.config_entry.options
+            ),
+        )
+
+
+class ZoneSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle a subentry flow for adding and modifying a zone."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Add a new zone."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            unique_id = f"{SUBENTRY_TYPE_ZONE}_{user_input[CONF_ZONE_NUMBER]}"
+
+            for existing_subentry in self._get_entry().subentries.values():
+                if existing_subentry.unique_id == unique_id:
+                    errors[CONF_ZONE_NUMBER] = "already_configured"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=f"{user_input[CONF_ZONENAME]} ({user_input[CONF_ZONE_NUMBER]})",
+                    data=user_input,
+                    unique_id=unique_id,
+                )
+
+        max_zone_number = MAX_ZONES_BY_EVL_VERSION[
+            self._get_entry().data[CONF_EVL_VERSION]
+        ]
+        return self.async_show_form(
+            step_id="user",
+            errors=errors,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ZONE_NUMBER): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=max_zone_number)
+                    ),
+                }
+            ).extend(ZONE_SCHEMA.schema),
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reconfigure an existing zone."""
+        subconfig_entry = self._get_reconfigure_subentry()
+
+        if user_input is not None:
+            return self.async_update_and_abort(
+                self._get_entry(),
+                subconfig_entry,
+                title=(
+                    f"{user_input[CONF_ZONENAME]}"
+                    f" ({subconfig_entry.data[CONF_ZONE_NUMBER]})"
+                ),
+                data_updates=user_input,
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                ZONE_SCHEMA, subconfig_entry.data
+            ),
+            description_placeholders={
+                CONF_ZONE_NUMBER: str(subconfig_entry.data[CONF_ZONE_NUMBER])
+            },
+        )
+
+
+class PartitionSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle a subentry flow for adding and modifying a partition."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Add a new partition."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            unique_id = f"{SUBENTRY_TYPE_PARTITION}_{user_input[CONF_PARTITION_NUMBER]}"
+
+            for existing_subentry in self._get_entry().subentries.values():
+                if existing_subentry.unique_id == unique_id:
+                    errors[CONF_PARTITION_NUMBER] = "already_configured"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=(
+                        f"{user_input[CONF_PARTITIONNAME]}"
+                        f" ({user_input[CONF_PARTITION_NUMBER]})"
+                    ),
+                    data=user_input,
+                    unique_id=unique_id,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            errors=errors,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PARTITION_NUMBER): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=MAX_PARTITIONS)
+                    ),
+                }
+            ).extend(PARTITION_SCHEMA.schema),
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reconfigure an existing partition."""
+        subconfig_entry = self._get_reconfigure_subentry()
+
+        if user_input is not None:
+            return self.async_update_and_abort(
+                self._get_entry(),
+                subconfig_entry,
+                title=(
+                    f"{user_input[CONF_PARTITIONNAME]}"
+                    f" ({subconfig_entry.data[CONF_PARTITION_NUMBER]})"
+                ),
+                data_updates=user_input,
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                PARTITION_SCHEMA, subconfig_entry.data
+            ),
+            description_placeholders={
+                CONF_PARTITION_NUMBER: str(subconfig_entry.data[CONF_PARTITION_NUMBER])
+            },
+        )

--- a/homeassistant/components/envisalink/const.py
+++ b/homeassistant/components/envisalink/const.py
@@ -1,0 +1,60 @@
+"""Constants for the Envisalink integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "envisalink"
+
+PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR, Platform.SENSOR]
+
+CONF_EVL_PORT = "port"
+CONF_EVL_VERSION = "evl_version"
+CONF_PANEL_TYPE = "panel_type"
+CONF_PANIC = "panic_type"
+CONF_PARTITIONNAME = "name"
+CONF_PARTITIONS = "partitions"
+CONF_PARTITION_NUMBER = "partition_number"
+CONF_PASS = "password"
+CONF_USERNAME = "user_name"
+CONF_ZONENAME = "name"
+CONF_ZONES = "zones"
+CONF_ZONETYPE = "type"
+CONF_ZONE_NUMBER = "zone_number"
+
+PANEL_TYPE_HONEYWELL = "HONEYWELL"
+PANEL_TYPE_DSC = "DSC"
+
+EVL_VERSIONS = [3, 4]
+
+# Matches pyenvisalink's own EnvisalinkAlarmPanel limits: 64 zones below EVL
+# version 4, 128 from version 4 on; partitions are always capped at 8.
+MAX_ZONES_BY_EVL_VERSION = {3: 64, 4: 128}
+MAX_PARTITIONS = 8
+
+PANIC_TYPES = ["Fire", "Ambulance", "Police"]
+
+DEFAULT_PORT = 4025
+DEFAULT_EVL_VERSION = 3
+DEFAULT_KEEPALIVE = 60
+DEFAULT_ZONEDUMP_INTERVAL = 30
+DEFAULT_ZONETYPE = "opening"
+DEFAULT_PANIC = "Police"
+DEFAULT_TIMEOUT = 10
+
+# Extra time allowed, on top of the connection timeout, for the panel to
+# respond to the login handshake once the raw TCP connection succeeds.
+LOGIN_RESPONSE_TIMEOUT = 10
+
+SIGNAL_ZONE_UPDATE = "envisalink.zones_updated"
+SIGNAL_PARTITION_UPDATE = "envisalink.partition_updated"
+SIGNAL_KEYPAD_UPDATE = "envisalink.keypad_updated"
+SIGNAL_ZONE_BYPASS_UPDATE = "envisalink.zone_bypass_updated"
+
+SUBENTRY_TYPE_ZONE = "zone"
+SUBENTRY_TYPE_PARTITION = "partition"
+
+SERVICE_CUSTOM_FUNCTION = "invoke_custom_function"
+ATTR_CUSTOM_FUNCTION = "pgm"
+ATTR_PARTITION = "partition"
+
+SERVICE_ALARM_KEYPRESS = "alarm_keypress"
+ATTR_KEYPRESS = "keypress"

--- a/homeassistant/components/envisalink/manifest.json
+++ b/homeassistant/components/envisalink/manifest.json
@@ -2,9 +2,11 @@
   "domain": "envisalink",
   "name": "Envisalink",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/envisalink",
+  "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyenvisalink"],
-  "quality_scale": "legacy",
-  "requirements": ["pyenvisalink==4.9"]
+  "requirements": ["pyenvisalink==4.9"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/envisalink/sensor.py
+++ b/homeassistant/components/envisalink/sensor.py
@@ -8,52 +8,44 @@ from pyenvisalink import EnvisalinkAlarmPanel
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import (
+from . import EnvisalinkConfigEntry
+from .const import (
+    CONF_PARTITION_NUMBER,
     CONF_PARTITIONNAME,
-    CONF_PARTITIONS,
-    DATA_EVL,
-    PARTITION_SCHEMA,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
+    SUBENTRY_TYPE_PARTITION,
 )
 from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: EnvisalinkConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Perform the setup for Envisalink sensor entities."""
-    if not discovery_info:
-        return
-    configured_partitions: dict[int, dict[str, Any]] = discovery_info[CONF_PARTITIONS]
+    """Set up the Envisalink sensor entities from a config entry."""
+    controller = entry.runtime_data
 
-    entities = []
-    for part_num, part_config in configured_partitions.items():
-        entity_config_data = PARTITION_SCHEMA(part_config)
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_PARTITION):
+        partition_number = subentry.data[CONF_PARTITION_NUMBER]
         entity = EnvisalinkSensor(
-            entity_config_data[CONF_PARTITIONNAME],
-            part_num,
-            hass.data[DATA_EVL].alarm_state["partition"][part_num],
-            hass.data[DATA_EVL],
+            subentry.data[CONF_PARTITIONNAME],
+            partition_number,
+            controller.alarm_state["partition"][partition_number],
+            controller,
         )
-
-        entities.append(entity)
-
-    async_add_entities(entities)
+        async_add_entities([entity], config_subentry_id=subentry.subentry_id)
 
 
 class EnvisalinkSensor(EnvisalinkEntity, SensorEntity):
     """Representation of an Envisalink keypad."""
 
-    _attr_icon = "mdi:alarm"
+    _attr_icon = "mdi:message-text"
 
     def __init__(
         self,
@@ -84,7 +76,7 @@ class EnvisalinkSensor(EnvisalinkEntity, SensorEntity):
 
     @property
     @override
-    def native_value(self):
+    def native_value(self) -> str | None:
         """Return the overall state."""
         return self._info["status"]["alpha"]
 

--- a/homeassistant/components/envisalink/strings.json
+++ b/homeassistant/components/envisalink/strings.json
@@ -1,4 +1,188 @@
 {
+  "config": {
+    "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_partition_number": "Partition {number} is not valid for this panel; partition numbers must be between 1 and {max}.",
+      "invalid_zone_number": "Zone {number} is not valid for this panel; zone numbers must be between 1 and {max}.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "code": {
+        "data": {
+          "code": "Alarm code",
+          "panic_type": "Panic alarm type"
+        },
+        "data_description": {
+          "code": "The default code to use when arming or disarming the alarm. Leave empty to be prompted for a code each time.",
+          "panic_type": "The type of panic alarm to trigger when the alarm's trigger action is used."
+        },
+        "title": "Alarm settings"
+      },
+      "user": {
+        "data": {
+          "evl_version": "Envisalink version",
+          "host": "[%key:common::config_flow::data::host%]",
+          "panel_type": "Panel type",
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "user_name": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "evl_version": "The hardware version of your Envisalink module.",
+          "host": "The hostname or IP address of your Envisalink module.",
+          "panel_type": "The type of alarm panel connected to your Envisalink module.",
+          "password": "The password configured for your Envisalink module's web interface.",
+          "port": "The TCP port used to connect to your Envisalink module.",
+          "user_name": "The username configured for your Envisalink module's web interface."
+        },
+        "title": "Connect to your Envisalink"
+      }
+    }
+  },
+  "config_subentries": {
+    "partition": {
+      "entry_type": "Partition",
+      "error": {
+        "already_configured": "A partition with this number is already configured"
+      },
+      "initiate_flow": {
+        "user": "Add partition"
+      },
+      "step": {
+        "reconfigure": {
+          "data": {
+            "name": "[%key:common::config_flow::data::name%]"
+          },
+          "title": "Reconfigure partition {partition_number}"
+        },
+        "user": {
+          "data": {
+            "name": "[%key:common::config_flow::data::name%]",
+            "partition_number": "Partition number"
+          },
+          "data_description": {
+            "partition_number": "The partition number as configured on your alarm panel."
+          },
+          "title": "Add partition"
+        }
+      }
+    },
+    "zone": {
+      "entry_type": "Zone",
+      "error": {
+        "already_configured": "A zone with this number is already configured"
+      },
+      "initiate_flow": {
+        "user": "Add zone"
+      },
+      "step": {
+        "reconfigure": {
+          "data": {
+            "name": "[%key:common::config_flow::data::name%]",
+            "type": "[%key:component::envisalink::config_subentries::zone::step::user::data::type%]"
+          },
+          "data_description": {
+            "type": "[%key:component::envisalink::config_subentries::zone::step::user::data_description::type%]"
+          },
+          "title": "Reconfigure zone {zone_number}"
+        },
+        "user": {
+          "data": {
+            "name": "[%key:common::config_flow::data::name%]",
+            "type": "Zone type",
+            "zone_number": "Zone number"
+          },
+          "data_description": {
+            "type": "The type of sensor connected to this zone.",
+            "zone_number": "The zone number as configured on your alarm panel."
+          },
+          "title": "Add zone"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "no_loaded_entry": {
+      "message": "No Envisalink integration is currently set up."
+    }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, a connection to the Envisalink module could not be established. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    },
+    "deprecated_yaml_import_issue_invalid_auth": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, the Envisalink module rejected the configured credentials. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    },
+    "deprecated_yaml_import_issue_invalid_partition_number": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, partition {number} was found configured, but partition numbers must be between 1 and {max}. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    },
+    "deprecated_yaml_import_issue_invalid_zone_number": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, zone {number} was found configured, but zone numbers must be between 1 and {max}. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    },
+    "deprecated_yaml_import_issue_unknown": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, an unknown error occurred. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "code": "[%key:component::envisalink::config::step::code::data::code%]",
+          "panic_type": "[%key:component::envisalink::config::step::code::data::panic_type%]"
+        },
+        "data_description": {
+          "code": "[%key:component::envisalink::config::step::code::data_description::code%]",
+          "panic_type": "[%key:component::envisalink::config::step::code::data_description::panic_type%]"
+        }
+      }
+    }
+  },
+  "selector": {
+    "binary_sensor_device_class": {
+      "options": {
+        "battery": "[%key:component::binary_sensor::entity_component::battery::name%]",
+        "battery_charging": "[%key:component::binary_sensor::entity_component::battery_charging::name%]",
+        "carbon_monoxide": "[%key:component::binary_sensor::entity_component::carbon_monoxide::name%]",
+        "cold": "[%key:component::binary_sensor::entity_component::cold::name%]",
+        "connectivity": "[%key:component::binary_sensor::entity_component::connectivity::name%]",
+        "door": "[%key:component::binary_sensor::entity_component::door::name%]",
+        "garage_door": "[%key:component::binary_sensor::entity_component::garage_door::name%]",
+        "gas": "[%key:component::binary_sensor::entity_component::gas::name%]",
+        "heat": "[%key:component::binary_sensor::entity_component::heat::name%]",
+        "light": "[%key:component::binary_sensor::entity_component::light::name%]",
+        "lock": "[%key:component::binary_sensor::entity_component::lock::name%]",
+        "moisture": "[%key:component::binary_sensor::entity_component::moisture::name%]",
+        "motion": "[%key:component::binary_sensor::entity_component::motion::name%]",
+        "moving": "[%key:component::binary_sensor::entity_component::moving::name%]",
+        "occupancy": "[%key:component::binary_sensor::entity_component::occupancy::name%]",
+        "opening": "[%key:component::binary_sensor::entity_component::opening::name%]",
+        "plug": "[%key:component::binary_sensor::entity_component::plug::name%]",
+        "power": "[%key:component::binary_sensor::entity_component::power::name%]",
+        "presence": "[%key:component::binary_sensor::entity_component::presence::name%]",
+        "problem": "[%key:component::binary_sensor::entity_component::problem::name%]",
+        "running": "[%key:component::binary_sensor::entity_component::running::name%]",
+        "safety": "[%key:component::binary_sensor::entity_component::safety::name%]",
+        "smoke": "[%key:component::binary_sensor::entity_component::smoke::name%]",
+        "sound": "[%key:component::binary_sensor::entity_component::sound::name%]",
+        "tamper": "[%key:component::binary_sensor::entity_component::tamper::name%]",
+        "update": "[%key:component::binary_sensor::entity_component::update::name%]",
+        "vibration": "[%key:component::binary_sensor::entity_component::vibration::name%]",
+        "window": "[%key:component::binary_sensor::entity_component::window::name%]"
+      }
+    }
+  },
   "services": {
     "alarm_keypress": {
       "description": "Sends custom keypresses to the alarm.",

--- a/homeassistant/components/envisalink/switch.py
+++ b/homeassistant/components/envisalink/switch.py
@@ -1,4 +1,9 @@
-"""Support for Envisalink zone bypass switches."""
+"""Support for Envisalink zone bypass switches.
+
+Not currently loaded as a platform (Platform.SWITCH is not in PLATFORMS) due to
+an issue with some panels; kept for a future re-enablement after further
+refactoring of the integration.
+"""
 
 import logging
 from typing import Any, override
@@ -8,47 +13,40 @@ from pyenvisalink import EnvisalinkAlarmPanel
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import (
+from . import EnvisalinkConfigEntry
+from .const import (
+    CONF_ZONE_NUMBER,
     CONF_ZONENAME,
-    CONF_ZONES,
-    DATA_EVL,
     SIGNAL_ZONE_BYPASS_UPDATE,
-    ZONE_SCHEMA,
+    SUBENTRY_TYPE_ZONE,
 )
 from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: EnvisalinkConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Envisalink switch entities."""
-    if not discovery_info:
-        return
-    configured_zones: dict[int, dict[str, Any]] = discovery_info[CONF_ZONES]
+    """Set up the Envisalink zone bypass switch entities from a config entry."""
+    controller = entry.runtime_data
 
-    entities = []
-    for zone_num, zone_data in configured_zones.items():
-        entity_config_data = ZONE_SCHEMA(zone_data)
-        zone_name = f"{entity_config_data[CONF_ZONENAME]}_bypass"
-        _LOGGER.debug("Setting up zone_bypass switch: %s", zone_name)
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_ZONE):
+        zone_number = subentry.data[CONF_ZONE_NUMBER]
+        zone_name = subentry.data[CONF_ZONENAME]
+        _LOGGER.debug("Setting up zone_bypass switch for zone: %s", zone_name)
 
         entity = EnvisalinkSwitch(
-            zone_num,
+            zone_number,
             zone_name,
-            hass.data[DATA_EVL].alarm_state["zone"][zone_num],
-            hass.data[DATA_EVL],
+            controller.alarm_state["zone"][zone_number],
+            controller,
         )
-        entities.append(entity)
-
-    async_add_entities(entities)
+        async_add_entities([entity], config_subentry_id=subentry.subentry_id)
 
 
 class EnvisalinkSwitch(EnvisalinkEntity, SwitchEntity):
@@ -64,7 +62,7 @@ class EnvisalinkSwitch(EnvisalinkEntity, SwitchEntity):
         """Initialize the switch."""
         self._zone_number = zone_number
 
-        super().__init__(zone_name, info, controller)
+        super().__init__(f"{zone_name} Bypass", info, controller)
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -215,6 +215,7 @@ FLOWS = {
         "enphase_envoy",
         "envertech_evt800",
         "environment_canada",
+        "envisalink",
         "epic_games_store",
         "epion",
         "epson",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1856,8 +1856,9 @@
     "envisalink": {
       "name": "Envisalink",
       "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_push"
+      "config_flow": true,
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "ephember": {
       "name": "EPH Controls",

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -6,25 +6,77 @@ from unittest.mock import MagicMock, patch
 from pyenvisalink.alarm_state import AlarmState
 import pytest
 
-from homeassistant.components.envisalink import DOMAIN
+from homeassistant.components.envisalink.const import (
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITION_NUMBER,
+    CONF_PARTITIONNAME,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONE_NUMBER,
+    CONF_ZONENAME,
+    CONF_ZONETYPE,
+    DOMAIN,
+    SUBENTRY_TYPE_PARTITION,
+    SUBENTRY_TYPE_ZONE,
+)
+from homeassistant.const import CONF_CODE, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 # The configured alarm code, shared with the tests so the service-call
 # assertions stay in sync with the code HA injects as the default.
 MOCK_CODE = "1234"
 
-# Mirrors the legacy YAML config keys (CONF_USERNAME == "user_name", CONF_PASS
-# == "password"). The integration is YAML-only (no config entry), so a future
-# config-entry migration replaces this whole fixture.
-MOCK_CONFIG = {
+MOCK_DATA = {
+    CONF_HOST: "1.2.3.4",
+    CONF_EVL_PORT: 4025,
+    CONF_PANEL_TYPE: "DSC",
+    CONF_EVL_VERSION: 3,
+    CONF_USERNAME: "user",
+    CONF_PASS: "pass",
+}
+
+MOCK_OPTIONS = {
+    CONF_CODE: MOCK_CODE,
+    CONF_PANIC: "Police",
+}
+
+MOCK_SUBENTRIES_DATA = [
+    {
+        "subentry_type": SUBENTRY_TYPE_PARTITION,
+        "title": "Main Home (1)",
+        "unique_id": f"{SUBENTRY_TYPE_PARTITION}_1",
+        "data": {
+            CONF_PARTITION_NUMBER: 1,
+            CONF_PARTITIONNAME: "Main Home",
+        },
+    },
+    {
+        "subentry_type": SUBENTRY_TYPE_ZONE,
+        "title": "Front Door (1)",
+        "unique_id": f"{SUBENTRY_TYPE_ZONE}_1",
+        "data": {
+            CONF_ZONE_NUMBER: 1,
+            CONF_ZONENAME: "Front Door",
+            CONF_ZONETYPE: "door",
+        },
+    },
+]
+
+# Legacy YAML shape, still accepted for import.
+MOCK_YAML_CONFIG = {
     DOMAIN: {
-        "host": "1.2.3.4",
-        "panel_type": "DSC",
-        "user_name": "user",
-        "password": "pass",
-        "code": MOCK_CODE,
+        CONF_HOST: "1.2.3.4",
+        CONF_PANEL_TYPE: "DSC",
+        CONF_USERNAME: "user",
+        CONF_PASS: "pass",
+        CONF_CODE: MOCK_CODE,
         "partitions": {1: {"name": "Main Home"}},
         "zones": {1: {"name": "Front Door", "type": "door"}},
     }
@@ -34,6 +86,17 @@ MOCK_CONFIG = {
 ALARM_ENTITY = "alarm_control_panel.main_home"
 KEYPAD_ENTITY = "sensor.main_home_keypad"
 ZONE_ENTITY = "binary_sensor.front_door"
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock Envisalink config entry with a zone and a partition."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_DATA,
+        options=MOCK_OPTIONS,
+        subentries_data=MOCK_SUBENTRIES_DATA,
+    )
 
 
 @pytest.fixture
@@ -54,13 +117,36 @@ def mock_controller() -> Generator[MagicMock]:
         # A non-empty alpha makes the initial partition state DISARMED (not None).
         controller.alarm_state["partition"][1]["status"]["alpha"] = "Ready"
         controller.start.side_effect = lambda: controller.callback_login_success(None)
+        # _client is a real (always-present) instance attribute on the
+        # actual library object, but autospec only sees the class - it has
+        # no idea this attribute exists, since it's only ever assigned
+        # inside __init__. disconnect_panel() accesses it directly, so the
+        # mock needs it set up to match.
+        controller._client = MagicMock()
+        controller._client._reconnect_task = None
         yield controller
 
 
 async def setup_envisalink(
+    hass: HomeAssistant, entry: MockConfigEntry | None = None
+) -> bool:
+    """Set up an envisalink config entry and wait for it to finish."""
+    entry = entry or MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_DATA,
+        options=MOCK_OPTIONS,
+        subentries_data=MOCK_SUBENTRIES_DATA,
+    )
+    entry.add_to_hass(hass)
+    result = await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return result
+
+
+async def setup_envisalink_yaml(
     hass: HomeAssistant, config: ConfigType | None = None
 ) -> bool:
-    """Set up the envisalink component and wait for it to finish."""
-    result = await async_setup_component(hass, DOMAIN, config or MOCK_CONFIG)
+    """Set up the envisalink component from YAML and wait for import to finish."""
+    result = await async_setup_component(hass, DOMAIN, config or MOCK_YAML_CONFIG)
     await hass.async_block_till_done()
     return result

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -1,6 +1,5 @@
 """Tests for the Envisalink alarm control panel."""
 
-from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,7 +19,16 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .conftest import ALARM_ENTITY, DOMAIN, MOCK_CODE, MOCK_CONFIG, setup_envisalink
+from .conftest import (
+    ALARM_ENTITY,
+    DOMAIN,
+    MOCK_CODE,
+    MOCK_DATA,
+    MOCK_SUBENTRIES_DATA,
+    setup_envisalink,
+)
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
@@ -116,9 +124,13 @@ async def test_code_format_without_configured_code(
     hass: HomeAssistant, mock_controller: MagicMock
 ) -> None:
     """Test the numeric keypad shows when no code is configured."""
-    config = deepcopy(MOCK_CONFIG)
-    del config[DOMAIN]["code"]
-    assert await setup_envisalink(hass, config)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_DATA,
+        options={},
+        subentries_data=MOCK_SUBENTRIES_DATA,
+    )
+    assert await setup_envisalink(hass, entry)
 
     assert hass.states.get(ALARM_ENTITY).attributes["code_format"] == CodeFormat.NUMBER
 

--- a/tests/components/envisalink/test_config_flow.py
+++ b/tests/components/envisalink/test_config_flow.py
@@ -1,0 +1,623 @@
+"""Tests for the Envisalink config flow."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.envisalink.const import (
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITION_NUMBER,
+    CONF_PARTITIONNAME,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONE_NUMBER,
+    CONF_ZONENAME,
+    CONF_ZONETYPE,
+    DOMAIN,
+    SUBENTRY_TYPE_PARTITION,
+    SUBENTRY_TYPE_ZONE,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_CODE, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
+
+from .conftest import (
+    ALARM_ENTITY,
+    KEYPAD_ENTITY,
+    MOCK_DATA,
+    MOCK_OPTIONS,
+    MOCK_YAML_CONFIG,
+    ZONE_ENTITY,
+    setup_envisalink,
+)
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {
+    CONF_HOST: MOCK_DATA[CONF_HOST],
+    CONF_EVL_PORT: MOCK_DATA[CONF_EVL_PORT],
+    CONF_PANEL_TYPE: MOCK_DATA[CONF_PANEL_TYPE],
+    CONF_EVL_VERSION: MOCK_DATA[CONF_EVL_VERSION],
+    CONF_USERNAME: MOCK_DATA[CONF_USERNAME],
+    CONF_PASS: MOCK_DATA[CONF_PASS],
+}
+
+CODE_INPUT = {CONF_CODE: "1234", CONF_PANIC: "Police"}
+
+
+def _suggested_values(result: dict[str, Any]) -> dict[str, Any]:
+    """Pull the values suggested to the user out of a form result."""
+    return {
+        str(key): key.description["suggested_value"]
+        for key in result["data_schema"].schema
+        if key.description and "suggested_value" in key.description
+    }
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock async_setup_entry."""
+    with patch(
+        "homeassistant.components.envisalink.async_setup_entry",
+        return_value=True,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test a successful user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "code"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], CODE_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_DATA[CONF_HOST]
+    assert result["data"] == USER_INPUT
+    assert result["options"] == CODE_INPUT
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the user flow shows an error and allows retry on connection timeout."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_timeout(
+        None
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    # The previously entered values are retained so the user doesn't have to
+    # retype them to retry.
+    assert _suggested_values(result) == USER_INPUT
+
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_success(
+        None
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "code"
+
+
+async def test_user_flow_invalid_auth(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the user flow shows an error when the panel rejects credentials."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_failure(
+        None
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_user_flow_login_timeout(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the user flow shows cannot_connect when no login response arrives.
+
+    Regression test: the outer asyncio.timeout in async_connect_panel raises
+    LoginTimeout (distinct from the library's own tolerate-and-retry
+    timeout), which must be mapped to the same "cannot_connect" error as any
+    other connection failure, not fall through to "unknown".
+    """
+    mock_controller.start.side_effect = None  # never resolves the connection
+
+    with (
+        patch("homeassistant.components.envisalink.LOGIN_RESPONSE_TIMEOUT", 0),
+        patch("homeassistant.components.envisalink.DEFAULT_TIMEOUT", 0),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_unknown_error(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the user flow shows an error on an unexpected connection failure."""
+    mock_controller.start.side_effect = RuntimeError("boom")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort the user flow if already configured.
+
+    single_config_entry aborts the flow at init, before any step runs, so
+    there's no form to submit input into first.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_import_flow_success(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test importing YAML configuration creates an entry with subentries."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_YAML_CONFIG[DOMAIN]
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_YAML_CONFIG[DOMAIN][CONF_HOST]
+    assert result["data"][CONF_HOST] == MOCK_YAML_CONFIG[DOMAIN][CONF_HOST]
+    assert result["options"][CONF_CODE] == MOCK_YAML_CONFIG[DOMAIN][CONF_CODE]
+
+    subentries = result["subentries"]
+    assert len(subentries) == 2
+
+    partition_subentry = next(
+        s for s in subentries if s["subentry_type"] == SUBENTRY_TYPE_PARTITION
+    )
+    assert partition_subentry["unique_id"] == f"{SUBENTRY_TYPE_PARTITION}_1"
+    assert partition_subentry["data"][CONF_PARTITIONNAME] == "Main Home"
+
+    zone_subentry = next(
+        s for s in subentries if s["subentry_type"] == SUBENTRY_TYPE_ZONE
+    )
+    assert zone_subentry["unique_id"] == f"{SUBENTRY_TYPE_ZONE}_1"
+    assert zone_subentry["data"][CONF_ZONENAME] == "Front Door"
+    assert zone_subentry["data"][CONF_ZONETYPE] == "door"
+
+
+async def test_import_flow_cannot_connect(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the import flow aborts when the connection times out."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_timeout(
+        None
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_YAML_CONFIG[DOMAIN]
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_import_flow_invalid_auth(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the import flow aborts when the panel rejects credentials."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_failure(
+        None
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_YAML_CONFIG[DOMAIN]
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_auth"
+
+
+async def test_import_flow_invalid_zone_number(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the import flow aborts when a YAML zone number is out of range.
+
+    Regression test: pyenvisalink only tracks zones 1..64 for the default
+    EVL version 3. A YAML config with an out-of-range zone number used to
+    pass straight through import and only fail later, with a raw KeyError,
+    when the platform tried to look up alarm_state["zone"][zone_number].
+    """
+    config = {
+        **MOCK_YAML_CONFIG[DOMAIN],
+        "zones": {65: {"name": "Out of Range", "type": "door"}},
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_zone_number"
+    assert result["description_placeholders"] == {"number": "65", "max": "64"}
+
+
+async def test_import_flow_invalid_partition_number(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the import flow aborts when a YAML partition number is out of range.
+
+    Regression test: pyenvisalink only ever tracks partitions 1..8. A YAML
+    config with an out-of-range partition number used to pass straight
+    through import and only fail later, with a raw KeyError, when the
+    platform tried to look up alarm_state["partition"][partition_number].
+    """
+    config = {
+        **MOCK_YAML_CONFIG[DOMAIN],
+        "partitions": {9: {"name": "Out of Range"}},
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_partition_number"
+    assert result["description_placeholders"] == {"number": "9", "max": "8"}
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort the import flow if already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_YAML_CONFIG[DOMAIN]
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the options flow updates the code and panic type."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_CODE: "9999", CONF_PANIC: "Fire"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options == {CONF_CODE: "9999", CONF_PANIC: "Fire"}
+
+
+async def test_zone_subentry_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test adding a zone through the subentry flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_ZONE),
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_ZONE_NUMBER: 5, CONF_ZONENAME: "Back Door", CONF_ZONETYPE: "door"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Back Door (5)"
+    assert result["data"][CONF_ZONE_NUMBER] == 5
+
+
+async def test_zone_subentry_number_out_of_range(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test a zone number beyond the panel's capacity is rejected.
+
+    Regression test: pyenvisalink only tracks zones 1..64 for EVL version 3
+    (mock_config_entry's configured version). An out-of-range number used to
+    pass schema validation and only fail later, with a raw KeyError, when
+    the platform tried to look up alarm_state["zone"][zone_number] - which
+    also crashed the whole config entry setup, not just this subentry.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_ZONE),
+        context={"source": SOURCE_USER},
+    )
+
+    with pytest.raises(InvalidData):
+        await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {CONF_ZONE_NUMBER: 65, CONF_ZONENAME: "Back Door", CONF_ZONETYPE: "door"},
+        )
+
+
+async def test_zone_subentry_creates_entity_without_restart(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test a zone added through the subentry flow gets an entity right away.
+
+    Regression test: adding a subentry doesn't reload the config entry on its
+    own; without an update listener scheduling that reload, the new entity
+    wouldn't appear until Home Assistant restarts.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS)
+    assert await setup_envisalink(hass, entry)
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_ZONE), context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_ZONE_NUMBER: 9, CONF_ZONENAME: "Back Door", CONF_ZONETYPE: "door"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.back_door") is not None
+
+
+async def test_zone_subentry_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test adding a zone number that is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_ZONE),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_ZONE_NUMBER: 1, CONF_ZONENAME: "Duplicate", CONF_ZONETYPE: "door"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_ZONE_NUMBER: "already_configured"}
+
+
+async def test_zone_subentry_reconfigure(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reconfiguring an existing zone."""
+    mock_config_entry.add_to_hass(hass)
+    zone_subentry_id = next(
+        subentry_id
+        for subentry_id, subentry in mock_config_entry.subentries.items()
+        if subentry.subentry_type == SUBENTRY_TYPE_ZONE
+    )
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, zone_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_ZONENAME: "Renamed Door", CONF_ZONETYPE: "window"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.subentries[zone_subentry_id].data[CONF_ZONENAME] == (
+        "Renamed Door"
+    )
+
+
+async def test_zone_subentry_removal_removes_entity(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test removing a zone subentry reloads the entry and tears it down.
+
+    Regression test: removal is promised alongside add/edit for subentries,
+    but nothing previously verified that the reload path this relies on
+    (see test_zone_subentry_creates_entity_without_restart) also runs on
+    removal, dropping the removed zone's entity.
+    """
+    assert await setup_envisalink(hass)
+    assert hass.states.get(ZONE_ENTITY) is not None
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    zone_subentry_id = next(
+        subentry_id
+        for subentry_id, subentry in entry.subentries.items()
+        if subentry.subentry_type == SUBENTRY_TYPE_ZONE
+    )
+
+    assert hass.config_entries.async_remove_subentry(entry, zone_subentry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ZONE_ENTITY) is None
+
+
+async def test_partition_subentry_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test adding a partition through the subentry flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_PARTITION),
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_PARTITION_NUMBER: 2, CONF_PARTITIONNAME: "Garage"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Garage (2)"
+    assert result["data"][CONF_PARTITION_NUMBER] == 2
+
+
+async def test_partition_subentry_number_out_of_range(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test a partition number beyond the panel's capacity is rejected.
+
+    Regression test: pyenvisalink only ever tracks partitions 1..8. An
+    out-of-range number used to pass schema validation and only fail later,
+    with a raw KeyError, when the platform tried to look up
+    alarm_state["partition"][partition_number] - which also crashed the
+    whole config entry setup, not just this subentry.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_PARTITION),
+        context={"source": SOURCE_USER},
+    )
+
+    with pytest.raises(InvalidData):
+        await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {CONF_PARTITION_NUMBER: 9, CONF_PARTITIONNAME: "Garage"},
+        )
+
+
+async def test_partition_subentry_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test adding a partition number that is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_PARTITION),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {CONF_PARTITION_NUMBER: 1, CONF_PARTITIONNAME: "Duplicate"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_PARTITION_NUMBER: "already_configured"}
+
+
+async def test_partition_subentry_reconfigure(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reconfiguring an existing partition."""
+    mock_config_entry.add_to_hass(hass)
+    partition_subentry_id = next(
+        subentry_id
+        for subentry_id, subentry in mock_config_entry.subentries.items()
+        if subentry.subentry_type == SUBENTRY_TYPE_PARTITION
+    )
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, partition_subentry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_PARTITIONNAME: "Renamed Partition"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert (
+        mock_config_entry.subentries[partition_subentry_id].data[CONF_PARTITIONNAME]
+        == "Renamed Partition"
+    )
+
+
+async def test_partition_subentry_removal_removes_entities(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test removing a partition subentry reloads the entry and tears it down.
+
+    Regression test: removal is promised alongside add/edit for subentries,
+    but nothing previously verified that the reload path this relies on
+    also runs on removal, dropping the removed partition's entities (alarm
+    panel and keypad sensor).
+    """
+    assert await setup_envisalink(hass)
+    assert hass.states.get(ALARM_ENTITY) is not None
+    assert hass.states.get(KEYPAD_ENTITY) is not None
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    partition_subentry_id = next(
+        subentry_id
+        for subentry_id, subentry in entry.subentries.items()
+        if subentry.subentry_type == SUBENTRY_TYPE_PARTITION
+    )
+
+    assert hass.config_entries.async_remove_subentry(entry, partition_subentry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ALARM_ENTITY) is None
+    assert hass.states.get(KEYPAD_ENTITY) is None

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -1,37 +1,43 @@
 """Tests for the Envisalink setup."""
 
-from collections.abc import Awaitable, Callable
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.envisalink.alarm_control_panel import (
-    async_setup_platform as alarm_setup_platform,
+from homeassistant.components.envisalink import (
+    LoginTimeout,
+    async_connect_panel,
+    disconnect_panel,
 )
-from homeassistant.components.envisalink.binary_sensor import (
-    async_setup_platform as binary_sensor_setup_platform,
+from homeassistant.components.envisalink.const import (
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_PANEL_TYPE,
+    CONF_PASS,
+    CONF_USERNAME,
 )
-from homeassistant.components.envisalink.sensor import (
-    async_setup_platform as sensor_setup_platform,
-)
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
 
 from .conftest import (
     ALARM_ENTITY,
     DOMAIN,
     KEYPAD_ENTITY,
     MOCK_CODE,
+    MOCK_DATA,
+    MOCK_OPTIONS,
+    MOCK_YAML_CONFIG,
     ZONE_ENTITY,
     setup_envisalink,
+    setup_envisalink_yaml,
 )
 
-SetupPlatform = Callable[
-    [HomeAssistant, ConfigType, AddEntitiesCallback, DiscoveryInfoType | None],
-    Awaitable[None],
-]
+from tests.common import MockConfigEntry
 
 
 async def test_setup_creates_entities(
@@ -55,6 +61,29 @@ async def test_setup_fails_on_login_failure(
 
     assert await setup_envisalink(hass) is False
     assert hass.states.get(ALARM_ENTITY) is None
+
+
+async def test_setup_retries_on_login_timeout(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test setup schedules a retry when our outer login timeout fires.
+
+    Regression test: the outer asyncio.timeout in async_connect_panel fully
+    disconnects the panel before giving up (unlike pyenvisalink's own
+    tolerate-and-retry timeout), so setup must raise ConfigEntryNotReady
+    instead of proceeding with a dead controller.
+    """
+    mock_controller.start.side_effect = None  # never resolves the connection
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS)
+    with (
+        patch("homeassistant.components.envisalink.LOGIN_RESPONSE_TIMEOUT", 0),
+        patch("homeassistant.components.envisalink.DEFAULT_TIMEOUT", 0),
+    ):
+        assert await setup_envisalink(hass, entry) is False
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    mock_controller.stop.assert_called_once()
 
 
 async def test_setup_succeeds_on_connection_timeout(
@@ -81,23 +110,6 @@ async def test_controller_stopped_on_shutdown(
     mock_controller.stop.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "setup_platform",
-    [
-        alarm_setup_platform,
-        binary_sensor_setup_platform,
-        sensor_setup_platform,
-    ],
-)
-async def test_platform_setup_without_discovery_is_noop(
-    hass: HomeAssistant, setup_platform: SetupPlatform
-) -> None:
-    """Test a platform set up directly (no discovery info) adds no entities."""
-    add_entities = MagicMock()
-    await setup_platform(hass, {}, add_entities, None)
-    add_entities.assert_not_called()
-
-
 async def test_invoke_custom_function_service(
     hass: HomeAssistant, mock_controller: MagicMock
 ) -> None:
@@ -114,3 +126,232 @@ async def test_invoke_custom_function_service(
     )
 
     mock_controller.command_output.assert_called_once_with(MOCK_CODE, "2", "7")
+
+
+async def test_invoke_custom_function_service_no_loaded_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test the PGM service errors when no entry is set up."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with pytest.raises(ServiceValidationError, match="currently set up"):
+        await hass.services.async_call(
+            DOMAIN,
+            "invoke_custom_function",
+            {"pgm": "7", "partition": "2"},
+            blocking=True,
+        )
+
+
+async def test_import_yaml_config(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test YAML config is imported with entities and a repair issue."""
+    assert await setup_envisalink_yaml(hass)
+
+    assert hass.states.get(ALARM_ENTITY) is not None
+    assert hass.states.get(KEYPAD_ENTITY) is not None
+    assert hass.states.get(ZONE_ENTITY) is not None
+    assert issue_registry.async_get_issue("homeassistant", f"deprecated_yaml_{DOMAIN}")
+
+
+async def test_async_connect_panel_stops_controller_on_cancel(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test cancelling a pending connection still stops the controller.
+
+    Regression test: if the caller (e.g. an aborted config flow) is
+    cancelled before the login result resolves, pyenvisalink's background
+    reconnect/keepalive loops must still be stopped, or they run forever on
+    an orphaned, unreferenced panel instance.
+    """
+    mock_controller.start.side_effect = None  # never resolves the connection
+
+    task = hass.async_create_task(
+        async_connect_panel(
+            hass,
+            MOCK_DATA[CONF_HOST],
+            MOCK_DATA[CONF_EVL_PORT],
+            MOCK_DATA[CONF_PANEL_TYPE],
+            MOCK_DATA[CONF_EVL_VERSION],
+            MOCK_DATA[CONF_USERNAME],
+            MOCK_DATA[CONF_PASS],
+        )
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    mock_controller.stop.assert_called_once()
+
+
+async def test_async_connect_panel_times_out_without_login_response(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test a connection that never gets a login response doesn't hang forever.
+
+    Regression test: if the wrong panel_type is selected, the panel's replies
+    are never recognized as a login success/failure/timeout, so none of the
+    login callbacks fire. Without an outer bound, this leaves the connection
+    attempt (and anything awaiting it, e.g. the config flow) hung forever.
+
+    This must be distinguishable from the library's own tolerate-and-retry
+    timeout: disconnect_panel() has already fully torn down the connection
+    here, so the caller can't treat it as still-running and self-healing.
+    """
+    mock_controller.start.side_effect = None  # never resolves the connection
+
+    with (
+        patch("homeassistant.components.envisalink.LOGIN_RESPONSE_TIMEOUT", 0),
+        pytest.raises(LoginTimeout),
+    ):
+        await async_connect_panel(
+            hass,
+            MOCK_DATA[CONF_HOST],
+            MOCK_DATA[CONF_EVL_PORT],
+            MOCK_DATA[CONF_PANEL_TYPE],
+            MOCK_DATA[CONF_EVL_VERSION],
+            MOCK_DATA[CONF_USERNAME],
+            MOCK_DATA[CONF_PASS],
+            connection_timeout=0,
+        )
+
+    mock_controller.stop.assert_called_once()
+
+
+async def test_async_connect_panel_disconnects_on_start_error(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test a controller that fails to start is still disconnected.
+
+    Regression test: start() used to run outside the try/except guarding
+    disconnect_panel(), so an error raised directly from start() (as opposed
+    to one reported later through a login callback) bypassed cleanup
+    entirely and leaked the controller.
+    """
+    mock_controller.start.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await async_connect_panel(
+            hass,
+            MOCK_DATA[CONF_HOST],
+            MOCK_DATA[CONF_EVL_PORT],
+            MOCK_DATA[CONF_PANEL_TYPE],
+            MOCK_DATA[CONF_EVL_VERSION],
+            MOCK_DATA[CONF_USERNAME],
+            MOCK_DATA[CONF_PASS],
+        )
+
+    mock_controller.stop.assert_called_once()
+
+
+def test_disconnect_panel_cancels_pending_reconnect() -> None:
+    """Test disconnect_panel force-closes the transport and cancels reconnects.
+
+    Regression test: pyenvisalink's own stop() doesn't close the transport
+    or cancel an already-scheduled reconnect when given an external event
+    loop (always true for us) - a reconnect scheduled before stop() is
+    called fires anyway, since reconnect() doesn't check the shutdown flag
+    itself. mock_controller is autospec'd and doesn't know about the
+    library's private _client/_reconnect_task attributes, so this uses a
+    plain mock to verify the real interaction.
+    """
+    controller = MagicMock()
+    controller._client._reconnect_task = MagicMock()
+
+    disconnect_panel(controller)
+
+    controller.stop.assert_called_once()
+    controller._client.disconnect.assert_called_once()
+    controller._client._reconnect_task.cancel.assert_called_once()
+
+
+def test_disconnect_panel_without_pending_reconnect() -> None:
+    """Test disconnect_panel doesn't error when no reconnect is scheduled."""
+    controller = MagicMock()
+    controller._client._reconnect_task = None
+
+    disconnect_panel(controller)
+
+    controller.stop.assert_called_once()
+    controller._client.disconnect.assert_called_once()
+
+
+async def test_setup_entry_disconnects_panel_on_later_failure(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the panel is disconnected if setup fails after connecting.
+
+    Regression test: a failure between connecting and finishing setup (e.g.
+    async_forward_entry_setups() itself raising) must still disconnect the
+    panel. Home Assistant's core failure handling only unregisters the
+    on_unload callbacks on a failed setup - it does not call
+    async_unload_entry - so without its own cleanup, async_setup_entry would
+    leave the panel connected and its background reconnect running,
+    unreferenced, forever.
+
+    Note this does NOT cover a platform crashing while creating an entity
+    (e.g. for an out-of-range zone/partition number): Home Assistant's own
+    entity_platform setup swallows exceptions raised by a platform's
+    async_setup_entry before they ever reach us, so that failure mode can't
+    reach this cleanup path at all - confirmed by forcing
+    binary_sensor.async_setup_entry to raise directly through the real
+    hass.config_entries.async_setup() call, which still reports success.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS)
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=RuntimeError("boom"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+    mock_controller.stop.assert_called_once()
+
+
+async def test_import_yaml_config_cannot_connect(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a YAML import failure raises the integration-specific repair issue."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_failure(
+        None
+    )
+
+    assert await setup_envisalink_yaml(hass)
+
+    assert issue_registry.async_get_issue(
+        DOMAIN, "deprecated_yaml_import_issue_invalid_auth"
+    )
+
+
+async def test_import_yaml_config_invalid_zone_number(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an out-of-range YAML zone number raises the integration issue."""
+    config = {
+        DOMAIN: {
+            **MOCK_YAML_CONFIG[DOMAIN],
+            "zones": {65: {"name": "Out of Range", "type": "door"}},
+        }
+    }
+
+    assert await setup_envisalink_yaml(hass, config)
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "deprecated_yaml_import_issue_invalid_zone_number"
+    )
+    assert issue is not None
+    assert issue.translation_placeholders["number"] == "65"
+    assert issue.translation_placeholders["max"] == "64"

--- a/tests/components/envisalink/test_switch.py
+++ b/tests/components/envisalink/test_switch.py
@@ -1,0 +1,95 @@
+"""Tests for the Envisalink zone bypass switch.
+
+Platform.SWITCH is intentionally left out of PLATFORMS pending a panel
+compatibility fix (see switch.py's module docstring), so these tests
+temporarily re-enable it to exercise the otherwise-dormant entity.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.envisalink.const import (
+    PLATFORMS,
+    SIGNAL_ZONE_BYPASS_UPDATE,
+)
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .conftest import setup_envisalink
+
+SWITCH_ENTITY = "switch.front_door_bypass"
+
+
+@pytest.fixture(autouse=True)
+def enable_switch_platform() -> None:
+    """Temporarily enable the dormant switch platform for these tests."""
+    with patch(
+        "homeassistant.components.envisalink.PLATFORMS",
+        [*PLATFORMS, Platform.SWITCH],
+    ):
+        yield
+
+
+async def test_switch_is_on(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+    """Test the switch reflects the zone's bypass status on an update.
+
+    pyenvisalink has no callback that fires SIGNAL_ZONE_BYPASS_UPDATE yet
+    (part of why this platform isn't wired into PLATFORMS), so the signal is
+    dispatched directly rather than through a controller callback.
+    """
+    assert await setup_envisalink(hass)
+    assert hass.states.get(SWITCH_ENTITY).state == STATE_OFF
+
+    mock_controller.alarm_state["zone"][1]["bypassed"] = True
+    async_dispatcher_send(hass, SIGNAL_ZONE_BYPASS_UPDATE, {1: True})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SWITCH_ENTITY).state == STATE_ON
+
+
+async def test_switch_turn_on(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+    """Test turning on the switch toggles the zone bypass."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": SWITCH_ENTITY},
+        blocking=True,
+    )
+
+    mock_controller.toggle_zone_bypass.assert_called_once_with(1)
+
+
+async def test_switch_turn_off(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+    """Test turning off the switch toggles the zone bypass."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": SWITCH_ENTITY},
+        blocking=True,
+    )
+
+    mock_controller.toggle_zone_bypass.assert_called_once_with(1)
+
+
+async def test_switch_update_filtering(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test bypass updates are filtered by zone; None applies to all."""
+    assert await setup_envisalink(hass)
+    mock_controller.alarm_state["zone"][1]["bypassed"] = True
+
+    # An update for a different zone is ignored.
+    async_dispatcher_send(hass, SIGNAL_ZONE_BYPASS_UPDATE, {2: True})
+    await hass.async_block_till_done()
+    assert hass.states.get(SWITCH_ENTITY).state == STATE_OFF
+
+    # A None bypass_map applies to every entity.
+    async_dispatcher_send(hass, SIGNAL_ZONE_BYPASS_UPDATE, None)
+    await hass.async_block_till_done()
+    assert hass.states.get(SWITCH_ENTITY).state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Replaces YAML-only configuration for the Envisalink integration with a ConfigFlow. Zones and partitions become config subentries (added/edited/removed from the UI), each with its own device grouped under a shared "Envisalink" hub device. Existing YAML configuration is imported automatically with a deprecation repair issue, following the same pattern as other recently migrated integrations (e.g. AquaLogic #173448  ).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Will update and link shortly
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] TODO

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure