### PR TITLE
Remove overbuilt traccar_server subscribe tests

### DIFF
--- a/tests/components/traccar_server/test_init.py
+++ b/tests/components/traccar_server/test_init.py
@@ -4,16 +4,12 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
-import sys
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytraccar import SubscriptionData, TraccarAuthenticationException, TraccarException
 
-from homeassistant.components.traccar_server.coordinator import (
-    _SUBSCRIPTION_RECONNECT_DELAY,
-)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -150,76 +146,6 @@ async def test_subscribe_raises_config_entry_auth_failed(
     assert mock_traccar_api_client.subscribe.call_count == 1
 
 
-async def test_subscribe_does_not_recurse_across_reconnects(
-    hass: HomeAssistant,
-    mock_traccar_api_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Subscribe retries must not grow the call stack."""
-    attempts = 0
-    target_attempts = sys.getrecursionlimit() * 2
-
-    async def _flaky_subscribe(_callback: object) -> None:
-        nonlocal attempts
-        attempts += 1
-        if attempts >= target_attempts:
-            # End the task deterministically, the same way an unload would.
-            raise asyncio.CancelledError
-        raise TraccarException("Simulated dropped connection")
-
-    mock_traccar_api_client.subscribe = AsyncMock(side_effect=_flaky_subscribe)
-
-    with patch(
-        "homeassistant.components.traccar_server.coordinator._SUBSCRIPTION_RECONNECT_DELAY",
-        0,
-    ):
-        await setup_integration(hass, mock_config_entry)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    assert attempts == target_attempts
-
-
-async def test_subscribe_does_not_busy_loop_on_clean_return(
-    hass: HomeAssistant,
-    mock_traccar_api_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """If client.subscribe() ever returns without raising, still throttle.
-
-    pytraccar's subscribe() should always raise on disconnect (see
-    pytraccar#477), so a clean return isn't expected in practice. But the
-    retry loop must not assume that - if it ever happens, reconnecting
-    immediately with no delay would spin the event loop at 100% CPU.
-    """
-    calls = 0
-
-    async def _clean_return_then_cancel(_callback: object) -> None:
-        nonlocal calls
-        calls += 1
-        if calls >= 3:
-            raise asyncio.CancelledError
-
-    mock_traccar_api_client.subscribe = AsyncMock(side_effect=_clean_return_then_cancel)
-
-    with patch(
-        "homeassistant.components.traccar_server.coordinator.asyncio.sleep",
-        new=AsyncMock(),
-    ) as mock_sleep:
-        await setup_integration(hass, mock_config_entry)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    assert calls == 3
-    # Only calls 1 and 2 (the clean returns) reach the loop's delay;
-    # call 3 raises CancelledError before that line, so exactly two real
-    # reconnect delays are attributable to this code path.
-    reconnect_delay_sleeps = [
-        call
-        for call in mock_sleep.await_args_list
-        if call.args == (_SUBSCRIPTION_RECONNECT_DELAY,)
-    ]
-    assert len(reconnect_delay_sleeps) == 2
-
-
 async def test_subscribe_retries_on_unexpected_exception(
     hass: HomeAssistant,
     mock_traccar_api_client: AsyncMock,
@@ -254,104 +180,3 @@ async def test_subscribe_retries_on_unexpected_exception(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert calls == 3
-
-
-async def test_subscribe_logs_error_once_then_periodic_reminder(
-    hass: HomeAssistant,
-    mock_traccar_api_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The first failure logs an error; later failures throttle to a periodic warning."""
-    calls = 0
-    target_attempts = 61  # Crosses two 30-attempt reminder boundaries (30, 60).
-
-    async def _always_fails(_callback: object) -> None:
-        nonlocal calls
-        calls += 1
-        if calls >= target_attempts:
-            raise asyncio.CancelledError
-        raise TraccarException("Simulated dropped connection")
-
-    mock_traccar_api_client.subscribe = AsyncMock(side_effect=_always_fails)
-
-    with (
-        patch(
-            "homeassistant.components.traccar_server.coordinator._SUBSCRIPTION_RECONNECT_DELAY",
-            0,
-        ),
-        caplog.at_level(logging.INFO, logger="homeassistant.components.traccar_server"),
-    ):
-        await setup_integration(hass, mock_config_entry)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    error_records = [
-        r
-        for r in caplog.records
-        if r.levelno == logging.ERROR
-        and r.name == "homeassistant.components.traccar_server"
-    ]
-    warning_records = [
-        r
-        for r in caplog.records
-        if r.levelno == logging.WARNING
-        and r.name == "homeassistant.components.traccar_server"
-    ]
-
-    assert len(error_records) == 1
-    assert "Error while subscribing to Traccar" in error_records[0].message
-    assert len(warning_records) == 2
-    assert all(
-        "Still unable to (re)connect to Traccar" in r.message for r in warning_records
-    )
-    assert any("60" in r.message for r in warning_records)
-
-
-async def test_subscribe_clean_return_resets_error_logging(
-    hass: HomeAssistant,
-    mock_traccar_api_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A clean return re-arms error logging for the next failure streak.
-
-    The should-log flag must reset alongside the failure counter - otherwise
-    a failure streak starting right after a clean return would be silently
-    throttled instead of logging its first error.
-    """
-    calls = 0
-
-    async def _fail_then_clean_return_then_fail(_callback: object) -> None:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            raise TraccarException("First failure")
-        if calls == 2:
-            return  # Clean return - should re-arm error logging.
-        if calls == 3:
-            raise TraccarException("Second failure, after clean return")
-        raise asyncio.CancelledError
-
-    mock_traccar_api_client.subscribe = AsyncMock(
-        side_effect=_fail_then_clean_return_then_fail
-    )
-
-    with (
-        patch(
-            "homeassistant.components.traccar_server.coordinator._SUBSCRIPTION_RECONNECT_DELAY",
-            0,
-        ),
-        caplog.at_level(logging.INFO, logger="homeassistant.components.traccar_server"),
-    ):
-        await setup_integration(hass, mock_config_entry)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    error_records = [
-        r
-        for r in caplog.records
-        if r.levelno == logging.ERROR
-        and r.name == "homeassistant.components.traccar_server"
-    ]
-    assert len(error_records) == 2
-    assert "First failure" in error_records[0].message
-    assert "Second failure, after clean return" in error_records[1].message


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In #177519 we fixed a real regression and went overboard with the tests. `subscribe()` retried a dropped connection by recursively awaiting itself, so the stack grew one frame per reconnect until a `RecursionError` silently killed the background task. That fix is correct and stays. The tests that came with it are the problem.

The regression test drove 2000 reconnects (`sys.getrecursionlimit() * 2`) to prove the retry no longer recurses. It took **2.56s** and went straight into the top 10 slowest tests of its CI runner ([run 32551925907](https://github.com/home-assistant/core/actions/runs/32551925907/job/96980207406#step:9:1)). The retry is now a flat loop that never calls itself, which is plain from the code, so that time guards a rewrite a reviewer would catch anyway.

This reverts that test and three more that pin implementation detail rather than behaviour: one asserts a reconnect delay that is unconditional in the loop body, and two pin exact log record counts and the 30-attempt reminder boundary.

No behavioural coverage is lost. The contracts that matter keep their tests: an authentication failure must not retry, and an unexpected exception must not kill the background task. Coordinator coverage moves from 88% to 87%, and the one line no longer covered is the throttled warning log. After this, no traccar test exceeds 0.07s.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177519
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RPuLdY9Qbgn1BAStwUqRw

---
_Generated by [Claude Code](https://claude.ai/code/session_012RPuLdY9Qbgn1BAStwUqRw)_