### PR TITLE
Restore the recommended LLM API fallback for LiteLLM

### DIFF
--- a/homeassistant/components/litellm/config_flow.py
+++ b/homeassistant/components/litellm/config_flow.py
@@ -180,7 +180,7 @@ class ConversationFlowHandler(LiteLLMSubentryFlowHandler):
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
-            if not user_input.get(CONF_LLM_HASS_API):
+            if user_input.get(CONF_LLM_HASS_API) is None:
                 user_input.pop(CONF_LLM_HASS_API, None)
             if self._is_new:
                 return self.async_create_entry(
@@ -241,7 +241,10 @@ class ConversationFlowHandler(LiteLLMSubentryFlowHandler):
                     ): TemplateSelector(),
                     vol.Optional(
                         CONF_LLM_HASS_API,
-                        default=self.options.get(CONF_LLM_HASS_API, []),
+                        default=self.options.get(
+                            CONF_LLM_HASS_API,
+                            RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
+                        ),
                     ): SelectSelector(
                         SelectSelectorConfig(options=hass_apis, multiple=True)
                     ),

--- a/tests/components/litellm/test_config_flow.py
+++ b/tests/components/litellm/test_config_flow.py
@@ -242,6 +242,7 @@ async def test_create_conversation_agent_no_control(
     assert result["data"] == {
         CONF_MODEL: "gpt-3.5-turbo",
         CONF_PROMPT: "you are an assistant",
+        CONF_LLM_HASS_API: [],
     }
 
 
@@ -360,7 +361,7 @@ async def test_reconfigure_conversation_agent_disable_llm_api(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert CONF_LLM_HASS_API not in mock_config_entry.subentries[subentry_id].data
+    assert mock_config_entry.subentries[subentry_id].data[CONF_LLM_HASS_API] == []
 
     result = await mock_config_entry.start_subentry_reconfigure_flow(hass, subentry_id)
     schema = result["data_schema"].schema


### PR DESCRIPTION
## Breaking change


## Proposed change

#178490 made an empty LLM API selection stick by changing the form default to an empty list, which also dropped the recommended value for a subentry that has no `llm_hass_api` key at all. Restore that fallback, and instead only remove the key when it is absent from the submitted input, so an empty selection is stored as empty rather than dropped.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178490
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D21QGmGduj7t1aQLX26pS