### PR TITLE
Fix EntityRegistry.async_clear_config_subentry ignoring config entry scope

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -2450,7 +2450,10 @@ class EntityRegistry(BaseRegistry):
         ]:
             self.async_remove(entity_id)
         for key, deleted_entity in list(self.deleted_entities.items()):
-            if config_subentry_id != deleted_entity.config_subentry_id:
+            if (
+                deleted_entity.config_entry_id != config_entry_id
+                or deleted_entity.config_subentry_id != config_subentry_id
+            ):
                 continue
             # Add a time stamp when the deleted entity became orphaned
             self.deleted_entities[key] = attr.evolve(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1821,6 +1821,62 @@ async def test_deleted_entity_removing_config_subentry_id(
     assert entity_registry.deleted_entities[("light", "hue", "1234")] == deleted_entry2
 
 
+async def test_deleted_entity_removing_config_subentry_id_scoped_to_config_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test clearing a config subentry only touches deleted entities of that config entry."""
+    subentry_data = config_entries.ConfigSubentryData(
+        data={},
+        subentry_id="shared-subentry-id",
+        subentry_type="test",
+        title="Mock title",
+        unique_id="test",
+    )
+    mock_config1 = MockConfigEntry(
+        domain="light", entry_id="mock-id-1", subentries_data=[subentry_data]
+    )
+    mock_config2 = MockConfigEntry(
+        domain="light", entry_id="mock-id-2", subentries_data=[subentry_data]
+    )
+    mock_config1.add_to_hass(hass)
+    mock_config2.add_to_hass(hass)
+
+    entry1 = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=mock_config1,
+        config_subentry_id="shared-subentry-id",
+    )
+    entry2 = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        config_entry=mock_config2,
+        config_subentry_id="shared-subentry-id",
+    )
+    entity_registry.async_remove(entry1.entity_id)
+    entity_registry.async_remove(entry2.entity_id)
+
+    assert len(entity_registry.deleted_entities) == 2
+
+    # Clearing the subentry for config entry 1 must not orphan the deleted
+    # entity that belongs to config entry 2, even though both share the same
+    # config_subentry_id.
+    entity_registry.async_clear_config_subentry("mock-id-1", "shared-subentry-id")
+
+    deleted_entry1 = entity_registry.deleted_entities[("light", "hue", "5678")]
+    assert deleted_entry1.config_entry_id is None
+    assert deleted_entry1.config_subentry_id is None
+    assert deleted_entry1.orphaned_timestamp is not None
+
+    deleted_entry2 = entity_registry.deleted_entities[("light", "hue", "1234")]
+    assert deleted_entry2.config_entry_id == "mock-id-2"
+    assert deleted_entry2.config_subentry_id == "shared-subentry-id"
+    assert deleted_entry2.orphaned_timestamp is None
+
+
 async def test_removing_area_id(entity_registry: er.EntityRegistry) -> None:
     """Make sure we can clear area id."""
     entry = entity_registry.async_get_or_create("light", "hue", "5678")


### PR DESCRIPTION
## Proposed change

`EntityRegistry.async_clear_config_subentry` clears the deleted-entities index by matching only `config_subentry_id`, ignoring `config_entry_id`. This is inconsistent with the live-entity loop in the very same method (which filters by both fields) and with `DeviceRegistry`'s equivalent method, which checks both. A deleted entity whose `config_subentry_id` happens to match, but that belongs to a different config entry, gets its `orphaned_timestamp` reset and `config_subentry_id` cleared incorrectly.

This fixes the deleted-entities loop to require both `config_entry_id` and `config_subentry_id` to match, mirroring `DeviceRegistry.async_clear_config_subentry`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr