### PR TITLE
Do not use a naive `datetime.now()` in BraviaTV

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -245,10 +245,9 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 start_datetime = start_datetime.replace(
                     tzinfo=dt_util.get_default_time_zone()
                 )
-            self.media_position = int(
-                (dt_util.utcnow() - start_datetime).total_seconds()
-            )
-            self.media_position_updated_at = dt_util.utcnow()
+            now = dt_util.utcnow()
+            self.media_position = int((now - start_datetime).total_seconds())
+            self.media_position_updated_at = now
         else:
             self.media_position = None
             self.media_position_updated_at = None

--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_NICKNAME,
@@ -240,11 +241,14 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
         self.source = None
         if start_datetime := playing_info.get("startDateTime"):
             start_datetime = datetime.fromisoformat(start_datetime)
-            current_datetime = datetime.now().replace(tzinfo=start_datetime.tzinfo)  # pylint: disable=home-assistant-enforce-naive-now
+            if start_datetime.tzinfo is None:
+                start_datetime = start_datetime.replace(
+                    tzinfo=dt_util.get_default_time_zone()
+                )
             self.media_position = int(
-                (current_datetime - start_datetime).total_seconds()
+                (dt_util.utcnow() - start_datetime).total_seconds()
             )
-            self.media_position_updated_at = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+            self.media_position_updated_at = dt_util.utcnow()
         else:
             self.media_position = None
             self.media_position_updated_at = None

--- a/tests/components/braviatv/test_coordinator.py
+++ b/tests/components/braviatv/test_coordinator.py
@@ -14,17 +14,16 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("start_datetime", "expected_position"),
+    "start_datetime",
     [
-        ("2026-08-22T12:00:00", 7200),  # naive, treated as local time (CEST UTC+2)
-        ("2026-08-22T12:00:00+02:00", 7200),  # aware
+        "2026-08-22T12:00:00",  # naive, treated as local time (CEST UTC+2)
+        "2026-08-22T12:00:00+02:00",  # aware
     ],
 )
 @pytest.mark.freeze_time("2026-08-22T12:00:00+00:00")
 async def test_async_update_playing(
     hass: HomeAssistant,
     start_datetime: str,
-    expected_position: int,
 ) -> None:
     """Test updating playing info with a start datetime."""
     await hass.config.async_set_time_zone("Europe/Warsaw")
@@ -43,7 +42,7 @@ async def test_async_update_playing(
 
     await coordinator.async_update_playing()
 
-    assert coordinator.media_position == expected_position
+    assert coordinator.media_position == 7200
     assert coordinator.media_position_updated_at == datetime(
         2026, 8, 22, 12, 0, 0, tzinfo=UTC
     )

--- a/tests/components/braviatv/test_coordinator.py
+++ b/tests/components/braviatv/test_coordinator.py
@@ -1,0 +1,48 @@
+"""Test the BraviaTV coordinator."""
+
+from unittest.mock import AsyncMock
+
+from freezegun import freeze_time
+import pytest
+
+from homeassistant.components.braviatv.const import CONF_USE_PSK, DOMAIN
+from homeassistant.components.braviatv.coordinator import BraviaTVCoordinator
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("start_datetime", "expected_position"),
+    [
+        ("2024-01-01T12:00:00", 3600),  # naive, treated as local time
+        ("2024-01-01T12:00:00+02:00", 7200),  # aware
+    ],
+)
+async def test_async_update_playing(
+    hass: HomeAssistant,
+    start_datetime: str,
+    expected_position: int,
+) -> None:
+    """Test updating playing info with a start datetime."""
+    await hass.config.async_set_time_zone("Europe/Warsaw")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "localhost",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+            CONF_USE_PSK: True,
+            CONF_PIN: "12345qwerty",
+        },
+    )
+    client = AsyncMock()
+    client.get_playing_info.return_value = {"startDateTime": start_datetime}
+    coordinator = BraviaTVCoordinator(hass, config_entry, client)
+
+    with freeze_time("2024-01-01 12:00:00+00:00"):
+        await coordinator.async_update_playing()
+
+        assert coordinator.media_position == expected_position
+        assert coordinator.media_position_updated_at == dt_util.utcnow()

--- a/tests/components/braviatv/test_coordinator.py
+++ b/tests/components/braviatv/test_coordinator.py
@@ -1,5 +1,6 @@
 """Test the BraviaTV coordinator."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 from freezegun import freeze_time
@@ -9,7 +10,6 @@ from homeassistant.components.braviatv.const import CONF_USE_PSK, DOMAIN
 from homeassistant.components.braviatv.coordinator import BraviaTVCoordinator
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -17,8 +17,8 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("start_datetime", "expected_position"),
     [
-        ("2024-01-01T12:00:00", 3600),  # naive, treated as local time
-        ("2024-01-01T12:00:00+02:00", 7200),  # aware
+        ("2026-08-22T12:00:00", 7200),  # naive, treated as local time (CEST UTC+2)
+        ("2026-08-22T12:00:00+02:00", 7200),  # aware
     ],
 )
 async def test_async_update_playing(
@@ -41,8 +41,10 @@ async def test_async_update_playing(
     client.get_playing_info.return_value = {"startDateTime": start_datetime}
     coordinator = BraviaTVCoordinator(hass, config_entry, client)
 
-    with freeze_time("2024-01-01 12:00:00+00:00"):
+    with freeze_time("2026-08-22 12:00:00+00:00"):
         await coordinator.async_update_playing()
 
         assert coordinator.media_position == expected_position
-        assert coordinator.media_position_updated_at == dt_util.utcnow()
+        assert coordinator.media_position_updated_at == datetime(
+            2026, 8, 22, 12, 0, 0, tzinfo=UTC
+        )

--- a/tests/components/braviatv/test_coordinator.py
+++ b/tests/components/braviatv/test_coordinator.py
@@ -3,7 +3,6 @@
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.braviatv.const import CONF_USE_PSK, DOMAIN
@@ -21,6 +20,7 @@ from tests.common import MockConfigEntry
         ("2026-08-22T12:00:00+02:00", 7200),  # aware
     ],
 )
+@pytest.mark.freeze_time("2026-08-22T12:00:00+00:00")
 async def test_async_update_playing(
     hass: HomeAssistant,
     start_datetime: str,
@@ -41,10 +41,9 @@ async def test_async_update_playing(
     client.get_playing_info.return_value = {"startDateTime": start_datetime}
     coordinator = BraviaTVCoordinator(hass, config_entry, client)
 
-    with freeze_time("2026-08-22 12:00:00+00:00"):
-        await coordinator.async_update_playing()
+    await coordinator.async_update_playing()
 
-        assert coordinator.media_position == expected_position
-        assert coordinator.media_position_updated_at == datetime(
-            2026, 8, 22, 12, 0, 0, tzinfo=UTC
-        )
+    assert coordinator.media_position == expected_position
+    assert coordinator.media_position_updated_at == datetime(
+        2026, 8, 22, 12, 0, 0, tzinfo=UTC
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace naive `datetime.now()` in the BraviaTV coordinator with a single `dt_util.utcnow()` capture and proper timezone-aware handling of `startDateTime`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177792
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
