### PR TITLE
Serialize Z-Wave JS add-on mutation with a flow ownership token

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, fields
 import logging
 from pathlib import Path
-from typing import Any, Self, override
+from typing import Any, Self, cast, override
 
 from awesomeversion import AwesomeVersion
 from propcache.api import cached_property
@@ -159,6 +159,13 @@ CONF_ADDON_RF_REGION = "rf_region"
 EXAMPLE_SERVER_URL = "ws://localhost:3000"
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 MIN_MIGRATION_SDK_VERSION = AwesomeVersion("6.61")
+
+# Context flag of the flow that owns the shared add-on config. A flow's
+# published step only updates when its step handler returns, but the
+# flow context is shared into in-progress flow results immediately, so
+# the flag is set without awaits between check and set. It dies with
+# the flow when the flow is removed from progress.
+_ADDON_OWNER_CONTEXT = "zwave_js_addon_owner"
 
 # Steps at which another flow has not yet changed any shared state,
 # e.g. the add-on config, and can be aborted safely when a config entry
@@ -478,11 +485,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="addon_already_configured")
 
         if config_updates := self._addon_config_updates:
-            if self._reconfigure_config_entry is None and any(
-                flow
-                for flow in self._async_in_progress()
-                if flow.get("step_id") not in ABORT_SAFE_STEPS
-            ):
+            if not self._async_acquire_addon_ownership():
                 # Another flow, e.g. a second discovered adapter being set
                 # up, is already changing the shared add-on config.
                 return self.async_abort(reason="already_in_progress")
@@ -984,6 +987,28 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.flow.async_abort(progress["flow_id"])
 
     @callback
+    def _async_acquire_addon_ownership(self) -> bool:
+        """Try to make this flow the owner of the shared add-on config.
+
+        Return False if another flow in progress owns it. Ownership ends
+        with the flow, when the flow is removed from progress.
+        """
+        # The context holds flow specific keys not in the typed dict.
+        context = cast(dict[str, Any], self.context)
+        if context.get(_ADDON_OWNER_CONTEXT):
+            return True
+        if any(
+            cast(dict[str, Any], flow["context"]).get(_ADDON_OWNER_CONTEXT)
+            # Include uninitialized flows: a discovery flow may change the
+            # add-on config in its first step, before it has a published
+            # step.
+            for flow in self._async_in_progress(include_uninitialized=True)
+        ):
+            return False
+        context[_ADDON_OWNER_CONTEXT] = True
+        return True
+
+    @callback
     def _addon_owned_by_other_entry(self) -> bool:
         """Return if another config entry uses the add-on."""
         return any(
@@ -1263,13 +1288,10 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        if any(
-            flow
-            for flow in self._async_in_progress()
-            if flow.get("step_id") not in ABORT_SAFE_STEPS
-        ):
+        if not self._async_acquire_addon_ownership():
             # Another flow, e.g. a competing migration confirmed earlier,
-            # has progressed beyond a prompt. Don't start a second migration.
+            # is already changing the shared add-on config. Don't start a
+            # second migration.
             return self.async_abort(reason="already_in_progress")
 
         # Remaining prompts, e.g. for other discovered adapters,
@@ -1476,6 +1498,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_ADDON_SOCKET: self.socket_path,
                     **self.security_keys.to_dict(),
                 }
+
+                if not self._async_acquire_addon_ownership():
+                    # Another flow is already changing the shared add-on
+                    # config.
+                    return self.async_abort(reason="already_in_progress")
 
                 addon_config_updates = self._addon_config_updates | addon_config_updates
                 self._addon_config_updates = {}
@@ -1721,6 +1748,10 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                     if existing_socket_path == discovery_info.socket_path:
                         # Config entry already has correct config
                         return self.async_abort(reason="already_configured")
+                    if not self._async_acquire_addon_ownership():
+                        # Another flow is already changing the shared
+                        # add-on config. The discovery is retried later.
+                        return self.async_abort(reason="already_in_progress")
                     await self._addon_setup.async_set_addon_config(
                         {CONF_ADDON_SOCKET: discovery_info.socket_path}
                     )

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -273,11 +273,10 @@ class AddonFlowManager:
     and tracks the original add-on config for reverts.
     """
 
-    def __init__(self, hass: HomeAssistant, flow_id: str) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Set up the add-on flow manager."""
         self.hass = hass
         self.addon_manager = get_addon_manager(hass)
-        self._flow_id = flow_id
         # Set to True if the add-on was running when its config was changed,
         # meaning a restart instead of a start is needed.
         self.restart_addon = False
@@ -320,15 +319,6 @@ class AddonFlowManager:
             # step sets the region.
             self.original_config = dict(addon_config)
         new_addon_config = SecurityKeys.migrate_network_key(new_addon_config)
-        if not any(
-            flow["flow_id"] == self._flow_id
-            for flow in self.hass.config_entries.flow.async_progress(
-                include_uninitialized=True
-            )
-        ):
-            # An abort doesn't cancel a step handler already running here,
-            # so don't write for a removed flow.
-            raise AbortFlow("already_in_progress")
         try:
             await self.addon_manager.async_set_addon_options(new_addon_config)
         except AddonError as err:
@@ -401,7 +391,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
     @cached_property
     def _addon_setup(self) -> AddonFlowManager:
         """Return the add-on flow manager."""
-        return AddonFlowManager(self.hass, self.flow_id)
+        return AddonFlowManager(self.hass)
 
     VERSION = 1
     MINOR_VERSION = 2
@@ -1217,13 +1207,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         self, original_config: dict[str, Any]
     ) -> None:
         """Restore the add-on config and reload the config entry."""
-        if any(
-            cast(dict[str, Any], flow["context"]).get(_ADDON_OWNER_CONTEXT)
-            for flow in self._async_in_progress(include_uninitialized=True)
-        ):
-            # A new owner is writing its own add-on config and now owns
-            # the entry's recovery; don't restore the snapshot under it.
-            return
         config_entry = self._reconfigure_config_entry
         assert config_entry is not None
         addon_manager = self._addon_setup.addon_manager

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -41,7 +41,6 @@ from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util import dt as dt_util
-from homeassistant.util.hass_dict import HassKey
 
 from . import helpers
 from .addon import get_addon_manager
@@ -161,18 +160,9 @@ EXAMPLE_SERVER_URL = "ws://localhost:3000"
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 MIN_MIGRATION_SDK_VERSION = AwesomeVersion("6.61")
 
-# Context flag of the flow that owns the shared add-on config. A flow's
-# published step only updates when its step handler returns, but the
-# flow context is shared into in-progress flow results immediately, so
-# the flag is set without awaits between check and set. It dies with
-# the flow when the flow is removed from progress.
+# Flags the flow that owns the shared add-on config. Kept in the flow
+# context, which is published immediately, unlike the flow's step.
 _ADDON_OWNER_CONTEXT = "zwave_js_addon_owner"
-
-# Serializes writes to the add-on config. The context flag above is
-# intent-level exclusion between flows; this lock guarantees that a
-# write still in flight from an aborted flow and a new owner's write
-# can't interleave.
-_ADDON_WRITE_LOCK: HassKey[asyncio.Lock] = HassKey(f"{DOMAIN}_addon_write_lock")
 
 # Steps at which another flow has not yet changed any shared state,
 # e.g. the add-on config, and can be aborted safely when a config entry
@@ -283,10 +273,11 @@ class AddonFlowManager:
     and tracks the original add-on config for reverts.
     """
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, flow_id: str) -> None:
         """Set up the add-on flow manager."""
         self.hass = hass
         self.addon_manager = get_addon_manager(hass)
+        self._flow_id = flow_id
         # Set to True if the add-on was running when its config was changed,
         # meaning a restart instead of a start is needed.
         self.restart_addon = False
@@ -329,9 +320,17 @@ class AddonFlowManager:
             # step sets the region.
             self.original_config = dict(addon_config)
         new_addon_config = SecurityKeys.migrate_network_key(new_addon_config)
+        if not any(
+            flow["flow_id"] == self._flow_id
+            for flow in self.hass.config_entries.flow.async_progress(
+                include_uninitialized=True
+            )
+        ):
+            # An abort doesn't cancel a step handler already running here,
+            # so don't write for a removed flow.
+            raise AbortFlow("already_in_progress")
         try:
-            async with self.hass.data.setdefault(_ADDON_WRITE_LOCK, asyncio.Lock()):
-                await self.addon_manager.async_set_addon_options(new_addon_config)
+            await self.addon_manager.async_set_addon_options(new_addon_config)
         except AddonError as err:
             _LOGGER.error(err)
             raise AbortFlow("addon_set_config_failed") from err
@@ -402,7 +401,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
     @cached_property
     def _addon_setup(self) -> AddonFlowManager:
         """Return the add-on flow manager."""
-        return AddonFlowManager(self.hass)
+        return AddonFlowManager(self.hass, self.flow_id)
 
     VERSION = 1
     MINOR_VERSION = 2
@@ -483,19 +482,8 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             if rf_region is None or rf_region == "Automatic":
                 # If the RF region is not set, we need to ask the user to select it.
                 return await self.async_step_rf_region()
-        if (
-            self._reconfigure_config_entry is None
-            and self._addon_owned_by_other_entry()
-        ):
-            # An add-on based entry was created while this flow was open,
-            # e.g. by a concurrent discovery flow. Abort before this flow
-            # overwrites the add-on config of that entry.
-            return self.async_abort(reason="addon_already_configured")
-
         if config_updates := self._addon_config_updates:
             if not self._async_acquire_addon_ownership():
-                # Another flow, e.g. a second discovered adapter being set
-                # up, is already changing the shared add-on config.
                 return self.async_abort(reason="already_in_progress")
             # If we have updates to the add-on config,
             # set them before starting the add-on.
@@ -994,9 +982,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             if progress.get("step_id") not in ABORT_SAFE_STEPS:
                 continue
             if cast(dict[str, Any], progress["context"]).get(_ADDON_OWNER_CONTEXT):
-                # The published step lags behind a running step handler,
-                # so an owner of the add-on config may be mid-write while
-                # its step still shows a safe prompt.
+                # An owner may be mid-write while still showing a prompt.
                 continue
             self.hass.config_entries.flow.async_abort(progress["flow_id"])
 
@@ -1004,18 +990,15 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
     def _async_acquire_addon_ownership(self) -> bool:
         """Try to make this flow the owner of the shared add-on config.
 
-        Return False if another flow in progress owns it. Ownership ends
-        with the flow, when the flow is removed from progress.
+        Return False if another flow in progress owns it.
+        Ownership ends when the flow is removed from progress.
         """
-        # The context holds flow specific keys not in the typed dict.
         context = cast(dict[str, Any], self.context)
         if context.get(_ADDON_OWNER_CONTEXT):
             return True
         if any(
             cast(dict[str, Any], flow["context"]).get(_ADDON_OWNER_CONTEXT)
-            # Include uninitialized flows: a discovery flow may change the
-            # add-on config in its first step, before it has a published
-            # step.
+            # A discovery flow may write the config in its first step.
             for flow in self._async_in_progress(include_uninitialized=True)
         ):
             return False
@@ -1234,32 +1217,35 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         self, original_config: dict[str, Any]
     ) -> None:
         """Restore the add-on config and reload the config entry."""
+        if any(
+            cast(dict[str, Any], flow["context"]).get(_ADDON_OWNER_CONTEXT)
+            for flow in self._async_in_progress(include_uninitialized=True)
+        ):
+            # A new owner is writing its own add-on config and now owns
+            # the entry's recovery; don't restore the snapshot under it.
+            return
         config_entry = self._reconfigure_config_entry
         assert config_entry is not None
         addon_manager = self._addon_setup.addon_manager
         # Migrate the legacy network key, like async_set_addon_config does,
         # so restoring doesn't drop the S0 key on older add-on configurations.
         restored_config = SecurityKeys.migrate_network_key(original_config)
-        # This task outlives the flow and its ownership flag, so hold the
-        # write lock to not interleave with a new owner's write.
-        async with self.hass.data.setdefault(_ADDON_WRITE_LOCK, asyncio.Lock()):
+        try:
+            await addon_manager.async_set_addon_options(restored_config)
+        except AddonError as err:
+            # Don't reload the entry if the options were not restored, so the
+            # reload doesn't adopt the unconfirmed options still on the add-on.
+            _LOGGER.error("Failed to restore add-on options: %s", err)
+            return
+        if self._addon_setup.restart_addon or self._addon_setup.addon_started:
+            # The add-on is running with the unconfirmed options this flow
+            # set. Restart it before the reload, so the entry doesn't
+            # reconnect to the unconfirmed adapter.
             try:
-                await addon_manager.async_set_addon_options(restored_config)
+                await addon_manager.async_restart_addon()
             except AddonError as err:
-                # Don't reload the entry if the options were not restored,
-                # so the reload doesn't adopt the unconfirmed options still
-                # on the add-on.
-                _LOGGER.error("Failed to restore add-on options: %s", err)
+                _LOGGER.error("Failed to restart add-on: %s", err)
                 return
-            if self._addon_setup.restart_addon or self._addon_setup.addon_started:
-                # The add-on is running with the unconfirmed options this
-                # flow set. Restart it before the reload, so the entry
-                # doesn't reconnect to the unconfirmed adapter.
-                try:
-                    await addon_manager.async_restart_addon()
-                except AddonError as err:
-                    _LOGGER.error("Failed to restart add-on: %s", err)
-                    return
         self.hass.config_entries.async_schedule_reload(config_entry.entry_id)
 
     async def async_step_intent_reconfigure(
@@ -1307,9 +1293,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         if not self._async_acquire_addon_ownership():
-            # Another flow, e.g. a competing migration confirmed earlier,
-            # is already changing the shared add-on config. Don't start a
-            # second migration.
             return self.async_abort(reason="already_in_progress")
 
         # Remaining prompts, e.g. for other discovered adapters,
@@ -1518,8 +1501,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
 
                 if not self._async_acquire_addon_ownership():
-                    # Another flow is already changing the shared add-on
-                    # config.
                     return self.async_abort(reason="already_in_progress")
 
                 addon_config_updates = self._addon_config_updates | addon_config_updates
@@ -1767,8 +1748,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                         # Config entry already has correct config
                         return self.async_abort(reason="already_configured")
                     if not self._async_acquire_addon_ownership():
-                        # Another flow is already changing the shared
-                        # add-on config. The discovery is retried later.
                         return self.async_abort(reason="already_in_progress")
                     await self._addon_setup.async_set_addon_config(
                         {CONF_ADDON_SOCKET: discovery_info.socket_path}

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
 
 from . import helpers
 from .addon import get_addon_manager
@@ -166,6 +167,12 @@ MIN_MIGRATION_SDK_VERSION = AwesomeVersion("6.61")
 # the flag is set without awaits between check and set. It dies with
 # the flow when the flow is removed from progress.
 _ADDON_OWNER_CONTEXT = "zwave_js_addon_owner"
+
+# Serializes writes to the add-on config. The context flag above is
+# intent-level exclusion between flows; this lock guarantees that a
+# write still in flight from an aborted flow and a new owner's write
+# can't interleave.
+_ADDON_WRITE_LOCK: HassKey[asyncio.Lock] = HassKey(f"{DOMAIN}_addon_write_lock")
 
 # Steps at which another flow has not yet changed any shared state,
 # e.g. the add-on config, and can be aborted safely when a config entry
@@ -323,7 +330,8 @@ class AddonFlowManager:
             self.original_config = dict(addon_config)
         new_addon_config = SecurityKeys.migrate_network_key(new_addon_config)
         try:
-            await self.addon_manager.async_set_addon_options(new_addon_config)
+            async with self.hass.data.setdefault(_ADDON_WRITE_LOCK, asyncio.Lock()):
+                await self.addon_manager.async_set_addon_options(new_addon_config)
         except AddonError as err:
             _LOGGER.error(err)
             raise AbortFlow("addon_set_config_failed") from err
@@ -983,8 +991,14 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         backed up the network, must not be interrupted.
         """
         for progress in self._async_in_progress():
-            if progress.get("step_id") in ABORT_SAFE_STEPS:
-                self.hass.config_entries.flow.async_abort(progress["flow_id"])
+            if progress.get("step_id") not in ABORT_SAFE_STEPS:
+                continue
+            if cast(dict[str, Any], progress["context"]).get(_ADDON_OWNER_CONTEXT):
+                # The published step lags behind a running step handler,
+                # so an owner of the add-on config may be mid-write while
+                # its step still shows a safe prompt.
+                continue
+            self.hass.config_entries.flow.async_abort(progress["flow_id"])
 
     @callback
     def _async_acquire_addon_ownership(self) -> bool:
@@ -1226,22 +1240,26 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         # Migrate the legacy network key, like async_set_addon_config does,
         # so restoring doesn't drop the S0 key on older add-on configurations.
         restored_config = SecurityKeys.migrate_network_key(original_config)
-        try:
-            await addon_manager.async_set_addon_options(restored_config)
-        except AddonError as err:
-            # Don't reload the entry if the options were not restored, so the
-            # reload doesn't adopt the unconfirmed options still on the add-on.
-            _LOGGER.error("Failed to restore add-on options: %s", err)
-            return
-        if self._addon_setup.restart_addon or self._addon_setup.addon_started:
-            # The add-on is running with the unconfirmed options this flow
-            # set. Restart it before the reload, so the entry doesn't
-            # reconnect to the unconfirmed adapter.
+        # This task outlives the flow and its ownership flag, so hold the
+        # write lock to not interleave with a new owner's write.
+        async with self.hass.data.setdefault(_ADDON_WRITE_LOCK, asyncio.Lock()):
             try:
-                await addon_manager.async_restart_addon()
+                await addon_manager.async_set_addon_options(restored_config)
             except AddonError as err:
-                _LOGGER.error("Failed to restart add-on: %s", err)
+                # Don't reload the entry if the options were not restored,
+                # so the reload doesn't adopt the unconfirmed options still
+                # on the add-on.
+                _LOGGER.error("Failed to restore add-on options: %s", err)
                 return
+            if self._addon_setup.restart_addon or self._addon_setup.addon_started:
+                # The add-on is running with the unconfirmed options this
+                # flow set. Restart it before the reload, so the entry
+                # doesn't reconnect to the unconfirmed adapter.
+                try:
+                    await addon_manager.async_restart_addon()
+                except AddonError as err:
+                    _LOGGER.error("Failed to restart add-on: %s", err)
+                    return
         self.hass.config_entries.async_schedule_reload(config_entry.entry_id)
 
     async def async_step_intent_reconfigure(

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -21,6 +21,7 @@ from zwave_js_server.version import VersionInfo
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.usb import SerialDevice, USBDevice
 from homeassistant.components.zwave_js.config_flow import (
+    _ADDON_OWNER_CONTEXT,
     TITLE,
     SecurityKeys,
     async_get_usb_ports,
@@ -2853,6 +2854,64 @@ async def test_concurrent_flow_during_addon_config_write(
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")
+async def test_aborted_flow_aborts_addon_config_write(
+    hass: HomeAssistant,
+    addon_info: AsyncMock,
+    set_addon_options: AsyncMock,
+    mock_usb_serial_by_id: MagicMock,
+) -> None:
+    """Test a flow aborted mid-handler does not write the add-on config.
+
+    Aborting a flow doesn't cancel its step handler, so a handler
+    suspended on its way to the add-on config write keeps running and
+    must give up instead of writing for a removed flow.
+    """
+    info_fetch_started = asyncio.Event()
+    resume_info_fetch = asyncio.Event()
+    info_calls = 0
+    default_info = addon_info.return_value
+
+    async def blocking_addon_info(addon: str) -> Any:
+        nonlocal info_calls
+        info_calls += 1
+        # The second fetch after the prompt is the one in the add-on
+        # config write path.
+        if info_calls == 2:
+            info_fetch_started.set()
+            await resume_info_fetch.wait()
+        return default_info
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+
+    assert result["step_id"] == "installation_type"
+
+    addon_info.side_effect = blocking_addon_info
+    task = hass.async_create_task(
+        hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "intent_recommended"}
+        )
+    )
+    # Release the blocked flow also when an assertion fails, so a
+    # regression fails the test instead of hanging it.
+    try:
+        async with asyncio.timeout(5):
+            await info_fetch_started.wait()
+        hass.config_entries.flow.async_abort(result["flow_id"])
+    finally:
+        resume_info_fetch.set()
+
+    result = await task
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+    set_addon_options.assert_not_called()
+
+
 @pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:
     """Test usb discovery aborted when existing entry not using add-on."""
@@ -3068,47 +3127,6 @@ async def test_reconfigure_addon_already_configured(
     assert result["reason"] == "addon_already_configured"
     # The other entry's add-on config is untouched.
     set_addon_options.assert_not_called()
-
-
-@pytest.mark.usefixtures("supervisor", "addon_installed")
-async def test_addon_already_configured_at_addon_start(
-    hass: HomeAssistant,
-    set_addon_options: AsyncMock,
-) -> None:
-    """Test the add-on start aborts when an add-on entry appeared late."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"next_step_id": "intent_recommended"}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "configure_addon_user"
-
-    # An add-on based entry is configured while the flow shows the form,
-    # e.g. by a concurrent discovery flow.
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "url": "ws://localhost:3000",
-            "usb_path": "/other",
-            "use_addon": True,
-        },
-        title=TITLE,
-        unique_id="4321",
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"usb_path": "/test"}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "addon_already_configured"
-    # The other entry's add-on config is untouched.
-    set_addon_options.assert_not_called()
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 @pytest.mark.usefixtures("supervisor", "addon_running")
@@ -6344,6 +6362,56 @@ async def test_reconfigure_abandoned_restores_addon_config(
         AddonsOptions(config={"device": "/test", "s0_legacy_key": "old123"}),
     )
     assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")
+async def test_reconfigure_abandoned_restore_skipped_for_new_owner(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    addon_options: dict[str, Any],
+    set_addon_options: AsyncMock,
+) -> None:
+    """Test an abandoned flow doesn't restore over a new owner's config."""
+    addon_options.update({"device": "/test", "s0_legacy_key": "old123"})
+    entry = integration
+    hass.config_entries.async_update_entry(
+        entry, unique_id="1234", data={**entry.data, "use_addon": True}
+    )
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "intent_reconfigure"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"use_addon": True}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "usb_path": "/new",
+            "s0_legacy_key": "old123",
+        },
+    )
+
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert set_addon_options.call_count == 1
+    set_addon_options.reset_mock()
+
+    # Simulate a flow that has taken ownership of the add-on config by
+    # the time the abandoned flow's restore task runs.
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER, _ADDON_OWNER_CONTEXT: True},
+    )
+
+    hass.config_entries.flow.async_abort(result["flow_id"])
+    await hass.async_block_till_done()
+
+    # The restore and reload are skipped; the new owner recovers the entry.
+    set_addon_options.assert_not_called()
+    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2741,7 +2741,8 @@ async def test_concurrent_flow_during_addon_config_write(
     so while the first flow is applying the add-on config inside the
     start add-on step, its published step is still the prompt it was
     submitted from. A second flow submitted at that moment must still
-    abort.
+    abort, and an entry created by another flow at that moment must not
+    abort the first flow as a redundant prompt.
     """
     options_write_started = asyncio.Event()
     resume_options_write = asyncio.Event()
@@ -2779,23 +2780,69 @@ async def test_concurrent_flow_during_addon_config_write(
             result_a["flow_id"], {"next_step_id": "intent_recommended"}
         )
     )
-    await options_write_started.wait()
+    # Release the blocked first flow also when an assertion fails,
+    # so a regression fails the test instead of hanging it.
+    try:
+        async with asyncio.timeout(5):
+            await options_write_started.wait()
 
-    # The first flow is changing the add-on config, but its published
-    # step is still the safe prompt it was submitted from.
-    flows_in_progress = {
-        flow["flow_id"]: flow for flow in hass.config_entries.flow.async_progress()
-    }
-    assert flows_in_progress[result_a["flow_id"]]["step_id"] == "installation_type"
+        # The first flow is changing the add-on config, but its published
+        # step is still the safe prompt it was submitted from.
+        flows_in_progress = {
+            flow["flow_id"]: flow for flow in hass.config_entries.flow.async_progress()
+        }
+        assert flows_in_progress[result_a["flow_id"]]["step_id"] == "installation_type"
 
-    result_b = await hass.config_entries.flow.async_configure(
-        result_b["flow_id"], {"next_step_id": "intent_recommended"}
-    )
+        result_b = await hass.config_entries.flow.async_configure(
+            result_b["flow_id"], {"next_step_id": "intent_recommended"}
+        )
 
-    assert result_b["type"] is FlowResultType.ABORT
-    assert result_b["reason"] == "already_in_progress"
+        assert result_b["type"] is FlowResultType.ABORT
+        assert result_b["reason"] == "already_in_progress"
 
-    resume_options_write.set()
+        # A manual flow that creates an entry supersedes prompt flows,
+        # but must not abort the flow that owns the add-on config, even
+        # though its published step still shows a safe prompt.
+        result_manual = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result_manual["type"] is FlowResultType.MENU
+        assert result_manual["step_id"] == "installation_type"
+
+        result_manual = await hass.config_entries.flow.async_configure(
+            result_manual["flow_id"], {"next_step_id": "intent_custom"}
+        )
+
+        assert result_manual["type"] is FlowResultType.FORM
+        assert result_manual["step_id"] == "on_supervisor"
+
+        result_manual = await hass.config_entries.flow.async_configure(
+            result_manual["flow_id"], {"use_addon": False}
+        )
+
+        assert result_manual["type"] is FlowResultType.FORM
+        assert result_manual["step_id"] == "manual"
+
+        with (
+            patch("homeassistant.components.zwave_js.async_setup", return_value=True),
+            patch(
+                "homeassistant.components.zwave_js.async_setup_entry",
+                return_value=True,
+            ),
+        ):
+            result_manual = await hass.config_entries.flow.async_configure(
+                result_manual["flow_id"], {"url": "ws://localhost:3000"}
+            )
+
+        assert result_manual["type"] is FlowResultType.CREATE_ENTRY
+        assert any(
+            flow["flow_id"] == result_a["flow_id"]
+            for flow in hass.config_entries.flow.async_progress()
+        )
+    finally:
+        resume_options_write.set()
+
     result_a = await task_a
 
     assert result_a["type"] is FlowResultType.SHOW_PROGRESS

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -21,7 +21,6 @@ from zwave_js_server.version import VersionInfo
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.usb import SerialDevice, USBDevice
 from homeassistant.components.zwave_js.config_flow import (
-    _ADDON_OWNER_CONTEXT,
     TITLE,
     SecurityKeys,
     async_get_usb_ports,
@@ -2852,64 +2851,6 @@ async def test_concurrent_flow_during_addon_config_write(
 
     hass.config_entries.flow.async_abort(result_a["flow_id"])
     await hass.async_block_till_done()
-
-
-@pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")
-async def test_aborted_flow_aborts_addon_config_write(
-    hass: HomeAssistant,
-    addon_info: AsyncMock,
-    set_addon_options: AsyncMock,
-    mock_usb_serial_by_id: MagicMock,
-) -> None:
-    """Test a flow aborted mid-handler does not write the add-on config.
-
-    Aborting a flow doesn't cancel its step handler, so a handler
-    suspended on its way to the add-on config write keeps running and
-    must give up instead of writing for a removed flow.
-    """
-    info_fetch_started = asyncio.Event()
-    resume_info_fetch = asyncio.Event()
-    info_calls = 0
-    default_info = addon_info.return_value
-
-    async def blocking_addon_info(addon: str) -> Any:
-        nonlocal info_calls
-        info_calls += 1
-        # The second fetch after the prompt is the one in the add-on
-        # config write path.
-        if info_calls == 2:
-            info_fetch_started.set()
-            await resume_info_fetch.wait()
-        return default_info
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USB},
-        data=USB_DISCOVERY_INFO,
-    )
-
-    assert result["step_id"] == "installation_type"
-
-    addon_info.side_effect = blocking_addon_info
-    task = hass.async_create_task(
-        hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": "intent_recommended"}
-        )
-    )
-    # Release the blocked flow also when an assertion fails, so a
-    # regression fails the test instead of hanging it.
-    try:
-        async with asyncio.timeout(5):
-            await info_fetch_started.wait()
-        hass.config_entries.flow.async_abort(result["flow_id"])
-    finally:
-        resume_info_fetch.set()
-
-    result = await task
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_in_progress"
-    set_addon_options.assert_not_called()
 
 
 @pytest.mark.usefixtures("supervisor", "addon_info")
@@ -6362,56 +6303,6 @@ async def test_reconfigure_abandoned_restores_addon_config(
         AddonsOptions(config={"device": "/test", "s0_legacy_key": "old123"}),
     )
     assert entry.state is config_entries.ConfigEntryState.LOADED
-
-
-@pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")
-async def test_reconfigure_abandoned_restore_skipped_for_new_owner(
-    hass: HomeAssistant,
-    integration: MockConfigEntry,
-    addon_options: dict[str, Any],
-    set_addon_options: AsyncMock,
-) -> None:
-    """Test an abandoned flow doesn't restore over a new owner's config."""
-    addon_options.update({"device": "/test", "s0_legacy_key": "old123"})
-    entry = integration
-    hass.config_entries.async_update_entry(
-        entry, unique_id="1234", data={**entry.data, "use_addon": True}
-    )
-
-    result = await entry.start_reconfigure_flow(hass)
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"next_step_id": "intent_reconfigure"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"use_addon": True}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "usb_path": "/new",
-            "s0_legacy_key": "old123",
-        },
-    )
-
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "start_addon"
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
-    assert set_addon_options.call_count == 1
-    set_addon_options.reset_mock()
-
-    # Simulate a flow that has taken ownership of the add-on config by
-    # the time the abandoned flow's restore task runs.
-    await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER, _ADDON_OWNER_CONTEXT: True},
-    )
-
-    hass.config_entries.flow.async_abort(result["flow_id"])
-    await hass.async_block_till_done()
-
-    # The restore and reload are skipped; the new owner recovers the entry.
-    set_addon_options.assert_not_called()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2707,6 +2707,104 @@ async def test_concurrent_usb_setup_flows(
     hass.config_entries.flow.async_abort(result_a["flow_id"])
     await hass.async_block_till_done()
 
+    # The aborted first flow is no longer in progress, so its ownership
+    # of the add-on config is gone and a new flow can change it.
+    result_c = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=second_stick,
+    )
+
+    assert result_c["step_id"] == "installation_type"
+
+    result_c = await hass.config_entries.flow.async_configure(
+        result_c["flow_id"], {"next_step_id": "intent_recommended"}
+    )
+
+    assert result_c["type"] is FlowResultType.SHOW_PROGRESS
+    assert result_c["step_id"] == "start_addon"
+    set_addon_options.assert_called_once()
+
+    hass.config_entries.flow.async_abort(result_c["flow_id"])
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("supervisor", "addon_running", "restart_addon")
+async def test_concurrent_flow_during_addon_config_write(
+    hass: HomeAssistant,
+    set_addon_options: AsyncMock,
+    mock_usb_serial_by_id: MagicMock,
+) -> None:
+    """Test a second flow aborts while the first is inside the start add-on step.
+
+    A flow's published step only updates when its step handler returns,
+    so while the first flow is applying the add-on config inside the
+    start add-on step, its published step is still the prompt it was
+    submitted from. A second flow submitted at that moment must still
+    abort.
+    """
+    options_write_started = asyncio.Event()
+    resume_options_write = asyncio.Event()
+
+    async def blocking_set_addon_options(slug: str, options: AddonsOptions) -> None:
+        options_write_started.set()
+        await resume_options_write.wait()
+
+    set_addon_options.side_effect = blocking_set_addon_options
+
+    second_stick = UsbServiceInfo(
+        device="/dev/zwave2",
+        pid="BBBB",
+        vid="BBBB",
+        serial_number="5678",
+        description="zwave radio",
+        manufacturer="test",
+    )
+    result_a = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+    result_b = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=second_stick,
+    )
+
+    assert result_a["step_id"] == "installation_type"
+    assert result_b["step_id"] == "installation_type"
+
+    task_a = hass.async_create_task(
+        hass.config_entries.flow.async_configure(
+            result_a["flow_id"], {"next_step_id": "intent_recommended"}
+        )
+    )
+    await options_write_started.wait()
+
+    # The first flow is changing the add-on config, but its published
+    # step is still the safe prompt it was submitted from.
+    flows_in_progress = {
+        flow["flow_id"]: flow for flow in hass.config_entries.flow.async_progress()
+    }
+    assert flows_in_progress[result_a["flow_id"]]["step_id"] == "installation_type"
+
+    result_b = await hass.config_entries.flow.async_configure(
+        result_b["flow_id"], {"next_step_id": "intent_recommended"}
+    )
+
+    assert result_b["type"] is FlowResultType.ABORT
+    assert result_b["reason"] == "already_in_progress"
+
+    resume_options_write.set()
+    result_a = await task_a
+
+    assert result_a["type"] is FlowResultType.SHOW_PROGRESS
+    assert result_a["step_id"] == "start_addon"
+    set_addon_options.assert_called_once()
+
+    hass.config_entries.flow.async_abort(result_a["flow_id"])
+    await hass.async_block_till_done()
+
 
 @pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The step-based concurrency guards have a race: a flow's published step only updates when its step handler returns, and one `async_configure` call can chain through several steps internally. While flow A is inside `start_addon`, its published step is still the prompt it was submitted from, so a concurrently submitted flow B passes the `ABORT_SAFE_STEPS` check and both flows interleave writes to the shared add-on config.

Replace those checks with an ownership flag in the flow context. The context dict is shared live into in-progress flow results (like `context["unique_id"]`), so a flow acquires ownership synchronously, with no awaits between check and set. The flag dies with the flow, so there is no release or leak handling. Ownership is acquired at the four sites that write the add-on config: `start_addon`, `intent_migrate`, `configure_addon_reconfigure`, and the ESPHome same-socket repoint.

`_async_abort_other_prompt_flows` skips flows that carry the flag, since its published-step check is blind to an owner mid-write.

Not covered on purpose: the stop-add-on branch of `on_supervisor_reconfigure` (writes no config) and the revert/restore helpers (they clean up while a flow is ending and must not be blocked). The start step also no longer rechecks for a late add-on based entry: such an entry can only be created by a flow holding the unique ownership flag through that step, which aborts or excludes every other flow first, so the scenario is unreachable. `ABORT_SAFE_STEPS` remains for the prompt-superseding UX only.

Follow-up to #179816.

cc @AlCalzone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io



