### PR TITLE
Fix llama.cpp streaming capability reporting

### DIFF
--- a/homeassistant/components/llama_cpp/conversation.py
+++ b/homeassistant/components/llama_cpp/conversation.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import LlamaCppConfigEntry
-from .const import DOMAIN
+from .const import CONF_STREAMING, DOMAIN
 from .entity import LlamaCppBaseLLMEntity
 
 
@@ -36,6 +36,9 @@ class LlamaCppConversationEntity(
     def __init__(self, entry: ConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the agent."""
         super().__init__(entry, subentry)
+        self._attr_supports_streaming = bool(
+            entry.data.get(CONF_STREAMING, subentry.data.get(CONF_STREAMING, False))
+        )
         if self.subentry.data.get(CONF_LLM_HASS_API):
             self._attr_supported_features = (
                 conversation.ConversationEntityFeature.CONTROL

--- a/homeassistant/components/llama_cpp/conversation.py
+++ b/homeassistant/components/llama_cpp/conversation.py
@@ -36,9 +36,7 @@ class LlamaCppConversationEntity(
     def __init__(self, entry: ConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the agent."""
         super().__init__(entry, subentry)
-        self._attr_supports_streaming = bool(
-            entry.data.get(CONF_STREAMING, subentry.data.get(CONF_STREAMING, False))
-        )
+        self._attr_supports_streaming = bool(entry.data.get(CONF_STREAMING, False))
         if self.subentry.data.get(CONF_LLM_HASS_API):
             self._attr_supported_features = (
                 conversation.ConversationEntityFeature.CONTROL

--- a/tests/components/llama_cpp/test_conversation.py
+++ b/tests/components/llama_cpp/test_conversation.py
@@ -101,6 +101,22 @@ async def test_conversation_entity(
     assert mock_chat_log.content[1:] == snapshot
 
 
+@pytest.mark.parametrize(
+    ("config_entry_data", "supports_streaming"),
+    [({CONF_STREAMING: True}, True), ({CONF_STREAMING: False}, False)],
+)
+async def test_conversation_entity_streaming_support(
+    hass: HomeAssistant, supports_streaming: bool
+) -> None:
+    """Verify the conversation entity advertises streaming support."""
+    agent_info = conversation.async_get_agent_info(
+        hass, "conversation.llama_cpp_conversation"
+    )
+
+    assert agent_info is not None
+    assert agent_info.supports_streaming is supports_streaming
+
+
 @pytest.mark.parametrize(("config_entry_options"), [ASSIST_OPTIONS])
 async def test_function_call(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


There are no breaking changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The llama.cpp conversation agent already streams response deltas when the configured endpoint supports streaming, but it did not advertise that capability to Assist. Set `supports_streaming` from the validated config entry setting so Assist can enable streaming TTS. The initial implementation mirrored the response-generation fallback for consistency; the subentry fallback was removed because `CONF_STREAMING` is stored on the main config entry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179924
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The focused regression assertions pass for both streaming-enabled and streaming-disabled config entries. Ruff linting and formatting pass. A production custom-component validation also produced `stream_response: true` with overlapping LLM generation and TTS playback.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
