### PR TITLE
Silence two pytest warnings in the pylint plugin tests

### DIFF
--- a/tests/pylint/quality_scale/test_test_before_configure.py
+++ b/tests/pylint/quality_scale/test_test_before_configure.py
@@ -7,7 +7,8 @@ import astroid
 from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
 from pylint_home_assistant.checkers.quality_scale.test_before_configure import (
-    TestBeforeConfigureChecker,
+    # Aliased so pytest does not try to collect it as a test class
+    TestBeforeConfigureChecker as BeforeConfigureChecker,
 )
 from pylint_home_assistant.helpers.integration import clear_caches
 from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cache
@@ -30,11 +31,11 @@ class MyConfigFlow(ConfigFlow, domain="test_integration"):
 
 
 @pytest.fixture(name="configure_checker")
-def configure_checker_fixture(linter: UnittestLinter) -> TestBeforeConfigureChecker:
+def configure_checker_fixture(linter: UnittestLinter) -> BeforeConfigureChecker:
     """Fixture to provide a test before configure checker."""
     clear_quality_scale_cache()
     clear_caches()
-    return TestBeforeConfigureChecker(linter)
+    return BeforeConfigureChecker(linter)
 
 
 def _make_integration(
@@ -157,7 +158,7 @@ def _expect_missing(class_node: nodes.ClassDef) -> MessageTest:
 )
 def test_before_configure_evidence_present(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
     flow_body: str,
 ) -> None:
@@ -215,7 +216,7 @@ class MyConfigFlow(ConfigFlow, domain="test_integration"):
 )
 def test_before_configure_missing_fires(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
     flow_source: str,
     manifest: dict | None,
@@ -233,7 +234,7 @@ def test_before_configure_missing_fires(
 
 def test_before_configure_oauth_flow_skipped(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
 ) -> None:
     """No warning for OAuth flows; the token exchange is the connection test."""
@@ -255,7 +256,7 @@ class MyConfigFlow(AbstractOAuth2FlowHandler, domain="test_integration"):
 
 def test_before_configure_inherited_evidence(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
 ) -> None:
     """No warning when surfacing evidence lives in an inherited flow class's module."""
@@ -291,7 +292,7 @@ class MyConfigFlow(BaseHardwareFlow, domain="test_integration"):
 
 def test_before_configure_inherited_entry_creation_fires(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
 ) -> None:
     """Warning when entry creation is inherited and nothing surfaces failures."""
@@ -323,7 +324,7 @@ class MyConfigFlow(BaseSharedFlow, domain="test_integration"):
 
 def test_before_configure_non_config_flow_class(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
 ) -> None:
     """No warning for classes that are not config flows."""
@@ -373,7 +374,7 @@ class MyHelper:
 )
 def test_before_configure_not_fired(
     linter: UnittestLinter,
-    configure_checker: TestBeforeConfigureChecker,
+    configure_checker: BeforeConfigureChecker,
     tmp_path: Path,
     module_name: str,
     rules: dict | None,

--- a/tests/pylint/quality_scale/test_test_before_configure.py
+++ b/tests/pylint/quality_scale/test_test_before_configure.py
@@ -7,7 +7,6 @@ import astroid
 from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
 from pylint_home_assistant.checkers.quality_scale.test_before_configure import (
-    # Aliased so pytest does not try to collect it as a test class
     TestBeforeConfigureChecker as BeforeConfigureChecker,
 )
 from pylint_home_assistant.helpers.integration import clear_caches

--- a/tests/pylint/type_hints/test_type_hints.py
+++ b/tests/pylint/type_hints/test_type_hints.py
@@ -5,6 +5,7 @@ import re
 from unittest.mock import patch
 
 import astroid
+from astroid import nodes
 from pylint.checkers import BaseChecker
 import pylint.testutils
 from pylint.testutils.unittest_linter import UnittestLinter
@@ -440,7 +441,7 @@ def test_invalid_flow_step(
     type_hint_checker: BaseChecker,
     code: str,
     expected_messages_fn: Callable[
-        [astroid.NodeNG], tuple[pylint.testutils.MessageTest, ...]
+        [nodes.NodeNG], tuple[pylint.testutils.MessageTest, ...]
     ],
 ) -> None:
     """Ensure invalid hints are rejected for flow step."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two unrelated warnings in the same test tree:

- `TestBeforeConfigureChecker` is imported into a test module, so pytest tries to collect the checker as a test class and warns that it cannot. Aliasing the import stops that.
- `NodeNG` is deprecated as a top level `astroid` re-export, import it from `astroid.nodes`.

Warnings in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 6 | 0 |

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_