### PR TITLE
Don't restore non-KNX attributes for KNX sensors

### DIFF
--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -181,7 +181,9 @@ class _KnxSensor(RestoreSensor, _KnxEntityBase):
             )
         ):
             self._attr_native_value = last_sensor_data.native_value
-            self._attr_extra_state_attributes.update(last_state.attributes)
+            # only restore KNX specific attributes - others may have changed
+            if (source := last_state.attributes.get(ATTR_SOURCE)) is not None:
+                self._attr_extra_state_attributes[ATTR_SOURCE] = source
         await super().async_added_to_hass()
 
     @override

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -12,8 +12,19 @@ from homeassistant.components.knx.const import (
     CONF_SYNC_STATE,
 )
 from homeassistant.components.knx.schema import SensorSchema
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import CONF_NAME, CONF_TYPE, STATE_UNKNOWN, Platform
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
+    CONF_TYPE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, State
 
 from . import KnxEntityGenerator
@@ -97,6 +108,55 @@ async def test_sensor_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
     events = async_capture_events(hass, "state_changed")
     await knx.receive_write(ADDRESS, RAW_FLOAT_21_0)
     assert not events
+
+
+async def test_sensor_restore_ignores_stale_attributes(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test that restoring doesn't reapply attributes the entity doesn't provide."""
+    fake_state = State(
+        "sensor.test",
+        "ignored in favour of native_value",
+        {
+            ATTR_SOURCE: knx.INDIVIDUAL_ADDRESS,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
+            ATTR_UNIT_OF_MEASUREMENT: "W",
+        },
+    )
+    extra_data = {"native_value": "42", "native_unit_of_measurement": None}
+    mock_restore_cache_with_extra_data(hass, [(fake_state, extra_data)])
+
+    await knx.setup_integration(
+        {
+            SensorSchema.PLATFORM: [
+                {
+                    CONF_NAME: "test",
+                    CONF_STATE_ADDRESS: "2/2/2",
+                    CONF_TYPE: "2byte_unsigned",  # no unit or device class
+                    CONF_SYNC_STATE: False,
+                },
+            ]
+        }
+    )
+
+    knx.assert_state(
+        "sensor.test",
+        "42",
+        **{ATTR_SOURCE: knx.INDIVIDUAL_ADDRESS},
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_of_measurement=None,
+    )
+    # a new telegram doesn't reintroduce the stale attributes either
+    await knx.receive_write("2/2/2", (0x00, 0x07))
+    knx.assert_state(
+        "sensor.test",
+        "7",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit_of_measurement=None,
+    )
 
 
 async def test_last_reported(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

KNX sensors restored the *full* attribute dict of their last state into
`_attr_extra_state_attributes`. Only `source` was meant to be restored.

```python
self._attr_extra_state_attributes.update(last_state.attributes)
```

This makes stale `state_class`, `device_class` and `unit_of_measurement`
values stick to the entity, because of how `Entity.__async_calculate_state`
composes the attributes:

- extra state attributes are merged over the capability attributes, so a
  restored `state_class` always shadows the one the entity currently reports
- `unit_of_measurement` and `device_class` are only written when they are not
  `None`, so a restored value survives whenever the current DPT provides
  neither (e.g. `2byte_unsigned`)

Since the restored values are part of the state on every update, they are
persisted again on shutdown and restored on the next start. That makes them
survive a config change, a config entry reload, an `entity_id` rename, entity
removal and recreation (the `entity_id` is restored from `deleted_entities`,
so the same restore state entry is hit again) and a restart — as reported in
#179890, where a `2byte_unsigned` sensor kept reporting `unit_of_measurement:
"W"` / `device_class: "power"` that appear nowhere in the configuration.

Only the KNX specific `source` attribute is restored now. Existing affected
entities recover on the first restart after this change: the stale attributes
are no longer read from the restore state and are overwritten in it once the
state is saved again.

Regression from #154318, released in 2025.11.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179890
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
