### PR TITLE
Add humidifier platform to Electrolux integration

### DIFF
--- a/homeassistant/components/electrolux/__init__.py
+++ b/homeassistant/components/electrolux/__init__.py
@@ -42,6 +42,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.FAN,
+    Platform.HUMIDIFIER,
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SENSOR,

--- a/homeassistant/components/electrolux/humidifier.py
+++ b/homeassistant/components/electrolux/humidifier.py
@@ -1,0 +1,162 @@
+"""Humidifier entity for Electrolux Integration."""
+
+import logging
+from typing import Any, override
+
+from electrolux_group_developer_sdk.client.appliances.appliance_data import (
+    ApplianceData,
+)
+from electrolux_group_developer_sdk.client.appliances.dh_appliance import DHAppliance
+
+from homeassistant.components.humidifier import (
+    HumidifierDeviceClass,
+    HumidifierEntity,
+    HumidifierEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ElectroluxConfigEntry, ElectroluxDataUpdateCoordinator
+from .entity import ElectroluxBaseEntity
+from .entity_helper import async_setup_entities_helper
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def build_entities_for_appliance(
+    appliance_data: ApplianceData,
+    coordinators: dict[str, ElectroluxDataUpdateCoordinator],
+) -> list[ElectroluxBaseEntity]:
+    """Return all entities for a single appliance."""
+    appliance = appliance_data.appliance
+    coordinator = coordinators[appliance.applianceId]
+    entities: list[ElectroluxBaseEntity] = []
+
+    if isinstance(appliance_data, DHAppliance):
+        entities.append(
+            DehumidifierEntity(appliance_data=appliance_data, coordinator=coordinator)
+        )
+
+    return entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElectroluxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set Dehumidifier entity for Electrolux Integration."""
+    await async_setup_entities_helper(
+        hass, entry, async_add_entities, build_entities_for_appliance
+    )
+
+
+class DehumidifierEntity(ElectroluxBaseEntity[DHAppliance], HumidifierEntity):
+    """Representation of an Electrolux Dehumidifier unit."""
+
+    _attr_supported_features = HumidifierEntityFeature.MODES
+
+    def __init__(
+        self,
+        appliance_data: DHAppliance,
+        coordinator: ElectroluxDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the Dehumidifier device."""
+        super().__init__(appliance_data, coordinator, "dehumidifier")
+
+        self._attr_key = "dehumidifier"
+        self._attr_translation_key = "dehumidifier"
+        self._attr_available_modes = self._get_supported_modes()
+        self._attr_max_humidity = (
+            self._appliance_data.get_supported_max_humidity() or 85
+        )
+        self._attr_min_humidity = (
+            self._appliance_data.get_supported_min_humidity() or 35
+        )
+        self._humidity_step = self._appliance_data.get_supported_step_humidity() or 5
+        self._attr_device_class = HumidifierDeviceClass.DEHUMIDIFIER
+
+        self._attr_mode = self._get_current_mode()
+        self._attr_current_humidity = self._get_sensor_humidity()
+        self._attr_target_humidity = self._get_target_humidity()
+        self._attr_is_on = self._is_dh_on()
+
+    @override
+    def _update_attr_state(self) -> bool:
+        state_changed = False
+
+        new_mode = self._get_current_mode()
+        if new_mode != self._attr_mode:
+            self._attr_mode = new_mode
+            state_changed = True
+
+        new_humidity = self._get_sensor_humidity()
+        if new_humidity != self._attr_current_humidity:
+            self._attr_current_humidity = new_humidity
+            state_changed = True
+
+        new_target_humidity = self._get_target_humidity()
+        if new_target_humidity != self._attr_target_humidity:
+            self._attr_target_humidity = new_target_humidity
+            state_changed = True
+
+        new_on_state = self._is_dh_on()
+        if new_on_state != self._attr_is_on:
+            self._attr_is_on = new_on_state
+            state_changed = True
+
+        return state_changed
+
+    def _get_supported_modes(self) -> list[str]:
+        supported_modes = self._appliance_data.get_supported_modes()
+        if not supported_modes:
+            return []
+        return list(supported_modes)
+
+    def _get_current_mode(self) -> str:
+        """Return current mode."""
+        return self._appliance_data.get_current_mode()
+
+    def _get_target_humidity(self) -> int:
+        """Return target humidity."""
+        return self._appliance_data.get_current_target_humidity() or 0
+
+    def _get_sensor_humidity(self) -> int:
+        """Return sensor humidity."""
+        return self._appliance_data.get_current_sensor_humidity() or 0
+
+    def _is_dh_on(self) -> bool:
+        """Return true if the DH is on."""
+        return self._appliance_data.is_appliance_on() or False
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        command = self._appliance_data.get_turn_off_command()
+
+        await self.coordinator.client.send_command(self._appliance_id, command)
+        await self.coordinator.async_refresh()
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        command = self._appliance_data.get_turn_on_command()
+        await self.coordinator.client.send_command(self._appliance_id, command)
+        await self.coordinator.async_refresh()
+
+    @override
+    async def async_set_humidity(self, humidity: int) -> None:
+        """Set new target humidity."""
+        rounded_humidity = int(
+            round(humidity / self._humidity_step) * self._humidity_step
+        )
+        command = self._appliance_data.get_humidity_command(rounded_humidity)
+        await self.coordinator.client.send_command(self._appliance_id, command)
+        await self.coordinator.async_refresh()
+
+    @override
+    async def async_set_mode(self, mode: str) -> None:
+        """Set new target preset mode."""
+        command = self._appliance_data.get_mode_command(mode)
+        await self.coordinator.client.send_command(self._appliance_id, command)
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/electrolux/humidifier.py
+++ b/homeassistant/components/electrolux/humidifier.py
@@ -65,7 +65,7 @@ class DehumidifierEntity(ElectroluxBaseEntity[DHAppliance], HumidifierEntity):
         super().__init__(appliance_data, coordinator, "dehumidifier")
 
         self._attr_key = "dehumidifier"
-        self._attr_translation_key = "dehumidifier"
+        self._attr_name = None
         self._attr_available_modes = self._get_supported_modes()
         self._attr_max_humidity = (
             self._appliance_data.get_supported_max_humidity() or 85

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -155,6 +155,11 @@
         }
       }
     },
+    "humidifier": {
+      "dehumidifier": {
+        "name": "Dehumidifier"
+      }
+    },
     "light": {
       "bottomoven_cavity_light": {
         "name": "Lower cavity light"

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -155,11 +155,6 @@
         }
       }
     },
-    "humidifier": {
-      "dehumidifier": {
-        "name": "Dehumidifier"
-      }
-    },
     "light": {
       "bottomoven_cavity_light": {
         "name": "Lower cavity light"

--- a/tests/components/electrolux/snapshots/test_humidifier.ambr
+++ b/tests/components/electrolux/snapshots/test_humidifier.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_humidifier[humidifier.dehumidifier_dehumidifier-entry]
+# name: test_humidifier[humidifier.dehumidifier-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -23,7 +23,7 @@
     'disabled_by': None,
     'domain': 'humidifier',
     'entity_category': None,
-    'entity_id': 'humidifier.dehumidifier_dehumidifier',
+    'entity_id': 'humidifier.dehumidifier',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -31,12 +31,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Dehumidifier',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
     'original_icon': None,
-    'original_name': 'Dehumidifier',
+    'original_name': None,
     'platform': 'electrolux',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -46,7 +46,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_humidifier[humidifier.dehumidifier_dehumidifier-state]
+# name: test_humidifier[humidifier.dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
@@ -58,7 +58,7 @@
       ]),
       <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'dehumidifier',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dehumidifier Dehumidifier',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dehumidifier',
       <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 35,
       <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 85,
       <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 35,
@@ -66,7 +66,7 @@
       <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,
-    'entity_id': 'humidifier.dehumidifier_dehumidifier',
+    'entity_id': 'humidifier.dehumidifier',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/electrolux/snapshots/test_humidifier.ambr
+++ b/tests/components/electrolux/snapshots/test_humidifier.ambr
@@ -1,0 +1,75 @@
+# serializer version: 1
+# name: test_humidifier[humidifier.dehumidifier_dehumidifier-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
+        'AUTO',
+        'CONTINUOUS',
+        'DRY',
+        'OFF',
+        'QUIET',
+      ]),
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 85,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 35,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'humidifier',
+    'entity_category': None,
+    'entity_id': 'humidifier.dehumidifier_dehumidifier',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Dehumidifier',
+    'options': dict({
+    }),
+    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
+    'original_icon': None,
+    'original_name': 'Dehumidifier',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <HumidifierEntityFeature: 1>,
+    'translation_key': 'dehumidifier',
+    'unique_id': '950133061_00:98802845-443E07021EF3_dehumidifier',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_humidifier[humidifier.dehumidifier_dehumidifier-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
+        'AUTO',
+        'CONTINUOUS',
+        'DRY',
+        'OFF',
+        'QUIET',
+      ]),
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'dehumidifier',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dehumidifier Dehumidifier',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 35,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 85,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 35,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'OFF',
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <HumidifierEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'humidifier.dehumidifier_dehumidifier',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/electrolux/snapshots/test_humidifier.ambr
+++ b/tests/components/electrolux/snapshots/test_humidifier.ambr
@@ -41,7 +41,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <HumidifierEntityFeature: 1>,
-    'translation_key': 'dehumidifier',
+    'translation_key': None,
     'unique_id': '950133061_00:98802845-443E07021EF3_dehumidifier',
     'unit_of_measurement': None,
   })

--- a/tests/components/electrolux/test_humidifier.py
+++ b/tests/components/electrolux/test_humidifier.py
@@ -1,0 +1,167 @@
+"""Humidifier tests of Electrolux integration."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.humidifier import (
+    ATTR_HUMIDITY,
+    ATTR_MODE,
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    SERVICE_SET_HUMIDITY,
+    SERVICE_SET_MODE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import get_appliance_id, merge_dict_recursive, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.electrolux.PLATFORMS", [Platform.HUMIDIFIER]):
+        yield
+
+
+@pytest.mark.usefixtures("appliances")
+async def test_humidifier(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test states of the humidifier."""
+    await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    (
+        "appliance_fixture",
+        "entity_id",
+        "appliance_state",
+        "service",
+        "data",
+        "commands",
+    ),
+    [
+        # turn on/off command tests
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {},
+            SERVICE_TURN_ON,
+            {},
+            [{"executeCommand": "ON"}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {},
+            SERVICE_TURN_OFF,
+            {},
+            [{"executeCommand": "OFF"}],
+        ),
+        # set humidity command tests
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_HUMIDITY,
+            {ATTR_HUMIDITY: 35},
+            [{"targetHumidity": 35}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_HUMIDITY,
+            {ATTR_HUMIDITY: 45},
+            [{"targetHumidity": 45}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_HUMIDITY,
+            {ATTR_HUMIDITY: 85},
+            [{"targetHumidity": 85}],
+        ),
+        # set mode command tests
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_MODE,
+            {ATTR_MODE: "AUTO"},
+            [{"mode": "AUTO"}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_MODE,
+            {ATTR_MODE: "CONTINUOUS"},
+            [{"mode": "CONTINUOUS"}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_MODE,
+            {ATTR_MODE: "DRY"},
+            [{"mode": "DRY"}],
+        ),
+        (
+            "electrolux_dehumidifier",
+            "humidifier.dehumidifier_dehumidifier",
+            {"applianceState": "RUNNING"},
+            SERVICE_SET_MODE,
+            {ATTR_MODE: "QUIET"},
+            [{"mode": "QUIET"}],
+        ),
+    ],
+)
+async def test_commands(
+    hass: HomeAssistant,
+    appliances: AsyncMock,
+    appliance_fixture: str,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    appliance_state: dict[str, Any],
+    service: str,
+    data: dict[str, Any],
+    commands: list[dict[str, Any]],
+) -> None:
+    """Test fan commands."""
+
+    appliance_id = get_appliance_id(appliance_fixture)
+
+    state = await appliances.get_appliance_state(appliance_id)
+    state.properties["reported"] = merge_dict_recursive(
+        state.properties["reported"], appliance_state
+    )
+
+    appliances.get_appliance_state.side_effect = None
+    appliances.get_appliance_state.return_value = state
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        HUMIDIFIER_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id} | data,
+        blocking=True,
+    )
+    assert appliances.send_command.mock_calls == [
+        call(appliance_id, command) for command in commands
+    ]

--- a/tests/components/electrolux/test_humidifier.py
+++ b/tests/components/electrolux/test_humidifier.py
@@ -57,7 +57,7 @@ async def test_humidifier(
         # turn on/off command tests
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {},
             SERVICE_TURN_ON,
             {},
@@ -65,7 +65,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {},
             SERVICE_TURN_OFF,
             {},
@@ -74,7 +74,7 @@ async def test_humidifier(
         # set humidity command tests
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_HUMIDITY,
             {ATTR_HUMIDITY: 35},
@@ -82,7 +82,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_HUMIDITY,
             {ATTR_HUMIDITY: 45},
@@ -90,7 +90,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_HUMIDITY,
             {ATTR_HUMIDITY: 85},
@@ -99,7 +99,7 @@ async def test_humidifier(
         # set mode command tests
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_MODE,
             {ATTR_MODE: "AUTO"},
@@ -107,7 +107,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_MODE,
             {ATTR_MODE: "CONTINUOUS"},
@@ -115,7 +115,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_MODE,
             {ATTR_MODE: "DRY"},
@@ -123,7 +123,7 @@ async def test_humidifier(
         ),
         (
             "electrolux_dehumidifier",
-            "humidifier.dehumidifier_dehumidifier",
+            "humidifier.dehumidifier",
             {"applianceState": "RUNNING"},
             SERVICE_SET_MODE,
             {ATTR_MODE: "QUIET"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for the humidifier platform to allow controlling dehumidifiers, by controlling operating modes, setting the target humidity, reading the current humidity, and turning the appliance on or off.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47544
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [xx] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
