### PR TITLE
Deprecate modbus get_hub in favour of async_get_unit

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -36,7 +36,7 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
         "calls `modbus.get_hub`, which is deprecated in favour of "
         "`modbus.async_get_unit`. Collect the connection details in your own "
         "config flow and ask for a unit on them",
-        breaks_in_ha_version="2027.9",
+        breaks_in_ha_version="2027.10",
         core_behavior=ReportBehavior.IGNORE,
         core_integration_behavior=ReportBehavior.IGNORE,
         custom_integration_behavior=ReportBehavior.LOG,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_platform import async_get_platforms
+from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
@@ -25,7 +26,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
-    """Return modbus hub with name."""
+    """Return modbus hub with name.
+
+    Deprecated. Use `async_get_unit` instead, which builds a connection from
+    credentials the integration holds rather than attaching to a hub the user
+    configured in YAML under a name the integration has to be told.
+    """
+    report_usage(
+        "calls `modbus.get_hub`, which is deprecated in favour of "
+        "`modbus.async_get_unit`. Collect the connection details in your own "
+        "config flow and ask for a unit on them",
+        breaks_in_ha_version="2027.2",
+        core_behavior=ReportBehavior.IGNORE,
+        core_integration_behavior=ReportBehavior.IGNORE,
+        custom_integration_behavior=ReportBehavior.LOG,
+    )
     return hass.data[DATA_MODBUS_HUBS][name]
 
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -36,7 +36,7 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
         "calls `modbus.get_hub`, which is deprecated in favour of "
         "`modbus.async_get_unit`. Collect the connection details in your own "
         "config flow and ask for a unit on them",
-        breaks_in_ha_version="2027.3",
+        breaks_in_ha_version="2027.4",
         core_behavior=ReportBehavior.IGNORE,
         core_integration_behavior=ReportBehavior.IGNORE,
         custom_integration_behavior=ReportBehavior.LOG,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -40,6 +40,10 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
         core_behavior=ReportBehavior.IGNORE,
         core_integration_behavior=ReportBehavior.IGNORE,
         custom_integration_behavior=ReportBehavior.LOG,
+        # get_hub is defined here, so its own frame is the first one the stack
+        # walk meets. Without this it reports modbus every time, and the core
+        # behavior above then silences the caller it was meant to name.
+        exclude_integrations={DOMAIN},
     )
     return hass.data[DATA_MODBUS_HUBS][name]
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -36,7 +36,7 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
         "calls `modbus.get_hub`, which is deprecated in favour of "
         "`modbus.async_get_unit`. Collect the connection details in your own "
         "config flow and ask for a unit on them",
-        breaks_in_ha_version="2027.4",
+        breaks_in_ha_version="2027.9",
         core_behavior=ReportBehavior.IGNORE,
         core_integration_behavior=ReportBehavior.IGNORE,
         custom_integration_behavior=ReportBehavior.LOG,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -36,7 +36,7 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
         "calls `modbus.get_hub`, which is deprecated in favour of "
         "`modbus.async_get_unit`. Collect the connection details in your own "
         "config flow and ask for a unit on them",
-        breaks_in_ha_version="2027.2",
+        breaks_in_ha_version="2027.3",
         core_behavior=ReportBehavior.IGNORE,
         core_integration_behavior=ReportBehavior.IGNORE,
         custom_integration_behavior=ReportBehavior.LOG,

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -64,7 +64,7 @@ async def test_a_custom_integration_is_warned(
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
-    assert "2027.10" in caplog.text  # the deadline the user acts on
+    assert "2027.10" in caplog.text
     assert "modbus" not in caplog.text.split("my_integration")[0]
 
 

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -64,7 +64,7 @@ async def test_a_custom_integration_is_warned(
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
-    assert "2027.9" in caplog.text  # the deadline the user acts on
+    assert "2027.10" in caplog.text  # the deadline the user acts on
     assert "modbus" not in caplog.text.split("my_integration")[0]
 
 

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -64,7 +64,7 @@ async def test_a_custom_integration_is_warned(
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
-    assert "2027.3" in caplog.text  # the deadline the user acts on
+    assert "2027.4" in caplog.text  # the deadline the user acts on
     assert "modbus" not in caplog.text.split("my_integration")[0]
 
 

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -1,0 +1,37 @@
+"""Test the deprecation of get_hub."""
+
+import pytest
+
+from homeassistant.components.modbus import get_hub
+from homeassistant.components.modbus.modbus import DATA_MODBUS_HUBS
+from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.parametrize("integration_frame_path", ["homeassistant/components/flexit"])
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_a_core_integration_is_not_warned(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Flexit is the one caller in core, and the user cannot change it."""
+    hub = object()
+    hass.data[DATA_MODBUS_HUBS] = {"hub": hub}
+
+    assert get_hub(hass, "hub") is hub
+
+    assert "deprecated" not in caplog.text
+
+
+@pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_a_custom_integration_is_warned(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Anything outside core has a config flow of its own to collect details in."""
+    hub = object()
+    hass.data[DATA_MODBUS_HUBS] = {"hub": hub}
+
+    assert get_hub(hass, "hub") is hub
+
+    assert "deprecated" in caplog.text
+    assert "async_get_unit" in caplog.text
+    assert "my_integration" in caplog.text

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -1,5 +1,10 @@
 """Test the deprecation of get_hub."""
 
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
 import pytest
 
 from homeassistant.components.modbus import get_hub
@@ -7,31 +12,79 @@ from homeassistant.components.modbus.modbus import DATA_MODBUS_HUBS
 from homeassistant.core import HomeAssistant
 
 
-@pytest.mark.parametrize("integration_frame_path", ["homeassistant/components/flexit"])
-@pytest.mark.usefixtures("mock_integration_frame")
-async def test_a_core_integration_is_not_warned(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Flexit is the one caller in core, and the user cannot change it."""
+def _caller_in(root: Path, path: str) -> ModuleType:
+    """Load a module that calls get_hub, from a file at *path*.
+
+    The report names an integration by walking the stack for a file under
+    `custom_components/` or `homeassistant/components/`, so a test of who gets
+    named has to call from a file that actually sits there.
+    """
+    source = root / path / "caller.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        "from homeassistant.components.modbus import get_hub\n"
+        "\n"
+        "def call(hass):\n"
+        '    return get_hub(hass, "hub")\n'
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        f"caller_{source.parent.name}", source
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(name="hub")
+def hub_fixture(hass: HomeAssistant) -> object:
+    """Put one hub in place for get_hub to return."""
     hub = object()
     hass.data[DATA_MODBUS_HUBS] = {"hub": hub}
-
-    assert get_hub(hass, "hub") is hub
-
-    assert "deprecated" not in caplog.text
+    return hub
 
 
-@pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])
-@pytest.mark.usefixtures("mock_integration_frame")
 async def test_a_custom_integration_is_warned(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    hub: object,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Anything outside core has a config flow of its own to collect details in."""
-    hub = object()
-    hass.data[DATA_MODBUS_HUBS] = {"hub": hub}
+    """A custom integration has its own config flow to collect details in.
 
-    assert get_hub(hass, "hub") is hub
+    Called through the real stack, so this also covers the report reaching
+    past modbus's own frame to the caller that asked.
+    """
+    caller = _caller_in(tmp_path, "custom_components/my_integration")
+
+    assert caller.call(hass) is hub
 
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
+    assert "modbus" not in caplog.text.split("my_integration")[0]
+
+
+async def test_a_core_integration_is_not_warned(
+    hass: HomeAssistant,
+    hub: object,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Flexit is the one caller in core, and the user cannot act on it."""
+    caller = _caller_in(tmp_path, "homeassistant/components/flexit")
+
+    assert caller.call(hass) is hub
+
+    assert "deprecated" not in caplog.text
+
+
+async def test_a_caller_outside_any_integration_is_not_warned(
+    hass: HomeAssistant, hub: object, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Nothing to name and nobody to tell, so it stays quiet."""
+    assert get_hub(hass, "hub") is hub
+
+    assert "deprecated" not in caplog.text

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -64,6 +64,7 @@ async def test_a_custom_integration_is_warned(
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
+    assert "2027.3" in caplog.text  # the deadline the user acts on
     assert "modbus" not in caplog.text.split("my_integration")[0]
 
 

--- a/tests/components/modbus/test_deprecation.py
+++ b/tests/components/modbus/test_deprecation.py
@@ -64,7 +64,7 @@ async def test_a_custom_integration_is_warned(
     assert "deprecated" in caplog.text
     assert "async_get_unit" in caplog.text
     assert "my_integration" in caplog.text
-    assert "2027.4" in caplog.text  # the deadline the user acts on
+    assert "2027.9" in caplog.text  # the deadline the user acts on
     assert "modbus" not in caplog.text.split("my_integration")[0]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Custom integrations that reach a Modbus device through a hub you set up in YAML using `get_hub` will stop working in Home Assistant 2027.10. Until then they keep working, and a warning naming the integration appears in your log.

Nothing in Home Assistant itself is affected, and no YAML you wrote needs changing. If you see the warning, the integration it names has to be updated by its author; report it to them with the log line.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`get_hub` attaches an integration to a hub the user configured in YAML, under a name the integration has to be told. `async_get_unit`, added in #179658, takes the connection details the integration collected in its own config flow, which is how every other integration reaches its device.

Not a like-for-like swap, so this only reports; nothing breaks yet.

Core integrations are excluded from the report. `flexit` is the only caller in core, and warning about code the user cannot change is noise. A contributor is working on a new Flexit integration, which lands well before the 2027.10 deprecation expires, so that caller goes away on its own rather than needing this to wait for it. Custom integrations get the log line, since they do have a config flow of their own to collect details in.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #179658
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3328/changes
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr





