### PR TITLE
Mock the go2rtc rest client in the setup error test

### DIFF
--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -799,8 +799,11 @@ async def test_setup_with_setup_error(
     caplog: pytest.LogCaptureFixture,
     has_go2rtc_entry: bool,
     expected_log_message: str,
+    rest_client: AsyncMock,
 ) -> None:
     """Test setup integration fails."""
+    # The cases that get as far as starting the server expect it to fail
+    rest_client.validate_server_version.side_effect = Go2RtcClientError()
 
     assert not await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION

## Breaking change




## Proposed change


Two of the parametrized cases in `test_setup_with_setup_error` expect `ERR_START_SERVER`. Every other case fails config validation before the server starts, but these two reach `Server._start()`, which ends with a real `Go2RtcRestClient.validate_server_version()` call. The `server` fixture wraps `Server` rather than replacing it, so the test proved "could not start" by letting a genuine connection to the managed server fail.

Raising `Go2RtcClientError` from the mocked client asserts the same outcome deliberately. This is the pattern the neighbouring tests already use, for example `test_setup_with_retryable_setup_entry_error_default_server`. The other cases never touch the client, so the side effect is inert for them.

`socket.socket.connect()` warnings from this test in a full CI run ([run 353867](https://github.com/home-assistant/core/actions/runs/32571598896)):

| Before | After |
| --- | --- |
| 4 | 0 |

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_