### PR TITLE
Offer the Modbus connections as an LLM API

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
+from . import llm_api
 from .connection import async_get_temporary_unit, async_get_unit
 from .const import DOMAIN
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
@@ -32,6 +33,8 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Modbus component."""
+    llm_api.async_setup(hass)
+
     if DOMAIN not in config:
         return True
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -33,9 +33,8 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Modbus component."""
-    llm_api.async_setup(hass)
-
     if DOMAIN not in config:
+        llm_api.async_setup(hass)
         return True
 
     async def _reload_config(call: Event | ServiceCall) -> None:
@@ -59,4 +58,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, _reload_config)
 
-    return await async_modbus_setup(hass, config)
+    if not await async_modbus_setup(hass, config):
+        return False
+
+    # Registered last: the API reads the component's connections, so it must
+    # not outlive a setup Home Assistant considers failed.
+    llm_api.async_setup(hass)
+    return True

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from typing import Any
 
@@ -36,18 +36,43 @@ DATA_MODBUS_CONNECTIONS: HassKey[dict[ModbusEndpoint, _SharedConnection]] = Hass
 
 @dataclass
 class _SharedConnection:
-    """A connection and how many units are held on it."""
+    """A connection and the units held on it."""
 
     params: ModbusParams
     connection: ModbusConnection
-    consumers: int = 0
+    units: dict[str, set[int]] = field(default_factory=dict)
+    """The unit ids each config entry holds, keyed by entry id."""
+    transient: int = 0
+    """Holds with no config entry behind them, taken by a config flow."""
+
+    @property
+    def consumers(self) -> int:
+        """How many holds are on this connection."""
+        return sum(len(held) for held in self.units.values()) + self.transient
+
+
+@dataclass(frozen=True, kw_only=True)
+class ModbusConnectionInfo:
+    """A connection the integration is keeping open, and who is using it."""
+
+    endpoint: ModbusEndpoint
+    connected: bool
+    units: dict[str, list[int]]
+    """The unit ids each config entry holds, keyed by entry id."""
 
 
 @callback
 def _async_acquire(
-    hass: HomeAssistant, params: ModbusParams
+    hass: HomeAssistant,
+    params: ModbusParams,
+    entry_id: str | None,
+    unit_id: int,
 ) -> tuple[ModbusConnection, Callable[[], Coroutine[Any, Any, None]]]:
     """Take a hold on the connection these credentials describe.
+
+    A hold with no ``entry_id`` behind it is a config flow's, which keeps the
+    connection up without belonging to anything that could be shown as using
+    it.
 
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
@@ -64,11 +89,19 @@ def _async_acquire(
             f"settings: {shared.params} against {params}"
         )
 
-    shared.consumers += 1
+    if entry_id is None:
+        shared.transient += 1
+    else:
+        shared.units.setdefault(entry_id, set()).add(unit_id)
 
     async def release() -> None:
         """Give up this hold, closing behind the last one."""
-        shared.consumers -= 1
+        if entry_id is None:
+            shared.transient -= 1
+        elif (held := shared.units.get(entry_id)) is not None:
+            held.discard(unit_id)
+            if not held:
+                del shared.units[entry_id]
         if shared.consumers or connections.get(endpoint) is not shared:
             return
         del connections[endpoint]
@@ -94,7 +127,7 @@ def async_get_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    connection, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params, entry.entry_id, unit_id)
     entry.async_on_unload(release)
     return connection.for_unit(unit_id)
 
@@ -114,8 +147,25 @@ async def async_get_temporary_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    connection, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params, None, unit_id)
     try:
         yield connection.for_unit(unit_id)
     finally:
         await release()
+
+
+@callback
+def async_get_connection_info(hass: HomeAssistant) -> list[ModbusConnectionInfo]:
+    """Return the connections the integration is keeping open.
+
+    One entry per physical device, naming the config entries holding units on
+    it. A device several integrations share appears once, with all of them.
+    """
+    return [
+        ModbusConnectionInfo(
+            endpoint=endpoint,
+            connected=shared.connection.connected,
+            units={entry_id: sorted(held) for entry_id, held in shared.units.items()},
+        )
+        for endpoint, shared in hass.data.get(DATA_MODBUS_CONNECTIONS, {}).items()
+    ]

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -159,7 +159,8 @@ def async_get_connection_info(hass: HomeAssistant) -> list[ModbusConnectionInfo]
     """Return the connections the integration is keeping open.
 
     One entry per physical device, naming the config entries holding units on
-    it. A device several integrations share appears once, with all of them.
+    it. A device several integrations share appears once, with all of them. A
+    connection a config flow is only probing is not one of them.
     """
     return [
         ModbusConnectionInfo(
@@ -168,4 +169,7 @@ def async_get_connection_info(hass: HomeAssistant) -> list[ModbusConnectionInfo]
             units={entry_id: sorted(held) for entry_id, held in shared.units.items()},
         )
         for endpoint, shared in hass.data.get(DATA_MODBUS_CONNECTIONS, {}).items()
+        # A connection held only by a config flow's probe is a device nobody
+        # has accepted yet, so it is not one of the integration's connections.
+        if shared.units
     ]

--- a/homeassistant/components/modbus/llm_api.py
+++ b/homeassistant/components/modbus/llm_api.py
@@ -29,15 +29,32 @@ API_ID: Final = "modbus"
 MIN_UNIT_ID: Final = 1
 MAX_UNIT_ID: Final = 247
 MAX_ADDRESS: Final = 0xFFFF
+
+# The four tables a device serves, and how many of each one request may carry:
+# registers are 16 bits and capped at 125, single-bit tables at 2000. Each is
+# its own address space, so address 0 means a different thing in each.
 MAX_REGISTER_COUNT: Final = 125
+MAX_BIT_COUNT: Final = 2000
+TABLE_LIMITS: Final[dict[str, int]] = {
+    "holding": MAX_REGISTER_COUNT,
+    "input": MAX_REGISTER_COUNT,
+    "coil": MAX_BIT_COUNT,
+    "discrete_input": MAX_BIT_COUNT,
+}
 
 
-def _fits_in_the_address_space(block: dict[str, Any]) -> dict[str, Any]:
-    """Reject a block running past the last register rather than sending it."""
+def _fits_the_table(block: dict[str, Any]) -> dict[str, Any]:
+    """Reject a block the table cannot answer, rather than sending it."""
+    limit = TABLE_LIMITS[block["table"]]
+    if block["count"] > limit:
+        raise vol.Invalid(
+            f"one request may carry {limit} of the {block['table']} table, "
+            f"not {block['count']}"
+        )
     if block["address"] + block["count"] - 1 > MAX_ADDRESS:
         raise vol.Invalid(
             f"a block of {block['count']} from {block['address']} runs past "
-            f"the last register ({MAX_ADDRESS})"
+            f"the last address ({MAX_ADDRESS})"
         )
     return block
 
@@ -61,13 +78,13 @@ class ModbusAPI(llm.API):
             api_prompt=(
                 "Read Modbus registers from the devices Home Assistant is "
                 "connected to. Call list_modbus_devices first: it names the "
-                "endpoints you may read from, and read_modbus_registers only "
-                "accepts one of those. Registers are read-only here. A device "
+                "endpoints you may read from, and read_modbus_block only "
+                "accepts one of those. Everything is read-only here. A device "
                 "answers one request at a time, so read the block you need "
                 "rather than one register at a time."
             ),
             llm_context=llm_context,
-            tools=[ListModbusDevicesTool(), ReadModbusRegistersTool()],
+            tools=[ListModbusDevicesTool(), ReadModbusBlockTool()],
         )
 
 
@@ -77,7 +94,7 @@ class ListModbusDevicesTool(llm.Tool):
     name = "list_modbus_devices"
     description = (
         "List the Modbus devices Home Assistant holds a connection to. "
-        "Returns each device's endpoint, which read_modbus_registers takes, "
+        "Returns each device's endpoint, which read_modbus_block takes, "
         "and the unit ids in use on it, keyed by the config entry using them."
     )
 
@@ -103,14 +120,16 @@ class ListModbusDevicesTool(llm.Tool):
         }
 
 
-class ReadModbusRegistersTool(llm.Tool):
-    """Read a block of registers from one device."""
+class ReadModbusBlockTool(llm.Tool):
+    """Read a block from one of a device's four tables."""
 
-    name = "read_modbus_registers"
+    name = "read_modbus_block"
     description = (
-        "Read a block of registers from a Modbus device, to compare against a "
-        "datasheet. Give the endpoint from list_modbus_devices, the unit id, "
-        "the first address and how many registers to read."
+        "Read a block from a Modbus device, to compare against a datasheet. "
+        "Give the endpoint from list_modbus_devices, the unit id, which table "
+        "to read, the first address and how many to read. The four tables are "
+        "separate address spaces: holding and input hold 16-bit registers, "
+        "coil and discrete_input hold single bits."
     )
     parameters = vol.Schema(
         vol.All(
@@ -123,13 +142,11 @@ class ReadModbusRegistersTool(llm.Tool):
                     int, vol.Range(min=0, max=MAX_ADDRESS)
                 ),
                 vol.Required("count"): vol.All(
-                    int, vol.Range(min=1, max=MAX_REGISTER_COUNT)
+                    int, vol.Range(min=1, max=MAX_BIT_COUNT)
                 ),
-                vol.Optional("register_type", default="holding"): vol.In(
-                    ["holding", "input"]
-                ),
+                vol.Optional("table", default="holding"): vol.In(TABLE_LIMITS),
             },
-            _fits_in_the_address_space,
+            _fits_the_table,
         )
     )
 
@@ -154,15 +171,25 @@ class ReadModbusRegistersTool(llm.Tool):
             )
 
         unit = shared.connection.for_unit(args["unit_id"])
-        read = (
-            unit.read_input_registers
-            if args["register_type"] == "input"
-            else unit.read_holding_registers
-        )
-        values = await read(args["address"], args["count"])
+        address: int = args["address"]
+        count: int = args["count"]
+
+        # Spelled out rather than dispatched through a mapping: the register
+        # tables answer with ints and the bit tables with bools, which no one
+        # callable type covers.
+        values: list[int] | list[bool]
+        match args["table"]:
+            case "input":
+                values = await unit.read_input_registers(address, count)
+            case "coil":
+                values = await unit.read_coils(address, count)
+            case "discrete_input":
+                values = await unit.read_discrete_inputs(address, count)
+            case _:
+                values = await unit.read_holding_registers(address, count)
 
         return {
-            "address": args["address"],
-            "register_type": args["register_type"],
+            "address": address,
+            "table": args["table"],
             "values": list(values),
         }

--- a/homeassistant/components/modbus/llm_api.py
+++ b/homeassistant/components/modbus/llm_api.py
@@ -1,0 +1,139 @@
+"""An LLM API for reading the registers of a device Home Assistant is talking to.
+
+Bringing a Modbus device up means reading raw registers and comparing them
+against a vendor datasheet. That normally needs a second connection alongside
+Home Assistant's, competing with it for a bus that answers one request at a
+time. The connections here are already open and already serialized, so an
+assistant can read through them instead.
+
+Read-only on purpose. A write to the wrong register on a heat pump or an
+inverter is not a mistake a model should be able to make on a user's behalf.
+"""
+
+from typing import Any, Final
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import llm
+from homeassistant.util.json import JsonObjectType
+
+from .connection import DATA_MODBUS_CONNECTIONS, async_get_connection_info
+
+API_ID: Final = "modbus"
+
+# One request may not span more than the protocol allows.
+MAX_REGISTER_COUNT: Final = 125
+
+
+@callback
+def async_setup(hass: HomeAssistant) -> None:
+    """Register the Modbus LLM API."""
+    llm.async_register_api(hass, ModbusAPI(hass=hass, id=API_ID, name="Modbus"))
+
+
+class ModbusAPI(llm.API):
+    """Read the registers of the devices Home Assistant has connections to."""
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return the tools, over whatever connections are open right now."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt=(
+                "Read Modbus registers from the devices Home Assistant is "
+                "connected to. Call list_modbus_devices first: it names the "
+                "endpoints you may read from, and read_modbus_registers only "
+                "accepts one of those. Registers are read-only here. A device "
+                "answers one request at a time, so read the block you need "
+                "rather than one register at a time."
+            ),
+            llm_context=llm_context,
+            tools=[ListModbusDevicesTool(), ReadModbusRegistersTool()],
+        )
+
+
+class ListModbusDevicesTool(llm.Tool):
+    """Name the devices that can be read."""
+
+    name = "list_modbus_devices"
+    description = (
+        "List the Modbus devices Home Assistant holds a connection to. "
+        "Returns each device's endpoint, which read_modbus_registers takes, "
+        "and the unit ids in use on it, keyed by the config entry using them."
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Return the open connections."""
+        return {
+            "devices": [
+                {
+                    "endpoint": list(info.endpoint),
+                    "connected": info.connected,
+                    "units": info.units,
+                }
+                for info in async_get_connection_info(hass)
+            ]
+        }
+
+
+class ReadModbusRegistersTool(llm.Tool):
+    """Read a block of registers from one device."""
+
+    name = "read_modbus_registers"
+    description = (
+        "Read a block of registers from a Modbus device, to compare against a "
+        "datasheet. Give the endpoint from list_modbus_devices, the unit id, "
+        "the first address and how many registers to read."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Required("endpoint"): [vol.Any(str, int)],
+            vol.Required("unit_id"): int,
+            vol.Required("address"): int,
+            vol.Required("count"): vol.All(
+                int, vol.Range(min=1, max=MAX_REGISTER_COUNT)
+            ),
+            vol.Optional("register_type", default="holding"): vol.In(
+                ["holding", "input"]
+            ),
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Read the block, over the connection that is already open."""
+        args: dict[str, Any] = tool_input.tool_args
+        endpoint = tuple(args["endpoint"])
+
+        shared = hass.data.get(DATA_MODBUS_CONNECTIONS, {}).get(endpoint)
+        if shared is None:
+            raise HomeAssistantError(
+                f"No Modbus connection to {list(endpoint)}. "
+                "Call list_modbus_devices for the ones there are."
+            )
+
+        unit = shared.connection.for_unit(args["unit_id"])
+        read = (
+            unit.read_input_registers
+            if args["register_type"] == "input"
+            else unit.read_holding_registers
+        )
+        values = await read(args["address"], args["count"])
+
+        return {
+            "address": args["address"],
+            "register_type": args["register_type"],
+            "values": list(values),
+        }

--- a/homeassistant/components/modbus/llm_api.py
+++ b/homeassistant/components/modbus/llm_api.py
@@ -10,7 +10,7 @@ Read-only on purpose. A write to the wrong register on a heat pump or an
 inverter is not a mistake a model should be able to make on a user's behalf.
 """
 
-from typing import Any, Final
+from typing import Any, Final, cast, override
 
 import voluptuous as vol
 
@@ -23,8 +23,23 @@ from .connection import DATA_MODBUS_CONNECTIONS, async_get_connection_info
 
 API_ID: Final = "modbus"
 
-# One request may not span more than the protocol allows.
+# What the protocol allows: a unit is addressed 1-247 (0 is a broadcast, which
+# has no reply to read), a register address is 16-bit, and one request may not
+# span more than 125 registers.
+MIN_UNIT_ID: Final = 1
+MAX_UNIT_ID: Final = 247
+MAX_ADDRESS: Final = 0xFFFF
 MAX_REGISTER_COUNT: Final = 125
+
+
+def _fits_in_the_address_space(block: dict[str, Any]) -> dict[str, Any]:
+    """Reject a block running past the last register rather than sending it."""
+    if block["address"] + block["count"] - 1 > MAX_ADDRESS:
+        raise vol.Invalid(
+            f"a block of {block['count']} from {block['address']} runs past "
+            f"the last register ({MAX_ADDRESS})"
+        )
+    return block
 
 
 @callback
@@ -36,6 +51,7 @@ def async_setup(hass: HomeAssistant) -> None:
 class ModbusAPI(llm.API):
     """Read the registers of the devices Home Assistant has connections to."""
 
+    @override
     async def async_get_api_instance(
         self, llm_context: llm.LLMContext
     ) -> llm.APIInstance:
@@ -65,6 +81,7 @@ class ListModbusDevicesTool(llm.Tool):
         "and the unit ids in use on it, keyed by the config entry using them."
     )
 
+    @override
     async def async_call(
         self,
         hass: HomeAssistant,
@@ -77,7 +94,9 @@ class ListModbusDevicesTool(llm.Tool):
                 {
                     "endpoint": list(info.endpoint),
                     "connected": info.connected,
-                    "units": info.units,
+                    # A mapping of JSON scalars, which the type cannot express
+                    # because dict and list are invariant in their contents.
+                    "units": cast(JsonObjectType, info.units),
                 }
                 for info in async_get_connection_info(hass)
             ]
@@ -94,19 +113,27 @@ class ReadModbusRegistersTool(llm.Tool):
         "the first address and how many registers to read."
     )
     parameters = vol.Schema(
-        {
-            vol.Required("endpoint"): [vol.Any(str, int)],
-            vol.Required("unit_id"): int,
-            vol.Required("address"): int,
-            vol.Required("count"): vol.All(
-                int, vol.Range(min=1, max=MAX_REGISTER_COUNT)
-            ),
-            vol.Optional("register_type", default="holding"): vol.In(
-                ["holding", "input"]
-            ),
-        }
+        vol.All(
+            {
+                vol.Required("endpoint"): [vol.Any(str, int)],
+                vol.Required("unit_id"): vol.All(
+                    int, vol.Range(min=MIN_UNIT_ID, max=MAX_UNIT_ID)
+                ),
+                vol.Required("address"): vol.All(
+                    int, vol.Range(min=0, max=MAX_ADDRESS)
+                ),
+                vol.Required("count"): vol.All(
+                    int, vol.Range(min=1, max=MAX_REGISTER_COUNT)
+                ),
+                vol.Optional("register_type", default="holding"): vol.In(
+                    ["holding", "input"]
+                ),
+            },
+            _fits_in_the_address_space,
+        )
     )
 
+    @override
     async def async_call(
         self,
         hass: HomeAssistant,
@@ -114,7 +141,9 @@ class ReadModbusRegistersTool(llm.Tool):
         llm_context: llm.LLMContext,
     ) -> JsonObjectType:
         """Read the block, over the connection that is already open."""
-        args: dict[str, Any] = tool_input.tool_args
+        # The caller is not required to have validated against `parameters`,
+        # and this reaches real hardware, so check the block here as well.
+        args: dict[str, Any] = self.parameters(tool_input.tool_args)
         endpoint = tuple(args["endpoint"])
 
         shared = hass.data.get(DATA_MODBUS_CONNECTIONS, {}).get(endpoint)

--- a/homeassistant/components/modbus/llm_api.py
+++ b/homeassistant/components/modbus/llm_api.py
@@ -19,7 +19,11 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import llm
 from homeassistant.util.json import JsonObjectType
 
-from .connection import DATA_MODBUS_CONNECTIONS, async_get_connection_info
+from .connection import (
+    DATA_MODBUS_CONNECTIONS,
+    async_get_connection_info,
+    async_get_temporary_unit,
+)
 
 API_ID: Final = "modbus"
 
@@ -163,30 +167,40 @@ class ReadModbusBlockTool(llm.Tool):
         args: dict[str, Any] = self.parameters(tool_input.tool_args)
         endpoint = tuple(args["endpoint"])
 
+        unit_id: int = args["unit_id"]
         shared = hass.data.get(DATA_MODBUS_CONNECTIONS, {}).get(endpoint)
-        if shared is None:
+
+        # Only a unit some config entry holds may be read. The endpoint alone
+        # would let a caller reach any address on a gateway, including devices
+        # behind it that no integration asked for, and a connection a config
+        # flow is only probing belongs to nothing yet.
+        if shared is None or not any(
+            unit_id in units for units in shared.units.values()
+        ):
             raise HomeAssistantError(
-                f"No Modbus connection to {list(endpoint)}. "
-                "Call list_modbus_devices for the ones there are."
+                f"Home Assistant holds no unit {unit_id} on {list(endpoint)}. "
+                "Call list_modbus_devices for the units there are."
             )
 
-        unit = shared.connection.for_unit(args["unit_id"])
         address: int = args["address"]
         count: int = args["count"]
 
-        # Spelled out rather than dispatched through a mapping: the register
-        # tables answer with ints and the bit tables with bools, which no one
-        # callable type covers.
-        values: list[int] | list[bool]
-        match args["table"]:
-            case "input":
-                values = await unit.read_input_registers(address, count)
-            case "coil":
-                values = await unit.read_coils(address, count)
-            case "discrete_input":
-                values = await unit.read_discrete_inputs(address, count)
-            case _:
-                values = await unit.read_holding_registers(address, count)
+        # Held for the read, so unloading the last consumer mid-request cannot
+        # close the connection underneath it.
+        async with async_get_temporary_unit(hass, shared.params, unit_id) as unit:
+            # Spelled out rather than dispatched through a mapping: the
+            # register tables answer with ints and the bit tables with bools,
+            # which no one callable type covers.
+            values: list[int] | list[bool]
+            match args["table"]:
+                case "input":
+                    values = await unit.read_input_registers(address, count)
+                case "coil":
+                    values = await unit.read_coils(address, count)
+                case "discrete_input":
+                    values = await unit.read_discrete_inputs(address, count)
+                case _:
+                    values = await unit.read_holding_registers(address, count)
 
         return {
             "address": address,

--- a/tests/components/modbus/test_connection.py
+++ b/tests/components/modbus/test_connection.py
@@ -257,3 +257,56 @@ async def test_a_temporary_unit_cannot_clash_with_held_link_settings(
 
     [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
     assert shared.consumers == 1
+
+
+async def test_one_entry_holding_the_same_unit_twice(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """Two holds on one unit are one unit, and release together.
+
+    The registry records which units an entry holds, not how many times it
+    asked, so asking twice adds nothing to release twice.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    params = ModbusTcpParams(host="1.2.3.4", port=502)
+    async_get_unit(hass, entry, params, 1)
+    async_get_unit(hass, entry, params, 1)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+    assert shared.units == {entry.entry_id: {1}}
+
+    with patch.object(shared.connection, "close") as close:
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert close.call_count == 1
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_two_entries_holding_the_same_unit(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """The link stays while anybody still holds that unit, however they asked."""
+    one = consumer()
+    await hass.config_entries.async_setup(one.entry_id)
+    two = consumer()
+    await hass.config_entries.async_setup(two.entry_id)
+
+    params = ModbusTcpParams(host="1.2.3.4", port=502)
+    async_get_unit(hass, one, params, 1)
+    async_get_unit(hass, one, params, 1)  # the same unit, asked for twice
+    async_get_unit(hass, two, params, 1)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    with patch.object(shared.connection, "close") as close:
+        await hass.config_entries.async_unload(one.entry_id)
+        await hass.async_block_till_done()
+
+        assert not close.called  # the other entry is still on that unit
+        assert hass.data[DATA_MODBUS_CONNECTIONS]
+
+        await hass.config_entries.async_unload(two.entry_id)
+        await hass.async_block_till_done()
+
+    assert close.called

--- a/tests/components/modbus/test_llm_api.py
+++ b/tests/components/modbus/test_llm_api.py
@@ -7,7 +7,7 @@ from modbus_connection import ModbusTcpParams
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.modbus import async_get_unit
+from homeassistant.components.modbus import async_get_temporary_unit, async_get_unit
 from homeassistant.components.modbus.llm_api import API_ID
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import Context, HomeAssistant
@@ -142,7 +142,7 @@ async def test_reading_an_unknown_device_is_refused(
     assert await async_setup_component(hass, "modbus", {})
     await _hold_a_unit(hass, consumer)
 
-    with pytest.raises(HomeAssistantError, match="No Modbus connection"):
+    with pytest.raises(HomeAssistantError, match="holds no unit"):
         await (await _instance(hass)).async_call_tool(
             llm.ToolInput(
                 tool_name="read_modbus_block",
@@ -289,3 +289,50 @@ async def test_a_bit_table_may_read_more_than_a_register_table(
                 tool_name="read_modbus_block", tool_args=args | {"table": "holding"}
             )
         )
+
+
+async def test_reading_a_unit_nobody_holds_is_refused(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """The endpoint alone is not the boundary: a gateway carries other devices."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer, 1)
+
+    with pytest.raises(HomeAssistantError, match="holds no unit 7"):
+        await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_block",
+                tool_args={
+                    "endpoint": ["tcp", "device.local", 502],
+                    "unit_id": 7,  # on the same bus, but nobody asked for it
+                    "address": 0,
+                    "count": 1,
+                },
+            )
+        )
+
+
+async def test_a_device_only_being_probed_is_invisible(hass: HomeAssistant) -> None:
+    """A config flow's hold is a device nobody has accepted yet."""
+    assert await async_setup_component(hass, "modbus", {})
+    params = ModbusTcpParams(host="probing.local", port=502)
+
+    async with async_get_temporary_unit(hass, params, 1):
+        listed = await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(tool_name="list_modbus_devices", tool_args={})
+        )
+
+        assert listed["devices"] == []
+
+        with pytest.raises(HomeAssistantError, match="holds no unit"):
+            await (await _instance(hass)).async_call_tool(
+                llm.ToolInput(
+                    tool_name="read_modbus_block",
+                    tool_args={
+                        "endpoint": ["tcp", "probing.local", 502],
+                        "unit_id": 1,
+                        "address": 0,
+                        "count": 1,
+                    },
+                )
+            )

--- a/tests/components/modbus/test_llm_api.py
+++ b/tests/components/modbus/test_llm_api.py
@@ -117,20 +117,20 @@ async def test_reading_goes_over_the_open_connection(
         for_unit.return_value.read_holding_registers = AsyncMock(return_value=[1, 2, 3])
         result = await (await _instance(hass)).async_call_tool(
             llm.ToolInput(
-                tool_name="read_modbus_registers",
+                tool_name="read_modbus_block",
                 tool_args={
                     "endpoint": ["tcp", "device.local", 502],
                     "unit_id": 1,
                     "address": 40000,
                     "count": 3,
-                    "register_type": "holding",
+                    "table": "holding",
                 },
             )
         )
 
     assert result == {
         "address": 40000,
-        "register_type": "holding",
+        "table": "holding",
         "values": [1, 2, 3],
     }
 
@@ -145,7 +145,7 @@ async def test_reading_an_unknown_device_is_refused(
     with pytest.raises(HomeAssistantError, match="No Modbus connection"):
         await (await _instance(hass)).async_call_tool(
             llm.ToolInput(
-                tool_name="read_modbus_registers",
+                tool_name="read_modbus_block",
                 tool_args={
                     "endpoint": ["tcp", "elsewhere.local", 502],
                     "unit_id": 1,
@@ -164,7 +164,7 @@ async def test_reading_an_unknown_device_is_refused(
         ({"address": -1}, "before the first register"),
         ({"address": 70000}, "past the last register"),
         ({"count": 0}, "a block of nothing"),
-        ({"count": 126}, "more than one request may carry"),
+        ({"count": 126}, "more registers than one request may carry"),
         ({"address": 65500, "count": 100}, "a block running off the end"),
     ],
 )
@@ -187,5 +187,105 @@ async def test_a_block_outside_the_protocol_is_refused(
 
     with pytest.raises(vol.Invalid):
         await (await _instance(hass)).async_call_tool(
-            llm.ToolInput(tool_name="read_modbus_registers", tool_args=tool_args)
+            llm.ToolInput(tool_name="read_modbus_block", tool_args=tool_args)
+        )
+
+
+@pytest.mark.parametrize(
+    ("table", "reader", "answer"),
+    [
+        ("holding", "read_holding_registers", [1, 2]),
+        ("input", "read_input_registers", [3, 4]),
+        ("coil", "read_coils", [True, False]),
+        ("discrete_input", "read_discrete_inputs", [False, True]),
+    ],
+)
+async def test_each_table_is_read_from_its_own_space(
+    hass: HomeAssistant,
+    consumer: ConsumerFactory,
+    table: str,
+    reader: str,
+    answer: list[int] | list[bool],
+) -> None:
+    """The four tables are separate, so each goes out on its own function."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    with patch("modbus_connection.tmodbus.ModbusConnection.for_unit") as for_unit:
+        setattr(for_unit.return_value, reader, AsyncMock(return_value=answer))
+        result = await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_block",
+                tool_args={
+                    "endpoint": ["tcp", "device.local", 502],
+                    "unit_id": 1,
+                    "address": 0,
+                    "count": 2,
+                    "table": table,
+                },
+            )
+        )
+
+    assert result == {"address": 0, "table": table, "values": answer}
+
+
+@pytest.mark.parametrize(
+    ("table", "count"),
+    [
+        ("holding", 126),
+        ("input", 126),
+        ("coil", 2001),
+        ("discrete_input", 2001),
+    ],
+)
+async def test_a_table_refuses_more_than_one_request_carries(
+    hass: HomeAssistant, consumer: ConsumerFactory, table: str, count: int
+) -> None:
+    """Registers cap at 125 and single-bit tables at 2000."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    with pytest.raises(vol.Invalid):
+        await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_block",
+                tool_args={
+                    "endpoint": ["tcp", "device.local", 502],
+                    "unit_id": 1,
+                    "address": 0,
+                    "count": count,
+                    "table": table,
+                },
+            )
+        )
+
+
+async def test_a_bit_table_may_read_more_than_a_register_table(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """1000 coils is one request; 1000 registers is not."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    args = {
+        "endpoint": ["tcp", "device.local", 502],
+        "unit_id": 1,
+        "address": 0,
+        "count": 1000,
+    }
+
+    with patch("modbus_connection.tmodbus.ModbusConnection.for_unit") as for_unit:
+        for_unit.return_value.read_coils = AsyncMock(return_value=[True] * 1000)
+        result = await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_block", tool_args=args | {"table": "coil"}
+            )
+        )
+    assert len(result["values"]) == 1000
+
+    with pytest.raises(vol.Invalid):
+        await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_block", tool_args=args | {"table": "holding"}
+            )
         )

--- a/tests/components/modbus/test_llm_api.py
+++ b/tests/components/modbus/test_llm_api.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from modbus_connection import ModbusTcpParams
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.modbus import async_get_unit
 from homeassistant.components.modbus.llm_api import API_ID
@@ -152,4 +153,39 @@ async def test_reading_an_unknown_device_is_refused(
                     "count": 1,
                 },
             )
+        )
+
+
+@pytest.mark.parametrize(
+    ("args", "why"),
+    [
+        ({"unit_id": 0}, "0 is a broadcast, which has no reply to read"),
+        ({"unit_id": 248}, "past the last addressable unit"),
+        ({"address": -1}, "before the first register"),
+        ({"address": 70000}, "past the last register"),
+        ({"count": 0}, "a block of nothing"),
+        ({"count": 126}, "more than one request may carry"),
+        ({"address": 65500, "count": 100}, "a block running off the end"),
+    ],
+)
+async def test_a_block_outside_the_protocol_is_refused(
+    hass: HomeAssistant,
+    consumer: ConsumerFactory,
+    args: dict[str, int],
+    why: str,
+) -> None:
+    """The schema rejects it here, rather than the transport rejecting it later."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    tool_args = {
+        "endpoint": ["tcp", "device.local", 502],
+        "unit_id": 1,
+        "address": 0,
+        "count": 1,
+    } | args
+
+    with pytest.raises(vol.Invalid):
+        await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(tool_name="read_modbus_registers", tool_args=tool_args)
         )

--- a/tests/components/modbus/test_llm_api.py
+++ b/tests/components/modbus/test_llm_api.py
@@ -1,0 +1,155 @@
+"""Test the Modbus LLM API."""
+
+from collections.abc import Callable, Generator
+from unittest.mock import AsyncMock, patch
+
+from modbus_connection import ModbusTcpParams
+import pytest
+
+from homeassistant.components.modbus import async_get_unit
+from homeassistant.components.modbus.llm_api import API_ID
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+type ConsumerFactory = Callable[[], MockConfigEntry]
+
+
+class MockFlow(ConfigFlow):
+    """A config flow for the integration standing in for a consumer."""
+
+
+@pytest.fixture(name="consumer")
+def consumer_fixture(hass: HomeAssistant) -> Generator[ConsumerFactory]:
+    """Return a factory for config entries that can be set up and unloaded."""
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=AsyncMock(return_value=True),
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "test.config_flow")
+
+    def _consumer() -> MockConfigEntry:
+        entry = MockConfigEntry(domain="test")
+        entry.add_to_hass(hass)
+        return entry
+
+    with mock_config_flow("test", MockFlow):
+        yield _consumer
+
+
+def _context(hass: HomeAssistant) -> llm.LLMContext:
+    """Build a context for calling the API."""
+    return llm.LLMContext(
+        platform="test",
+        context=Context(),
+        language="en",
+        assistant=None,
+        device_id=None,
+    )
+
+
+async def _instance(hass: HomeAssistant) -> llm.APIInstance:
+    """Return the API instance."""
+    return await llm.async_get_api(hass, API_ID, _context(hass))
+
+
+async def _hold_a_unit(
+    hass: HomeAssistant, consumer: ConsumerFactory, unit_id: int = 1
+) -> MockConfigEntry:
+    """Open one connection by asking for a unit on it."""
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="device.local", port=502), unit_id)
+    return entry
+
+
+async def test_the_api_is_registered(hass: HomeAssistant) -> None:
+    """Setting the component up offers the API to assistants."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    assert API_ID in [api.id for api in llm.async_get_apis(hass)]
+
+
+async def test_listing_names_the_open_connections(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """The tool reports what is connected, and which units are in use on it."""
+    assert await async_setup_component(hass, "modbus", {})
+    first = await _hold_a_unit(hass, consumer, 1)
+    second = await _hold_a_unit(hass, consumer, 2)
+
+    result = await (await _instance(hass)).async_call_tool(
+        llm.ToolInput(tool_name="list_modbus_devices", tool_args={})
+    )
+
+    assert result["devices"] == [
+        {
+            "endpoint": ["tcp", "device.local", 502],
+            "connected": False,
+            "units": {first.entry_id: [1], second.entry_id: [2]},
+        }
+    ]
+
+
+async def test_reading_goes_over_the_open_connection(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """A read reaches the device through the connection already held."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    with patch("modbus_connection.tmodbus.ModbusConnection.for_unit") as for_unit:
+        for_unit.return_value.read_holding_registers = AsyncMock(return_value=[1, 2, 3])
+        result = await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_registers",
+                tool_args={
+                    "endpoint": ["tcp", "device.local", 502],
+                    "unit_id": 1,
+                    "address": 40000,
+                    "count": 3,
+                    "register_type": "holding",
+                },
+            )
+        )
+
+    assert result == {
+        "address": 40000,
+        "register_type": "holding",
+        "values": [1, 2, 3],
+    }
+
+
+async def test_reading_an_unknown_device_is_refused(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """The model may only read a device Home Assistant already talks to."""
+    assert await async_setup_component(hass, "modbus", {})
+    await _hold_a_unit(hass, consumer)
+
+    with pytest.raises(HomeAssistantError, match="No Modbus connection"):
+        await (await _instance(hass)).async_call_tool(
+            llm.ToolInput(
+                tool_name="read_modbus_registers",
+                tool_args={
+                    "endpoint": ["tcp", "elsewhere.local", 502],
+                    "unit_id": 1,
+                    "address": 0,
+                    "count": 1,
+                },
+            )
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bringing a Modbus device up means reading raw registers and comparing them against a vendor datasheet. Doing that alongside Home Assistant normally needs a second connection to the device, competing with Home Assistant for a bus that answers one request at a time. Since #179658 those connections are shared and serialized, so an assistant can read through the one that is already open instead.

Registers an LLM API with two tools:

- `list_modbus_devices` names the devices there are connections to, and the unit ids in use on each, keyed by the config entry using them.
- `read_modbus_block` reads a block from one of them, from any of the four tables: holding registers, input registers, coils or discrete inputs.

Only units a config entry holds are visible and readable. An endpoint alone is not the boundary, because a gateway carries devices nobody asked for. Hubs from the YAML integration are a separate pool on pymodbus and are not reachable here.

We're starting read-only first, and will evolve this over time based on community engagement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: builds on #179658
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

