### PR TITLE
Deduplicate LLM tools by name in async_get_tools

### DIFF
--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 DATA_PLATFORMS: HassKey[LazyIntegrationPlatforms[LLMToolsPlatformProtocol]] = HassKey(
     "llm_platforms"
 )
+DATA_WARNED_DUPLICATE_TOOLS: HassKey[set[str]] = HassKey("llm_warned_duplicate_tools")
 
 
 @dataclass(slots=True)
@@ -57,6 +58,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_PLATFORMS] = LazyIntegrationPlatforms(
         hass, DOMAIN, _process_llm_tools_platform
     )
+    hass.data[DATA_WARNED_DUPLICATE_TOOLS] = set()
     async_register_api(hass, AssistAPI(hass))
     async_setup_ws_api(hass)
     return True
@@ -78,6 +80,10 @@ async def async_get_tools(
 
     tools: list[Tool] = []
     prompts: list[str] = []
+    # LLM APIs reject duplicate tool names, so the first platform to contribute
+    # a name wins. Remember the source so the warning can name both platforms.
+    tool_sources: dict[str, str] = {}
+    warned = hass.data[DATA_WARNED_DUPLICATE_TOOLS]
     # Sort by domain so the tool and prompt order is independent of load order.
     for domain, platform in sorted(platforms.items()):
         try:
@@ -87,7 +93,21 @@ async def async_get_tools(
             continue
         if result is None:
             continue
-        tools.extend(result.tools)
+        for tool in result.tools:
+            if (source := tool_sources.get(tool.name)) is not None:
+                # This runs on every conversation turn, so only warn once per name.
+                if tool.name not in warned:
+                    warned.add(tool.name)
+                    _LOGGER.warning(
+                        "Ignoring LLM tool %s from platform %s; platform %s already"
+                        " provides a tool with that name",
+                        tool.name,
+                        domain,
+                        source,
+                    )
+                continue
+            tool_sources[tool.name] = domain
+            tools.append(tool)
         if result.prompt:
             prompts.append(result.prompt)
     return LLMTools(tools=tools, prompt="\n".join(prompts) if prompts else None)

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -83,6 +83,7 @@ async def async_get_tools(
     # LLM APIs reject duplicate tool names, so the first platform to contribute
     # a name wins. Remember the source so the warning can name both platforms.
     tool_sources: dict[str, str] = {}
+    collided: set[str] = set()
     warned = hass.data[DATA_WARNED_DUPLICATE_TOOLS]
     # Sort by domain so the tool and prompt order is independent of load order.
     for domain, platform in sorted(platforms.items()):
@@ -95,6 +96,7 @@ async def async_get_tools(
             continue
         for tool in result.tools:
             if (source := tool_sources.get(tool.name)) is not None:
+                collided.add(tool.name)
                 # This runs on every conversation turn, so only warn once per name.
                 if tool.name not in warned:
                     warned.add(tool.name)
@@ -110,6 +112,8 @@ async def async_get_tools(
             tools.append(tool)
         if result.prompt:
             prompts.append(result.prompt)
+    # Forget names that no longer collide so the warning returns if they do again.
+    warned.difference_update(tool_sources.keys() - collided)
     return LLMTools(tools=tools, prompt="\n".join(prompts) if prompts else None)
 
 

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -137,3 +137,32 @@ async def test_get_tools_isolates_failing_platform(
     assert [tool.name for tool in result.tools] == ["GetDateTime", "good_tool"]
     assert result.prompt == "prompt"
     assert "Error getting tools from LLM platform test_bad" in caplog.text
+
+
+async def test_get_tools_deduplicates_by_name(
+    hass: HomeAssistant,
+    llm_context: llm.LLMContext,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a tool name contributed by two platforms is only returned once."""
+    first_tool = _StubTool("shared_tool")
+    second_tool = _StubTool("shared_tool")
+    _mock_tools_platform(hass, "test_a", LLMTools(tools=[first_tool]))
+    _mock_tools_platform(hass, "test_b", LLMTools(tools=[second_tool]))
+
+    assert await async_setup_component(hass, "llm", {})
+
+    result = await async_get_tools(hass, llm_context, "assist")
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "shared_tool"]
+    # Sorted by domain, so the tool from "test_a" wins.
+    assert result.tools[1] is first_tool
+    assert (
+        "Ignoring LLM tool shared_tool from platform test_b; platform test_a already"
+        " provides a tool with that name"
+    ) in caplog.text
+
+    # The collision is logged once, not on every call.
+    caplog.clear()
+    result = await async_get_tools(hass, llm_context, "assist")
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "shared_tool"]
+    assert "shared_tool" not in caplog.text

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -148,7 +148,7 @@ async def test_get_tools_deduplicates_by_name(
     first_tool = _StubTool("shared_tool")
     second_tool = _StubTool("shared_tool")
     _mock_tools_platform(hass, "test_a", LLMTools(tools=[first_tool]))
-    _mock_tools_platform(hass, "test_b", LLMTools(tools=[second_tool]))
+    platform_b = _mock_tools_platform(hass, "test_b", LLMTools(tools=[second_tool]))
 
     assert await async_setup_component(hass, "llm", {})
 
@@ -166,3 +166,15 @@ async def test_get_tools_deduplicates_by_name(
     result = await async_get_tools(hass, llm_context, "assist")
     assert [tool.name for tool in result.tools] == ["GetDateTime", "shared_tool"]
     assert "shared_tool" not in caplog.text
+
+    # Once the collision goes away (e.g. the integration was disabled) and
+    # comes back, the warning is logged again.
+    platform_b.return_value = LLMTools(tools=[])
+    result = await async_get_tools(hass, llm_context, "assist")
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "shared_tool"]
+    assert "shared_tool" not in caplog.text
+
+    platform_b.return_value = LLMTools(tools=[second_tool])
+    result = await async_get_tools(hass, llm_context, "assist")
+    assert result.tools[1] is first_tool
+    assert "Ignoring LLM tool shared_tool from platform test_b" in caplog.text


### PR DESCRIPTION
## Proposed change

`llm/__init__.py::async_get_tools()` is where each integration's `llm.py` platform
contribution is merged into one tool list, but the merge has no uniqueness guarantee —
it is a bare `tools.extend(result.tools)`. Nothing stops two platforms from contributing
the same tool name.

LLM providers reject duplicate tool names, so when that happens the result is not a
degraded experience but a hard failure: the Anthropic Messages API returns
`400 invalid_request_error - tools: Tool names must be unique.` for *every* utterance that
reaches the LLM, on every satellite. It is reachable today — e.g. `intent/llm.py` and
`intent_script/llm.py` can both emit a tool for the same handler object — and there is no
config-only way to drop one contribution without dropping both.

This deduplicates by `tool.name` at the merge point. Platforms already iterate sorted by
domain, so first-wins is deterministic. Rather than dropping the duplicate silently, a
warning naming both platforms is logged — once per tool name, since `async_get_tools()`
runs on every conversation turn — so a user whose configuration collides learns about it
while the assistant keeps working. A test covering the collision is included.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178687
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

<!-- I will sign the CLA when the bot prompts. -->
