### PR TITLE
Speed up the freezegun module scan in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,9 @@ def pytest_runtest_setup() -> None:
     - Modified to include
       https://github.com/spulec/freezegun/pull/424
       and improve class str.
+
+    - Modified to not force lazily imported module attributes to be resolved
+      when scanning the loaded modules for time related objects.
     """
     pytest_socket.socket_allow_hosts(["127.0.0.1"])
     pytest_socket.disable_socket(allow_unix_socket=True)
@@ -236,6 +239,10 @@ def pytest_runtest_setup() -> None:
 
     freezegun.api.datetime_to_fakedatetime = patch_time.ha_datetime_to_fakedatetime  # type: ignore[attr-defined]
     freezegun.api.FakeDatetime = patch_time.HAFakeDatetime  # type: ignore[attr-defined]
+    freezegun.api._get_module_attributes = patch_time.ha_get_module_attributes  # type: ignore[attr-defined]
+    freezegun.api._get_module_attributes_hash = (  # type: ignore[attr-defined]
+        patch_time.ha_get_module_attributes_hash
+    )
 
     def adapt_datetime(val):
         return val.isoformat(" ")

--- a/tests/patch_time.py
+++ b/tests/patch_time.py
@@ -2,6 +2,8 @@
 
 import datetime
 import time
+import types
+from typing import Any
 
 import freezegun
 
@@ -22,6 +24,27 @@ def ha_datetime_to_fakedatetime(datetime) -> freezegun.api.FakeDatetime:  # type
         datetime.tzinfo,
         fold=datetime.fold,
     )
+
+
+def ha_get_module_attributes(module: types.ModuleType) -> list[tuple[str, Any]]:
+    """Return the attributes of a module.
+
+    Modified to only look at attributes which are already set, instead of every
+    name dir() offers. Packages with a lazy __getattr__, such as scipy or
+    elevenlabs, import their whole tree when each name is read, which takes
+    seconds and is charged to whichever test freezes time next.
+    """
+    return list(getattr(module, "__dict__", {}).items())
+
+
+def ha_get_module_attributes_hash(module: types.ModuleType) -> str:
+    """Return a hash of the module attributes.
+
+    Modified to hash the same namespace ha_get_module_attributes reads, so that
+    a module which grows an attribute after it was first scanned is scanned
+    again. dir() does not report such a change for lazy modules.
+    """
+    return f"{id(module)}-{hash(frozenset(getattr(module, '__dict__', {})))}"
 
 
 class HAFakeDateMeta(freezegun.api.FakeDateMeta):

--- a/tests/test_patch_time.py
+++ b/tests/test_patch_time.py
@@ -1,0 +1,55 @@
+"""Test the freezegun modifications in tests.patch_time."""
+
+from collections.abc import Generator
+import datetime
+import sys
+import types
+
+from freezegun import freeze_time
+import pytest
+
+
+@pytest.fixture
+def lazy_module() -> Generator[types.ModuleType]:
+    """Register a module which only resolves its attributes when they are read."""
+    module = types.ModuleType("freezegun_lazy_module")
+    module.probed = []
+
+    def module_getattr(name: str) -> object:
+        module.probed.append(name)
+        raise AttributeError(name)
+
+    module.__getattr__ = module_getattr
+    module.__dir__ = lambda: ["lazy_attribute"]
+
+    sys.modules[module.__name__] = module
+    yield module
+    del sys.modules[module.__name__]
+
+
+def test_freezing_time_does_not_resolve_lazy_attributes(
+    lazy_module: types.ModuleType,
+) -> None:
+    """Test freezing time does not read attributes which are not set yet."""
+    with freeze_time("2023-01-01"):
+        pass
+
+    assert lazy_module.probed == []
+
+
+def test_freezing_time_rescans_a_changed_module(
+    lazy_module: types.ModuleType,
+) -> None:
+    """Test an attribute set after the first freeze is patched by the next one."""
+    real_datetime = datetime.datetime
+
+    with freeze_time("2023-01-01"):
+        pass
+
+    lazy_module.datetime = real_datetime
+
+    with freeze_time("2023-01-01"):
+        assert lazy_module.datetime is not real_datetime
+        assert lazy_module.datetime.now() == real_datetime(2023, 1, 1)
+
+    assert lazy_module.datetime is real_datetime


### PR DESCRIPTION
## Breaking change

## Proposed change

Every time a test freezes time, freezegun walks all loaded modules looking for references to datetime objects, reading every name `dir()` offers.

Packages with a lazy `__getattr__` import their whole tree when their names are read. `elevenlabs` advertises 1847 lazy names against 18 real ones. In a session with 12k modules loaded, a single freeze took 11.7s, 1.9s of it in `elevenlabs` and 1.6s in `scipy`, and the modules it pulled in stay loaded for the rest of the run. Which test pays depends only on what the previous test module happened to import.

This reads the module namespace instead, which finds the same references without resolving lazy names. It also hashes that same namespace for the cache key, so a module which grows an attribute after it was first scanned is scanned again — `dir()` does not report such a change for a lazy module, so the current key would keep serving a stale entry.

`tests/patch_time.py` already carries modifications to freezegun, so both go there.

### Benchmarks

A single freeze, in a session where the previous module imported 300 more integrations (12737 modules loaded):

| | before | after |
| --- | --- | --- |
| freeze after new imports | 3.711s | 0.131s |
| worst module in that scan | 1.915s (`elevenlabs`) | 0.000s |
| modules loaded afterwards | 12737 | 10500 |

Instrumented run of CI test group 10 (12586 tests, `--numprocesses auto --dist=loadfile`, coverage on, same as CI). 947 of those tests freeze time:

| | before | after |
| --- | --- | --- |
| total time spent freezing time | 165.9s | 108.5s |
| worst single freeze | 1.59s | 0.29s |
| total setup time | 777.4s | 708.5s |

No test that passed before fails after, across that group plus `tests/helpers`, `automation`, `template`, `sun`, `tod`, `input_datetime`, `history_stats` and `util/test_dt.py`.

Worth upstreaming to freezegun as well; it is not specific to Home Assistant.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sfUAbtrCrCkPjTdCYA5ZK

---
_Generated by [Claude Code](https://claude.ai/code/session_017sfUAbtrCrCkPjTdCYA5ZK)_