### PR TITLE
Send rest credentials as an Authorization header

### DIFF
--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -30,7 +30,7 @@ class RestData:
         method: str,
         resource: str,
         encoding: str,
-        auth: aiohttp.DigestAuthMiddleware | aiohttp.BasicAuth | tuple[str, str] | None,
+        auth: aiohttp.DigestAuthMiddleware | tuple[str, str] | None,
         headers: dict[str, str] | None,
         params: dict[str, str] | None,
         data: str | None,
@@ -45,13 +45,13 @@ class RestData:
         self._encoding = encoding
         self._force_use_set_encoding = False
 
-        # Convert auth tuple to aiohttp.BasicAuth if needed
+        # Convert an auth tuple to a basic Authorization header if needed
+        self._basic_auth: str | None = None
+        self._digest_auth: aiohttp.DigestAuthMiddleware | None = None
         if isinstance(auth, tuple) and len(auth) == 2:
-            self._auth: aiohttp.BasicAuth | aiohttp.DigestAuthMiddleware | None = (
-                aiohttp.BasicAuth(auth[0], auth[1], encoding="utf-8")
-            )
-        else:
-            self._auth = auth
+            self._basic_auth = aiohttp.encode_basic_auth(auth[0], auth[1])
+        elif isinstance(auth, aiohttp.DigestAuthMiddleware):
+            self._digest_auth = auth
 
         self._headers = headers
         self._params = params
@@ -137,11 +137,14 @@ class RestData:
             "timeout": self._timeout,
         }
 
-        # Handle authentication
-        if isinstance(self._auth, aiohttp.BasicAuth):
-            request_kwargs["auth"] = self._auth
-        elif isinstance(self._auth, aiohttp.DigestAuthMiddleware):
-            request_kwargs["middlewares"] = (self._auth,)
+        # Handle authentication. A configured Authorization header wins.
+        if self._basic_auth is not None:
+            request_kwargs["headers"] = {
+                aiohttp.hdrs.AUTHORIZATION: self._basic_auth,
+                **(rendered_headers or {}),
+            }
+        elif self._digest_auth is not None:
+            request_kwargs["middlewares"] = (self._digest_auth,)
 
         # Handle data/content
         if self._request_data:

--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import aiohttp
 from aiohttp import hdrs
-from multidict import CIMultiDictProxy
+from multidict import CIMultiDict, CIMultiDictProxy
 import xmltodict
 
 from homeassistant.core import HomeAssistant
@@ -137,12 +137,12 @@ class RestData:
             "timeout": self._timeout,
         }
 
-        # Handle authentication. A configured Authorization header wins.
+        # Handle authentication. A configured Authorization header wins,
+        # whatever its casing, so setdefault runs on a CIMultiDict.
         if self._basic_auth is not None:
-            request_kwargs["headers"] = {
-                aiohttp.hdrs.AUTHORIZATION: self._basic_auth,
-                **(rendered_headers or {}),
-            }
+            headers = CIMultiDict(rendered_headers or {})
+            headers.setdefault(hdrs.AUTHORIZATION, self._basic_auth)
+            request_kwargs["headers"] = headers
         elif self._digest_auth is not None:
             request_kwargs["middlewares"] = (self._digest_auth,)
 

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -4,7 +4,9 @@ from datetime import timedelta
 import logging
 from unittest.mock import patch
 
+from aiohttp import hdrs
 from freezegun.api import FrozenDateTimeFactory
+from multidict import CIMultiDict
 import pytest
 
 from homeassistant.components.rest import DOMAIN
@@ -551,3 +553,51 @@ async def test_rest_data_boolean_params_converted_to_strings(
     assert url.query["boolFalse"] == "false"
     assert url.query["stringParam"] == "test"
     assert url.query["intParam"] == "123"
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        pytest.param("Authorization", id="canonical_casing"),
+        pytest.param("authorization", id="lowercase"),
+    ],
+)
+async def test_rest_data_configured_authorization_header_wins(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    header_name: str,
+) -> None:
+    """Test a configured Authorization header replaces generated basic auth."""
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        json={"status": "ok"},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "username": "user",
+                "password": "pass",
+                "headers": {header_name: "Bearer configured"},
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.status }}",
+                    }
+                ],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+    _method, _url, _data, headers = aioclient_mock.mock_calls[0]
+
+    # The generated basic auth must not be sent as a second Authorization header
+    assert CIMultiDict(headers).getall(hdrs.AUTHORIZATION) == ["Bearer configured"]


### PR DESCRIPTION

## Breaking change




## Proposed change


aiohttp deprecates `BasicAuth` and the per-request `auth` argument in favour of `encode_basic_auth()` plus an `Authorization` header.

`RestData` accepted `DigestAuthMiddleware | BasicAuth | tuple | None`, but the only caller passes a tuple or a `DigestAuthMiddleware`, so the `BasicAuth` branch goes away and the module no longer references it at all.

Behaviour changes in one edge case: today, configuring both credentials and an `Authorization` header makes aiohttp raise `ValueError: Cannot combine AUTHORIZATION header with AUTH argument`. Now the configured header wins. Happy to guard that case explicitly instead if you would rather keep it an error.

The configured header wins in any casing. The merge happens in a `CIMultiDict`, so a lowercase `authorization` key replaces the generated credentials rather than becoming a second Authorization header. Covered by a regression test over both spellings.

`BasicAuth is deprecated` warnings in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 5 | 0 |

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
