### PR TITLE
Handle a missing Alexa link when syncing entities

### DIFF
--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -383,7 +383,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
 
             # State reporting is reported as a property on entities.
             # So when we change it, we need to sync all entities.
-            await self.async_sync_entities()
+            await self._async_sync_entities_unless_relink_needed()
             return
 
         # Nothing to do if no Alexa related things have changed
@@ -396,7 +396,14 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         ):
             return
 
-        await self.async_sync_entities()
+        await self._async_sync_entities_unless_relink_needed()
+
+    async def _async_sync_entities_unless_relink_needed(self) -> None:
+        """Sync entities, tolerating an account with no linked Alexa skill."""
+        try:
+            await self.async_sync_entities()
+        except alexa_errors.NoTokenAvailable, alexa_errors.RequireRelink:
+            await self.set_authorized(False)
 
     @callback
     def _async_exposed_entities_updated(self) -> None:

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -905,3 +905,56 @@ async def test_alexa_config_migrate_expose_entity_prefs_default(
     assert async_get_entity_settings(hass, water_heater.entity_id) == {
         "cloud.alexa": {"should_expose": False}
     }
+
+
+@pytest.mark.parametrize(
+    "lib_exception",
+    [
+        pytest.param(
+            AlexaApiNeedsRelinkError("RefreshTokenNotFound"), id="needs_relink"
+        ),
+        pytest.param(AlexaApiNoTokenError("OtherReason"), id="no_token"),
+    ],
+)
+async def test_alexa_config_prefs_update_without_linked_skill(
+    hass: HomeAssistant,
+    cloud_prefs: CloudPreferences,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+    lib_exception: Exception,
+) -> None:
+    """Test updating prefs when the Alexa skill was never linked.
+
+    A freshly registered account has no Alexa refresh token, so syncing
+    entities must not raise out of the preferences listener.
+    """
+    assert await async_setup_component(hass, "homeassistant", {})
+    expose_new(hass, True)
+    entity_entry = entity_registry.async_get_or_create(
+        "fan", "test", "unique", suggested_object_id="test_fan"
+    )
+    hass.states.async_set(entity_entry.entity_id, "off")
+
+    await cloud_prefs.async_update(alexa_enabled=False, alexa_report_state=False)
+    conf = alexa_config.CloudAlexaConfig(
+        hass,
+        ALEXA_SCHEMA({}),
+        "mock-user-id",
+        cloud_prefs,
+        Mock(
+            servicehandlers_server="example",
+            auth=Mock(async_check_token=AsyncMock()),
+            websession=async_get_clientsession(hass),
+            alexa_api=Mock(access_token=AsyncMock(side_effect=lib_exception)),
+        ),
+    )
+    await conf.async_initialize()
+    await conf.set_authorized(True)
+    assert conf.authorized is True
+
+    await cloud_prefs.async_update(alexa_enabled=True)
+    await hass.async_block_till_done()
+
+    # The sync could not authenticate, so the skill is marked as needing a relink.
+    assert conf.authorized is False
+    assert "RequireRelink" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor improvement to the cloud integration - suppresses Alexa-thrown errors on cloud preference sync if Alexa was never linked.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
