### PR TITLE
Add preferred_bitrate option to TTS audio conversion

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -71,6 +71,7 @@ from .models import Voice
 
 __all__ = [
     "ATTR_AUDIO_OUTPUT",
+    "ATTR_PREFERRED_BITRATE",
     "ATTR_PREFERRED_FORMAT",
     "ATTR_PREFERRED_SAMPLE_BYTES",
     "ATTR_PREFERRED_SAMPLE_CHANNELS",
@@ -99,6 +100,7 @@ ATTR_PREFERRED_FORMAT = "preferred_format"
 ATTR_PREFERRED_SAMPLE_RATE = "preferred_sample_rate"
 ATTR_PREFERRED_SAMPLE_CHANNELS = "preferred_sample_channels"
 ATTR_PREFERRED_SAMPLE_BYTES = "preferred_sample_bytes"
+ATTR_PREFERRED_BITRATE = "preferred_bitrate"
 ATTR_MEDIA_PLAYER_ENTITY_ID = "media_player_entity_id"
 ATTR_VOICE = "voice"
 
@@ -108,6 +110,7 @@ _PREFFERED_FORMAT_OPTIONS: Final[set[str]] = {
     ATTR_PREFERRED_SAMPLE_RATE,
     ATTR_PREFERRED_SAMPLE_CHANNELS,
     ATTR_PREFERRED_SAMPLE_BYTES,
+    ATTR_PREFERRED_BITRATE,
 }
 
 CONF_LANG = "language"
@@ -317,6 +320,7 @@ async def _async_convert_audio(
     to_sample_rate: int | None = None,
     to_sample_channels: int | None = None,
     to_sample_bytes: int | None = None,
+    to_bitrate: int | None = None,
 ) -> AsyncGenerator[bytes]:
     """Convert audio to a preferred format using ffmpeg."""
     ffmpeg_manager = ffmpeg.get_ffmpeg_manager(hass)
@@ -345,8 +349,13 @@ async def _async_convert_audio(
     if to_sample_channels is not None:
         command.extend(["-ac", str(to_sample_channels)])
     if to_extension == "mp3":
-        # Max quality for MP3.
-        command.extend(["-q:a", "0"])
+        if to_bitrate is not None:
+            # Constant bitrate. Some hardware decoders cannot handle the
+            # variable bitrate that -q:a produces.
+            command.extend(["-b:a", f"{to_bitrate}k"])
+        else:
+            # Max quality for MP3.
+            command.extend(["-q:a", "0"])
     if to_sample_bytes == 2:
         # 16-bit samples.
         command.extend(["-sample_fmt", "s16"])
@@ -588,6 +597,7 @@ class ResultStream:
                 ATTR_PREFERRED_SAMPLE_RATE,
                 ATTR_PREFERRED_SAMPLE_CHANNELS,
                 ATTR_PREFERRED_SAMPLE_BYTES,
+                ATTR_PREFERRED_BITRATE,
             )
         )
 
@@ -633,6 +643,7 @@ class ResultStream:
             to_sample_rate=self.options.get(ATTR_PREFERRED_SAMPLE_RATE),
             to_sample_channels=self.options.get(ATTR_PREFERRED_SAMPLE_CHANNELS),
             to_sample_bytes=self.options.get(ATTR_PREFERRED_SAMPLE_BYTES),
+            to_bitrate=self.options.get(ATTR_PREFERRED_BITRATE),
         )
         async for chunk in converted_audio:
             yield chunk
@@ -1082,6 +1093,14 @@ class SpeechManager:
         if sample_bytes is not None:
             sample_bytes = int(sample_bytes)
 
+        if ATTR_PREFERRED_BITRATE in supported_options:
+            bitrate = options.get(ATTR_PREFERRED_BITRATE)
+        else:
+            bitrate = options.pop(ATTR_PREFERRED_BITRATE, None)
+
+        if bitrate is not None:
+            bitrate = int(bitrate)
+
         if engine_instance.name is None or engine_instance.name is UNDEFINED:
             raise HomeAssistantError("TTS engine name is not set.")
 
@@ -1134,6 +1153,7 @@ class SpeechManager:
             or (sample_rate is not None)
             or (sample_channels is not None)
             or (sample_bytes is not None)
+            or (bitrate is not None)
         )
 
         if needs_conversion:
@@ -1145,6 +1165,7 @@ class SpeechManager:
                 to_sample_rate=sample_rate,
                 to_sample_channels=sample_channels,
                 to_sample_bytes=sample_bytes,
+                to_bitrate=bitrate,
             )
 
         async for chunk in data_gen:

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1930,6 +1930,54 @@ async def test_async_convert_audio_probe_size(
     ]
 
 
+@pytest.mark.parametrize(
+    ("to_bitrate", "expected_encoder_args"),
+    [
+        pytest.param(None, ["-q:a", "0"], id="default_vbr"),
+        pytest.param(48, ["-b:a", "48k"], id="cbr_48k"),
+    ],
+)
+async def test_async_convert_audio_mp3_bitrate(
+    hass: HomeAssistant,
+    to_bitrate: int | None,
+    expected_encoder_args: list[str],
+) -> None:
+    """Test that a preferred bitrate produces a constant bitrate MP3."""
+    assert await async_setup_component(hass, ffmpeg.DOMAIN, {})
+
+    mock_process = MagicMock()
+    mock_process.stdin.drain = AsyncMock()
+    mock_process.stdout.read = AsyncMock(return_value=b"")
+    mock_process.wait = AsyncMock(return_value=0)
+
+    with patch(
+        "asyncio.create_subprocess_exec", return_value=mock_process
+    ) as mock_create_subprocess_exec:
+        async for _chunk in tts._async_convert_audio(
+            hass,
+            "wav",
+            _audio_data_gen(),
+            "mp3",
+            to_sample_rate=24000,
+            to_sample_channels=1,
+            to_bitrate=to_bitrate,
+        ):
+            pass
+
+    command = list(mock_create_subprocess_exec.call_args.args)
+    input_index = command.index("-i")
+    assert command[input_index + 2 :] == [
+        "-f",
+        "mp3",
+        "-ar",
+        "24000",
+        "-ac",
+        "1",
+        *expected_encoder_args,
+        "pipe:1",
+    ]
+
+
 async def test_default_engine_prefer_entity(
     hass: HomeAssistant,
     mock_tts_entity: MockTTSEntity,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

MP3 output in `_async_convert_audio` is hardcoded to `-q:a 0`, which produces a
variable bitrate stream. A number of hardware MP3 decoders only accept constant
bitrate audio, and there is currently no option that can produce it. The
existing `preferred_*` settings cover format, sample rate, channels and sample
width, but not bitrate.

This PR adds a `preferred_bitrate` option, in kbps, alongside the existing
preferred audio settings. When set, `-b:a <n>k` is used instead of `-q:a 0`.
When absent, behavior is unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Concrete case: first-generation Echo hardware decodes TTS audio with a demuxer
that reads the MPEG frame header of the first frame and rejects anything that is
not 48 kbps / 24 kHz mono, throwing:

```
java.io.IOException: Input file/stream seems to be corrupted or unknown mp3 format,
cannot estimate length of the next mp3 frame:  data-type=14
```

`0x14` there is the third header byte of the first frame - 8 kbps, which is what
`-q:a 0` emits for a leading near-silent frame. With `preferred_format: mp3`,
`preferred_sample_rate: 24000`, `preferred_sample_channels: 1` and
`preferred_bitrate: 48`, every frame header is identical and the audio plays.

I verified the produced stream frame by frame: with `-q:a 0` the clip contains 8
distinct frame-header bytes ranging 8-160 kbps, and with `-b:a 48k` all 79 frames
are byte-identical. Playback then succeeds on the device.

Note that the Xing/Info header is not a factor here: this function always writes
to `pipe:1`, and ffmpeg omits the Xing frame entirely on non-seekable output.

- This PR fixes or closes issue: NA
- This PR is related to issue: #136466 (requested this option; closed as stale, never triaged on the merits)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47552
- Link to developer documentation pull request: NA
- Link to frontend pull request: NA

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
