### PR TITLE
Run the mypy plugin tests out of process

### DIFF
--- a/tests/mypy_plugins/test_enum_identity_compare.py
+++ b/tests/mypy_plugins/test_enum_identity_compare.py
@@ -12,10 +12,10 @@ deliberately skipped — see the plugin module docstring.
 
 import os
 from pathlib import Path
+import subprocess
 import sys
 import textwrap
 
-from mypy import api as mypy_api
 import pytest
 
 _IS_EQ = ("`is`", "`==`")
@@ -46,24 +46,29 @@ def _run_mypy(code: str, tmp_path: Path, mypy_path: str | None = None) -> list[s
         config_body += f"mypy_path = {mypy_path}\n"
     config.write_text(config_body)
 
-    env_pythonpath = os.environ.get("PYTHONPATH", "")
-    os.environ["PYTHONPATH"] = f"{_PLUGINS_ROOT}{os.pathsep}{env_pythonpath}"
-    # Make sure mypy can import the plugin from the current process.
-    sys.path.insert(0, str(_PLUGINS_ROOT))
-    try:
-        # mypy ships as a compiled extension; pylint can't introspect it.
-        stdout, _stderr, _rc = mypy_api.run(  # pylint: disable=c-extension-no-member
-            [
-                "--no-incremental",
-                f"--cache-dir={cache}",
-                "--config-file",
-                str(config),
-                str(src),
-            ]
-        )
-    finally:
-        os.environ["PYTHONPATH"] = env_pythonpath
-        sys.path.pop(0)
+    # Run mypy in a subprocess: type checking a snippet in process leaves
+    # hundreds of thousands of objects behind, which the next test module pays
+    # for in its garbage collection.
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(_PLUGINS_ROOT), env.get("PYTHONPATH")))
+    )
+    stdout = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--no-incremental",
+            f"--cache-dir={cache}",
+            "--config-file",
+            str(config),
+            str(src),
+        ],
+        capture_output=True,
+        check=False,
+        encoding="utf-8",
+        env=env,
+    ).stdout
 
     errors: list[str] = []
     for line in stdout.splitlines():

--- a/tests/mypy_plugins/test_enum_identity_compare.py
+++ b/tests/mypy_plugins/test_enum_identity_compare.py
@@ -1,6 +1,6 @@
 """Tests for the enum_identity_compare mypy plugin.
 
-Each test snippet is run through mypy's API with the plugin enabled.
+Each test snippet is run through mypy in a subprocess with the plugin enabled.
 Tests assert the number of ``home-assistant-enum-identity-compare`` errors emitted
 and the relevant message content (operator pair and enum class name).
 


### PR DESCRIPTION
## Breaking change

## Proposed change

The mypy plugin tests type check snippets through the mypy API, in the pytest worker. Each test leaves around 200k objects behind.

The next test module pays for them. The module scoped `garbage_collection` fixture calls `gc.collect()` during the setup of that module's first test, and traversing the heap mypy left takes ~10s. pytest-timeout budgets setup, call and teardown together, so an unrelated test fails with `Timeout (>9.0s)`.

That is what failed CI in `tests/components/holiday/test_calendar.py::test_holiday_calendar_entity[Asia/Tokyo]` ([job](https://github.com/home-assistant/core/actions/runs/32639322480/job/97194086755), 8.58s of the 9s spent in setup). It reproduces locally:

```
pytest tests/mypy_plugins tests/components/holiday --timeout=9
→ holiday's first test: setup=9.55s, of which gc=9.54s → Timeout (>9.0s)
```

Running mypy in a subprocess keeps that heap out of the worker.

### Benchmarks

Instrumented run of CI test group 10 (12586 tests, `--numprocesses auto --dist=loadfile`, coverage on, same as CI), measuring per test setup, `gc.collect()` and freezegun cost:

| | before | after |
| --- | --- | --- |
| worst item setup | 10.30s | 2.13s |
| items with setup >3s | 3 | 0 |
| total `gc.collect()` | 52.0s | 29.6s |
| worst `gc.collect()` | 10.30s | 1.58s |

The worst item before was `media_extractor/test_init.py::test_play_media_service_is_registered` (setup 10.30s, all of it gc), which ran right after the mypy plugin tests on that worker. It timed out and took the other 17 tests in its module with it; all 18 pass after.

The mypy tests themselves get slightly faster too, 39.2s → 34.6s, as they stop running against an oversized heap.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sfUAbtrCrCkPjTdCYA5ZK

---
_Generated by [Claude Code](https://claude.ai/code/session_017sfUAbtrCrCkPjTdCYA5ZK)_