### PR TITLE
Speed up the Aurora ABB Powerone tests

### DIFF
--- a/tests/components/aurora_abb_powerone/test_init.py
+++ b/tests/components/aurora_abb_powerone/test_init.py
@@ -14,6 +14,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unloading the aurora_abb_powerone entry."""
 
     with (
+        patch("homeassistant.components.aurora_abb_powerone.coordinator.sleep"),
         patch("aurorapy.client.AuroraSerialClient.connect", return_value=None),
         patch(
             "aurorapy.client.AuroraSerialClient.serial_number",

--- a/tests/components/aurora_abb_powerone/test_init.py
+++ b/tests/components/aurora_abb_powerone/test_init.py
@@ -3,9 +3,12 @@
 from unittest.mock import patch
 
 from homeassistant.components.aurora_abb_powerone.const import ATTR_FIRMWARE, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_MODEL, ATTR_SERIAL_NUMBER, CONF_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from .test_sensor import _simulated_returns
 
 from tests.common import MockConfigEntry
 
@@ -14,8 +17,16 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unloading the aurora_abb_powerone entry."""
 
     with (
-        patch("homeassistant.components.aurora_abb_powerone.coordinator.sleep"),
         patch("aurorapy.client.AuroraSerialClient.connect", return_value=None),
+        patch(
+            "aurorapy.client.AuroraSerialClient.measure",
+            side_effect=_simulated_returns,
+        ),
+        patch("aurorapy.client.AuroraSerialClient.alarms", return_value=["No alarm"]),
+        patch(
+            "aurorapy.client.AuroraSerialClient.cumulated_energy",
+            side_effect=_simulated_returns,
+        ),
         patch(
             "aurorapy.client.AuroraSerialClient.serial_number",
             return_value="9876543",
@@ -46,5 +57,8 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         mock_entry.add_to_hass(hass)
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        assert mock_entry.state is ConfigEntryState.LOADED
+
         assert await hass.config_entries.async_unload(mock_entry.entry_id)
         await hass.async_block_till_done()
+        assert mock_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -278,6 +278,7 @@ async def test_sensor_unknown_error(
         await hass.async_block_till_done()
 
     with (
+        patch("homeassistant.components.aurora_abb_powerone.coordinator.sleep"),
         patch("aurorapy.client.AuroraSerialClient.connect", return_value=None),
         patch(
             "aurorapy.client.AuroraSerialClient.measure",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`pytest tests/components/aurora_abb_powerone`: 5.2s -> 1.5s.

The coordinator sleeps a second between update retries, and two tests waited for it.

`test_unload_entry` waited for it by accident. It never mocked `measure`, so the first refresh failed and left the entry in `SETUP_RETRY`; `async_unload` then only cancelled the retry and the integration's unload path never ran. Mocking a successful refresh fixes what the test covers and removes the wait as a side effect. It now asserts the entry is `LOADED` before unloading and `NOT_LOADED` after, which is what fails if the entry goes back to setting up on retry.

`test_sensor_unknown_error` waits for it on purpose: it asserts on the retry log, so it patches the sleep rather than avoiding the retry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr