### PR TITLE
Fix config entries not recovering from IP address changes in Midea

### DIFF
--- a/homeassistant/components/midea/__init__.py
+++ b/homeassistant/components/midea/__init__.py
@@ -1,7 +1,12 @@
 """The Midea integration."""
 
+from collections.abc import Mapping
+from typing import Any
+
 from midealocal.const import ProtocolVersion
+from midealocal.device import MideaDevice
 from midealocal.devices import device_selector
+from midealocal.discover import discover
 
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -17,24 +22,19 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
-from .const import CONF_KEY, CONF_SUBTYPE
+from .const import CONF_KEY, CONF_SUBTYPE, LOGGER
 from .entity import MideaConfigEntry
 
 _PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.HUMIDIFIER]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: MideaConfigEntry) -> bool:
-    """Set up Midea from a config entry."""
-
-    data = entry.data
-    device_id: int = data[CONF_DEVICE_ID]
-
-    device = await hass.async_add_executor_job(
-        device_selector,
+def _create_device(data: Mapping[str, Any], ip_address: str) -> MideaDevice | None:
+    """Create the device object for the given entry data and IP address."""
+    return device_selector(
         data[CONF_NAME],
-        device_id,
+        data[CONF_DEVICE_ID],
         data[CONF_TYPE],
-        data[CONF_IP_ADDRESS],
+        ip_address,
         data[CONF_PORT],
         data[CONF_TOKEN],
         data[CONF_KEY],
@@ -43,16 +43,66 @@ async def async_setup_entry(hass: HomeAssistant, entry: MideaConfigEntry) -> boo
         data[CONF_SUBTYPE],
         "",
     )
+
+
+def _connect(device: MideaDevice) -> bool:
+    """Connect to the device, always closing the socket on failure.
+
+    connect() swallows AuthException/SocketException internally and can
+    leave the socket open even though it reports failure, so it must be
+    closed explicitly here to avoid a ResourceWarning.
+    """
+    connected = device.connect(True)
+    if not connected:
+        device.close_socket()
+    return connected
+
+
+def _discover_current_ip(device_id: int) -> str | None:
+    """Look up the device's current IP address via local discovery.
+
+    Devices reply to the discovery broadcast with a persistent device_id
+    regardless of their current IP, so this can find a device that has
+    moved to a new DHCP-assigned address.
+    """
+    found = discover()
+    device = found.get(device_id)
+    return device[CONF_IP_ADDRESS] if device else None
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: MideaConfigEntry) -> bool:
+    """Set up Midea from a config entry."""
+
+    data: Mapping[str, Any] = entry.data
+    device_id: int = data[CONF_DEVICE_ID]
+    ip_address: str = data[CONF_IP_ADDRESS]
+
+    device = await hass.async_add_executor_job(_create_device, data, ip_address)
     if device is None:
         raise ConfigEntryError("Unable to initialize device")
 
-    connected = await hass.async_add_executor_job(device.connect, True)
+    connected = await hass.async_add_executor_job(_connect, device)
     if not connected:
-        # connect() swallows AuthException/SocketException internally and can
-        # leave the socket open even though it reports failure, so it must be
-        # closed explicitly here to avoid a ResourceWarning.
-        await hass.async_add_executor_job(device.close_socket)
-        raise ConfigEntryNotReady(f"Unable to connect to device {device_id}")
+        new_ip_address = await hass.async_add_executor_job(
+            _discover_current_ip, device_id
+        )
+        if new_ip_address and new_ip_address != ip_address:
+            LOGGER.debug(
+                "Device %s moved from %s to %s, updating config entry",
+                device_id,
+                ip_address,
+                new_ip_address,
+            )
+            data = {**data, CONF_IP_ADDRESS: new_ip_address}
+            hass.config_entries.async_update_entry(entry, data=data)
+            new_device = await hass.async_add_executor_job(
+                _create_device, data, new_ip_address
+            )
+            if new_device is not None:
+                device = new_device
+                connected = await hass.async_add_executor_job(_connect, device)
+        if not connected:
+            raise ConfigEntryNotReady(f"Unable to connect to device {device_id}")
 
     # The library's reconnect loop keeps retrying with a growing backoff
     # (up to 600s) without checking for a stop request while sleeping, so

--- a/tests/components/midea/test_init.py
+++ b/tests/components/midea/test_init.py
@@ -103,7 +103,64 @@ async def test_setup_entry_not_ready_on_connect_failure(
             return_value=device,
         ),
         patch.object(device, "connect", return_value=False),
+        patch("homeassistant.components.midea.discover", return_value={}),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert ("close_socket",) in device.calls
+    assert entry.data[CONF_IP_ADDRESS] == _ENTRY_DATA[CONF_IP_ADDRESS]
+
+
+async def test_setup_entry_recovers_ip_on_connect_failure(
+    hass: HomeAssistant,
+) -> None:
+    """Test async_setup_entry loads successfully after discovering a moved device.
+
+    When the stored IP no longer answers, a device with the same device_id
+    found at a different address by the discovery broadcast should update
+    the config entry and connect there, finishing setup normally.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+    stale_device = DummyDevice(DeviceType.AC)
+    recovered_device = DummyDevice(DeviceType.AC)
+
+    with (
+        patch(
+            "homeassistant.components.midea.device_selector",
+            side_effect=[stale_device, recovered_device],
+        ),
+        patch.object(stale_device, "connect", return_value=False),
+        patch(
+            "homeassistant.components.midea.discover",
+            return_value={TEST_DEVICE_ID: {CONF_IP_ADDRESS: "2.2.2.2"}},
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.data[CONF_IP_ADDRESS] == "2.2.2.2"
+    assert recovered_device.daemon is True
+    assert ("open",) in recovered_device.calls
+
+
+async def test_setup_entry_no_recovery_when_device_not_discovered(
+    hass: HomeAssistant,
+) -> None:
+    """Test the stored IP is left untouched when discovery finds no match."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+    device = DummyDevice(DeviceType.AC)
+    with (
+        patch(
+            "homeassistant.components.midea.device_selector",
+            return_value=device,
+        ),
+        patch.object(device, "connect", return_value=False),
+        patch(
+            "homeassistant.components.midea.discover",
+            return_value={TEST_DEVICE_ID + 1: {CONF_IP_ADDRESS: "2.2.2.2"}},
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.data[CONF_IP_ADDRESS] == _ENTRY_DATA[CONF_IP_ADDRESS]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix config entries not recovering from IP address changes in Midea

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179698
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
