### PR TITLE
Universal media player:  track active child changes

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -152,6 +152,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         self._children = config.get(CONF_CHILDREN)
         self._active_child_template = config.get(CONF_ACTIVE_CHILD_TEMPLATE)
         self._active_child_template_result = None
+        self._active_child_change_tracker_cancel = None
         self._cmds = config.get(CONF_COMMANDS)
         self._attrs = {}
         for key, val in config.get(CONF_ATTRS).items():
@@ -197,6 +198,9 @@ class UniversalMediaPlayer(MediaPlayerEntity):
                     self._active_child_template_result = (
                         None if isinstance(result, TemplateError) else result
                     )
+                    self._clean_up_active_child_change_tracker()
+                    if self._active_child_template_result:
+                        self._active_child_change_tracker_cancel = async_track_state_change_event(self.hass, self._active_child_template_result, _async_on_dependency_update)
 
             if event:
                 self.async_set_context(event.context)
@@ -231,6 +235,14 @@ class UniversalMediaPlayer(MediaPlayerEntity):
                 self.hass, list(set(depend)), _async_on_dependency_update
             )
         )
+        self.async_on_remove(self._clean_up_active_child_change_tracker)
+
+    @callback
+    def _clean_up_active_child_change_tracker(self) -> None:
+        """Remove active child change tracker."""
+        if self._active_child_change_tracker_cancel:
+            self._active_child_change_tracker_cancel()
+            self._active_child_change_tracker_cancel = None
 
     def _entity_lkp(self, entity_id, state_attr=None):
         """Look up an entity state."""

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -199,8 +199,14 @@ class UniversalMediaPlayer(MediaPlayerEntity):
                         None if isinstance(result, TemplateError) else result
                     )
                     self._clean_up_active_child_change_tracker()
-                    if self._active_child_template_result:
-                        self._active_child_change_tracker_cancel = async_track_state_change_event(self.hass, self._active_child_template_result, _async_on_dependency_update)
+                    if (_ac := self._active_child_template_result) and _ac not in (
+                        self._children + list(self._attrs.values())
+                    ):
+                        self._active_child_change_tracker_cancel = (
+                            async_track_state_change_event(
+                                self.hass, _ac, _async_on_dependency_update
+                            )
+                        )
 
             if event:
                 self.async_set_context(event.context)

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -200,7 +200,8 @@ class UniversalMediaPlayer(MediaPlayerEntity):
                     )
                     self._clean_up_active_child_change_tracker()
                     if (_ac := self._active_child_template_result) and _ac not in (
-                        self._children + list(self._attrs.values())
+                        self._children
+                        + [entity[0] for entity in self._attrs.values()]
                     ):
                         self._active_child_change_tracker_cancel = (
                             async_track_state_change_event(

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1,9 +1,10 @@
 """The tests for the Universal Media player platform."""
 
 from copy import copy
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
+from pytest_unordered import unordered
 from voluptuous.error import MultipleInvalid
 
 from homeassistant import config as hass_config
@@ -1325,25 +1326,77 @@ async def test_active_child_template(hass: HomeAssistant) -> None:
     hass.states.async_set("media_player.mock1", STATE_PLAYING)
     hass.states.async_set("media_player.mock2", STATE_PAUSED)
 
-    await async_setup_component(
-        hass,
-        "media_player",
-        {
-            "media_player": {
-                "platform": "universal",
-                "name": "tv",
-                "children": ["media_player.mock1", "media_player.mock2"],
-                "active_child_template": "{{ 'media_player.mock2' }}",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await hass.async_start()
+    with patch(
+        "homeassistant.components.universal.media_player.async_track_state_change_event",
+        wraps=async_track_state_change_event,
+    ) as atsce:
+        await async_setup_component(
+            hass,
+            "media_player",
+            {
+                "media_player": {
+                    "platform": "universal",
+                    "name": "tv",
+                    "children": ["media_player.mock1", "media_player.mock2"],
+                    "active_child_template": "{{ 'media_player.mock2' }}",
+                }
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_start()
+        atsce.assert_called_once_with(
+            hass, unordered(["media_player.mock1", "media_player.mock2"]), ANY
+        )
 
-    hass.states.async_set("media_player.mock2", STATE_ON)
+        hass.states.async_set("media_player.mock2", STATE_ON)
 
-    await hass.async_block_till_done()
-    assert hass.states.get("media_player.tv").state == STATE_ON
+        await hass.async_block_till_done()
+        assert hass.states.get("media_player.tv").state == STATE_ON
+
+
+async def test_active_child_template_tracking(hass: HomeAssistant) -> None:
+    """Test active child template state tracking without explicit child listed."""
+    hass.states.async_set("media_player.mock1", STATE_ON)
+    hass.states.async_set("media_player.mock2", STATE_PAUSED)
+
+    with patch(
+        "homeassistant.components.universal.media_player.async_track_state_change_event",
+        wraps=async_track_state_change_event,
+    ) as atsce:
+        await async_setup_component(
+            hass,
+            "media_player",
+            {
+                "media_player": {
+                    "platform": "universal",
+                    "name": "tv",
+                    "active_child_template": "{{ 'media_player.mock2' if is_state('media_player.mock2', 'playing') else 'media_player.mock1' }}",
+                }
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_start()
+        atsce.assert_has_calls(
+            [call(hass, [], ANY), call(hass, "media_player.mock1", ANY)]
+        )
+        atsce.reset_mock()
+
+        hass.states.async_set("media_player.mock2", STATE_PLAYING)
+        await hass.async_block_till_done()
+        assert hass.states.get("media_player.tv").state == STATE_PLAYING
+        assert (
+            hass.states.get("media_player.tv").attributes["active_child"]
+            == "media_player.mock2"
+        )
+        atsce.assert_called_once_with(hass, "media_player.mock2", ANY)
+
+        hass.states.async_set("media_player.mock2", STATE_OFF)
+        await hass.async_block_till_done()
+        assert hass.states.get("media_player.tv").state == STATE_ON
+        assert (
+            hass.states.get("media_player.tv").attributes["active_child"]
+            == "media_player.mock1"
+        )
 
 
 async def test_reload(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR ensures the Universal MediaPlayer tracks changes to the `active_child` entity when this entity is not part of the listed children.

Without this change the Universal MediaPlayer relies on tracking state changes of only entities that are explicitly mentioned as either a child entity or as part of its attributes. This makes it unsuitable for combining all media player entities of a certain type (e.g. Jellyfin) or in a specific room without updating the YAML config every time this set of entities changes.

Use-case example: (mirroring the active Jellyfin mediaplayer entity)
```
media_player:
  - platform: universal
    name: Jellyfin active
    active_child_template: >-
      {% set jellyfin_entities = integration_entities("jellyfin") | select("contains", "media_player.") | list %}
      {% set ns = namespace(entity_id='media_player.lg_smart_tv') %}
      {% for e in jellyfin_entities -%}
        {%- if is_state(e, ["playing", "paused", "buffering"]) -%}
          {%- set ns.entity_id = e -%}
        {%- endif -%}
      {%- endfor %}
      {{ ns.entity_id }}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
