### PR TITLE
Send the SmartThings token request credentials as a header

### DIFF
--- a/homeassistant/components/smartthings/application_credentials.py
+++ b/homeassistant/components/smartthings/application_credentials.py
@@ -4,7 +4,7 @@ from json import JSONDecodeError
 import logging
 from typing import cast, override
 
-from aiohttp import BasicAuth, ClientError
+from aiohttp import ClientError, encode_basic_auth
 
 from homeassistant.components.application_credentials import (
     AuthImplementation,
@@ -46,7 +46,9 @@ class SmartThingsOAuth2Implementation(AuthImplementation):
         resp = await session.post(
             self.token_url,
             data=data,
-            auth=BasicAuth(self.client_id, self.client_secret),
+            headers={
+                "Authorization": encode_basic_auth(self.client_id, self.client_secret)
+            },
         )
         if resp.status >= 400:
             try:

--- a/tests/components/smartthings/test_application_credentials.py
+++ b/tests/components/smartthings/test_application_credentials.py
@@ -1,0 +1,44 @@
+"""Test the SmartThings application credentials platform."""
+
+import base64
+
+from homeassistant.components.application_credentials import (
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.components.smartthings.application_credentials import (
+    SmartThingsOAuth2Implementation,
+)
+from homeassistant.components.smartthings.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+TOKEN_URL = "https://auth-global.api.smartthings.com/oauth/token"
+
+
+async def test_token_request_sends_credentials_as_header(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the token request authenticates with an Authorization header."""
+    aioclient_mock.post(TOKEN_URL, json={"access_token": "mock-access-token"})
+
+    implementation = SmartThingsOAuth2Implementation(
+        hass,
+        DOMAIN,
+        ClientCredential("client-id", "client-secret"),
+        authorization_server=AuthorizationServer(
+            authorize_url="https://api.smartthings.com/oauth/authorize",
+            token_url=TOKEN_URL,
+        ),
+    )
+
+    assert await implementation._token_request({"grant_type": "refresh_token"}) == {
+        "access_token": "mock-access-token"
+    }
+
+    assert len(aioclient_mock.mock_calls) == 1
+    _method, _url, _data, headers = aioclient_mock.mock_calls[0]
+    encoded = base64.b64encode(b"client-id:client-secret").decode()
+    assert (headers or {}).get("Authorization") == f"Basic {encoded}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

aiohttp deprecates `BasicAuth` and the per-request `auth` argument in favour of `encode_basic_auth()` plus an `Authorization` header. This is a single token request to a fixed URL, so it is a direct swap.

`BasicAuth is deprecated` warnings in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 9 | 0 |

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_