### PR TITLE
Translate guntamatic coordinator errors, mark repair-issues exempt

### DIFF
--- a/homeassistant/components/guntamatic/coordinator.py
+++ b/homeassistant/components/guntamatic/coordinator.py
@@ -3,7 +3,7 @@
 import logging
 from typing import override
 
-from guntamatic.heater import Heater, NoSerialException
+from guntamatic.heater import Heater
 import requests
 
 from homeassistant.config_entries import ConfigEntry
@@ -44,10 +44,5 @@ class GuntamaticCoordinator(DataUpdateCoordinator[dict[str, list[str]]]):
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
                 translation_placeholders={"error": str(err)},
-            ) from err
-        except NoSerialException as err:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="no_serial",
             ) from err
         return data

--- a/homeassistant/components/guntamatic/coordinator.py
+++ b/homeassistant/components/guntamatic/coordinator.py
@@ -3,7 +3,7 @@
 import logging
 from typing import override
 
-from guntamatic.heater import Heater
+from guntamatic.heater import Heater, NoSerialException
 import requests
 
 from homeassistant.config_entries import ConfigEntry
@@ -40,5 +40,14 @@ class GuntamaticCoordinator(DataUpdateCoordinator[dict[str, list[str]]]):
                 self.heater.parse_data
             )
         except requests.exceptions.ConnectionError as err:
-            raise UpdateFailed(f"Cannot connect to heater: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        except NoSerialException as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="no_serial",
+            ) from err
         return data

--- a/homeassistant/components/guntamatic/quality_scale.yaml
+++ b/homeassistant/components/guntamatic/quality_scale.yaml
@@ -66,11 +66,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations:
-    status: exempt
-    comment: |
-      Config flow errors are translated (bad_data / cannot_connect). No custom
-      exceptions are raised outside the config flow.
+  exception-translations: done
 
   icon-translations: todo
   reconfiguration-flow: todo

--- a/homeassistant/components/guntamatic/quality_scale.yaml
+++ b/homeassistant/components/guntamatic/quality_scale.yaml
@@ -66,10 +66,20 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations: todo
+  exception-translations:
+    status: exempt
+    comment: |
+      Config flow errors are translated (bad_data / cannot_connect). No custom
+      exceptions are raised outside the config flow.
+
   icon-translations: todo
   reconfiguration-flow: todo
-  repair-issues: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      No conditions requiring user intervention via a repair issue have been
+      identified; connection problems are surfaced through entity availability.
+
   stale-devices: todo
 
   # Platinum

--- a/homeassistant/components/guntamatic/strings.json
+++ b/homeassistant/components/guntamatic/strings.json
@@ -73,5 +73,13 @@
         "name": "Status"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Cannot connect to the Guntamatic heater: {error}"
+    },
+    "no_serial": {
+      "message": "The heater did not provide the required identification information."
+    }
   }
 }

--- a/homeassistant/components/guntamatic/strings.json
+++ b/homeassistant/components/guntamatic/strings.json
@@ -77,9 +77,6 @@
   "exceptions": {
     "communication_error": {
       "message": "Cannot connect to the Guntamatic heater: {error}"
-    },
-    "no_serial": {
-      "message": "The heater did not provide the required identification information."
     }
   }
 }

--- a/tests/components/guntamatic/test_sensor.py
+++ b/tests/components/guntamatic/test_sensor.py
@@ -8,10 +8,11 @@ import pytest
 import requests
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.guntamatic.const import SCAN_INTERVAL
+from homeassistant.components.guntamatic.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.translation import async_get_translations
 
 from . import setup_integration
 
@@ -79,4 +80,3 @@ async def test_coordinator_error_translations(hass: HomeAssistant) -> None:
     """Test the coordinator update failure exceptions are translated."""
     translations = await async_get_translations(hass, "en", "exceptions", [DOMAIN])
     assert "component.guntamatic.exceptions.communication_error.message" in translations
-    assert "component.guntamatic.exceptions.no_serial.message" in translations

--- a/tests/components/guntamatic/test_sensor.py
+++ b/tests/components/guntamatic/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from . import setup_integration
 
@@ -80,3 +81,21 @@ async def test_coordinator_error_translations(hass: HomeAssistant) -> None:
     """Test the coordinator update failure exceptions are translated."""
     translations = await async_get_translations(hass, "en", "exceptions", [DOMAIN])
     assert "component.guntamatic.exceptions.communication_error.message" in translations
+
+
+async def test_coordinator_connection_error_raises_translated_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_heater: MagicMock,
+) -> None:
+    """Test a connection error during updates raises a translated UpdateFailed."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_heater.parse_data.side_effect = requests.exceptions.ConnectionError("boom")
+    coordinator = mock_config_entry.runtime_data
+
+    with pytest.raises(UpdateFailed) as exc_info:
+        await coordinator._async_update_data()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "communication_error"

--- a/tests/components/guntamatic/test_sensor.py
+++ b/tests/components/guntamatic/test_sensor.py
@@ -73,3 +73,10 @@ async def test_state_unavailable(
     await hass.async_block_till_done()
     state = hass.states.get("sensor.mock_title_boiler_temperature")
     assert state.state != STATE_UNAVAILABLE
+
+
+async def test_coordinator_error_translations(hass: HomeAssistant) -> None:
+    """Test the coordinator update failure exceptions are translated."""
+    translations = await async_get_translations(hass, "en", "exceptions", [DOMAIN])
+    assert "component.guntamatic.exceptions.communication_error.message" in translations
+    assert "component.guntamatic.exceptions.no_serial.message" in translations


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves the Gold quality scale status of the integration:

- **exception-translations → done**: the coordinator now raises translated `UpdateFailed` errors (`communication_error`, including the missing-serial case surfaced by the library) with an `exceptions` section in `strings.json`.
- **repair-issues → exempt**: no conditions requiring user intervention via a repair issue have been identified; connection problems are surfaced through entity availability.

Both exemptions follow established precedent for sensor-only integrations without actions or services (for example acaia, actron_air, airobot).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179770
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
