### PR TITLE
Add local Starlink dish sensors

### DIFF
--- a/homeassistant/components/starlink/sensor.py
+++ b/homeassistant/components/starlink/sensor.py
@@ -183,6 +183,7 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
     StarlinkSensorEntityDescription(
         key="gps_satellites",
         translation_key="gps_satellites",
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda data: data.status["gps_sats"],

--- a/homeassistant/components/starlink/sensor.py
+++ b/homeassistant/components/starlink/sensor.py
@@ -168,6 +168,23 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
         entity_class=StarlinkSensorEntity,
     ),
     StarlinkSensorEntityDescription(
+        key="obstruction",
+        translation_key="obstruction",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=2,
+        value_fn=lambda data: data.status["fraction_obstructed"] * 100,
+        entity_class=StarlinkSensorEntity,
+    ),
+    StarlinkSensorEntityDescription(
+        key="gps_satellites",
+        translation_key="gps_satellites",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.status["gps_sats"],
+        entity_class=StarlinkSensorEntity,
+    ),
+    StarlinkSensorEntityDescription(
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/starlink/sensor.py
+++ b/homeassistant/components/starlink/sensor.py
@@ -173,7 +173,11 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=2,
-        value_fn=lambda data: data.status["fraction_obstructed"] * 100,
+        value_fn=lambda data: (
+            value * 100
+            if (value := data.status["fraction_obstructed"]) is not None
+            else None
+        ),
         entity_class=StarlinkSensorEntity,
     ),
     StarlinkSensorEntityDescription(

--- a/homeassistant/components/starlink/strings.json
+++ b/homeassistant/components/starlink/strings.json
@@ -62,8 +62,14 @@
       "elevation": {
         "name": "[%key:common::config_flow::data::elevation%]"
       },
+      "gps_satellites": {
+        "name": "GPS satellites"
+      },
       "last_restart": {
         "name": "Last restart"
+      },
+      "obstruction": {
+        "name": "Obstruction"
       },
       "ping": {
         "name": "Ping"

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -126,7 +126,9 @@ async def test_restore_cache_with_accumulation(hass: HomeAssistant) -> None:
         assert hass.states.get(entity_id).state == str(1 + 0.01572462736977)
 
 
-async def test_additional_local_sensors(hass: HomeAssistant) -> None:
+async def test_additional_local_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test additional sensors sourced from the local dish API."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -149,7 +151,7 @@ async def test_additional_local_sensors(hass: HomeAssistant) -> None:
 
     assert hass.states.get("sensor.starlink_obstruction").state == "0.0"
 
-    gps_satellites = er.async_get(hass).async_get("sensor.starlink_gps_satellites")
+    gps_satellites = entity_registry.async_get("sensor.starlink_gps_satellites")
     assert gps_satellites
     assert gps_satellites.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from freezegun import freeze_time
 
@@ -145,11 +145,12 @@ async def test_additional_local_sensors(
         f"{status_data[0]['id']}_gps_satellites",
         suggested_object_id="starlink_gps_satellites",
     )
+    status_data_mock = MagicMock(return_value=status_data)
 
     with (
         LOCATION_DATA_SUCCESS_PATCHER,
         SLEEP_DATA_SUCCESS_PATCHER,
-        patch(STATUS_DATA_TARGET, return_value=status_data) as status_data_mock,
+        patch(STATUS_DATA_TARGET, status_data_mock),
         HISTORY_STATS_SUCCESS_PATCHER,
     ):
         entry.add_to_hass(hass)

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.starlink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .patchers import (
@@ -123,6 +124,34 @@ async def test_restore_cache_with_accumulation(hass: HomeAssistant) -> None:
             await entry.runtime_data.async_refresh()
 
         assert hass.states.get(entity_id).state == str(1 + 0.01572462736977)
+
+
+async def test_additional_local_sensors(hass: HomeAssistant) -> None:
+    """Test additional sensors sourced from the local dish API."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4:0000"},
+    )
+
+    status_data = deepcopy(STATUS_DATA_FIXTURE)
+    status_data[0]["gps_sats"] = 1
+
+    with (
+        LOCATION_DATA_SUCCESS_PATCHER,
+        SLEEP_DATA_SUCCESS_PATCHER,
+        patch(STATUS_DATA_TARGET, return_value=status_data),
+        HISTORY_STATS_SUCCESS_PATCHER,
+    ):
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.starlink_obstruction").state == "0.0"
+
+    gps_satellites = er.async_get(hass).async_get("sensor.starlink_gps_satellites")
+    assert gps_satellites
+    assert gps_satellites.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_last_restart_state(hass: HomeAssistant) -> None:

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -136,12 +136,20 @@ async def test_additional_local_sensors(
     )
 
     status_data = deepcopy(STATUS_DATA_FIXTURE)
+    status_data[0]["fraction_obstructed"] = 0.1234
     status_data[0]["gps_sats"] = 1
+
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{status_data[0]['id']}_gps_satellites",
+        suggested_object_id="starlink_gps_satellites",
+    )
 
     with (
         LOCATION_DATA_SUCCESS_PATCHER,
         SLEEP_DATA_SUCCESS_PATCHER,
-        patch(STATUS_DATA_TARGET, return_value=status_data),
+        patch(STATUS_DATA_TARGET, return_value=status_data) as status_data_mock,
         HISTORY_STATS_SUCCESS_PATCHER,
     ):
         entry.add_to_hass(hass)
@@ -149,11 +157,16 @@ async def test_additional_local_sensors(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.starlink_obstruction").state == "0.0"
+        assert hass.states.get("sensor.starlink_obstruction").state == "12.34"
+        assert hass.states.get("sensor.starlink_gps_satellites").state == "1"
 
-    gps_satellites = entity_registry.async_get("sensor.starlink_gps_satellites")
-    assert gps_satellites
-    assert gps_satellites.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        status_data_unavailable = deepcopy(status_data)
+        status_data_unavailable[0]["fraction_obstructed"] = None
+        status_data_mock.return_value = status_data_unavailable
+        await entry.runtime_data.async_refresh()
+        await hass.async_block_till_done()
+
+        assert hass.states.get("sensor.starlink_obstruction").state == "unknown"
 
 
 async def test_last_restart_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add two read-only sensors to the existing Starlink integration using data that its coordinator already retrieves from the online Starlink user terminal:

- **Obstruction** exposes `fraction_obstructed` as a percentage.
- **GPS satellites** exposes `gps_sats` as a diagnostic entity that is disabled by default.

Both values are polled locally and directly from the dish over its LAN gRPC API at the configured Starlink endpoint (normally `192.168.100.1:9200`). The change does not add any Starlink account authentication, cloud API call, router API call, dependency, or extra polling request. It therefore works independently of the Starlink router and is compatible with bypass mode, provided Home Assistant has a route to the dish's local API.

The exact pinned dependency, `starlink-grpc-core==1.2.5`, was also checked against a live `rev4_panda_prod2` dish in bypass mode. Both `fraction_obstructed` and `gps_sats` were populated directly from the local dish response.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47562
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging the code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

