### PR TITLE
Fix race in assist_pipeline saved audio empty queue test

### DIFF
--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 import itertools as it
 from pathlib import Path
 import tempfile
+import time
 from unittest.mock import Mock, patch
 import wave
 
@@ -675,6 +676,11 @@ async def test_pipeline_saved_audio_empty_queue(
         )
 
         def proc_wrapper(run_recording_dir, queue):
+            # Wait for the WAV file name to be queued. Forcing the timeout before
+            # it arrives makes the thread exit without ever creating the file.
+            while queue.empty():
+                time.sleep(0.01)
+
             _pipeline_debug_recording_thread_proc(
                 run_recording_dir, queue, message_timeout=0
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix a race in `test_pipeline_saved_audio_empty_queue` that makes it flaky on CI.

Example failure: [`FAILED tests/components/assist_pipeline/test_init.py::test_pipeline_saved_audio_empty_queue - RuntimeError: coroutine raised StopIteration`](https://github.com/home-assistant/core/actions/runs/32592175993/job/97077857497)

The test patches `_pipeline_debug_recording_thread_proc` with `message_timeout=0` to force the debug recording thread to time out immediately. But the WAV file name is only put on the queue after the thread has already started:

1. `PipelineRun.start()` spawns the recording thread (`pipeline.py:1538`)
2. `PipelineRun.wake_word_detection()` puts the WAV file name on the queue (`pipeline.py:752`)

With `message_timeout=0`, `queue.get()` raises `Empty` right away when nothing is queued yet. If the thread reaches its first `get()` before step 2, it exits without ever calling `wave.open()`, so the run directory stays empty. The `run-end` callback then calls `next()` on that empty directory, and the resulting `StopIteration` escaping a coroutine is reported as `RuntimeError: coroutine raised StopIteration`.

The wrapper now waits for the first message before running the real thread proc with `message_timeout=0`. The test still covers what it was written for — the thread times out on an empty queue and must still close the WAV file — but no longer races the producer. The wait always terminates, because `PipelineRun.end()` runs in a `finally` and puts the `None` stop signal on the queue before joining the thread.

Verified by widening the race window with 8 busy-loop CPU hogs on the same machine:

| | failures |
| --- | --- |
| before | 1/25, then 1/3 |
| after | 0/50 |

The reproduced failure was `tests/components/assist_pipeline/test_init.py:663: StopIteration`, matching CI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Failing CI run: https://github.com/home-assistant/core/actions/runs/32592175993/job/97077857497

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LmfoF98rXUN6rscevtgpo