### PR TITLE
Fix for media_player. and remote.turn_off toggling power in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -86,9 +86,7 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if (
-            self.coordinator.is_on is False or self._bridge.power_off_in_progress
-        ):
+        if self.coordinator.is_on is False or self._bridge.power_off_in_progress:
             # The power key toggles the TV, sending it while the TV is
             # already off would turn it back on.
             return

--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -86,6 +86,10 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
+        if self.coordinator.is_on is False:
+            # The power key toggles the TV, sending it while the TV is
+            # already off would turn it back on.
+            return
         await self._bridge.async_power_off()
         await self.coordinator.async_refresh()
 

--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -86,7 +86,9 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if self.coordinator.is_on is False:
+        if (
+            self.coordinator.is_on is False or self._bridge.power_off_in_progress
+        ):
             # The power key toggles the TV, sending it while the TV is
             # already off would turn it back on.
             return

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -776,6 +776,33 @@ async def test_turn_off_websocket(
     remote_websocket.send_commands.assert_not_called()
 
 
+@pytest.mark.usefixtures("rest_api")
+async def test_turn_off_websocket_already_off(
+    hass: HomeAssistant, remote_websocket: Mock, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test turn_off is a no-op when the TV is already known to be off."""
+    await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
+
+    with patch.object(remote_websocket, "is_alive", return_value=False):
+        freezer.tick(timedelta(seconds=20))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+
+    remote_websocket.send_commands.reset_mock()
+
+    await hass.services.async_call(
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+
+    # KEY_POWER toggles the TV, so it must not be sent when already off
+    remote_websocket.send_commands.assert_not_called()
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+
+
 async def test_turn_off_websocket_frame(
     hass: HomeAssistant, remote_websocket: Mock, rest_api: Mock
 ) -> None:

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -1,7 +1,9 @@
 """The tests for the SamsungTV remote platform."""
 
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from samsungtvws.encrypted.remote import SamsungTVEncryptedCommand
 
@@ -11,7 +13,12 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.components.samsungtv.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -19,7 +26,7 @@ from homeassistant.helpers import entity_registry as er
 from . import setup_samsungtv_entry
 from .const import ENTRYDATA_ENCRYPTED_WEBSOCKET, ENTRYDATA_LEGACY, ENTRYDATA_WEBSOCKET
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 ENTITY_ID = f"{REMOTE_DOMAIN}.mock_title"
 
@@ -79,6 +86,35 @@ async def test_main_services(
     )
     assert "TV is powering off, not sending keys: ['dash']" in caplog.text
     remote_encrypted_websocket.send_commands.assert_not_called()
+
+
+@pytest.mark.usefixtures("remote_encrypted_websocket", "rest_api")
+async def test_turn_off_already_off(
+    hass: HomeAssistant,
+    remote_encrypted_websocket: Mock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test turn_off is a no-op when the TV is already known to be off."""
+    await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
+
+    with patch.object(remote_encrypted_websocket, "is_alive", return_value=False):
+        freezer.tick(timedelta(seconds=20))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+
+    remote_encrypted_websocket.send_commands.reset_mock()
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+
+    # KEY_POWEROFF/KEY_POWER toggle the TV, so they must not be sent when already off
+    remote_encrypted_websocket.send_commands.assert_not_called()
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.usefixtures("remote_encrypted_websocket", "rest_api")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`media_player.turn_off` and `remote.turn_off` no longer act as a power toggle.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a proposed fix for #163001. There was no check to determine if the device
was already off. Since `self._bridge.async_power_off()` for websocket based TVs
sends a remote `KEY_POWER` command, this mimics the remote by acting as a
toggle, so if the TV is off, it gets powered on from a `.turn_off` event. This fix
now checks to see if the TV is off and if so, returns. If the TV is in any other state
(e.g., on or unknown) it will still send the event.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163001 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

It adds 2 new unit tests for both `media_player.turn_off` and `remote.turn_off`.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
