### PR TITLE
Import components concurrently in the circular import test

### DIFF
--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -27,32 +27,44 @@ COMPONENTS = sorted(
     }
 )
 
+# Each import is a whole interpreter loading a component's dependency tree, so it
+# is both CPU and memory hungry. The suite already runs one xdist worker per CPU;
+# a small fixed ceiling keeps this from oversubscribing the host, and measuring
+# showed nothing to gain above it.
+MAX_CONCURRENT_IMPORTS = 4
+IMPORT_TIMEOUT = 120
 
-def _import_component(component: str) -> subprocess.CompletedProcess[str]:
-    """Import a component in a clean interpreter."""
-    return subprocess.run(
-        [sys.executable, "-c", f"import homeassistant.components.{component}"],
-        capture_output=True,
-        check=False,
-        text=True,
-    )
+
+def _import_component(component: str) -> tuple[int, str]:
+    """Import a component in a clean interpreter, returning its exit code."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", f"import homeassistant.components.{component}"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=IMPORT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return 1, f"importing timed out after {IMPORT_TIMEOUT} seconds"
+    return result.returncode, result.stderr
 
 
 @pytest.fixture(scope="session", autouse=True)
-def component_imports() -> dict[str, subprocess.CompletedProcess[str]]:
+def component_imports() -> dict[str, tuple[int, str]]:
     """Import every component, several interpreters at a time."""
-    with ThreadPoolExecutor(max_workers=os.process_cpu_count()) as executor:
+    workers = min(MAX_CONCURRENT_IMPORTS, os.process_cpu_count() or 1)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
         return dict(
             zip(COMPONENTS, executor.map(_import_component, COMPONENTS), strict=True)
         )
 
 
-@pytest.mark.timeout(600)  # covers importing every component in the first setup
+@pytest.mark.timeout(600)  # the first test imports every component
 @pytest.mark.parametrize("component", COMPONENTS)
 def test_circular_imports(
-    component: str,
-    component_imports: dict[str, subprocess.CompletedProcess[str]],
+    component: str, component_imports: dict[str, tuple[int, str]]
 ) -> None:
     """Check that components can be imported without circular imports."""
-    result = component_imports[component]
-    assert result.returncode == 0, result.stderr
+    returncode, stderr = component_imports[component]
+    assert returncode == 0, stderr

--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -1,6 +1,8 @@
 """Test to check for circular imports in core components."""
 
-import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import os
+import subprocess
 import sys
 
 import pytest
@@ -12,27 +14,45 @@ from homeassistant.bootstrap import (
     STAGE_1_INTEGRATIONS,
 )
 
-
-@pytest.mark.timeout(30)  # cloud can take > 9s
-@pytest.mark.parametrize(
-    "component",
-    sorted(
-        {
-            *CORE_INTEGRATIONS,
-            *(
-                domain
-                for name, domains, timeout in STAGE_0_INTEGRATIONS
-                for domain in domains
-            ),
-            *STAGE_1_INTEGRATIONS,
-            *DEFAULT_INTEGRATIONS,
-        }
-    ),
+COMPONENTS = sorted(
+    {
+        *CORE_INTEGRATIONS,
+        *(
+            domain
+            for name, domains, timeout in STAGE_0_INTEGRATIONS
+            for domain in domains
+        ),
+        *STAGE_1_INTEGRATIONS,
+        *DEFAULT_INTEGRATIONS,
+    }
 )
-async def test_circular_imports(component: str) -> None:
-    """Check that components can be imported without circular imports."""
-    process = await asyncio.create_subprocess_exec(
-        sys.executable, "-c", f"import homeassistant.components.{component}"
+
+
+def _import_component(component: str) -> subprocess.CompletedProcess[str]:
+    """Import a component in a clean interpreter."""
+    return subprocess.run(
+        [sys.executable, "-c", f"import homeassistant.components.{component}"],
+        capture_output=True,
+        check=False,
+        text=True,
     )
-    await process.communicate()
-    assert process.returncode == 0
+
+
+@pytest.fixture(scope="session", autouse=True)
+def component_imports() -> dict[str, subprocess.CompletedProcess[str]]:
+    """Import every component, several interpreters at a time."""
+    with ThreadPoolExecutor(max_workers=os.process_cpu_count()) as executor:
+        return dict(
+            zip(COMPONENTS, executor.map(_import_component, COMPONENTS), strict=True)
+        )
+
+
+@pytest.mark.timeout(600)  # covers importing every component in the first setup
+@pytest.mark.parametrize("component", COMPONENTS)
+def test_circular_imports(
+    component: str,
+    component_imports: dict[str, subprocess.CompletedProcess[str]],
+) -> None:
+    """Check that components can be imported without circular imports."""
+    result = component_imports[component]
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`test_circular_imports` spawns one interpreter per component and imports it there. That is 95 interpreters, and they run one after another: `--dist=loadfile` puts a whole file on a single xdist worker, so the file is serial however many workers the job has.

The imports themselves are honest work. `homeassistant.core` is only 0.29s; the rest is each component's real dependency tree, so there is nothing to trim there. The only thing to win back is the serialisation. A session fixture now imports every component through a small thread pool and each test asserts its own result, which keeps one test id per component and still reports a failure against the component that caused it.

Measured on the group that holds this file, [run 353822](https://github.com/home-assistant/core/actions/runs/32556634288) before against [run 353830](https://github.com/home-assistant/core/actions/runs/32558974161) after:

| | Before | After |
| --- | --- | --- |
| `test_circular_imports` | 201.6s over 84 entries | 93.4s in one fixture setup |
| whole pytest step for that group | 9m46s | 8m53s |

Two things worth being straight about. The file speeds up more than the group does, because the extra interpreters compete with the xdist workers already running on the same 4 vCPU runner — some of the win is paid back by the rest of the group. And this does not shorten the overall run: groups 7 and 8 are the critical path at roughly 13 minutes against this group's 9, since the buckets are split by test count rather than duration. What it does buy is CI minutes on this job, and the 84 slow test entries collapsing into 1.

Concurrency is capped at 4 rather than the host's CPU count: locally 4 workers gave 26.5s and 8 gave 28.2s, so there was nothing above it to win, and an uncapped pool would start one interpreter per core on a large machine while xdist is already using them all. Each child import also has its own timeout, so a hung import is reported against its component instead of outliving the pytest timeout and stalling the pool.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr