### PR TITLE
Protect the DeviceRegistry.deleted_devices container

### DIFF
--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -441,7 +441,7 @@ async def async_cleanup_device_registry(
     entity_registry = er.async_get(hass)
     if (
         device_id
-        and device_id not in device_registry.deleted_devices
+        and device_id not in device_registry._deleted_devices  # noqa: SLF001
         and config_entry_id
         and (device := device_registry.async_get(device_id)) is not None
         # Only remove the device if it is owned by the MQTT config entry

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -252,7 +252,9 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     def _updated_device(event: Event[EventDeviceRegistryUpdatedData]) -> None:
         if event.data["action"] != "remove":
             return
-        device_entry = device_registry.deleted_devices[event.data["device_id"]]
+        device_entry = device_registry._deleted_devices[  # noqa: SLF001
+            event.data["device_id"]
+        ]
         if entry.entry_id not in device_entry.config_entries:
             return
         device_id = get_device_tuple_from_identifiers(device_entry.identifiers)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1528,61 +1528,69 @@ class ActiveDeviceRegistryItems(DeviceRegistryItems[DeviceEntry]):
         }
 
 
-class _DeprecatedDeviceRegistryItemsView:
-    """Backwards-compatible view returned by the `DeviceRegistry.devices` property.
+class _DeprecatedRegistryItemsView[_EntryTypeT: (DeviceEntry, DeletedDeviceEntry)]:
+    """Backwards-compatible view for devices and deleted_devices.
 
     Can be removed in release 2027.9.
 
-    Iterating this yields the `DeviceEntry` values, which is the supported way to
-    enumerate the registry (`for entry in registry.devices`, `list(registry.devices)`
-    and similar). Using it as a mapping - subscription, device-id membership,
-    `.values()`, `.get()`, `.get_entry()` and the other container methods - is
-    deprecated: each such access is reported via `report_usage` (raising for core code
-    and core integrations, warning for custom integrations) and then delegated to the
-    underlying container.
+    Iterating this yields the entry values, which is the supported way to enumerate the
+    registry (`for entry in view`, `list(view)` and similar). Using it as a mapping -
+    subscription, device-id membership, `.values()`, `.get()`, `.get_entry()` and the
+    other container methods - is deprecated: each such access is reported via
+    `report_usage` (raising for core code and core integrations, warning for custom
+    integrations) and then delegated to the underlying container.
     """
 
-    __slots__ = ("_devices",)
+    __slots__ = ("_deprecation_message", "_devices", "_entry_type")
 
-    def __init__(self, devices: ActiveDeviceRegistryItems) -> None:
-        """Initialize the view over a device registry."""
+    # Explicit annotations so the `__getattr__` fallback below does not make these
+    # slots resolve to `Any`.
+    _devices: DeviceRegistryItems[_EntryTypeT]
+    _entry_type: type[_EntryTypeT]
+
+    def __init__(
+        self,
+        devices: DeviceRegistryItems[_EntryTypeT],
+        entry_type: type[_EntryTypeT],
+        deprecation_message: str,
+    ) -> None:
+        """Initialize the view over a device registry container."""
         self._devices = devices
+        self._entry_type = entry_type
+        self._deprecation_message = deprecation_message
 
-    def __iter__(self) -> Iterator[DeviceEntry]:
-        """Iterate over the device entries."""
+    def __iter__(self) -> Iterator[_EntryTypeT]:
+        """Iterate over the entries."""
         return iter(self._devices.values())
 
     def __len__(self) -> int:
-        """Return the number of device entries."""
+        """Return the number of entries."""
         return len(self._devices)
 
     def _report_deprecated_use(self) -> None:
-        """Report deprecated use of `DeviceRegistry.devices`."""
+        """Report deprecated mapping use of the container."""
         report_usage(
-            "uses `device_registry.devices` as a mapping or calls its lookup "
-            "methods, which is deprecated; iterate it to get the device entries, "
-            "or use `async_get`, `async_entries_for_config_entry` and similar "
-            "helpers for lookups",
+            self._deprecation_message,
             breaks_in_ha_version="2027.9.0",
             core_behavior=ReportBehavior.ERROR,
             core_integration_behavior=ReportBehavior.ERROR,
             custom_integration_behavior=ReportBehavior.LOG,
         )
 
-    def __getitem__(self, key: str) -> DeviceEntry:
-        """Return the device entry for a device id (deprecated)."""
+    def __getitem__(self, key: str) -> _EntryTypeT:
+        """Return the entry for a device id (deprecated)."""
         self._report_deprecated_use()
         return self._devices[key]
 
     def __contains__(self, obj: object) -> bool:
-        """Return whether a device entry - or, deprecated, a device id - is registered.
+        """Return whether an entry - or, deprecated, a device id - is registered.
 
-        Value membership (`DeviceEntry in registry.devices`) is the supported use and
-        matches the `Collection[DeviceEntry]` type. Membership by device id (a `str`)
-        is the old key-based mapping behavior and is deprecated.
+        Value membership (`entry in view`) is the supported use and matches the
+        `Collection` type. Membership by device id (a `str`) is the old key-based
+        mapping behavior and is deprecated.
         """
-        # DeviceEntry is never subclassed, a direct type check is safe
-        if type(obj) is DeviceEntry:
+        # The entry type is never subclassed, a direct type check is safe
+        if type(obj) is self._entry_type:
             return self._devices.get(obj.id) == obj
         if isinstance(obj, str):
             self._report_deprecated_use()
@@ -1788,7 +1796,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     _devices: ActiveDeviceRegistryItems
     devices: Collection[DeviceEntry]
     child_devices: ChildDeviceRegistryItems
-    deleted_devices: DeletedDeviceRegistryItems
+    _deleted_devices: DeletedDeviceRegistryItems
+    deleted_devices: Collection[DeletedDeviceEntry]
     _device_data: dict[str, DeviceEntry]
     _child_device_data: dict[str, ChildDeviceEntry]
 
@@ -2389,7 +2398,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         if device is None:
             is_new = True
 
-            deleted_device = self.deleted_devices.get_entry(
+            deleted_device = self._deleted_devices.get_entry(
                 connections=connections,
                 identifiers=identifiers,
                 config_entry_id=config_entry_id,
@@ -2400,7 +2409,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 # rather than create a fresh device. Matching on the recorded domain keeps
                 # a chance identifier/connection collision from restoring another
                 # integration's device.
-                deleted_device = self.deleted_devices.get_orphaned_entry(
+                deleted_device = self._deleted_devices.get_orphaned_entry(
                     identifiers, connections, config_entry.domain
                 )
             if deleted_device is None:
@@ -2427,7 +2436,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 )
 
             else:
-                self.deleted_devices.pop(deleted_device.id)
+                self._deleted_devices.pop(deleted_device.id)
                 device = deleted_device.to_device_entry(
                     config_entry,
                     # Interpret not specifying a subentry as None
@@ -2738,14 +2747,14 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         if child_device is None:
             is_new = True
 
-            deleted_device = self.deleted_devices.get_entry(
+            deleted_device = self._deleted_devices.get_entry(
                 identifiers=identifiers,
                 config_entry_id=config_entry_id,
             )
             if deleted_device is None:
                 # Fall back to an orphan (its owning config entry was removed), as
                 # for a full device
-                deleted_device = self.deleted_devices.get_orphaned_entry(
+                deleted_device = self._deleted_devices.get_orphaned_entry(
                     identifiers, None, domain
                 )
             if deleted_device is None:
@@ -2767,7 +2776,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                     parent_device_id=parent.id,
                 )
             else:
-                self.deleted_devices.pop(deleted_device.id)
+                self._deleted_devices.pop(deleted_device.id)
                 child_device = deleted_device.to_child_device_entry(
                     config_entry,
                     effective_config_subentry_id,
@@ -3384,13 +3393,13 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             match_identifiers = added_identifiers
             match_connections = added_connections
         # A deleted device holding an identity the device now owns can never restore
-        for deleted_device_id in self.deleted_devices.get_colliding_device_ids(
+        for deleted_device_id in self._deleted_devices.get_colliding_device_ids(
             match_identifiers or set(),
             match_connections or set(),
             config_entry_id=effective_config_entry_id,
             exclude_device_id=None,
         ):
-            del self.deleted_devices[deleted_device_id]
+            del self._deleted_devices[deleted_device_id]
 
         # If its only run time attributes (suggested_area)
         # that do not get saved we do not want to write
@@ -3576,13 +3585,13 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         # A deleted device holding an identity the child device now owns can never
         # restore
-        for deleted_device_id in self.deleted_devices.get_colliding_device_ids(
+        for deleted_device_id in self._deleted_devices.get_colliding_device_ids(
             added_identifiers or set(),
             set(),
             config_entry_id=old.config_entry_id,
             exclude_device_id=None,
         ):
-            del self.deleted_devices[deleted_device_id]
+            del self._deleted_devices[deleted_device_id]
 
         self.async_schedule_save()
 
@@ -3883,7 +3892,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         elif not device.has_composite_identifiers:
             identifiers = device.identifiers | identifiers
             connections = device.connections | connections
-        colliding = self.deleted_devices.get_colliding_device_ids(
+        colliding = self._deleted_devices.get_colliding_device_ids(
             identifiers,
             connections,
             config_entry_id=device.config_entry_id,
@@ -3898,7 +3907,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 deleted_device_id,
                 device.id,
             )
-            del self.deleted_devices[deleted_device_id]
+            del self._deleted_devices[deleted_device_id]
         self.async_schedule_save()
 
     @callback
@@ -4054,7 +4063,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_remove_child_device(child)
         device = self._devices.pop(device_id)
         config_entry = self.hass.config_entries.async_get_entry(device.config_entry_id)
-        self.deleted_devices[device_id] = DeletedDeviceEntry(
+        self._deleted_devices[device_id] = DeletedDeviceEntry(
             area_id=device.area_id,
             config_entry_id=device.config_entry_id,
             config_subentry_id=device.config_subentry_id,
@@ -4088,7 +4097,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         config_entry = self.hass.config_entries.async_get_entry(
             child_device.config_entry_id
         )
-        self.deleted_devices[child_device.id] = DeletedDeviceEntry(
+        self._deleted_devices[child_device.id] = DeletedDeviceEntry(
             area_id=child_device.area_id,
             config_entry_id=child_device.config_entry_id,
             config_subentry_id=child_device.config_subentry_id,
@@ -4262,9 +4271,23 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             )
 
         self._devices = devices
-        self.devices = _DeprecatedDeviceRegistryItemsView(self._devices)
+        self.devices = _DeprecatedRegistryItemsView(
+            self._devices,
+            DeviceEntry,
+            "uses `device_registry.devices` as a mapping or calls its lookup "
+            "methods, which is deprecated; iterate it to get the device entries, "
+            "or use `async_get`, `async_entries_for_config_entry` and similar "
+            "helpers for lookups",
+        )
         self.child_devices = child_devices
-        self.deleted_devices = deleted_devices
+        self._deleted_devices = deleted_devices
+        self.deleted_devices = _DeprecatedRegistryItemsView(
+            self._deleted_devices,
+            DeletedDeviceEntry,
+            "uses `device_registry.deleted_devices` as a mapping or calls its "
+            "lookup methods, which is deprecated; iterate it to get the deleted "
+            "device entries",
+        )
         self._device_data = devices.data
         self._child_device_data = child_devices.data
 
@@ -4294,7 +4317,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             ],
             "deleted_devices": [
                 entry.as_storage_fragment
-                for entry in list(self.deleted_devices.values())
+                for entry in list(self._deleted_devices.values())
             ],
         }
 
@@ -4322,7 +4345,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             # device from the same integration is orphaned, drop any existing orphan
             # it overlaps so the newest one wins deterministically instead of shadowing
             # it.
-            for existing in list(self.deleted_devices.values()):
+            for existing in list(self._deleted_devices.values()):
                 if (
                     existing.config_entry_id is None
                     and existing.domain == domain
@@ -4331,8 +4354,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                         or existing.identifiers & deleted_device.identifiers
                     )
                 ):
-                    del self.deleted_devices[existing.id]
-        self.deleted_devices[deleted_device.id] = attr.evolve(
+                    del self._deleted_devices[existing.id]
+        self._deleted_devices[deleted_device.id] = attr.evolve(
             deleted_device,
             config_entry_id=None,
             config_subentry_id=None,
@@ -4381,7 +4404,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_entry_id == config_entry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
-        for deleted_device in list(self.deleted_devices.values()):
+        for deleted_device in list(self._deleted_devices.values()):
             if deleted_device.config_entry_id != config_entry_id:
                 continue
             self._async_orphan_deleted_device(deleted_device, domain, now_time)
@@ -4416,7 +4439,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_subentry_id == config_subentry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
-        for deleted_device in list(self.deleted_devices.values()):
+        for deleted_device in list(self._deleted_devices.values()):
             if (
                 deleted_device.config_entry_id != config_entry_id
                 or deleted_device.config_subentry_id != config_subentry_id
@@ -4432,7 +4455,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         growing without bound.
         """
         now_time = time.time()
-        for deleted_device in list(self.deleted_devices.values()):
+        for deleted_device in list(self._deleted_devices.values()):
             if deleted_device.orphaned_timestamp is None:
                 continue
 
@@ -4440,7 +4463,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 deleted_device.orphaned_timestamp + ORPHANED_DEVICE_KEEP_SECONDS
                 < now_time
             ):
-                del self.deleted_devices[deleted_device.id]
+                del self._deleted_devices[deleted_device.id]
 
     @callback
     def async_clear_area_id(self, area_id: str) -> None:
@@ -4449,10 +4472,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_device(device.id, area_id=None)
         for child_device in self.child_devices.get_devices_for_area_id(area_id):
             self._async_update_child_device(child_device.id, area_id=None)
-        for deleted_device in list(self.deleted_devices.values()):
+        for deleted_device in list(self._deleted_devices.values()):
             if deleted_device.area_id != area_id:
                 continue
-            self.deleted_devices[deleted_device.id] = attr.evolve(
+            self._deleted_devices[deleted_device.id] = attr.evolve(
                 deleted_device, area_id=None
             )
             self.async_schedule_save()
@@ -4466,10 +4489,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_child_device(
                 child_device.id, labels=child_device.labels - {label_id}
             )
-        for deleted_device in list(self.deleted_devices.values()):
+        for deleted_device in list(self._deleted_devices.values()):
             if label_id not in deleted_device.labels:
                 continue
-            self.deleted_devices[deleted_device.id] = attr.evolve(
+            self._deleted_devices[deleted_device.id] = attr.evolve(
                 deleted_device, labels=deleted_device.labels - {label_id}
             )
             self.async_schedule_save()

--- a/tests/common.py
+++ b/tests/common.py
@@ -768,7 +768,8 @@ def mock_device_registry(
         mock_entries = {}
     for key, entry in mock_entries.items():
         registry._devices[key] = entry
-    registry.deleted_devices = dr.DeletedDeviceRegistryItems()
+    registry._deleted_devices = dr.DeletedDeviceRegistryItems()
+    registry.deleted_devices = registry._deleted_devices.values()
 
     hass.data[dr.DATA_REGISTRY] = registry
     return registry

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -462,7 +462,7 @@ async def test_loading_from_storage(
     assert loaded_child.disabled_by is dr.DeviceEntryDisabler.DEVICE
     assert loaded_child.identifiers == {("test", "strip_outlet_1")}
 
-    assert registry.deleted_devices["bcdefghijklmn"] == dr.DeletedDeviceEntry(
+    assert registry._deleted_devices["bcdefghijklmn"] == dr.DeletedDeviceEntry(
         area_id="12345A",
         config_entry_id=mock_config_entry.entry_id,
         config_subentry_id=None,
@@ -604,7 +604,7 @@ async def test_migration_from_1_1(
     )
     assert entry.id == "abcdefghijklm"
 
-    deleted_entry = registry.deleted_devices["deletedid"]
+    deleted_entry = registry._deleted_devices["deletedid"]
     assert deleted_entry.disabled_by is UNDEFINED
 
     # Update to trigger a store
@@ -1669,7 +1669,7 @@ async def test_migration_from_1_10(
         identifiers={("serial", "123456ABCDEF")},
     )
     assert entry.id == "abcdefghijklm"
-    deleted_entry = registry.deleted_devices.get_entry(
+    deleted_entry = registry._deleted_devices.get_entry(
         connections=set(),
         identifiers={("serial", "123456ABCDAB")},
     )
@@ -1812,7 +1812,7 @@ async def test_migration_from_1_11(
         identifiers={("serial", "123456ABCDEF")},
     )
     assert entry.id == "abcdefghijklm"
-    deleted_entry = registry.deleted_devices.get_entry(
+    deleted_entry = registry._deleted_devices.get_entry(
         connections=set(),
         identifiers={("serial", "123456ABCDAB")},
     )
@@ -2901,7 +2901,7 @@ async def test_move_to_config_entry_clears_target_entry_deleted_device(
 
     # Leave a deleted device owned by entry_b with the shared identity
     device_registry.async_remove_device(device_b.id)
-    assert device_b.id in device_registry.deleted_devices
+    assert device_b.id in device_registry._deleted_devices
 
     # Move device_a into entry_b, retaining its identity
     device_registry.async_update_device(
@@ -2910,7 +2910,7 @@ async def test_move_to_config_entry_clears_target_entry_deleted_device(
 
     assert device_registry.async_get(device_a.id).config_entry_id == entry_b.entry_id
     # The deleted device entry_b held for the same identity is cleared, not left immortal
-    assert device_b.id not in device_registry.deleted_devices
+    assert device_b.id not in device_registry._deleted_devices
 
 
 async def test_get_or_create_via_device_and_via_device_id_raises_cleanly(
@@ -3001,7 +3001,7 @@ async def test_reregister_restores_orphan(
 
     # Removing the config entry orphans the deleted device (config_entry_id=None)
     device_registry.async_clear_config_entry(entry.entry_id, clear_domain)
-    orphan = device_registry.deleted_devices[device.id]
+    orphan = device_registry._deleted_devices[device.id]
     assert orphan.config_entry_id is None
     assert orphan.domain == "light"
 
@@ -3032,7 +3032,7 @@ async def test_orphan_not_restored_for_other_domain(
         config_entry_id=entry.entry_id, identifiers={("light", "1")}
     )
     device_registry.async_clear_config_entry(entry.entry_id, entry.domain)
-    assert device_registry.deleted_devices[device.id].domain == "light"
+    assert device_registry._deleted_devices[device.id].domain == "light"
 
     # A different integration registering a device with the same identifiers gets a fresh
     # device, and the orphan is left intact for its own integration to restore later
@@ -3042,7 +3042,7 @@ async def test_orphan_not_restored_for_other_domain(
         config_entry_id=other_entry.entry_id, identifiers={("light", "1")}
     )
     assert fresh.id != device.id
-    assert device.id in device_registry.deleted_devices
+    assert device.id in device_registry._deleted_devices
 
 
 async def test_orphaning_replaces_colliding_same_domain_orphan(
@@ -3071,12 +3071,12 @@ async def test_orphaning_replaces_colliding_same_domain_orphan(
     )
 
     device_registry.async_clear_config_entry(entry_1.entry_id, entry_1.domain)
-    assert device_1.id in device_registry.deleted_devices
+    assert device_1.id in device_registry._deleted_devices
 
     device_registry.async_clear_config_entry(entry_2.entry_id, entry_2.domain)
     # The newer orphan replaces the stale one it collides with on the shared connection
-    assert device_1.id not in device_registry.deleted_devices
-    assert device_2.id in device_registry.deleted_devices
+    assert device_1.id not in device_registry._deleted_devices
+    assert device_2.id in device_registry._deleted_devices
 
     # Re-adding under the same domain restores the surviving orphan
     entry_3 = MockConfigEntry(domain="hue")
@@ -3104,7 +3104,7 @@ async def test_orphaned_domain_survives_store_round_trip(
     await flush_store(device_registry._store)
     await registry2.async_load()
 
-    assert registry2.deleted_devices[device.id].domain == "hue"
+    assert registry2._deleted_devices[device.id].domain == "hue"
 
 
 async def test_orphan_keeps_domain_when_config_entry_removed(
@@ -3126,7 +3126,7 @@ async def test_orphan_keeps_domain_when_config_entry_removed(
 
     await hass.config_entries.async_remove(entry.entry_id)
 
-    orphan = device_registry.deleted_devices[device.id]
+    orphan = device_registry._deleted_devices[device.id]
     assert orphan.config_entry_id is None
     assert orphan.domain == "hue"
 
@@ -3189,7 +3189,7 @@ async def test_domainless_orphan_not_restored(
     # orphans over without one)
     with patch.object(hass.config_entries, "async_get_entry", return_value=None):
         device_registry.async_clear_config_entry(entry_1.entry_id)
-    assert device_registry.deleted_devices[device_1.id].domain is None
+    assert device_registry._deleted_devices[device_1.id].domain is None
 
     # Re-registering the shared identifier does not restore the domain-less orphan
     entry_2 = MockConfigEntry(domain="hue")
@@ -3199,7 +3199,7 @@ async def test_domainless_orphan_not_restored(
     )
     assert fresh.id != device_1.id
     # The un-restored orphan lingers until the periodic purge
-    assert device_1.id in device_registry.deleted_devices
+    assert device_1.id in device_registry._deleted_devices
 
 
 async def test_clear_config_subentry_removes_device_with_pending_move(
@@ -3797,8 +3797,8 @@ async def test_migration_splits_deleted_device_with_multiple_config_entries(
 
     # Split into one deleted device per config entry, each keeping identity/customizations
     assert len(registry.deleted_devices) == 2
-    assert "deletedcomposite0000000000000" not in registry.deleted_devices
-    by_entry = {d.config_entry_id: d for d in registry.deleted_devices.values()}
+    assert "deletedcomposite0000000000000" not in registry._deleted_devices
+    by_entry = {d.config_entry_id: d for d in registry._deleted_devices.values()}
     assert set(by_entry) == {entry_a.entry_id, entry_b.entry_id}
     for deleted in by_entry.values():
         assert deleted.identifiers == {("domain_a", "1")}
@@ -3889,15 +3889,15 @@ async def test_deleted_device_removing_config_entries(
 
     # Deleted devices are kept but orphaned (config entry cleared) so they can be purged
     assert len(device_registry.deleted_devices) == 2
-    assert device_registry.deleted_devices[entry.id].config_entry_id is None
+    assert device_registry._deleted_devices[entry.id].config_entry_id is None
     assert (
-        device_registry.deleted_devices[entry2.id].config_entry_id
+        device_registry._deleted_devices[entry2.id].config_entry_id
         == config_entry_2.entry_id
     )
 
     device_registry.async_clear_config_entry(config_entry_2.entry_id)
     assert len(device_registry.deleted_devices) == 2
-    assert device_registry.deleted_devices[entry2.id].config_entry_id is None
+    assert device_registry._deleted_devices[entry2.id].config_entry_id is None
 
 
 async def test_removing_config_subentries(
@@ -3998,9 +3998,9 @@ async def test_deleted_device_removing_config_subentries(
 
     # Only the deleted device on the cleared subentry is orphaned
     assert len(device_registry.deleted_devices) == 2
-    assert device_registry.deleted_devices[entry.id].config_entry_id is None
+    assert device_registry._deleted_devices[entry.id].config_entry_id is None
     assert (
-        device_registry.deleted_devices[entry2.id].config_entry_id
+        device_registry._deleted_devices[entry2.id].config_entry_id
         == config_entry.entry_id
     )
 
@@ -4345,26 +4345,61 @@ async def test_update_device_unknown_via_device_id_raises_before_removal(
     assert device_registry.async_get(device.id) == device
 
 
-async def test_devices_collection_operations(
+def _keep_active_device(
+    device_registry: dr.DeviceRegistry, entry: dr.DeviceEntry
+) -> dr.DeviceEntry:
+    """Leave the device active; the active entry is the `devices` view's value."""
+    return entry
+
+
+def _delete_device(
+    device_registry: dr.DeviceRegistry, entry: dr.DeviceEntry
+) -> dr.DeletedDeviceEntry:
+    """Remove the device and return the resulting `deleted_devices` view value."""
+    device_registry.async_remove_device(entry.id)
+    return device_registry._deleted_devices[entry.id]
+
+
+# The `devices` and `deleted_devices` views share the same deprecation machinery; each
+# param carries the view's attribute name and how to reach an entry in it.
+_REGISTRY_CONTAINER_PARAMS = [
+    pytest.param("devices", _keep_active_device, id="devices"),
+    pytest.param("deleted_devices", _delete_device, id="deleted_devices"),
+]
+
+
+@pytest.mark.parametrize(
+    ("container_attr", "prepare_entry"), _REGISTRY_CONTAINER_PARAMS
+)
+async def test_registry_items_view_collection_operations(
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
+    container_attr: str,
+    prepare_entry: Callable[
+        [dr.DeviceRegistry, dr.DeviceEntry], dr.DeviceEntry | dr.DeletedDeviceEntry
+    ],
 ) -> None:
-    """Test the supported `Collection[DeviceEntry]` surface of `DeviceRegistry.devices`.
+    """Test the supported `Collection` surface of the `devices`/`deleted_devices` views.
 
-    Iteration yields the entries (not the ids), `len()` returns the count, and
-    `DeviceEntry` membership works.
+    Iteration yields the entries (not the ids), `len()` returns the count, and entry
+    membership works.
     """
     entry = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("bridgeid", "0123")},
     )
+    expected_entry = prepare_entry(device_registry, entry)
+    view = getattr(device_registry, container_attr)
 
-    assert list(device_registry.devices) == [entry]
-    assert [device.id for device in device_registry.devices] == [entry.id]
-    assert len(device_registry.devices) == 1
-    assert entry in device_registry.devices
+    assert list(view) == [expected_entry]
+    assert [item.id for item in view] == [entry.id]
+    assert len(view) == 1
+    assert expected_entry in view
 
 
+@pytest.mark.parametrize(
+    ("container_attr", "prepare_entry"), _REGISTRY_CONTAINER_PARAMS
+)
 @pytest.mark.parametrize(
     ("integration_frame_path", "expectation", "expected_log"),
     [
@@ -4386,14 +4421,18 @@ async def test_devices_collection_operations(
     ],
 )
 @pytest.mark.usefixtures("mock_integration_frame")
-async def test_devices_mapping_access_deprecated(
+async def test_registry_items_view_mapping_access_deprecated(
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
     expectation: AbstractContextManager,
     expected_log: int,
+    container_attr: str,
+    prepare_entry: Callable[
+        [dr.DeviceRegistry, dr.DeviceEntry], dr.DeviceEntry | dr.DeletedDeviceEntry
+    ],
 ) -> None:
-    """Test mapping-style access to `DeviceRegistry.devices` is deprecated.
+    """Test mapping-style access to the `devices`/`deleted_devices` views is deprecated.
 
     It logs for custom integrations and raises for core and core integrations, while
     iterating the view keeps working for every caller.
@@ -4402,42 +4441,53 @@ async def test_devices_mapping_access_deprecated(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("bridgeid", "0123")},
     )
-    what = "uses `device_registry.devices` as a mapping"
+    expected_entry = prepare_entry(device_registry, entry)
+    view = getattr(device_registry, container_attr)
+    what = f"uses `device_registry.{container_attr}` as a mapping"
 
     # Iterating the view is the supported API and is never reported.
-    assert list(device_registry.devices) == [entry]
+    assert list(view) == [expected_entry]
     assert caplog.text.count(what) == 0
 
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
-        _ = device_registry.devices[entry.id]
+        _ = view[entry.id]
 
     assert caplog.text.count(what) == expected_log
 
 
 @pytest.mark.parametrize(
+    ("container_attr", "prepare_entry"), _REGISTRY_CONTAINER_PARAMS
+)
+@pytest.mark.parametrize(
     "integration_frame_path", ["custom_components/test_integration"]
 )
 @pytest.mark.usefixtures("mock_integration_frame")
-async def test_devices_membership_by_entry_supported_by_id_deprecated(
+async def test_registry_items_view_membership_by_entry_supported_by_id_deprecated(
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
+    container_attr: str,
+    prepare_entry: Callable[
+        [dr.DeviceRegistry, dr.DeviceEntry], dr.DeviceEntry | dr.DeletedDeviceEntry
+    ],
 ) -> None:
-    """Test `DeviceEntry` membership is supported while device-id (str) membership warns."""
+    """Test entry membership is supported while device-id (str) membership warns."""
     entry = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("bridgeid", "0123")},
     )
-    what = "uses `device_registry.devices` as a mapping"
+    expected_entry = prepare_entry(device_registry, entry)
+    view = getattr(device_registry, container_attr)
+    what = f"uses `device_registry.{container_attr}` as a mapping"
 
-    # DeviceEntry (value) membership is supported and never reported.
-    assert entry in device_registry.devices
+    # Entry (value) membership is supported and never reported.
+    assert expected_entry in view
     assert caplog.text.count(what) == 0
 
     # Device-id (str) membership is the deprecated key lookup; it warns here (custom
     # integration).
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
-        assert entry.id in device_registry.devices
+        assert entry.id in view
     assert caplog.text.count(what) == 1
 
 
@@ -5113,7 +5163,7 @@ async def test_loading_saving_data(
 
     # Ensure same order
     assert list(device_registry._devices) == list(registry2._devices)
-    assert list(device_registry.deleted_devices) == list(registry2.deleted_devices)
+    assert list(device_registry._deleted_devices) == list(registry2._deleted_devices)
 
     new_via = registry2.async_get_device(identifiers={("hue", "0123")})
     new_light = registry2.async_get_device(identifiers={("hue", "456")})
@@ -5931,8 +5981,8 @@ async def test_create_reflects_config_entry_disabled_state(
     # Restoring a deleted device from a legacy store without a recorded
     # disabled_by is reconciled the same way
     device_registry.async_remove_device(device.id)
-    deleted_entry = device_registry.deleted_devices[device.id]
-    device_registry.deleted_devices[device.id] = attr.evolve(
+    deleted_entry = device_registry._deleted_devices[device.id]
+    device_registry._deleted_devices[device.id] = attr.evolve(
         deleted_entry, disabled_by=UNDEFINED
     )
     restored = device_registry.async_get_or_create(
@@ -7033,7 +7083,7 @@ async def test_deleted_device_to_device_entry_uses_reregistered_identity(
         identifiers={("bridgeid", "0123")},
     )
     device_registry.async_remove_device(entry.id)
-    deleted_device = device_registry.deleted_devices[entry.id]
+    deleted_device = device_registry._deleted_devices[entry.id]
 
     restored = deleted_device.to_device_entry(
         mock_config_entry,
@@ -7097,8 +7147,8 @@ async def test_restore_migrated_device_disabled_by(
     assert len(device_registry.devices) == 0
     assert len(device_registry.deleted_devices) == 1
 
-    deleted_entry = device_registry.deleted_devices[entry.id]
-    device_registry.deleted_devices[entry.id] = attr.evolve(
+    deleted_entry = device_registry._deleted_devices[entry.id]
+    device_registry._deleted_devices[entry.id] = attr.evolve(
         deleted_entry, disabled_by=UNDEFINED
     )
 
@@ -7271,8 +7321,8 @@ async def test_restore_disabled_by(
     # last changed - deleted devices are not updated when a config entry is
     # enabled or disabled, so the stored flag can contradict the entry's
     # current disabled state.
-    deleted_entry = device_registry.deleted_devices[entry.id]
-    device_registry.deleted_devices[entry.id] = attr.evolve(
+    deleted_entry = device_registry._deleted_devices[entry.id]
+    device_registry._deleted_devices[entry.id] = attr.evolve(
         deleted_entry, disabled_by=device_disabled_by_deleted
     )
 
@@ -8752,7 +8802,7 @@ async def test_legacy_duplicate_fully_stripped_device_removed(
     assert registered.id == "device"
     assert registered.identifiers == {("test", "device"), ("test", "shared")}
     assert device_registry.async_get("stale") is None
-    assert "stale" not in device_registry.deleted_devices
+    assert "stale" not in device_registry._deleted_devices
     assert (
         device_registry.async_get_device(identifiers={("test", "shared")}).id
         == "device"
@@ -8851,7 +8901,7 @@ async def test_loading_from_storage_with_legacy_duplicates(
     )
     assert registered.id == "new"
     assert registry.async_get("old") is None
-    assert "old" not in registry.deleted_devices
+    assert "old" not in registry._deleted_devices
 
     # The reconciled state is persisted
     await flush_store(registry._store)
@@ -8882,13 +8932,13 @@ async def test_registration_purges_same_entry_deleted_duplicates(
             ),
         },
     )
-    device_registry.deleted_devices["deleted_shadowed"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_shadowed"] = _mock_deleted_device(
         "deleted_shadowed", entry.entry_id, {("test", "shared"), ("test", "other")}
     )
-    device_registry.deleted_devices["deleted_winner"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_winner"] = _mock_deleted_device(
         "deleted_winner", entry.entry_id, {("test", "shared")}
     )
-    device_registry.deleted_devices["deleted_other_entry"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_other_entry"] = _mock_deleted_device(
         "deleted_other_entry", other_entry.entry_id, {("test", "shared")}
     )
 
@@ -8897,9 +8947,9 @@ async def test_registration_purges_same_entry_deleted_duplicates(
     )
 
     assert registered.id == "device"
-    assert "deleted_winner" not in device_registry.deleted_devices
-    assert "deleted_shadowed" not in device_registry.deleted_devices
-    assert "deleted_other_entry" in device_registry.deleted_devices
+    assert "deleted_winner" not in device_registry._deleted_devices
+    assert "deleted_shadowed" not in device_registry._deleted_devices
+    assert "deleted_other_entry" in device_registry._deleted_devices
     # The purge is persisted
     await flush_store(device_registry._store)
     assert [
@@ -8915,10 +8965,10 @@ async def test_restore_purges_same_entry_deleted_duplicate(
     entry = MockConfigEntry(domain="test")
     entry.add_to_hass(hass)
     device_registry = mock_device_registry(hass)
-    device_registry.deleted_devices["deleted_shadowed"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_shadowed"] = _mock_deleted_device(
         "deleted_shadowed", entry.entry_id, {("test", "shared")}
     )
-    device_registry.deleted_devices["deleted_winner"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_winner"] = _mock_deleted_device(
         "deleted_winner", entry.entry_id, {("test", "shared")}
     )
 
@@ -8927,8 +8977,8 @@ async def test_restore_purges_same_entry_deleted_duplicate(
     )
 
     assert restored.id == "deleted_winner"
-    assert "deleted_winner" not in device_registry.deleted_devices
-    assert "deleted_shadowed" not in device_registry.deleted_devices
+    assert "deleted_winner" not in device_registry._deleted_devices
+    assert "deleted_shadowed" not in device_registry._deleted_devices
     assert len(device_registry.devices) == 1
 
 
@@ -8945,10 +8995,10 @@ async def test_add_identifier_prunes_shadowed_deleted_duplicates(
     device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id, identifiers={("test", "device")}
     )
-    device_registry.deleted_devices["deleted_shadowed"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_shadowed"] = _mock_deleted_device(
         "deleted_shadowed", entry.entry_id, {("test", "shared")}
     )
-    device_registry.deleted_devices["deleted_winner"] = _mock_deleted_device(
+    device_registry._deleted_devices["deleted_winner"] = _mock_deleted_device(
         "deleted_winner", entry.entry_id, {("test", "shared"), ("test", "other")}
     )
 
@@ -8956,8 +9006,8 @@ async def test_add_identifier_prunes_shadowed_deleted_duplicates(
         device.id, merge_identifiers={("test", "shared")}
     )
 
-    assert "deleted_winner" not in device_registry.deleted_devices
-    assert "deleted_shadowed" not in device_registry.deleted_devices
+    assert "deleted_winner" not in device_registry._deleted_devices
+    assert "deleted_shadowed" not in device_registry._deleted_devices
 
 
 async def test_via_device_id_to_removed_stale_duplicate_raises(
@@ -10657,8 +10707,8 @@ async def test_remove_parent_cascades_to_children(
     assert device_registry.async_get(parent.id) is None
     assert device_registry.async_get(child_device.id) is None
     assert not device_registry.child_devices
-    assert child_device.id in device_registry.deleted_devices
-    assert parent.id in device_registry.deleted_devices
+    assert child_device.id in device_registry._deleted_devices
+    assert parent.id in device_registry._deleted_devices
 
     await hass.async_block_till_done()
     assert [event.data for event in remove_events] == [
@@ -12404,13 +12454,13 @@ async def test_update_child_identifiers_purges_colliding_deleted_device(
         name="Ghost",
     )
     device_registry.async_remove_device(ghost.id)
-    assert ghost.id in device_registry.deleted_devices
+    assert ghost.id in device_registry._deleted_devices
 
     device_registry.async_update_child_device(
         child_device.id,
         new_identifiers={("test", "strip_outlet_1"), ("test", "ghost")},
     )
-    assert ghost.id not in device_registry.deleted_devices
+    assert ghost.id not in device_registry._deleted_devices
 
 
 @pytest.mark.usefixtures("hass")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Protect the `DeviceRegistry.deleted_devices` container

Rationale:
The `deleted_devices` container is not meant for external use, users should call public `DeviceRegistry` methods or module level helper functions.

This is the same similar solution as #179578 which protects the `devices` container

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
