### PR TITLE
Protect the DeviceRegistry.child_devices container

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -774,7 +774,7 @@ async def _async_snapshot_payload(hass: HomeAssistant) -> dict:  # noqa: C901
     removed_devices: set[str] = set()
 
     # Get device list
-    for device_entry in (*dev_reg.devices, *dev_reg.child_devices.values()):
+    for device_entry in (*dev_reg.devices, *dev_reg.child_devices):
         config_entry = hass.config_entries.async_get_entry(device_entry.config_entry_id)
 
         if config_entry is None:

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -92,8 +92,7 @@ def websocket_list_devices(
     inner = b",".join(
         [
             entry.json_repr
-            for container in (registry._devices, registry.child_devices)  # noqa: SLF001
-            for entry in container.values()
+            for entry in (*registry.devices, *registry.child_devices)
             if entry.json_repr is not None
         ]
     )

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1787,7 +1787,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
     _devices: ActiveDeviceRegistryItems
     devices: Collection[DeviceEntry]
-    child_devices: ChildDeviceRegistryItems
+    _child_devices: ChildDeviceRegistryItems
+    child_devices: Collection[ChildDeviceEntry]
     deleted_devices: DeletedDeviceRegistryItems
     _device_data: dict[str, DeviceEntry]
     _child_device_data: dict[str, ChildDeviceEntry]
@@ -2003,7 +2004,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         Identifiers are unique within a config entry, so the lookup cannot be
         ambiguous.
         """
-        return self.child_devices.get_entry(
+        return self._child_devices.get_entry(
             identifiers={identifier}, config_entry_id=config_entry_id
         )
 
@@ -2333,7 +2334,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # We do not allow registering a device without parent_device_id if the
         # identifiers match an existing child.
         if (
-            matched_child_device := self.child_devices.get_entry(
+            matched_child_device := self._child_devices.get_entry(
                 identifiers=identifiers, config_entry_id=config_entry_id
             )
         ) is not None:
@@ -2673,7 +2674,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 f"parent device {parent.id}",
             )
 
-        child_device = self.child_devices.get_entry(
+        child_device = self._child_devices.get_entry(
             identifiers=identifiers, config_entry_id=config_entry_id
         )
 
@@ -2681,7 +2682,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # owned by another child device.
         for identifier in sorted(identifiers):
             if (
-                other_child := self.child_devices.get_entry(
+                other_child := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) is not None and (
@@ -2777,7 +2778,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 )
                 disabled_by = UNDEFINED
 
-            self.child_devices[child_device.id] = child_device
+            self._child_devices[child_device.id] = child_device
 
         self._async_purge_colliding_deleted_devices(child_device, identifiers, set())
 
@@ -2814,7 +2815,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             raise DeviceInfoError(
                 config_entry.domain, device_info, "a device can't be its own parent"
             )
-        if self.child_devices.get_children_for_device_id(device.id):
+        if self._child_devices.get_children_for_device_id(device.id):
             raise DeviceInfoError(
                 config_entry.domain,
                 device_info,
@@ -2907,7 +2908,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             parent_device_id=parent.id,
         )
         del self._devices[device.id]
-        self.child_devices[child_device.id] = child_device
+        self._child_devices[child_device.id] = child_device
 
         # A via_device_id must not resolve to a child device; detach inbound via
         # links to the converted device, as async_remove_device does, before firing
@@ -3146,7 +3147,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 # A parent with child devices can't move (enforced again below); reject
                 # here before mutating the runtime-only sibling pending moves, so the
                 # rejected move leaves no partial state behind.
-                if self.child_devices.get_children_for_device_id(device_id):
+                if self._child_devices.get_children_for_device_id(device_id):
                     raise HomeAssistantError(
                         f"Can't move device {device_id}: it has child devices"
                     )
@@ -3215,7 +3216,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # supported.
         if (
             is_move or "config_subentry_id" in new_values
-        ) and self.child_devices.get_children_for_device_id(device_id):
+        ) and self._child_devices.get_children_for_device_id(device_id):
             raise HomeAssistantError(
                 f"Can't move device {device_id}: it has child devices"
             )
@@ -3417,7 +3418,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # async_config_entry_disabled_by_changed, which iterates all the config
         # entry's devices.
         if "disabled_by" in old_values and (
-            children := self.child_devices.get_children_for_device_id(device_id)
+            children := self._child_devices.get_children_for_device_id(device_id)
         ):
             if new.disabled_by is None:
                 for child in children:
@@ -3447,7 +3448,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
     ) -> ChildDeviceEntry | None:
         """Private update child device attributes."""
-        old = self.child_devices[child_device_id]
+        old = self._child_devices[child_device_id]
 
         new_values: dict[str, Any] = {}  # Dict with new key/value pairs
         old_values: dict[str, Any] = {}  # Dict with old key/value pairs
@@ -3572,7 +3573,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         self.hass.verify_event_loop_thread("device_registry._async_update_child_device")
         new = attr.evolve(old, **new_values)
-        self.child_devices[child_device_id] = new
+        self._child_devices[child_device_id] = new
 
         # A deleted device holding an identity the child device now owns can never
         # restore
@@ -3960,7 +3961,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             ) and existing_device.id != device_id:
                 raise DeviceIdentifierCollisionError(identifiers, existing_device)
             if (
-                existing_child_device := self.child_devices.get_entry(
+                existing_child_device := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) is not None:
@@ -3982,7 +3983,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """
         for identifier in identifiers:
             if (
-                existing_child_device := self.child_devices.get_entry(
+                existing_child_device := self._child_devices.get_entry(
                     identifiers={identifier}, config_entry_id=config_entry_id
                 )
             ) and existing_child_device.id != child_device_id:
@@ -4050,7 +4051,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             return
         self.hass.verify_event_loop_thread("device_registry.async_remove_device")
         # Removing the parent removes its child devices
-        for child in self.child_devices.get_children_for_device_id(device_id):
+        for child in self._child_devices.get_children_for_device_id(device_id):
             self._async_remove_child_device(child)
         device = self._devices.pop(device_id)
         config_entry = self.hass.config_entries.async_get_entry(device.config_entry_id)
@@ -4084,7 +4085,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     def _async_remove_child_device(self, child_device: ChildDeviceEntry) -> None:
         """Remove a child device from the device registry."""
         self.hass.verify_event_loop_thread("device_registry.async_remove_device")
-        del self.child_devices[child_device.id]
+        del self._child_devices[child_device.id]
         config_entry = self.hass.config_entries.async_get_entry(
             child_device.config_entry_id
         )
@@ -4263,7 +4264,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         self._devices = devices
         self.devices = _DeprecatedDeviceRegistryItemsView(self._devices)
-        self.child_devices = child_devices
+        self._child_devices = child_devices
+        self.child_devices = self._child_devices.values()
         self.deleted_devices = deleted_devices
         self._device_data = devices.data
         self._child_device_data = child_devices.data
@@ -4290,7 +4292,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 entry.as_storage_fragment for entry in list(self._devices.values())
             ],
             "child_devices": [
-                entry.as_storage_fragment for entry in list(self.child_devices.values())
+                entry.as_storage_fragment
+                for entry in list(self._child_devices.values())
             ],
             "deleted_devices": [
                 entry.as_storage_fragment
@@ -4358,7 +4361,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self.async_remove_device(device.id)
         # Child devices share their parent's config entry, so the loop above removes
         # them through the parent cascade; guard against store corruption anyway.
-        for child_device in self.child_devices.get_devices_for_config_entry_id(
+        for child_device in self._child_devices.get_devices_for_config_entry_id(
             config_entry_id
         ):
             self.async_remove_device(child_device.id)
@@ -4399,7 +4402,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self.async_remove_device(device.id)
         # Child devices share their parent's subentry, so the loop above removes them
         # through the parent cascade; guard against store corruption anyway.
-        for child_device in self.child_devices.get_devices_for_config_entry_id(
+        for child_device in self._child_devices.get_devices_for_config_entry_id(
             config_entry_id
         ):
             if child_device.config_subentry_id != config_subentry_id:
@@ -4447,7 +4450,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """Clear area id from registry entries."""
         for device in self._devices.get_devices_for_area_id(area_id):
             self._async_update_device(device.id, area_id=None)
-        for child_device in self.child_devices.get_devices_for_area_id(area_id):
+        for child_device in self._child_devices.get_devices_for_area_id(area_id):
             self._async_update_child_device(child_device.id, area_id=None)
         for deleted_device in list(self.deleted_devices.values()):
             if deleted_device.area_id != area_id:
@@ -4462,7 +4465,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """Clear label from registry entries."""
         for device in self._devices.get_devices_for_label(label_id):
             self._async_update_device(device.id, labels=device.labels - {label_id})
-        for child_device in self.child_devices.get_devices_for_label(label_id):
+        for child_device in self._child_devices.get_devices_for_label(label_id):
             self._async_update_child_device(
                 child_device.id, labels=child_device.labels - {label_id}
             )
@@ -4557,11 +4560,13 @@ def async_entries_for_area(
     """
     devices = registry._devices.get_devices_for_area_id(area_id)  # noqa: SLF001
     entries: list[AnyDeviceEntry] = list(devices)
-    entries.extend(registry.child_devices.get_devices_for_area_id(area_id))
+    entries.extend(
+        registry._child_devices.get_devices_for_area_id(area_id)  # noqa: SLF001
+    )
     for device in devices:
         entries.extend(
             child_device
-            for child_device in registry.child_devices.get_children_for_device_id(
+            for child_device in registry._child_devices.get_children_for_device_id(  # noqa: SLF001
                 device.id
             )
             if child_device.area_id is None
@@ -4600,7 +4605,9 @@ def async_entries_for_label(
     entries: list[AnyDeviceEntry] = list(
         registry._devices.get_devices_for_label(label_id)  # noqa: SLF001
     )
-    entries.extend(registry.child_devices.get_devices_for_label(label_id))
+    entries.extend(
+        registry._child_devices.get_devices_for_label(label_id)  # noqa: SLF001
+    )
     return entries
 
 
@@ -4619,7 +4626,9 @@ def async_entries_for_parent_device(
     registry: DeviceRegistry, parent_device_id: str
 ) -> list[ChildDeviceEntry]:
     """Return the child device entries of a parent device."""
-    return registry.child_devices.get_children_for_device_id(parent_device_id)
+    return registry._child_devices.get_children_for_device_id(  # noqa: SLF001
+        parent_device_id
+    )
 
 
 @callback
@@ -4627,7 +4636,9 @@ def async_child_entries_for_config_entry(
     registry: DeviceRegistry, config_entry_id: str
 ) -> list[ChildDeviceEntry]:
     """Return child device entries that match a config entry."""
-    return registry.child_devices.get_devices_for_config_entry_id(config_entry_id)
+    return registry._child_devices.get_devices_for_config_entry_id(  # noqa: SLF001
+        config_entry_id
+    )
 
 
 @callback
@@ -4730,7 +4741,7 @@ def async_cleanup(
 
     # A child device shares its parent's (valid) config entry, and the remove cascade
     # makes a child without its parent impossible; guard against store corruption anyway.
-    for child_device in list(dev_reg.child_devices.values()):
+    for child_device in list(dev_reg.child_devices):
         if child_device.parent_device_id not in dev_reg._devices:  # noqa: SLF001
             _LOGGER.error(
                 "Removing child device %s: its parent device %s is not in the "

--- a/homeassistant/helpers/target.py
+++ b/homeassistant/helpers/target.py
@@ -179,18 +179,16 @@ def _resolve_referenced_devices(
                 selected.referenced_devices.add(split_device.id)
                 selected.referenced_devices.update(
                     child_device.id
-                    for child_device in (
-                        dev_reg.child_devices.get_children_for_device_id(
-                            split_device.id
-                        )
+                    for child_device in dr.async_entries_for_parent_device(
+                        dev_reg, split_device.id
                     )
                 )
         else:
             selected.referenced_devices.add(device_id)
             selected.referenced_devices.update(
                 child_device.id
-                for child_device in dev_reg.child_devices.get_children_for_device_id(
-                    device_id
+                for child_device in dr.async_entries_for_parent_device(
+                    dev_reg, device_id
                 )
             )
 

--- a/homeassistant/helpers/template/extensions/devices.py
+++ b/homeassistant/helpers/template/extensions/devices.py
@@ -84,9 +84,8 @@ class DeviceExtension(BaseTemplateExtension):
         dev_reg = dr.async_get(self.hass)
         return next(
             (
-                device_id
-                for container in (dev_reg._devices, dev_reg.child_devices)  # noqa: SLF001
-                for device_id, device in container.items()
+                device.id
+                for device in (*dev_reg.devices, *dev_reg.child_devices)
                 if (name := device.name_by_user or device.name)
                 and (str(entity_id_or_device_name) == name)
             ),

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -249,7 +249,7 @@ def test_entities_areas_area_inherited_from_parent(hass: HomeAssistant) -> None:
         },
     )
     # The child has no area of its own and inherits the parent's area.
-    device_registry.child_devices["mock-child-id"] = ChildDeviceEntry(
+    device_registry._child_devices["mock-child-id"] = ChildDeviceEntry(
         config_entry_id="mock-config-entry",
         id="mock-child-id",
         parent_device_id="mock-parent-id",

--- a/tests/common.py
+++ b/tests/common.py
@@ -761,7 +761,7 @@ def mock_device_registry(
     registry = dr.DeviceRegistry(hass)
     registry._devices = dr.ActiveDeviceRegistryItems()
     registry.devices = registry._devices.values()
-    registry._device_data = registry.devices.data
+    registry._device_data = registry._devices.data
     registry._child_devices = dr.ChildDeviceRegistryItems()
     registry.child_devices = registry._child_devices.values()
     registry._child_device_data = registry._child_devices.data

--- a/tests/common.py
+++ b/tests/common.py
@@ -761,9 +761,10 @@ def mock_device_registry(
     registry = dr.DeviceRegistry(hass)
     registry._devices = dr.ActiveDeviceRegistryItems()
     registry.devices = registry._devices.values()
-    registry._device_data = registry._devices.data
-    registry.child_devices = dr.ChildDeviceRegistryItems()
-    registry._child_device_data = registry.child_devices.data
+    registry._device_data = registry.devices.data
+    registry._child_devices = dr.ChildDeviceRegistryItems()
+    registry.child_devices = registry._child_devices.values()
+    registry._child_device_data = registry._child_devices.data
     if mock_entries is None:
         mock_entries = {}
     for key, entry in mock_entries.items():

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -11076,7 +11076,7 @@ async def test_link_device_info_matching_child_raises(
     # The child device is left untouched: not converted, no new device created
     assert len(device_registry.devices) == 1
     assert len(device_registry.child_devices) == 1
-    assert device_registry.child_devices[child_device.id] == child_device
+    assert device_registry._child_devices[child_device.id] == child_device
     assert child_device.identifiers == {("test", "strip_outlet_1")}
 
 
@@ -12373,7 +12373,7 @@ async def test_recreate_child_clears_stale_config_entry_disable(
     _, child_device = _create_parent_and_child(
         device_registry, mock_config_entry.entry_id
     )
-    device_registry.child_devices[child_device.id] = attr.evolve(
+    device_registry._child_devices[child_device.id] = attr.evolve(
         device_registry.async_get(child_device.id, include_main_devices=False),
         disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Protect the `DeviceRegistry.child_devices` container

Rationale:
The `child_devices` container is not meant for external use, users should call public `DeviceRegistry` methods or module level helper functions.

This is a similar solution to #179578, but without backwards compatibility

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
