### PR TITLE
Pass the bluetooth detection callback to the scanner constructor

### DIFF
--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2850,9 +2850,10 @@ async def test_wrapped_instance_with_filter(
 
         assert _get_manager() is not None
         scanner = HaBleakScannerWrapper(
-            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
+            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]},
+            detection_callback=_device_detected,
         )
-        scanner.register_detection_callback(_device_detected)
+        await scanner.start()
 
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
         await hass.async_block_till_done()
@@ -2862,11 +2863,12 @@ async def test_wrapped_instance_with_filter(
         assert discovered == [switchbot_device]
         assert len(detected) == 1
 
-        scanner.register_detection_callback(_device_detected)
-        # We should get a reply from the history when we register again
+        # register_detection_callback is deprecated but still replays the history
+        with pytest.warns(DeprecationWarning, match="is deprecated"):
+            scanner.register_detection_callback(_device_detected)
         assert len(detected) == 2
-        scanner.register_detection_callback(_device_detected)
-        # We should get a reply from the history when we register again
+        with pytest.warns(DeprecationWarning, match="is deprecated"):
+            scanner.register_detection_callback(_device_detected)
         assert len(detected) == 3
 
         with patch_discovered_devices([]):
@@ -2923,9 +2925,10 @@ async def test_wrapped_instance_with_service_uuids(
 
         assert _get_manager() is not None
         scanner = HaBleakScannerWrapper(
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+            detection_callback=_device_detected,
         )
-        scanner.register_detection_callback(_device_detected)
+        await scanner.start()
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -2983,9 +2986,10 @@ async def test_wrapped_instance_with_service_uuids_with_coro_callback(
 
         assert _get_manager() is not None
         scanner = HaBleakScannerWrapper(
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+            detection_callback=_device_detected,
         )
-        scanner.register_detection_callback(_device_detected)
+        await scanner.start()
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -3037,9 +3041,10 @@ async def test_wrapped_instance_with_broken_callbacks(
 
         assert _get_manager() is not None
         scanner = HaBleakScannerWrapper(
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+            detection_callback=_device_detected,
         )
-        scanner.register_detection_callback(_device_detected)
+        await scanner.start()
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         await hass.async_block_till_done()
@@ -3086,11 +3091,11 @@ async def test_wrapped_instance_changes_uuids(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        scanner = HaBleakScannerWrapper()
+        scanner = HaBleakScannerWrapper(detection_callback=_device_detected)
+        await scanner.start()
         scanner.set_scanning_filter(
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
-        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -3142,11 +3147,11 @@ async def test_wrapped_instance_changes_filters(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        scanner = HaBleakScannerWrapper()
+        scanner = HaBleakScannerWrapper(detection_callback=_device_detected)
+        await scanner.start()
         scanner.set_scanning_filter(
             filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
         )
-        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

bleak removed `register_detection_callback` from `BleakScanner`, and habluetooth keeps it only as a deprecated shim that will be removed in a future release.

The five tests that register once now pass `detection_callback` to the `HaBleakScannerWrapper` constructor. That argument is only wired up in `start()`, so those tests also start the scanner, which is how the API is meant to be used.

`test_wrapped_instance_with_filter` still calls the shim, because what it asserts is the shim's own behaviour: re-registering replays the history. Those two calls now assert the deprecation instead of leaking the warning.

`register_detection_callback() is deprecated` warnings in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 8 | 0 |

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_