### PR TITLE
Use a long enough JWT signing key in the Enphase Envoy tests

### DIFF
--- a/tests/components/enphase_envoy/__init__.py
+++ b/tests/components/enphase_envoy/__init__.py
@@ -10,6 +10,9 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
+# PyJWT warns about HS256 keys shorter than 32 bytes
+TOKEN_SIGNING_KEY = "envoy-test-signing-key-0123456789"
+
 
 async def setup_integration(
     hass: HomeAssistant,
@@ -31,6 +34,6 @@ def envoy_token(days_to_expiry: int = 365) -> str:
             "name": "envoy",
             "exp": (dt_util.utcnow() + timedelta(days=days_to_expiry)).timestamp(),
         },
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )

--- a/tests/components/enphase_envoy/__init__.py
+++ b/tests/components/enphase_envoy/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
-# PyJWT warns about HS256 keys shorter than 32 bytes
 TOKEN_SIGNING_KEY = "envoy-test-signing-key-0123456789"
 
 

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -42,7 +42,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from . import setup_integration
+from . import TOKEN_SIGNING_KEY, setup_integration
 
 from tests.common import MockConfigEntry, async_capture_events, async_fire_time_changed
 from tests.typing import WebSocketGenerator
@@ -72,7 +72,7 @@ async def test_token_in_config_file(
     """Test coordinator with token provided from config."""
     token = encode(
         payload={"name": "envoy", "exp": 1907837780},
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )
     entry = MockConfigEntry(
@@ -105,7 +105,7 @@ async def test_expired_token_in_config(
     current_token = encode(
         # some time in 2021
         payload={"name": "envoy", "exp": 1627314600},
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )
 
@@ -305,7 +305,7 @@ async def test_coordinator_token_refresh_error(
     token = encode(
         # some time in 2021
         payload={"name": "envoy", "exp": 1627314600},
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )
     entry = MockConfigEntry(
@@ -344,7 +344,7 @@ async def test_coordinator_first_update_auth_error(
     current_token = encode(
         # some time in future
         payload={"name": "envoy", "exp": 1927314600},
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )
 
@@ -796,7 +796,7 @@ async def test_retry_timeout_settings(
     """Test coordinator with token provided from config."""
     token = encode(
         payload={"name": "envoy", "exp": 1907837780},
-        key="secret",
+        key=TOKEN_SIGNING_KEY,
         algorithm="HS256",
     )
     entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PyJWT warns when an HS256 key is shorter than the 32 bytes RFC 7518 recommends. The tests signed with a six byte key.

`InsecureKeyLengthWarning` in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 272 | 0 |

No snapshots change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_