### PR TITLE
Fix OpenRouter forgetting an empty LLM API selection

### DIFF
--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -207,10 +207,7 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=self.options.get(
-                            CONF_LLM_HASS_API,
-                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
-                        ),
+                        default=self.options.get(CONF_LLM_HASS_API, []),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -146,8 +146,6 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
-            if not user_input.get(CONF_LLM_HASS_API):
-                user_input.pop(CONF_LLM_HASS_API, None)
             if self._is_new:
                 return self.async_create_entry(
                     title=self.models[user_input[CONF_MODEL]].name, data=user_input
@@ -207,7 +205,10 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=self.options.get(CONF_LLM_HASS_API, []),
+                        default=self.options.get(
+                            CONF_LLM_HASS_API,
+                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
+                        ),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -146,6 +146,8 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
+            if user_input.get(CONF_LLM_HASS_API) is None:
+                user_input.pop(CONF_LLM_HASS_API, None)
             if self._is_new:
                 return self.async_create_entry(
                     title=self.models[user_input[CONF_MODEL]].name, data=user_input

--- a/tests/components/open_router/test_config_flow.py
+++ b/tests/components/open_router/test_config_flow.py
@@ -528,3 +528,29 @@ async def test_reconfigure_conversation_subentry_llm_api_schema(
     assert [
         opt["value"] for opt in field_schema.config.get("options")
     ] == expected_options
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_conversation_subentry_no_llm_api(
+    hass: HomeAssistant,
+    mock_open_router_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the llm_hass_api field is empty when the subentry has no LLM API."""
+    await setup_integration(hass, mock_config_entry)
+
+    subentry = next(iter(mock_config_entry.subentries.values()))
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        subentry,
+        data={k: v for k, v in subentry.data.items() if k != CONF_LLM_HASS_API},
+    )
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, subentry.subentry_id
+    )
+
+    schema = result["data_schema"].schema
+    key = next(k for k in schema if k == CONF_LLM_HASS_API)
+    assert key.default() == []

--- a/tests/components/open_router/test_config_flow.py
+++ b/tests/components/open_router/test_config_flow.py
@@ -207,6 +207,7 @@ async def test_create_conversation_agent_no_control(
     assert result["data"] == {
         CONF_MODEL: "openai/gpt-3.5-turbo",
         CONF_PROMPT: "you are an assistant",
+        CONF_LLM_HASS_API: [],
         CONF_WEB_SEARCH: "off",
     }
 
@@ -531,25 +532,30 @@ async def test_reconfigure_conversation_subentry_llm_api_schema(
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_reconfigure_conversation_subentry_no_llm_api(
+async def test_reconfigure_conversation_subentry_empty_llm_api(
     hass: HomeAssistant,
     mock_open_router_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the llm_hass_api field is empty when the subentry has no LLM API."""
+    """Test an empty LLM API selection is stored and kept when reopening the form."""
     await setup_integration(hass, mock_config_entry)
 
-    subentry = next(iter(mock_config_entry.subentries.values()))
-    hass.config_entries.async_update_subentry(
-        mock_config_entry,
-        subentry,
-        data={k: v for k, v in subentry.data.items() if k != CONF_LLM_HASS_API},
-    )
-    await hass.async_block_till_done()
+    subentry_id = get_subentry_id(mock_config_entry, "conversation")
 
-    result = await mock_config_entry.start_subentry_reconfigure_flow(
-        hass, subentry.subentry_id
+    result = await mock_config_entry.start_subentry_reconfigure_flow(hass, subentry_id)
+    await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODEL: "openai/gpt-4",
+            CONF_PROMPT: "updated prompt",
+            CONF_LLM_HASS_API: [],
+            CONF_WEB_SEARCH: "off",
+        },
     )
+
+    assert mock_config_entry.subentries[subentry_id].data[CONF_LLM_HASS_API] == []
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(hass, subentry_id)
 
     schema = result["data_schema"].schema
     key = next(k for k in schema if k == CONF_LLM_HASS_API)


### PR DESCRIPTION
## Breaking change


## Proposed change

Unselecting every LLM API is not remembered: the key is dropped from the subentry data on save, so reopening the form falls back to the recommended value and shows Assist selected again. Only remove the key when it is absent from the submitted input, so an empty selection is stored as empty while a subentry with no key still gets the recommended value.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179758
- This PR is related to issue: #178490
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D21QGmGduj7t1aQLX26pS