### PR TITLE
Handle hidden Last.fm listening history without failing updates

### DIFF
--- a/homeassistant/components/lastfm/config_flow.py
+++ b/homeassistant/components/lastfm/config_flow.py
@@ -19,10 +19,13 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
 )
 
-from .const import CONF_MAIN_USER, CONF_USERS, DOMAIN
+from .const import CONF_MAIN_USER, CONF_USERS, DOMAIN, ERROR_CODE_LOGIN_REQUIRED
 from .coordinator import LastFMConfigEntry
 
-PLACEHOLDERS = {"api_account_url": "https://www.last.fm/api/account/create"}
+PLACEHOLDERS = {
+    "api_account_url": "https://www.last.fm/api/account/create",
+    "privacy_settings_url": "https://www.last.fm/settings/privacy",
+}
 
 CONFIG_SCHEMA: vol.Schema = vol.Schema(
     {
@@ -40,8 +43,11 @@ def get_lastfm_user(api_key: str, username: str) -> tuple[User, dict[str, str]]:
     errors = {}
     try:
         user.get_playcount()
+        user.get_recent_tracks(limit=1)
     except WSError as error:
-        if error.details == "User not found":
+        if error.status == ERROR_CODE_LOGIN_REQUIRED:
+            errors["base"] = "hidden_recent_tracks"
+        elif error.details == "User not found":
             errors["base"] = "invalid_account"
         elif (
             error.details
@@ -144,6 +150,7 @@ class LastFmConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="friends",
             errors=errors,
+            description_placeholders=PLACEHOLDERS,
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(
                     {
@@ -203,6 +210,7 @@ class LastFmOptionsFlowHandler(OptionsFlowWithReload):
         return self.async_show_form(
             step_id="init",
             errors=errors,
+            description_placeholders=PLACEHOLDERS,
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(
                     {

--- a/homeassistant/components/lastfm/config_flow.py
+++ b/homeassistant/components/lastfm/config_flow.py
@@ -77,6 +77,12 @@ def validate_lastfm_users(
     return valid_users, errors
 
 
+def get_user_friends(api_key: str, username: str) -> list[User]:
+    """Get the friends of a Last.fm user."""
+    user, _ = get_lastfm_user(api_key, username)
+    return user.get_friends()
+
+
 class LastFmConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow handler for LastFm."""
 
@@ -99,8 +105,8 @@ class LastFmConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             self.data = user_input.copy()
-            _, errors = get_lastfm_user(
-                self.data[CONF_API_KEY], self.data[CONF_MAIN_USER]
+            _, errors = await self.hass.async_add_executor_job(
+                get_lastfm_user, self.data[CONF_API_KEY], self.data[CONF_MAIN_USER]
             )
             if not errors:
                 return await self.async_step_friends()
@@ -117,8 +123,10 @@ class LastFmConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Form to select other users and friends."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            users, errors = validate_lastfm_users(
-                self.data[CONF_API_KEY], user_input[CONF_USERS]
+            users, errors = await self.hass.async_add_executor_job(
+                validate_lastfm_users,
+                self.data[CONF_API_KEY],
+                user_input[CONF_USERS],
             )
             user_input[CONF_USERS] = users
             if not errors:
@@ -135,11 +143,8 @@ class LastFmConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                     },
                 )
         try:
-            main_user, _ = get_lastfm_user(
-                self.data[CONF_API_KEY], self.data[CONF_MAIN_USER]
-            )
             friends_response = await self.hass.async_add_executor_job(
-                main_user.get_friends
+                get_user_friends, self.data[CONF_API_KEY], self.data[CONF_MAIN_USER]
             )
             friends = [
                 SelectOptionDict(value=friend.name, label=friend.get_name(True))
@@ -178,8 +183,10 @@ class LastFmOptionsFlowHandler(OptionsFlowWithReload):
         errors: dict[str, str] = {}
         options = self.config_entry.options
         if user_input is not None:
-            users, errors = validate_lastfm_users(
-                options[CONF_API_KEY], user_input[CONF_USERS]
+            users, errors = await self.hass.async_add_executor_job(
+                validate_lastfm_users,
+                options[CONF_API_KEY],
+                user_input[CONF_USERS],
             )
             user_input[CONF_USERS] = users
             if not errors:
@@ -192,12 +199,10 @@ class LastFmOptionsFlowHandler(OptionsFlowWithReload):
                 )
         if options[CONF_MAIN_USER]:
             try:
-                main_user, _ = get_lastfm_user(
+                friends_response = await self.hass.async_add_executor_job(
+                    get_user_friends,
                     options[CONF_API_KEY],
                     options[CONF_MAIN_USER],
-                )
-                friends_response = await self.hass.async_add_executor_job(
-                    main_user.get_friends
                 )
                 friends = [
                     SelectOptionDict(value=friend.name, label=friend.get_name(True))

--- a/homeassistant/components/lastfm/const.py
+++ b/homeassistant/components/lastfm/const.py
@@ -13,6 +13,9 @@ DEFAULT_NAME = "LastFM"
 CONF_MAIN_USER = "main_user"
 CONF_USERS = "users"
 
+# Last.fm API error returned when a user hides their recent listening information
+ERROR_CODE_LOGIN_REQUIRED = "17"
+
 ATTR_LAST_PLAYED = "last_played"
 ATTR_PLAY_COUNT = "play_count"
 ATTR_TOP_PLAYED = "top_played"

--- a/homeassistant/components/lastfm/coordinator.py
+++ b/homeassistant/components/lastfm/coordinator.py
@@ -50,6 +50,7 @@ class LastFMDataUpdateCoordinator(DataUpdateCoordinator[dict[str, LastFMUserData
             update_interval=timedelta(seconds=30),
         )
         self._client = LastFMNetwork(api_key=config_entry.options[CONF_API_KEY])
+        self._warned_hidden_users: set[str] = set()
 
     @override
     async def _async_update_data(self) -> dict[str, LastFMUserData]:
@@ -84,13 +85,16 @@ class LastFMDataUpdateCoordinator(DataUpdateCoordinator[dict[str, LastFMUserData
                 if self.last_update_success:
                     LOGGER.error("LastFM update for %s failed: %r", username, exc)
                 return None
-            if self.last_update_success:
+            if username not in self._warned_hidden_users:
+                self._warned_hidden_users.add(username)
                 LOGGER.warning(
                     "LastFM user %s has hidden their recent listening information "
                     "(https://www.last.fm/settings/privacy); now playing and last "
                     "played track are unavailable",
                     username,
                 )
+        else:
+            self._warned_hidden_users.discard(username)
         top_track = None
         if len(top_tracks) > 0:
             top_track = format_track(top_tracks[0].item)

--- a/homeassistant/components/lastfm/coordinator.py
+++ b/homeassistant/components/lastfm/coordinator.py
@@ -4,14 +4,14 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import override
 
-from pylast import LastFMNetwork, PyLastError, Track
+from pylast import LastFMNetwork, PyLastError, Track, WSError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_USERS, DOMAIN, LOGGER
+from .const import CONF_USERS, DOMAIN, ERROR_CODE_LOGIN_REQUIRED, LOGGER
 
 type LastFMConfigEntry = ConfigEntry[LastFMDataUpdateCoordinator]
 
@@ -67,13 +67,30 @@ class LastFMDataUpdateCoordinator(DataUpdateCoordinator[dict[str, LastFMUserData
         try:
             play_count = user.get_playcount()
             image = user.get_image()
-            now_playing = format_track(user.get_now_playing())
             top_tracks = user.get_top_tracks(limit=1)
-            last_tracks = user.get_recent_tracks(limit=1)
         except PyLastError as exc:
             if self.last_update_success:
                 LOGGER.error("LastFM update for %s failed: %r", username, exc)
             return None
+        now_playing = None
+        last_tracks = []
+        try:
+            now_playing = format_track(user.get_now_playing())
+            last_tracks = user.get_recent_tracks(limit=1)
+        except PyLastError as exc:
+            if not (
+                isinstance(exc, WSError) and exc.status == ERROR_CODE_LOGIN_REQUIRED
+            ):
+                if self.last_update_success:
+                    LOGGER.error("LastFM update for %s failed: %r", username, exc)
+                return None
+            if self.last_update_success:
+                LOGGER.warning(
+                    "LastFM user %s has hidden their recent listening information "
+                    "(https://www.last.fm/settings/privacy); now playing and last "
+                    "played track are unavailable",
+                    username,
+                )
         top_track = None
         if len(top_tracks) > 0:
             top_track = format_track(top_tracks[0].item)

--- a/homeassistant/components/lastfm/strings.json
+++ b/homeassistant/components/lastfm/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "error": {
+      "hidden_recent_tracks": "User has hidden their recent listening information. Disable \"Hide recent listening information\" at {privacy_settings_url}",
       "invalid_account": "Invalid username",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
@@ -23,6 +24,7 @@
   },
   "options": {
     "error": {
+      "hidden_recent_tracks": "[%key:component::lastfm::config::error::hidden_recent_tracks%]",
       "invalid_account": "[%key:component::lastfm::config::error::invalid_account%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/tests/components/lastfm/__init__.py
+++ b/tests/components/lastfm/__init__.py
@@ -54,6 +54,7 @@ class MockUser:
         username: str = USERNAME_1,
         now_playing_result: Track | None = None,
         thrown_error: Exception | None = None,
+        recent_tracks_error: Exception | None = None,
         friends: list | UndefinedType = UNDEFINED,
         recent_tracks: list[Track] | UndefinedType = UNDEFINED,
         top_tracks: list[Track] | UndefinedType = UNDEFINED,
@@ -61,6 +62,7 @@ class MockUser:
         """Initialize the mock."""
         self._now_playing_result = now_playing_result
         self._thrown_error = thrown_error
+        self._recent_tracks_error = recent_tracks_error
         self._friends = [] if friends is UNDEFINED else friends
         self._recent_tracks = [] if recent_tracks is UNDEFINED else recent_tracks
         self._top_tracks = [] if top_tracks is UNDEFINED else top_tracks
@@ -82,6 +84,8 @@ class MockUser:
 
     def get_recent_tracks(self, limit: int) -> list[MockLastTrack]:
         """Get mock recent tracks."""
+        if self._recent_tracks_error:
+            raise self._recent_tracks_error
         return [MockLastTrack(track) for track in self._recent_tracks]
 
     def get_top_tracks(self, limit: int) -> list[MockTopTrack]:
@@ -90,6 +94,8 @@ class MockUser:
 
     def get_now_playing(self) -> Track:
         """Get mock now playing."""
+        if self._recent_tracks_error:
+            raise self._recent_tracks_error
         return self._now_playing_result
 
     def get_friends(self) -> list[Any]:

--- a/tests/components/lastfm/conftest.py
+++ b/tests/components/lastfm/conftest.py
@@ -103,3 +103,12 @@ def mock_hidden_user() -> MockUser:
             "network", "17", "Login: User required to be logged in"
         ),
     )
+
+
+@pytest.fixture(name="recent_tracks_error_user")
+def mock_recent_tracks_error_user() -> MockUser:
+    """Return mock user whose recent tracks request fails."""
+    return MockUser(
+        recent_tracks=[Track("artist", "title", MockNetwork("lastfm"))],
+        recent_tracks_error=WSError("network", "status", "Something strange"),
+    )

--- a/tests/components/lastfm/conftest.py
+++ b/tests/components/lastfm/conftest.py
@@ -92,3 +92,14 @@ def mock_first_time_user() -> MockUser:
 def mock_not_found_user() -> MockUser:
     """Return not found mock user."""
     return MockUser(thrown_error=WSError("network", "status", "User not found"))
+
+
+@pytest.fixture(name="hidden_user")
+def mock_hidden_user() -> MockUser:
+    """Return mock user who hides their recent listening information."""
+    return MockUser(
+        recent_tracks=[Track("artist", "title", MockNetwork("lastfm"))],
+        recent_tracks_error=WSError(
+            "network", "17", "Login: User required to be logged in"
+        ),
+    )

--- a/tests/components/lastfm/snapshots/test_sensor.ambr
+++ b/tests/components/lastfm/snapshots/test_sensor.ambr
@@ -35,6 +35,24 @@
     'state': 'Not Scrobbling',
   })
 # ---
+# name: test_sensors[hidden_user]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Last.fm',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'image',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LastFM testaccount1',
+      'last_played': None,
+      'play_count': 1,
+      'top_played': 'artist - title',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lastfm_testaccount1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Not Scrobbling',
+  })
+# ---
 # name: test_sensors[not_found_user]
   None
 # ---

--- a/tests/components/lastfm/snapshots/test_sensor.ambr
+++ b/tests/components/lastfm/snapshots/test_sensor.ambr
@@ -56,3 +56,6 @@
 # name: test_sensors[not_found_user]
   None
 # ---
+# name: test_sensors[recent_tracks_error_user]
+  None
+# ---

--- a/tests/components/lastfm/test_config_flow.py
+++ b/tests/components/lastfm/test_config_flow.py
@@ -99,6 +99,35 @@ async def test_flow_fails(
         assert result["options"] == CONF_DATA
 
 
+async def test_flow_hidden_recent_tracks(
+    hass: HomeAssistant, default_user: MockUser
+) -> None:
+    """Test user initialized flow when user hides recent listening information."""
+    with patch(
+        "pylast.User",
+        return_value=MockUser(
+            recent_tracks_error=WSError(
+                "network", "17", "Login: User required to be logged in"
+            )
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=CONF_USER_DATA
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "hidden_recent_tracks"
+
+    with patch("pylast.User", return_value=default_user), patch_setup_entry():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=CONF_USER_DATA,
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert not result["errors"]
+        assert result["step_id"] == "friends"
+
+
 async def test_flow_friends_invalid_username(
     hass: HomeAssistant, default_user: MockUser
 ) -> None:
@@ -233,6 +262,41 @@ async def test_options_flow_incorrect_username(
         CONF_MAIN_USER: USERNAME_1,
         CONF_USERS: [USERNAME_1],
     }
+
+
+async def test_options_flow_hidden_recent_tracks(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+    default_user: MockUser,
+) -> None:
+    """Test updating options fails when user hides recent listening information."""
+    await setup_integration(config_entry, default_user)
+    with patch("pylast.User", return_value=default_user):
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+    with patch(
+        "pylast.User",
+        return_value=MockUser(
+            recent_tracks_error=WSError(
+                "network", "17", "Login: User required to be logged in"
+            )
+        ),
+    ):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERS: [USERNAME_1]},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"]["base"] == "hidden_recent_tracks"
 
 
 async def test_options_flow_from_import(

--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -19,6 +19,7 @@ from tests.common import MockConfigEntry
         ("first_time_user"),
         ("default_user"),
         ("hidden_user"),
+        ("recent_tracks_error_user"),
     ],
 )
 async def test_sensors(
@@ -53,4 +54,11 @@ async def test_sensor_hidden_listening_information(
     state = hass.states.get("sensor.lastfm_testaccount1")
     assert state.state == STATE_NOT_SCROBBLING
     assert state.attributes[ATTR_LAST_PLAYED] is None
-    assert "has hidden their recent listening information" in caplog.text
+    warnings = caplog.text.count("has hidden their recent listening information")
+    assert warnings > 0
+
+    await config_entry.runtime_data.async_refresh()
+
+    assert (
+        caplog.text.count("has hidden their recent listening information") == warnings
+    )

--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -3,8 +3,10 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.lastfm.const import ATTR_LAST_PLAYED, STATE_NOT_SCROBBLING
 from homeassistant.core import HomeAssistant
 
+from . import MockUser
 from .conftest import ComponentSetup
 
 from tests.common import MockConfigEntry
@@ -16,6 +18,7 @@ from tests.common import MockConfigEntry
         ("not_found_user"),
         ("first_time_user"),
         ("default_user"),
+        ("hidden_user"),
     ],
 )
 async def test_sensors(
@@ -35,3 +38,19 @@ async def test_sensors(
     state = hass.states.get(entity_id)
 
     assert state == snapshot
+
+
+async def test_sensor_hidden_listening_information(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+    hidden_user: MockUser,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test sensor stays available when the user hides recent listening info."""
+    await setup_integration(config_entry, hidden_user)
+
+    state = hass.states.get("sensor.lastfm_testaccount1")
+    assert state.state == STATE_NOT_SCROBBLING
+    assert state.attributes[ATTR_LAST_PLAYED] is None
+    assert "has hidden their recent listening information" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a Last.fm user has enabled the "Hide recent listening information" privacy setting, the API returns error 17 ("Login: User required to be logged in") even though nothing is wrong with the credentials. Today the integration fails the whole update over it: the sensor goes unavailable and a misleading error is logged, sending users hunting for authentication problems that do not exist.

This PR improves the experience for that scenario:

- The coordinator detects this specific API error, keeps the entity available with the data that still works (play count, avatar, top track), and logs a single clear warning pointing at the Last.fm privacy settings page instead of the confusing "login required" error.
- The config and options flows probe for the same condition and show an actionable error telling the user to disable "Hide recent listening information", instead of silently creating a broken entry.
- If the Last.fm user has set "Hide recent listening information", the integration shows "Not Scrobbling" instead of failing to load.

Note: this does not make the hidden listening data itself available; that would require authenticated session support, which I plan to propose as a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #129737
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr