### PR TITLE
Add default support to object selector fields

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1660,6 +1660,7 @@ class NumericThresholdSelector(Selector[NumericThresholdSelectorConfig]):
 class ObjectSelectorField(TypedDict, total=False):
     """Class to represent an object selector fields dict."""
 
+    default: Any
     label: str
     required: bool
     selector: Required[Selector | dict[str, Any]]
@@ -1686,6 +1687,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
             vol.Optional("fields"): {
                 str: {
                     vol.Required("selector"): vol.Any(Selector, validate_selector),
+                    vol.Optional("default"): cv.match_all,
                     vol.Optional("required"): bool,
                     vol.Optional("label"): str,
                 }

--- a/tests/helpers/snapshots/test_selector.ambr
+++ b/tests/helpers/snapshots/test_selector.ambr
@@ -255,6 +255,7 @@
             }),
           }),
           'percentage': dict({
+            'default': 0,
             'selector': dict({
               'number': dict({
                 'max': 100.0,

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1370,6 +1370,32 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
     _test_selector("object", schema, valid_selections, invalid_selections)
 
 
+@pytest.mark.parametrize(
+    "default",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param(False, id="false"),
+        pytest.param("", id="empty-string"),
+        pytest.param([], id="empty-list"),
+        pytest.param({}, id="empty-dict"),
+    ],
+)
+def test_object_selector_field_default(default: object) -> None:
+    """Test object selector field default."""
+    selector.validate_selector(
+        {
+            "object": {
+                "fields": {
+                    "field": {
+                        "selector": {"text": {}},
+                        "default": default,
+                    }
+                }
+            }
+        }
+    )
+
+
 def test_object_selector_uses_selectors(snapshot: SnapshotAssertion) -> None:
     """Test ObjectSelector serializer with Selector in ObjectSelectorField."""
 
@@ -1384,6 +1410,7 @@ def test_object_selector_uses_selectors(snapshot: SnapshotAssertion) -> None:
                 "selector": selector.NumberSelector(
                     selector.NumberSelectorConfig(min=0, max=100)
                 ),
+                "default": 0,
             },
         },
         "multiple": True,

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1382,7 +1382,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
 )
 def test_object_selector_field_default(default: object) -> None:
     """Test object selector field default."""
-validated = selector.validate_selector(
+    validated = selector.validate_selector(
         {
             "object": {
                 "fields": {

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1382,7 +1382,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
 )
 def test_object_selector_field_default(default: object) -> None:
     """Test object selector field default."""
-    selector.validate_selector(
+validated = selector.validate_selector(
         {
             "object": {
                 "fields": {
@@ -1394,6 +1394,7 @@ def test_object_selector_field_default(default: object) -> None:
             }
         }
     )
+    assert validated["object"]["fields"]["field"]["default"] == default
 
 
 def test_object_selector_uses_selectors(snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for `default` values in object selector fields.

Object selector field definitions can now include a `default` value, which is
preserved when the selector is validated and serialized.

The default value is passed through unchanged, allowing selector-specific values,
including falsy and structured values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/52906
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47558
- Link to developer documentation pull request:
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53739

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr