### PR TITLE
Send rest_command credentials as an Authorization header

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -168,8 +168,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
             # Kept out of the debug log above so the credentials are not logged.
-            # A configured Authorization header wins over the credentials,
-            # whatever its casing, so setdefault runs on a CIMultiDict.
             request_headers = CIMultiDict(headers)
             if basic_auth is not None:
                 request_headers.setdefault(hdrs.AUTHORIZATION, basic_auth)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -125,7 +125,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
                 digest_auth = (username, password)
             else:
-                basic_auth = aiohttp.encode_basic_auth(username, password)
+                basic_auth = aiohttp.encode_basic_auth(
+                    username, password, encoding="latin1"
+                )
 
         template_payload = None
         if CONF_PAYLOAD in command_config:

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -63,7 +63,10 @@ COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_AUTHENTICATION): vol.In(
             [HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]
         ),
-        vol.Inclusive(CONF_USERNAME, "authentication"): cv.string,
+        # A colon cannot be encoded into basic credentials, RFC 7617#section-2
+        vol.Inclusive(CONF_USERNAME, "authentication"): vol.All(
+            cv.string, vol.Match(r"^[^:]*$")
+        ),
         vol.Inclusive(CONF_PASSWORD, "authentication"): cv.string,
         vol.Optional(CONF_PAYLOAD): cv.template,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
@@ -77,14 +80,6 @@ COMMAND_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: cv.schema_with_slug_keys(COMMAND_SCHEMA)}, extra=vol.ALLOW_EXTRA
 )
-
-
-def _validated_credentials(username: str, password: str) -> tuple[str, str]:
-    """Return credentials for the handler to encode when the command runs."""
-    # encode_basic_auth runs per call, so it would only reject this much later
-    if ":" in username:
-        raise ValueError('A ":" is not allowed in login (RFC 7617#section-2)')
-    return (username, password)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -133,7 +128,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
                 digest_auth = (username, password)
             else:
-                basic_auth = _validated_credentials(username, password)
+                basic_auth = (username, password)
 
         template_payload = None
         if CONF_PAYLOAD in command_config:

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -117,7 +117,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         template_url = command_config[CONF_URL]
         skip_url_encoding = command_config[CONF_SKIP_URL_ENCODING]
 
-        basic_auth: str | None = None
+        basic_auth: tuple[str, str] | None = None
         digest_auth: tuple[str, str] | None = None
         if CONF_USERNAME in command_config:
             username = command_config[CONF_USERNAME]
@@ -125,9 +125,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
                 digest_auth = (username, password)
             else:
-                basic_auth = aiohttp.encode_basic_auth(
-                    username, password, encoding="latin1"
-                )
+                basic_auth = (username, password)
 
         template_payload = None
         if CONF_PAYLOAD in command_config:
@@ -170,9 +168,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
             # Kept out of the debug log above so the credentials are not logged.
+            # Encoding here rather than at registration keeps a credential
+            # outside latin-1 a failure of this call, not of the whole setup.
             request_headers = CIMultiDict(headers)
-            if basic_auth is not None:
-                request_headers.setdefault(hdrs.AUTHORIZATION, basic_auth)
+            if basic_auth is not None and hdrs.AUTHORIZATION not in request_headers:
+                request_headers[hdrs.AUTHORIZATION] = aiohttp.encode_basic_auth(
+                    *basic_auth, encoding="latin1"
+                )
 
             try:
                 # Prepare request kwargs

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -116,7 +116,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         template_url = command_config[CONF_URL]
         skip_url_encoding = command_config[CONF_SKIP_URL_ENCODING]
 
-        auth = None
+        basic_auth: str | None = None
         digest_auth: tuple[str, str] | None = None
         if CONF_USERNAME in command_config:
             username = command_config[CONF_USERNAME]
@@ -124,7 +124,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
                 digest_auth = (username, password)
             else:
-                auth = aiohttp.BasicAuth(username, password=password)
+                basic_auth = aiohttp.encode_basic_auth(username, password)
 
         template_payload = None
         if CONF_PAYLOAD in command_config:
@@ -166,18 +166,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 payload,
             )
 
+            # Kept out of the debug log above so the credentials are not logged.
+            # A configured Authorization header wins over the credentials.
+            request_headers = headers
+            if basic_auth is not None:
+                request_headers = {hdrs.AUTHORIZATION: basic_auth, **headers}
+
             try:
                 # Prepare request kwargs
                 request_kwargs = {
                     "data": payload,
-                    "headers": headers or None,
+                    "headers": request_headers or None,
                     "timeout": timeout,
                 }
 
                 # Add authentication
-                if auth is not None:
-                    request_kwargs["auth"] = auth
-                elif digest_auth is not None:
+                if digest_auth is not None:
                     request_kwargs["middlewares"] = (
                         aiohttp.DigestAuthMiddleware(*digest_auth),
                     )

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import aiohttp
 from aiohttp import hdrs
+from multidict import CIMultiDict
 import voluptuous as vol
 from yarl import URL
 
@@ -167,10 +168,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
             # Kept out of the debug log above so the credentials are not logged.
-            # A configured Authorization header wins over the credentials.
-            request_headers = headers
+            # A configured Authorization header wins over the credentials,
+            # whatever its casing, so setdefault runs on a CIMultiDict.
+            request_headers = CIMultiDict(headers)
             if basic_auth is not None:
-                request_headers = {hdrs.AUTHORIZATION: basic_auth, **headers}
+                request_headers.setdefault(hdrs.AUTHORIZATION, basic_auth)
 
             try:
                 # Prepare request kwargs

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -79,6 +79,14 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _validated_credentials(username: str, password: str) -> tuple[str, str]:
+    """Return credentials for the handler to encode when the command runs."""
+    # encode_basic_auth runs per call, so it would only reject this much later
+    if ":" in username:
+        raise ValueError('A ":" is not allowed in login (RFC 7617#section-2)')
+    return (username, password)
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the REST command component."""
 
@@ -125,7 +133,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
                 digest_auth = (username, password)
             else:
-                basic_auth = (username, password)
+                basic_auth = _validated_credentials(username, password)
 
         template_payload = None
         if CONF_PAYLOAD in command_config:

--- a/tests/components/rest_command/conftest.py
+++ b/tests/components/rest_command/conftest.py
@@ -23,7 +23,7 @@ TEST_CONFIG = {
     "auth_test": {
         "url": TEST_URL,
         "method": "get",
-        "username": "test",
+        "username": "tøst",
         "password": "123456",
     },
 }

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -125,7 +125,7 @@ async def test_rest_command_auth(
 
     assert len(aioclient_mock.mock_calls) == 1
     _method, _url, _data, headers = aioclient_mock.mock_calls[0]
-    encoded = base64.b64encode(b"test:123456").decode()
+    encoded = base64.b64encode("tøst:123456".encode("latin-1")).decode()
     assert CIMultiDict(headers).getall("Authorization") == [f"Basic {encoded}"]
 
 

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -124,6 +124,45 @@ async def test_rest_command_auth(
     await hass.services.async_call(DOMAIN, "auth_test", {}, blocking=True)
 
     assert len(aioclient_mock.mock_calls) == 1
+    _method, _url, _data, headers = aioclient_mock.mock_calls[0]
+    encoded = base64.b64encode(b"test:123456").decode()
+    assert CIMultiDict(headers).getall("Authorization") == [f"Basic {encoded}"]
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        pytest.param("Authorization", id="canonical_casing"),
+        pytest.param("authorization", id="lowercase"),
+    ],
+)
+async def test_rest_command_configured_authorization_header_wins(
+    hass: HomeAssistant,
+    setup_component: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    header_name: str,
+) -> None:
+    """Call a rest command that configures its own Authorization header."""
+    config = {
+        "auth_header_test": {
+            "url": TEST_URL,
+            "method": "get",
+            "username": "test",
+            "password": "123456",
+            "headers": {header_name: "Bearer configured"},
+        }
+    }
+    await setup_component(config)
+
+    aioclient_mock.get(TEST_URL, content=b"success")
+
+    await hass.services.async_call(DOMAIN, "auth_header_test", {}, blocking=True)
+
+    assert len(aioclient_mock.mock_calls) == 1
+    _method, _url, _data, headers = aioclient_mock.mock_calls[0]
+
+    # The generated basic auth must not be sent as a second Authorization header
+    assert CIMultiDict(headers).getall("Authorization") == ["Bearer configured"]
 
 
 @pytest.mark.usefixtures("aioclient_mock")

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_URL, ComponentSetup
 
@@ -127,6 +128,22 @@ async def test_rest_command_auth(
     _method, _url, _data, headers = aioclient_mock.mock_calls[0]
     encoded = base64.b64encode("tøst:123456".encode("latin-1")).decode()
     assert CIMultiDict(headers).getall("Authorization") == [f"Basic {encoded}"]
+
+
+async def test_rest_command_auth_username_with_colon(hass: HomeAssistant) -> None:
+    """Call a rest command configured with a colon in the username."""
+    config = {
+        "auth_test": {
+            "url": TEST_URL,
+            "method": "get",
+            "username": "user:name",
+            "password": "123456",
+        }
+    }
+    # RFC 7617 forbids the colon, and it must be rejected while setting up
+    assert not await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+
+    assert not hass.services.has_service(DOMAIN, "auth_test")
 
 
 async def test_rest_command_auth_outside_latin_1(

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -129,6 +129,29 @@ async def test_rest_command_auth(
     assert CIMultiDict(headers).getall("Authorization") == [f"Basic {encoded}"]
 
 
+async def test_rest_command_auth_outside_latin_1(
+    hass: HomeAssistant,
+    setup_component: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Call a rest command with a credential latin-1 cannot encode."""
+    config = {
+        "auth_test": {
+            "url": TEST_URL,
+            "method": "get",
+            "username": "用户",
+            "password": "123456",
+        }
+    }
+    # Setting up must not fail, only the call that needs the credential
+    await setup_component(config)
+
+    aioclient_mock.get(TEST_URL, content=b"success")
+
+    with pytest.raises(UnicodeEncodeError):
+        await hass.services.async_call(DOMAIN, "auth_test", {}, blocking=True)
+
+
 @pytest.mark.parametrize(
     "header_name",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

aiohttp deprecates `BasicAuth` and the per-request `auth` argument in favour of `encode_basic_auth()` plus an `Authorization` header.

Two things worth a look:

- The header is built **after** the debug log that prints the rendered headers, so the credentials are not written to the log.
- Behaviour changes in one edge case. Today, configuring both `username`/`password` and an `Authorization` header makes aiohttp raise `ValueError: Cannot combine AUTHORIZATION header with AUTH argument`. Now the configured header wins over the credentials. Happy to guard that case explicitly instead if you would rather keep it an error.

Digest authentication is untouched and still uses `DigestAuthMiddleware`.

`BasicAuth is deprecated` warnings in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 18 | 0 |

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_