### PR TITLE
Replace a caller supplied Authorization header case-insensitively

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -792,8 +792,6 @@ async def async_oauth2_request(
     This method will not refresh tokens. Use OAuth2 session for that.
     """
     session = async_get_clientsession(hass)
-    # A CIMultiDict so the token replaces a caller supplied Authorization
-    # header whatever its casing, instead of being sent alongside it.
     headers = CIMultiDict(kwargs.pop("headers", {}))
     headers[hdrs.AUTHORIZATION] = f"Bearer {token['access_token']}"
     return await session.request(method, url, **kwargs, headers=headers)

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -19,9 +19,10 @@ import secrets
 import time
 from typing import Any, cast, override
 
-from aiohttp import ClientError, ClientResponseError, client, web
+from aiohttp import ClientError, ClientResponseError, client, hdrs, web
 from habluetooth import BluetoothServiceInfoBleak
 import jwt
+from multidict import CIMultiDict
 import voluptuous as vol
 from yarl import URL
 
@@ -791,16 +792,11 @@ async def async_oauth2_request(
     This method will not refresh tokens. Use OAuth2 session for that.
     """
     session = async_get_clientsession(hass)
-    headers = kwargs.pop("headers", {})
-    return await session.request(
-        method,
-        url,
-        **kwargs,
-        headers={
-            **headers,
-            "authorization": f"Bearer {token['access_token']}",
-        },
-    )
+    # A CIMultiDict so the token replaces a caller supplied Authorization
+    # header whatever its casing, instead of being sent alongside it.
+    headers = CIMultiDict(kwargs.pop("headers", {}))
+    headers[hdrs.AUTHORIZATION] = f"Bearer {token['access_token']}"
+    return await session.request(method, url, **kwargs, headers=headers)
 
 
 @callback

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from aiohttp import ClientError
+from multidict import CIMultiDict
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
@@ -1431,3 +1432,33 @@ async def test_async_get_config_entry_implementation_missing_provider(
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, config_entry
         )
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        pytest.param("Authorization", id="canonical_casing"),
+        pytest.param("authorization", id="lowercase"),
+    ],
+)
+async def test_oauth2_request_replaces_caller_authorization_header(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    header_name: str,
+) -> None:
+    """Test the token replaces a caller supplied Authorization header."""
+    aioclient_mock.post("https://example.com", status=201)
+
+    await config_entry_oauth2_flow.async_oauth2_request(
+        hass,
+        {"access_token": ACCESS_TOKEN_1},
+        "post",
+        "https://example.com",
+        headers={header_name: "Bearer caller supplied"},
+    )
+
+    assert len(aioclient_mock.mock_calls) == 1
+    headers = CIMultiDict(aioclient_mock.mock_calls[0][3])
+
+    # The token must not be sent as a second Authorization header
+    assert headers.getall("Authorization") == [f"Bearer {ACCESS_TOKEN_1}"]


### PR DESCRIPTION

## Breaking change




## Proposed change


`async_oauth2_request` merged the caller headers into a dict literal with a lowercase `authorization` key:

```python
headers={
    **headers,
    "authorization": f"Bearer {token['access_token']}",
}
```

HTTP header names are case-insensitive, but a plain dict is not. A caller passing canonical `Authorization` therefore keeps both keys, and aiohttp sends two Authorization headers rather than the token replacing the caller value:

```
merged dict : {'Authorization': 'Bearer caller-supplied', 'authorization': 'Bearer generated'}
as sent     : ['Bearer caller-supplied', 'Bearer generated']
```

Building a `CIMultiDict` and assigning into it drops any existing entry whatever its casing, which is the behaviour the dict literal was reaching for.

This is latent rather than live. `async_oauth2_request` has one caller, `OAuth2Session.async_request`, and no integration passes an Authorization header through it, which is unsurprising since supplying that header is the session's job. It is worth fixing anyway because every OAuth2 integration goes through this helper.

Found while fixing the same defect in [rest](https://github.com/home-assistant/core/pull/179856) and [rest_command](https://github.com/home-assistant/core/pull/179855). I searched the rest of `homeassistant/` for the pattern; the sites in `mcp`, `hassio` and `smartthings` build their header dicts locally from literals with no caller merge and are unaffected.

Existing tests read the outgoing header as `mock_calls[...][3]["authorization"]`. That keeps working, because lookup on the `CIMultiDict` is case-insensitive.

## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_