### PR TITLE
Fix OVHcloud AI Endpoints forgetting an empty LLM API selection

### DIFF
--- a/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
@@ -176,6 +176,8 @@ class ConversationFlowHandler(ConfigSubentryFlow):
         existing = subentry.data
 
         if user_input is not None:
+            if user_input.get(CONF_LLM_HASS_API) is None:
+                user_input.pop(CONF_LLM_HASS_API, None)
             user_input[CONF_MODEL] = existing[CONF_MODEL]
             return self.async_update_and_abort(
                 self._get_entry(), subentry, data=user_input
@@ -219,6 +221,8 @@ class ConversationFlowHandler(ConfigSubentryFlow):
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
+            if user_input.get(CONF_LLM_HASS_API) is None:
+                user_input.pop(CONF_LLM_HASS_API, None)
             return self.async_create_entry(
                 title=user_input[CONF_MODEL], data=user_input
             )

--- a/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
@@ -202,10 +202,7 @@ class ConversationFlowHandler(ConfigSubentryFlow):
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=existing.get(
-                            CONF_LLM_HASS_API,
-                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
-                        ),
+                        default=existing.get(CONF_LLM_HASS_API, []),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),

--- a/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
@@ -176,8 +176,6 @@ class ConversationFlowHandler(ConfigSubentryFlow):
         existing = subentry.data
 
         if user_input is not None:
-            if not user_input.get(CONF_LLM_HASS_API):
-                user_input.pop(CONF_LLM_HASS_API, None)
             user_input[CONF_MODEL] = existing[CONF_MODEL]
             return self.async_update_and_abort(
                 self._get_entry(), subentry, data=user_input
@@ -202,7 +200,10 @@ class ConversationFlowHandler(ConfigSubentryFlow):
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=existing.get(CONF_LLM_HASS_API, []),
+                        default=existing.get(
+                            CONF_LLM_HASS_API,
+                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
+                        ),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),
@@ -218,8 +219,6 @@ class ConversationFlowHandler(ConfigSubentryFlow):
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
-            if not user_input.get(CONF_LLM_HASS_API):
-                user_input.pop(CONF_LLM_HASS_API, None)
             return self.async_create_entry(
                 title=user_input[CONF_MODEL], data=user_input
             )

--- a/tests/components/ovhcloud_ai_endpoints/test_config_flow.py
+++ b/tests/components/ovhcloud_ai_endpoints/test_config_flow.py
@@ -201,6 +201,7 @@ async def test_create_conversation_agent_no_control(
     assert result["data"] == {
         CONF_MODEL: "Mistral-Nemo-Instruct-2407",
         CONF_PROMPT: "you are an assistant",
+        CONF_LLM_HASS_API: [],
     }
 
 
@@ -499,29 +500,10 @@ async def test_reconfigure_conversation_agent_clears_llm_api(
 
     subentry = mock_config_entry.subentries[subentry_id]
     assert subentry.data[CONF_PROMPT] == "updated prompt"
-    assert CONF_LLM_HASS_API not in subentry.data
+    assert subentry.data[CONF_LLM_HASS_API] == []
     assert subentry.data[CONF_MODEL] == "Meta-Llama-3_3-70B-Instruct"
 
-
-async def test_reconfigure_conversation_subentry_no_llm_api(
-    hass: HomeAssistant,
-    mock_openai_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test the llm_hass_api field is empty when the subentry has no LLM API."""
-    await setup_integration(hass, mock_config_entry, mock_openai_client)
-
-    subentry = next(iter(mock_config_entry.subentries.values()))
-    hass.config_entries.async_update_subentry(
-        mock_config_entry,
-        subentry,
-        data={k: v for k, v in subentry.data.items() if k != CONF_LLM_HASS_API},
-    )
-    await hass.async_block_till_done()
-
-    result = await mock_config_entry.start_subentry_reconfigure_flow(
-        hass, subentry.subentry_id
-    )
+    result = await mock_config_entry.start_subentry_reconfigure_flow(hass, subentry_id)
 
     schema = result["data_schema"].schema
     key = next(k for k in schema if k == CONF_LLM_HASS_API)

--- a/tests/components/ovhcloud_ai_endpoints/test_config_flow.py
+++ b/tests/components/ovhcloud_ai_endpoints/test_config_flow.py
@@ -501,3 +501,28 @@ async def test_reconfigure_conversation_agent_clears_llm_api(
     assert subentry.data[CONF_PROMPT] == "updated prompt"
     assert CONF_LLM_HASS_API not in subentry.data
     assert subentry.data[CONF_MODEL] == "Meta-Llama-3_3-70B-Instruct"
+
+
+async def test_reconfigure_conversation_subentry_no_llm_api(
+    hass: HomeAssistant,
+    mock_openai_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the llm_hass_api field is empty when the subentry has no LLM API."""
+    await setup_integration(hass, mock_config_entry, mock_openai_client)
+
+    subentry = next(iter(mock_config_entry.subentries.values()))
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        subentry,
+        data={k: v for k, v in subentry.data.items() if k != CONF_LLM_HASS_API},
+    )
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, subentry.subentry_id
+    )
+
+    schema = result["data_schema"].schema
+    key = next(k for k in schema if k == CONF_LLM_HASS_API)
+    assert key.default() == []


### PR DESCRIPTION
## Breaking change


## Proposed change

Unselecting every LLM API is not remembered: the key is dropped from the subentry data on save, so reopening the form falls back to the recommended value and shows Assist selected again. Only remove the key when it is absent from the submitted input, so an empty selection is stored as empty while a subentry with no key still gets the recommended value.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179759
- This PR is related to issue: #178490
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D21QGmGduj7t1aQLX26pS