### PR TITLE
Fix Tesla Fleet steering wheel heater missing medium level

### DIFF
--- a/homeassistant/components/tesla_fleet/select.py
+++ b/homeassistant/components/tesla_fleet/select.py
@@ -164,6 +164,7 @@ class TeslaFleetWheelHeaterSelectEntity(TeslaFleetVehicleEntity, SelectEntity):
     _attr_options = [
         OFF,
         LOW,
+        MEDIUM,
         HIGH,
     ]
 

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -308,6 +308,7 @@
         "state": {
           "high": "[%key:common::state::high%]",
           "low": "[%key:common::state::low%]",
+          "medium": "[%key:common::state::medium%]",
           "off": "[%key:common::state::off%]"
         }
       },

--- a/tests/components/tesla_fleet/snapshots/test_select.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_select.ambr
@@ -572,6 +572,7 @@
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
+        'medium',
         'high',
       ]),
     }),
@@ -612,6 +613,7 @@
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
+        'medium',
         'high',
       ]),
     }),


### PR DESCRIPTION
## Proposed change

The steering wheel heater select entity listed only three levels:

```python
_attr_options = [
    OFF,
    LOW,
    HIGH,
]
```

Tesla reports four levels for this control, matching the seat heater selects in the same file, which already list `OFF, LOW, MEDIUM, HIGH`. The `MEDIUM` constant was already defined and used there.

With only three options, a vehicle whose steering wheel heater is on the top setting reports level `3`, so `_attr_options[value]` raises:

```
File "homeassistant/components/tesla_fleet/select.py", line 190, in _async_update_attrs
    self._attr_current_option = self._attr_options[value]
IndexError: list index out of range
```

This fires on every coordinator update, logged as `Unexpected error updating listener ... for Tesla Fleet Vehicle`, and leaves the entity stuck at a stale value. Level `2` did not raise, but was reported as `high` rather than `medium`.

Adding `MEDIUM` to the list fixes both the exception and the mislabelling. `strings.json` gains the matching `medium` state, reusing the existing `[%key:common::state::medium%]` reference the seat heaters use, and the select snapshot is updated.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

