### PR TITLE
Speed up VoIP tests

### DIFF
--- a/tests/components/voip/conftest.py
+++ b/tests/components/voip/conftest.py
@@ -8,6 +8,7 @@ from voip_utils import CallInfo
 from voip_utils.sip import get_sip_endpoint
 
 from homeassistant.components.voip import DOMAIN
+from homeassistant.components.voip.assist_satellite import VoipAssistSatellite
 from homeassistant.components.voip.devices import VoIPDevice, VoIPDevices
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -44,6 +45,18 @@ def reduce_satellite_delays() -> Generator[None]:
             0.1,
         ),
     ):
+        yield
+
+
+@pytest.fixture
+def silent_tones() -> Generator[None]:
+    """Give every tone empty audio.
+
+    A real tone is up to two seconds streamed in real time, which outlasts the
+    shortened hangup window. The tone paths still run, so the processing tone
+    still gates _send_tts.
+    """
+    with patch.object(VoipAssistSatellite, "_load_pcm", return_value=b""):
         yield
 
 

--- a/tests/components/voip/conftest.py
+++ b/tests/components/voip/conftest.py
@@ -1,5 +1,6 @@
 """Test helpers for VoIP integration."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -22,6 +23,28 @@ from tests.components.tts.conftest import (
 async def load_homeassistant(hass: HomeAssistant) -> None:
     """Load the homeassistant integration."""
     assert await async_setup_component(hass, "homeassistant", {})
+
+
+@pytest.fixture(autouse=True)
+def reduce_satellite_delays() -> Generator[None]:
+    """Shorten the delays that the satellite always waits out.
+
+    Tests must send audio chunks more often than _HANGUP_SEC, or the satellite
+    treats the gap as the caller hanging up. Timeouts that only elapse when audio
+    never arrives are left alone: they cost nothing unless a test exercises them.
+    """
+    with (
+        patch("homeassistant.components.voip.assist_satellite._HANGUP_SEC", 0.2),
+        patch(
+            "homeassistant.components.voip.assist_satellite._ANNOUNCEMENT_BEFORE_DELAY",
+            0.1,
+        ),
+        patch(
+            "homeassistant.components.voip.assist_satellite._ANNOUNCEMENT_AFTER_DELAY",
+            0.1,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -577,6 +577,8 @@ async def test_tts_wrong_extension(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
+        # The listening tone is ~1s of audio, streamed in real time
+        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence
@@ -587,13 +589,13 @@ async def test_tts_wrong_extension(
 
         # silence (assumes relaxed VAD sensitivity)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
 
         # Wait for mock pipeline to exhaust the audio stream
@@ -667,6 +669,8 @@ async def test_tts_wrong_wav_format(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
+        # The listening tone is ~1s of audio, streamed in real time
+        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence
@@ -677,13 +681,13 @@ async def test_tts_wrong_wav_format(
 
         # silence (assumes relaxed VAD sensitivity)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
 
         # Wait for mock pipeline to exhaust the audio stream
@@ -747,6 +751,8 @@ async def test_empty_tts_output(
             "homeassistant.components.voip.assist_satellite.VoipAssistSatellite._send_tts",
         ) as mock_send_tts,
     ):
+        # The listening tone is ~1s of audio, streamed in real time
+        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence
@@ -757,16 +763,9 @@ async def test_empty_tts_output(
 
         # silence (assumes relaxed VAD sensitivity)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
-        satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
-        satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
-        satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
-        satellite.on_chunk(bytes(_ONE_SECOND))
 
-        # Wait for mock pipeline to finish
+        # No more chunks: another chunk would start a second pipeline run, which
+        # clears _tts_done again.
         async with asyncio.timeout(2):
             await satellite._tts_done.wait()
 
@@ -877,9 +876,9 @@ async def test_announce(
 
         # Trigger announcement
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
         async with asyncio.timeout(2):
             await announce_task
@@ -937,9 +936,9 @@ async def test_voip_id_is_ip_address(
 
         # Trigger announcement
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
         async with asyncio.timeout(2):
             await announce_task
@@ -1032,11 +1031,11 @@ async def test_announce_disconnect(
 
         # Trigger announcement
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
 
         assert satellite._announcement is announcement
         assert voip_device.is_active
@@ -1196,18 +1195,17 @@ async def test_start_conversation(
 
         # Trigger announcement and wait for it to finish
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
         async with asyncio.timeout(2):
             await tts_sent.wait()
 
         # Trigger pipeline
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.05)
         satellite.on_chunk(bytes(_ONE_SECOND))
-        await asyncio.sleep(3)
         async with asyncio.timeout(3):
             # Wait for Conversation end
             await conversation_task

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -48,10 +48,6 @@ def satellite(
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
 
-    # Tones are up to 2s of audio, streamed in real time. Tests that assert on a
-    # tone enable the one they need.
-    satellite._tones = Tones(0)
-
     yield satellite
 
     if satellite.voip_device.is_active:
@@ -513,6 +509,7 @@ async def test_tts_timeout(
             await done.wait()
 
 
+@pytest.mark.usefixtures("silent_tones")
 async def test_tts_wrong_extension(
     hass: HomeAssistant,
     satellite: VoipAssistSatellite,
@@ -603,6 +600,7 @@ async def test_tts_wrong_extension(
             await done.wait()
 
 
+@pytest.mark.usefixtures("silent_tones")
 async def test_tts_wrong_wav_format(
     hass: HomeAssistant,
     satellite: VoipAssistSatellite,
@@ -693,6 +691,7 @@ async def test_tts_wrong_wav_format(
             await done.wait()
 
 
+@pytest.mark.usefixtures("silent_tones")
 async def test_empty_tts_output(
     hass: HomeAssistant,
     satellite: VoipAssistSatellite,

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -48,6 +48,10 @@ def satellite(
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
 
+    # Tones are up to 2s of audio, streamed in real time. Tests that assert on a
+    # tone enable the one they need.
+    satellite._tones = Tones(0)
+
     yield satellite
 
     if satellite.voip_device.is_active:
@@ -348,7 +352,6 @@ async def test_pipeline(
         ),
         patch.object(satellite, "tts_response_finished", tts_response_finished),
     ):
-        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         assert satellite.state == AssistSatelliteState.IDLE
@@ -400,7 +403,6 @@ async def test_stt_stream_timeout(
         "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
         new=async_pipeline_from_audio_stream,
     ):
-        satellite._tones = Tones(0)
         satellite._audio_chunk_timeout = 0.001
         transport = Mock(spec=["close"])
         satellite.connection_made(transport)
@@ -577,8 +579,6 @@ async def test_tts_wrong_extension(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
-        # The listening tone is ~1s of audio, streamed in real time
-        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence
@@ -669,8 +669,6 @@ async def test_tts_wrong_wav_format(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
-        # The listening tone is ~1s of audio, streamed in real time
-        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence
@@ -751,8 +749,6 @@ async def test_empty_tts_output(
             "homeassistant.components.voip.assist_satellite.VoipAssistSatellite._send_tts",
         ) as mock_send_tts,
     ):
-        # The listening tone is ~1s of audio, streamed in real time
-        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         # silence

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -348,6 +348,7 @@ async def test_pipeline(
         ),
         patch.object(satellite, "tts_response_finished", tts_response_finished),
     ):
+        satellite._tones = Tones(0)
         satellite.connection_made(Mock())
 
         assert satellite.state == AssistSatelliteState.IDLE
@@ -399,6 +400,7 @@ async def test_stt_stream_timeout(
         "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
         new=async_pipeline_from_audio_stream,
     ):
+        satellite._tones = Tones(0)
         satellite._audio_chunk_timeout = 0.001
         transport = Mock(spec=["close"])
         satellite.connection_made(transport)


### PR DESCRIPTION

## Breaking change



## Proposed change

The VoIP tests waited in real time.

| | Old | New |
|---|---|---|
| **`tests/components/voip/`** | **15.70s** | **6.78s** |
| `test_start_conversation` | 3.71s | 0.41s |
| `test_tts_wrong_wav_format` | 1.51s | 0.21s |
| `test_tts_wrong_extension` | 1.12s | 0.21s |
| `test_empty_tts_output` | 1.12s | &lt;0.10s |
| `test_announce` | 1.01s | 0.31s |
| `test_voip_id_is_ip_address` | 1.01s | 0.31s |

What changed:

- `reduce_satellite_delays` (autouse) shortens the delays the satellite always waits out: `_HANGUP_SEC`, `_ANNOUNCEMENT_BEFORE_DELAY`, `_ANNOUNCEMENT_AFTER_DELAY`. Timeouts that only elapse when audio never arrives (`_ANNOUNCEMENT_RING_TIMEOUT`, `_PIPELINE_TIMEOUT_SEC`) are left alone — they cost nothing unless a test exercises them.
- `silent_tones` (opt-in) gives every tone empty audio, for the three tests whose runtime was dominated by tone playback: `test_tts_wrong_extension`, `test_tts_wrong_wav_format` and `test_empty_tts_output`. It patches `_load_pcm` rather than the entity's `_tones`, so tones stay enabled and the paths still run — `on_pipeline_event()` still starts the processing-tone task and `_send_tts()` still synchronizes on `_processing_tone_done`.
- `test_pipeline` and `test_stt_stream_timeout` keep the `_tones = Tones(0)` they already had. `silent_tones` is not enough for them: `_play_tone()` passes `silence_before=0.2` for the listening tone, which is the whole shortened `_HANGUP_SEC`, so the hangup checker fires before the pipeline starts and the test passes without running it.
- Chunk spacing drops to 0.05s to stay under the shortened `_HANGUP_SEC`. `test_start_conversation` also loses a 3s sleep that sat immediately before an `await` on the same condition.
- `test_empty_tts_output` no longer sends trailing chunks. Without the tone delay they start a second pipeline run, which clears `_tts_done` again.

Unrelated to this PR, but found while checking the above: `test_start_conversation` never invokes the conversation pipeline. Instrumenting the mocked `async_pipeline_from_audio_stream` shows it is not entered on `dev` either, so the conversation task is being completed by the hangup checker rather than by the pipeline. Worth a separate look.

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ```''https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure''```


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017p6LJyN5FXHgMtZSjtffZ9

---
_Generated by [Claude Code](https://claude.ai/code/session_017p6LJyN5FXHgMtZSjtffZ9)_