### PR TITLE
Fix Z-Wave JS legacy security key handling

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1364,11 +1364,15 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
 
+        default_keys = SecurityKeys.from_config(addon_config, self.security_keys)
+
         if user_input is not None:
-            # The revert helper only passes keys present in the original
-            # add-on config, which may lack some of the security keys,
-            # so treat missing keys as empty.
-            self.security_keys = SecurityKeys().updated_from_user_input(user_input)
+            # Missing keys default to the current add-on config, so
+            # existing keys are preserved. While reverting, the helper only
+            # passes the keys present in the original config, so missing keys
+            # must be treated as empty to actually revert them.
+            key_defaults = SecurityKeys() if self.revert_reason else default_keys
+            self.security_keys = key_defaults.updated_from_user_input(user_input)
             self.usb_path = user_input.get(CONF_USB_PATH) or None
             self.socket_path = user_input.get(CONF_SOCKET_PATH) or None
 
@@ -1402,8 +1406,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         usb_path = addon_config.get(CONF_ADDON_DEVICE, self.usb_path or "")
         socket_path = addon_config.get(CONF_ADDON_SOCKET, self.socket_path or "")
-        default_keys = SecurityKeys.from_config(addon_config, self.security_keys)
-
         try:
             ports = await async_get_usb_ports(self.hass)
         except OSError as err:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -48,6 +48,7 @@ from .const import (
     ADDON_SLUG,
     CONF_ADDON_DEVICE,
     CONF_ADDON_NETWORK_KEY,
+    CONF_ADDON_S0_LEGACY_KEY,
     CONF_ADDON_SOCKET,
     CONF_INTEGRATION_CREATED_ADDON,
     CONF_SOCKET_PATH,
@@ -74,6 +75,20 @@ ADDON_SETUP_TIMEOUT_ROUNDS = 40
 SERVER_CONNECT_TIMEOUT = 60
 
 
+def migrate_network_key(addon_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Migrate the legacy network key to the S0 legacy key.
+
+    The network key was renamed to the S0 legacy key when S2 was added.
+    Old add-on configs may still only carry the legacy network key.
+    """
+    migrated = dict(addon_config)
+    if (network_key := migrated.pop(CONF_ADDON_NETWORK_KEY, None)) and not migrated.get(
+        CONF_ADDON_S0_LEGACY_KEY
+    ):
+        migrated[CONF_ADDON_S0_LEGACY_KEY] = network_key
+    return migrated
+
+
 @dataclass
 class SecurityKeys:
     """Security keys of a Z-Wave network.
@@ -94,6 +109,7 @@ class SecurityKeys:
         cls, config: Mapping[str, Any], defaults: SecurityKeys | None = None
     ) -> Self:
         """Return keys from an add-on config or entry data, with defaults."""
+        config = migrate_network_key(config)
         return cls(
             **{
                 field.name: config.get(
@@ -284,8 +300,7 @@ class AddonFlowManager:
         if addon_info.state is AddonState.RUNNING:
             self.restart_addon = True
         self.original_config = dict(addon_config)
-        # Remove legacy network_key
-        new_addon_config.pop(CONF_ADDON_NETWORK_KEY, None)
+        new_addon_config = migrate_network_key(new_addon_config)
         try:
             await self.addon_manager.async_set_addon_options(new_addon_config)
         except AddonError as err:
@@ -1705,9 +1720,12 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason=reason)
 
         self.revert_reason = reason
+        # Migrate a legacy network key so it is reverted as the S0 legacy key,
+        # which is what ADDON_USER_INPUT_MAP knows about.
+        original_config = migrate_network_key(self._addon_setup.original_config)
         addon_config_input = {
             ADDON_USER_INPUT_MAP[addon_key]: addon_val
-            for addon_key, addon_val in self._addon_setup.original_config.items()
+            for addon_key, addon_val in original_config.items()
             if addon_key in ADDON_USER_INPUT_MAP
         }
         _LOGGER.debug("Reverting app options, reason: %s", reason)

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -75,20 +75,6 @@ ADDON_SETUP_TIMEOUT_ROUNDS = 40
 SERVER_CONNECT_TIMEOUT = 60
 
 
-def migrate_network_key(addon_config: Mapping[str, Any]) -> dict[str, Any]:
-    """Migrate the legacy network key to the S0 legacy key.
-
-    The network key was renamed to the S0 legacy key when S2 was added.
-    Old add-on configs may still only carry the legacy network key.
-    """
-    migrated = dict(addon_config)
-    if (network_key := migrated.pop(CONF_ADDON_NETWORK_KEY, None)) and not migrated.get(
-        CONF_ADDON_S0_LEGACY_KEY
-    ):
-        migrated[CONF_ADDON_S0_LEGACY_KEY] = network_key
-    return migrated
-
-
 @dataclass
 class SecurityKeys:
     """Security keys of a Z-Wave network.
@@ -104,12 +90,26 @@ class SecurityKeys:
     lr_s2_access_control_key: str | None = None
     lr_s2_authenticated_key: str | None = None
 
+    @staticmethod
+    def migrate_network_key(config: Mapping[str, Any]) -> dict[str, Any]:
+        """Migrate the legacy network key to the S0 legacy key.
+
+        The network key was renamed to the S0 legacy key when S2 was added.
+        Old add-on configs may still only carry the legacy network key.
+        """
+        migrated = dict(config)
+        if (
+            network_key := migrated.pop(CONF_ADDON_NETWORK_KEY, None)
+        ) and not migrated.get(CONF_ADDON_S0_LEGACY_KEY):
+            migrated[CONF_ADDON_S0_LEGACY_KEY] = network_key
+        return migrated
+
     @classmethod
     def from_config(
         cls, config: Mapping[str, Any], defaults: SecurityKeys | None = None
     ) -> Self:
         """Return keys from an add-on config or entry data, with defaults."""
-        config = migrate_network_key(config)
+        config = cls.migrate_network_key(config)
         return cls(
             **{
                 field.name: config.get(
@@ -300,7 +300,7 @@ class AddonFlowManager:
         if addon_info.state is AddonState.RUNNING:
             self.restart_addon = True
         self.original_config = dict(addon_config)
-        new_addon_config = migrate_network_key(new_addon_config)
+        new_addon_config = SecurityKeys.migrate_network_key(new_addon_config)
         try:
             await self.addon_manager.async_set_addon_options(new_addon_config)
         except AddonError as err:
@@ -1368,11 +1368,9 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Missing keys default to the current add-on config, so
-            # existing keys are preserved. While reverting, the helper only
-            # passes the keys present in the original config, so missing keys
-            # must be treated as empty to actually revert them.
-            key_defaults = SecurityKeys() if self.revert_reason else default_keys
-            self.security_keys = key_defaults.updated_from_user_input(user_input)
+            # existing keys are preserved. The revert helper always passes
+            # all keys, so the defaults never apply while reverting.
+            self.security_keys = default_keys.updated_from_user_input(user_input)
             self.usb_path = user_input.get(CONF_USB_PATH) or None
             self.socket_path = user_input.get(CONF_SOCKET_PATH) or None
 
@@ -1722,13 +1720,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason=reason)
 
         self.revert_reason = reason
-        # Migrate a legacy network key so it is reverted as the S0 legacy key,
-        # which is what ADDON_USER_INPUT_MAP knows about.
-        original_config = migrate_network_key(self._addon_setup.original_config)
-        addon_config_input = {
+        original_config = self._addon_setup.original_config
+        addon_config_input = SecurityKeys.from_config(original_config).to_dict() | {
             ADDON_USER_INPUT_MAP[addon_key]: addon_val
             for addon_key, addon_val in original_config.items()
-            if addon_key in ADDON_USER_INPUT_MAP
+            if addon_key in (CONF_ADDON_DEVICE, CONF_ADDON_SOCKET)
         }
         _LOGGER.debug("Reverting app options, reason: %s", reason)
         return await self.async_step_configure_addon_reconfigure(addon_config_input)

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -24,7 +24,6 @@ from homeassistant.components.zwave_js.config_flow import (
     TITLE,
     SecurityKeys,
     async_get_usb_ports,
-    migrate_network_key,
 )
 from homeassistant.components.zwave_js.const import (
     ADDON_SLUG,
@@ -1341,7 +1340,7 @@ def test_migrate_legacy_network_key(
     """Test the legacy network key is migrated to the S0 legacy key."""
     original = dict(addon_config)
 
-    migrated = migrate_network_key(addon_config)
+    migrated = SecurityKeys.migrate_network_key(addon_config)
     assert "network_key" not in migrated
     assert migrated.get("s0_legacy_key", "") == expected_s0
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -20,7 +20,12 @@ from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.usb import SerialDevice, USBDevice
-from homeassistant.components.zwave_js.config_flow import TITLE, async_get_usb_ports
+from homeassistant.components.zwave_js.config_flow import (
+    TITLE,
+    SecurityKeys,
+    async_get_usb_ports,
+    migrate_network_key,
+)
 from homeassistant.components.zwave_js.const import (
     ADDON_SLUG,
     CONF_ADDON_DEVICE,
@@ -1317,6 +1322,34 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
     assert entry.data["socket_path"] is None
     assert entry.data["use_addon"] is True
     assert entry.unique_id == "3245146787"
+
+
+@pytest.mark.parametrize(
+    ("addon_config", "expected_s0"),
+    [
+        pytest.param({"network_key": "legacy"}, "legacy", id="legacy_only"),
+        pytest.param(
+            {"network_key": "legacy", "s0_legacy_key": "s0"}, "s0", id="s0_wins"
+        ),
+        pytest.param({"s0_legacy_key": "s0"}, "s0", id="s0_only"),
+        pytest.param({}, "", id="neither"),
+    ],
+)
+def test_migrate_legacy_network_key(
+    addon_config: dict[str, str], expected_s0: str
+) -> None:
+    """Test the legacy network key is migrated to the S0 legacy key."""
+    original = dict(addon_config)
+
+    migrated = migrate_network_key(addon_config)
+    assert "network_key" not in migrated
+    assert migrated.get("s0_legacy_key", "") == expected_s0
+
+    keys = SecurityKeys.from_config(addon_config)
+    assert keys.s0_legacy_key == expected_s0
+
+    # Neither call mutates the caller's dict.
+    assert addon_config == original
 
 
 @pytest.mark.usefixtures("supervisor", "addon_info")

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4790,6 +4790,64 @@ async def test_reconfigure_addon_running_server_info_failure(
     assert client.disconnect.call_count == 1
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running")
+async def test_reconfigure_preserves_omitted_security_keys(
+    hass: HomeAssistant,
+    client: MagicMock,
+    integration: MockConfigEntry,
+    addon_options: dict[str, Any],
+    set_addon_options: AsyncMock,
+    restart_addon: AsyncMock,
+) -> None:
+    """Test a partial reconfigure keeps security keys not in the submission."""
+    addon_options.update({"device": "/test", "s0_legacy_key": "keep-me"})
+    entry = integration
+    hass.config_entries.async_update_entry(entry, unique_id="1234")
+    client.driver.controller.data["homeId"] = 1234
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "intent_reconfigure"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configure_addon_reconfigure"
+
+    # The submission omits the security key fields and only changes the device.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"usb_path": "/new"}
+    )
+
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+    # The existing S0 key is preserved, not wiped to an empty string.
+    assert set_addon_options.call_args == call(
+        "core_zwave_js",
+        AddonsOptions(
+            config={
+                "device": "/new",
+                "s0_legacy_key": "keep-me",
+                "s2_access_control_key": "",
+                "s2_authenticated_key": "",
+                "s2_unauthenticated_key": "",
+                "lr_s2_access_control_key": "",
+                "lr_s2_authenticated_key": "",
+            }
+        ),
+    )
+
+    await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data["s0_legacy_key"] == "keep-me"
+
+
 @pytest.mark.usefixtures("supervisor")
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two key handling fixes on top of the #179600 refactor. A very old add-on config that only carries the legacy `network_key` lost its only S0 key on any config write or revert; the key is now migrated to `s0_legacy_key` wherever the config is read or written. A partial reconfigure submission wiped omitted security keys to empty strings; missing keys now default from the current add-on config, with empty defaults only while reverting.

Extracted from #176135.

cc @AlCalzone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
