### PR TITLE
Add Hotspring sensor platform

### DIFF
--- a/homeassistant/components/hotspring/__init__.py
+++ b/homeassistant/components/hotspring/__init__.py
@@ -5,7 +5,10 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
 
-PLATFORMS = [Platform.NUMBER]
+PLATFORMS = [
+    Platform.NUMBER,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HotSpringConfigEntry) -> bool:

--- a/homeassistant/components/hotspring/sensor.py
+++ b/homeassistant/components/hotspring/sensor.py
@@ -1,0 +1,125 @@
+"""Support for Hot Spring sensors."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from hotspring import Spa
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
+from .entity import HotSpringEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class HotSpringSensorEntityDescription(SensorEntityDescription):
+    """Describes Hot Spring sensor entity."""
+
+    exists_fn: Callable[[Spa], bool] = lambda _: True
+    value_fn: Callable[[Spa], StateType]
+
+
+SENSORS: tuple[HotSpringSensorEntityDescription, ...] = (
+    HotSpringSensorEntityDescription(
+        key="current_temperature",
+        translation_key="current_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        value_fn=lambda spa: spa.heater.current_temperature,
+    ),
+    HotSpringSensorEntityDescription(
+        key="water_care_120_day_timer",
+        translation_key="water_care_120_day_timer",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        value_fn=lambda spa: spa.water_care.one_twenty_day_timer,
+        exists_fn=lambda spa: spa.water_care.cartridge_installed,
+    ),
+    HotSpringSensorEntityDescription(
+        key="water_care_salt_value",
+        translation_key="water_care_salt_value",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda spa: spa.water_care.salt_value,
+        exists_fn=lambda spa: spa.water_care.cartridge_installed,
+    ),
+    HotSpringSensorEntityDescription(
+        key="water_care_10_day_timer",
+        translation_key="water_care_10_day_timer",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        value_fn=lambda spa: spa.water_care.ten_day_timer,
+        exists_fn=lambda spa: spa.water_care.cartridge_installed,
+    ),
+    HotSpringSensorEntityDescription(
+        key="control_box_version",
+        translation_key="control_box_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda spa: spa.versions.control_box,
+        exists_fn=lambda spa: bool(spa.versions.control_box),
+    ),
+    HotSpringSensorEntityDescription(
+        key="wifi_dongle_version",
+        translation_key="wifi_dongle_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda spa: spa.versions.wifi_dongle,
+        exists_fn=lambda spa: bool(spa.versions.wifi_dongle),
+    ),
+    HotSpringSensorEntityDescription(
+        key="fwss_version",
+        translation_key="fwss_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda spa: spa.versions.fwss,
+        exists_fn=lambda spa: bool(spa.versions.fwss),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HotSpringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Hot Spring sensor entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        HotSpringSensorEntity(coordinator, description)
+        for description in SENSORS
+        if description.exists_fn(coordinator.data)
+    )
+
+
+class HotSpringSensorEntity(HotSpringEntity, SensorEntity):
+    """Defines a Hot Spring sensor entity."""
+
+    entity_description: HotSpringSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HotSpringDataUpdateCoordinator,
+        description: HotSpringSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor entity."""
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/hotspring/strings.json
+++ b/homeassistant/components/hotspring/strings.json
@@ -30,6 +30,29 @@
       "target_temperature": {
         "name": "Target temperature"
       }
+    },
+    "sensor": {
+      "control_box_version": {
+        "name": "Control box version"
+      },
+      "current_temperature": {
+        "name": "Current temperature"
+      },
+      "fwss_version": {
+        "name": "FreshWater Salt System version"
+      },
+      "water_care_10_day_timer": {
+        "name": "Salt 10-day check timer"
+      },
+      "water_care_120_day_timer": {
+        "name": "Salt cartridge age"
+      },
+      "water_care_salt_value": {
+        "name": "Salt value"
+      },
+      "wifi_dongle_version": {
+        "name": "Wi-Fi dongle version"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/hotspring/conftest.py
+++ b/tests/components/hotspring/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from hotspring import Heater, Spa, SpaBrand, SpaInfo, Versions
+from hotspring import Heater, Spa, SpaBrand, SpaInfo, Versions, WaterCare
 import pytest
 
 from homeassistant.components.hotspring.const import DOMAIN
@@ -52,7 +52,7 @@ def device_fixture() -> Spa:
     spa.versions = Versions(
         control_box="3.0.0",
         control_panel="2.0.0",
-        fwss="",
+        fwss="1.0.0",
         fwiq="",
         btxr="",
         cool_zone="",
@@ -66,6 +66,16 @@ def device_fixture() -> Spa:
     heater.set_temperature = 104.0
     heater.is_on = True
     spa.heater = heater
+    spa.water_care = WaterCare(
+        cartridge_installed=True,
+        ten_day_timer=0,
+        one_twenty_day_timer=117,
+        level=2,
+        system_enabled=True,
+        ace_mode="inactive",
+        boost_active=False,
+        salt_value=12,
+    )
     return spa
 
 

--- a/tests/components/hotspring/snapshots/test_sensor.ambr
+++ b/tests/components/hotspring/snapshots/test_sensor.ambr
@@ -1,0 +1,372 @@
+# serializer version: 1
+# name: test_sensors[sensor.connectedspa_ddeeff_control_box_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.connectedspa_ddeeff_control_box_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Control box version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Control box version',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'control_box_version',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_control_box_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_control_box_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Control box version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_control_box_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.0.0',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_current_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.connectedspa_ddeeff_current_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Current temperature',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_temperature',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_current_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_current_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Current temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_current_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '38.8888888888889',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_freshwater_salt_system_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.connectedspa_ddeeff_freshwater_salt_system_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'FreshWater Salt System version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'FreshWater Salt System version',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fwss_version',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_fwss_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_freshwater_salt_system_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF FreshWater Salt System version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_freshwater_salt_system_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.0.0',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_10_day_check_timer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_10_day_check_timer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Salt 10-day check timer',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Salt 10-day check timer',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_care_10_day_timer',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_water_care_10_day_timer',
+    'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_10_day_check_timer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Salt 10-day check timer',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.DAYS: 'd'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_10_day_check_timer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_cartridge_age-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_cartridge_age',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Salt cartridge age',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Salt cartridge age',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_care_120_day_timer',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_water_care_120_day_timer',
+    'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_cartridge_age-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Salt cartridge age',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.DAYS: 'd'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_cartridge_age',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '117',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_value-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_value',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Salt value',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Salt value',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_care_salt_value',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_water_care_salt_value',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_salt_value-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Salt value',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_salt_value',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12',
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_wi_fi_dongle_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.connectedspa_ddeeff_wi_fi_dongle_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi dongle version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi dongle version',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_dongle_version',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_wifi_dongle_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.connectedspa_ddeeff_wi_fi_dongle_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Wi-Fi dongle version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.connectedspa_ddeeff_wi_fi_dongle_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.0.0',
+  })
+# ---

--- a/tests/components/hotspring/test_sensor.py
+++ b/tests/components/hotspring/test_sensor.py
@@ -1,7 +1,5 @@
 """Tests for the Hot Spring sensor platform."""
 
-from unittest.mock import MagicMock
-
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -24,64 +22,3 @@ async def test_sensors(
     """Test the sensor platform state."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
-
-
-@pytest.mark.usefixtures("mock_hotspring")
-@pytest.mark.parametrize(
-    "entity_id",
-    [
-        "sensor.connectedspa_ddeeff_control_box_version",
-        "sensor.connectedspa_ddeeff_wi_fi_dongle_version",
-        "sensor.connectedspa_ddeeff_freshwater_salt_system_version",
-    ],
-)
-async def test_disabled_by_default_sensors(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
-    entity_id: str,
-) -> None:
-    """Test the disabled by default Hot Spring sensors."""
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
-
-    assert hass.states.get(entity_id) is None
-
-    assert (entry := entity_registry.async_get(entity_id))
-    assert entry.disabled
-    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-
-
-async def test_no_salt_cartridge(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_hotspring: MagicMock,
-) -> None:
-    """Test water care sensors are not added when cartridge is not installed."""
-    mock_hotspring.update.return_value.water_care.cartridge_installed = False
-
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
-
-    assert hass.states.get("sensor.connectedspa_ddeeff_salt_cartridge_age") is None
-    assert hass.states.get("sensor.connectedspa_ddeeff_salt_value") is None
-    assert hass.states.get("sensor.connectedspa_ddeeff_salt_10_day_check_timer") is None
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_no_version_information(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_hotspring: MagicMock,
-) -> None:
-    """Test version sensors are not added when version string is empty."""
-    mock_hotspring.update.return_value.versions.control_box = ""
-    mock_hotspring.update.return_value.versions.wifi_dongle = ""
-    mock_hotspring.update.return_value.versions.fwss = ""
-
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
-
-    assert hass.states.get("sensor.connectedspa_ddeeff_control_box_version") is None
-    assert hass.states.get("sensor.connectedspa_ddeeff_wi_fi_dongle_version") is None
-    assert (
-        hass.states.get("sensor.connectedspa_ddeeff_freshwater_salt_system_version")
-        is None
-    )

--- a/tests/components/hotspring/test_sensor.py
+++ b/tests/components/hotspring/test_sensor.py
@@ -1,0 +1,96 @@
+"""Tests for the Hot Spring sensor platform."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_with_selected_platforms
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.hotspring.PLATFORMS", [Platform.SENSOR]):
+        yield
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the sensor platform state."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "sensor.connectedspa_ddeeff_control_box_version",
+        "sensor.connectedspa_ddeeff_wi_fi_dongle_version",
+        "sensor.connectedspa_ddeeff_freshwater_salt_system_version",
+    ],
+)
+async def test_disabled_by_default_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    entity_registry: er.EntityRegistry,
+    entity_id: str,
+) -> None:
+    """Test the disabled by default Hot Spring sensors."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
+
+    assert hass.states.get(entity_id) is None
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_no_salt_cartridge(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test water care sensors are not added when cartridge is not installed."""
+    mock_hotspring.update.return_value.water_care.cartridge_installed = False
+
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
+
+    assert hass.states.get("sensor.connectedspa_ddeeff_salt_cartridge_age") is None
+    assert hass.states.get("sensor.connectedspa_ddeeff_salt_value") is None
+    assert hass.states.get("sensor.connectedspa_ddeeff_salt_10_day_check_timer") is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_no_version_information(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test version sensors are not added when version string is empty."""
+    mock_hotspring.update.return_value.versions.control_box = ""
+    mock_hotspring.update.return_value.versions.wifi_dongle = ""
+    mock_hotspring.update.return_value.versions.fwss = ""
+
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
+
+    assert hass.states.get("sensor.connectedspa_ddeeff_control_box_version") is None
+    assert hass.states.get("sensor.connectedspa_ddeeff_wi_fi_dongle_version") is None
+    assert (
+        hass.states.get("sensor.connectedspa_ddeeff_freshwater_salt_system_version")
+        is None
+    )

--- a/tests/components/hotspring/test_sensor.py
+++ b/tests/components/hotspring/test_sensor.py
@@ -1,7 +1,6 @@
 """Tests for the Hot Spring sensor platform."""
 
-from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -15,18 +14,10 @@ from . import setup_with_selected_platforms
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None]:
-    """Override PLATFORMS."""
-    with patch("homeassistant.components.hotspring.PLATFORMS", [Platform.SENSOR]):
-        yield
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_hotspring")
 async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_hotspring: MagicMock,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -35,6 +26,7 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_hotspring")
 @pytest.mark.parametrize(
     "entity_id",
     [
@@ -46,7 +38,6 @@ async def test_sensors(
 async def test_disabled_by_default_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_hotspring: MagicMock,
     entity_registry: er.EntityRegistry,
     entity_id: str,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the initial set of sensor platform to the Hotspring integration:
- Current temperature
- Salt cartridge age
- Salt value
- Salt 10-day check timer
- Control box version
- Wi-Fi dongle version
- FreshWater Salt System version


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47542
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
