### PR TITLE
Expose the Modbus connections over a websocket API

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -4,6 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.typing import ConfigType
 
+from . import websocket_api
 from .connection import async_get_temporary_unit, async_get_unit
 from .const import DATA_MODBUS_HUBS, DOMAIN
 from .modbus import ModbusHub, async_modbus_setup
@@ -45,6 +46,7 @@ def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Modbus component."""
     async_setup_services(hass)
+    websocket_api.async_setup(hass)
 
     if DOMAIN not in config:
         return True

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from typing import Any
 
@@ -36,18 +36,43 @@ DATA_MODBUS_CONNECTIONS: HassKey[dict[ModbusEndpoint, _SharedConnection]] = Hass
 
 @dataclass
 class _SharedConnection:
-    """A connection and how many units are held on it."""
+    """A connection and the units held on it."""
 
     params: ModbusParams
     connection: ModbusConnection
-    consumers: int = 0
+    units: dict[str, set[int]] = field(default_factory=dict)
+    """The unit ids each config entry holds, keyed by entry id."""
+    transient: int = 0
+    """Holds with no config entry behind them, taken by a config flow."""
+
+    @property
+    def consumers(self) -> int:
+        """How many holds are on this connection."""
+        return sum(len(held) for held in self.units.values()) + self.transient
+
+
+@dataclass(frozen=True, kw_only=True)
+class ModbusConnectionInfo:
+    """A connection the integration is keeping open, and who is using it."""
+
+    endpoint: ModbusEndpoint
+    connected: bool
+    units: dict[str, list[int]]
+    """The unit ids each config entry holds, keyed by entry id."""
 
 
 @callback
 def _async_acquire(
-    hass: HomeAssistant, params: ModbusParams
+    hass: HomeAssistant,
+    params: ModbusParams,
+    entry_id: str | None,
+    unit_id: int,
 ) -> tuple[ModbusConnection, Callable[[], Coroutine[Any, Any, None]]]:
     """Take a hold on the connection these credentials describe.
+
+    A hold with no ``entry_id`` behind it is a config flow's, which keeps the
+    connection up without belonging to anything that could be shown as using
+    it.
 
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
@@ -64,11 +89,19 @@ def _async_acquire(
             f"settings: {shared.params} against {params}"
         )
 
-    shared.consumers += 1
+    if entry_id is None:
+        shared.transient += 1
+    else:
+        shared.units.setdefault(entry_id, set()).add(unit_id)
 
     async def release() -> None:
         """Give up this hold, closing behind the last one."""
-        shared.consumers -= 1
+        if entry_id is None:
+            shared.transient -= 1
+        elif (held := shared.units.get(entry_id)) is not None:
+            held.discard(unit_id)
+            if not held:
+                del shared.units[entry_id]
         if shared.consumers or connections.get(endpoint) is not shared:
             return
         del connections[endpoint]
@@ -94,7 +127,7 @@ def async_get_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    connection, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params, entry.entry_id, unit_id)
     entry.async_on_unload(release)
     return connection.for_unit(unit_id)
 
@@ -114,8 +147,25 @@ async def async_get_temporary_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    connection, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params, None, unit_id)
     try:
         yield connection.for_unit(unit_id)
     finally:
         await release()
+
+
+@callback
+def async_get_connection_info(hass: HomeAssistant) -> list[ModbusConnectionInfo]:
+    """Return the connections the integration is keeping open.
+
+    One entry per physical device, naming the config entries holding units on
+    it. A device several integrations share appears once, with all of them.
+    """
+    return [
+        ModbusConnectionInfo(
+            endpoint=endpoint,
+            connected=shared.connection.connected,
+            units={entry_id: sorted(held) for entry_id, held in shared.units.items()},
+        )
+        for endpoint, shared in hass.data.get(DATA_MODBUS_CONNECTIONS, {}).items()
+    ]

--- a/homeassistant/components/modbus/websocket_api.py
+++ b/homeassistant/components/modbus/websocket_api.py
@@ -1,0 +1,42 @@
+"""Websocket API exposing the Modbus connections the integration keeps open."""
+
+from typing import Any, Final
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from .connection import async_get_connection_info
+
+TYPE_LIST_CONNECTIONS: Final = "modbus/connections/list"
+
+
+@callback
+def async_setup(hass: HomeAssistant) -> None:
+    """Register the Modbus websocket commands."""
+    websocket_api.async_register_command(hass, websocket_list_connections)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): TYPE_LIST_CONNECTIONS})
+@callback
+def websocket_list_connections(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List the connections, and which config entries hold units on each."""
+    connection.send_result(
+        msg["id"],
+        {
+            "connections": [
+                {
+                    "endpoint": list(info.endpoint),
+                    "connected": info.connected,
+                    "units": info.units,
+                }
+                for info in async_get_connection_info(hass)
+            ]
+        },
+    )

--- a/tests/components/modbus/test_connection.py
+++ b/tests/components/modbus/test_connection.py
@@ -257,3 +257,56 @@ async def test_a_temporary_unit_cannot_clash_with_held_link_settings(
 
     [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
     assert shared.consumers == 1
+
+
+async def test_one_entry_holding_the_same_unit_twice(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """Two holds on one unit are one unit, and release together.
+
+    The registry records which units an entry holds, not how many times it
+    asked, so asking twice adds nothing to release twice.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    params = ModbusTcpParams(host="1.2.3.4", port=502)
+    async_get_unit(hass, entry, params, 1)
+    async_get_unit(hass, entry, params, 1)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+    assert shared.units == {entry.entry_id: {1}}
+
+    with patch.object(shared.connection, "close") as close:
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert close.call_count == 1
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_two_entries_holding_the_same_unit(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """The link stays while anybody still holds that unit, however they asked."""
+    one = consumer()
+    await hass.config_entries.async_setup(one.entry_id)
+    two = consumer()
+    await hass.config_entries.async_setup(two.entry_id)
+
+    params = ModbusTcpParams(host="1.2.3.4", port=502)
+    async_get_unit(hass, one, params, 1)
+    async_get_unit(hass, one, params, 1)  # the same unit, asked for twice
+    async_get_unit(hass, two, params, 1)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    with patch.object(shared.connection, "close") as close:
+        await hass.config_entries.async_unload(one.entry_id)
+        await hass.async_block_till_done()
+
+        assert not close.called  # the other entry is still on that unit
+        assert hass.data[DATA_MODBUS_CONNECTIONS]
+
+        await hass.config_entries.async_unload(two.entry_id)
+        await hass.async_block_till_done()
+
+    assert close.called

--- a/tests/components/modbus/test_websocket_api.py
+++ b/tests/components/modbus/test_websocket_api.py
@@ -1,0 +1,137 @@
+"""Test the Modbus websocket API."""
+
+from collections.abc import Callable, Generator
+from unittest.mock import AsyncMock
+
+from modbus_connection import ModbusTcpParams
+import pytest
+
+from homeassistant.components.modbus import async_get_unit
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+from tests.typing import WebSocketGenerator
+
+type ConsumerFactory = Callable[[], MockConfigEntry]
+
+
+class MockFlow(ConfigFlow):
+    """A config flow for the integration standing in for a consumer."""
+
+
+@pytest.fixture(name="consumer")
+def consumer_fixture(hass: HomeAssistant) -> Generator[ConsumerFactory]:
+    """Return a factory for config entries that can be set up and unloaded."""
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=AsyncMock(return_value=True),
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "test.config_flow")
+
+    def _consumer() -> MockConfigEntry:
+        entry = MockConfigEntry(domain="test")
+        entry.add_to_hass(hass)
+        return entry
+
+    with mock_config_flow("test", MockFlow):
+        yield _consumer
+
+
+async def test_list_connections(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    consumer: ConsumerFactory,
+) -> None:
+    """Two entries on one device are one connection naming both."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    first = consumer()
+    await hass.config_entries.async_setup(first.entry_id)
+    second = consumer()
+    await hass.config_entries.async_setup(second.entry_id)
+
+    params = ModbusTcpParams(host="device.local", port=502)
+    async_get_unit(hass, first, params, 1)
+    async_get_unit(hass, second, params, 2)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert len(result["connections"]) == 1
+    reported = result["connections"][0]
+    assert reported["endpoint"] == ["tcp", "device.local", 502]
+    assert reported["units"] == {first.entry_id: [1], second.entry_id: [2]}
+
+
+async def test_unloading_an_entry_drops_it_from_the_listing(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    consumer: ConsumerFactory,
+) -> None:
+    """The connection stays while somebody else holds a unit on it."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    first = consumer()
+    await hass.config_entries.async_setup(first.entry_id)
+    second = consumer()
+    await hass.config_entries.async_setup(second.entry_id)
+
+    params = ModbusTcpParams(host="device.local", port=502)
+    async_get_unit(hass, first, params, 1)
+    async_get_unit(hass, second, params, 2)
+
+    await hass.config_entries.async_unload(first.entry_id)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert len(result["connections"]) == 1
+    assert result["connections"][0]["units"] == {second.entry_id: [2]}
+
+
+async def test_no_connections_when_nobody_asked(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Nothing is opened until an integration asks for a unit."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+
+    assert (await client.receive_json())["result"] == {"connections": []}
+
+
+async def test_one_entry_holding_two_units(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    consumer: ConsumerFactory,
+) -> None:
+    """An entry with two devices on one link reports both units."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    params = ModbusTcpParams(host="device.local", port=502)
+    async_get_unit(hass, entry, params, 1)
+    async_get_unit(hass, entry, params, 2)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert result["connections"][0]["units"] == {entry.entry_id: [1, 2]}

--- a/tests/components/modbus/test_websocket_api.py
+++ b/tests/components/modbus/test_websocket_api.py
@@ -1,9 +1,10 @@
 """Test the Modbus websocket API."""
 
 from collections.abc import Callable, Generator
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from modbus_connection import ModbusTcpParams
+from modbus_connection.tmodbus import ModbusConnection
 import pytest
 
 from homeassistant.components.modbus import async_get_unit
@@ -70,10 +71,59 @@ async def test_list_connections(
     await client.send_json_auto_id({"type": "modbus/connections/list"})
     result = (await client.receive_json())["result"]
 
-    assert len(result["connections"]) == 1
-    reported = result["connections"][0]
-    assert reported["endpoint"] == ["tcp", "device.local", 502]
-    assert reported["units"] == {first.entry_id: [1], second.entry_id: [2]}
+    assert result == {
+        "connections": [
+            {
+                "endpoint": ["tcp", "device.local", 502],
+                "connected": False,
+                "units": {first.entry_id: [1], second.entry_id: [2]},
+            }
+        ]
+    }
+
+
+async def test_a_connection_that_is_up_reports_itself_connected(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    consumer: ConsumerFactory,
+) -> None:
+    """The reported state follows the connection, rather than being fixed."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="device.local", port=502), 1)
+
+    client = await hass_ws_client(hass)
+    with patch.object(ModbusConnection, "connected", True):
+        await client.send_json_auto_id({"type": "modbus/connections/list"})
+        result = (await client.receive_json())["result"]
+
+    assert result == {
+        "connections": [
+            {
+                "endpoint": ["tcp", "device.local", 502],
+                "connected": True,
+                "units": {entry.entry_id: [1]},
+            }
+        ]
+    }
+
+
+async def test_listing_the_connections_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """The endpoint names devices and config entries, so admins only."""
+    assert await async_setup_component(hass, "modbus", {})
+
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    response = await client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "unauthorized"
 
 
 async def test_unloading_an_entry_drops_it_from_the_listing(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Websocket API for the Modbus panel https://github.com/home-assistant/frontend/pull/54036

Since #179658 a Modbus connection is shared between the integrations on one device, which means no single config entry can say what is open or who else is on it. A Modbus panel needs exactly that, and there is nowhere to ask.

The registry already tracked how many holds each config entry had, purely so the connection could close behind the last one. It now records *which unit ids* each entry holds instead, which answers both questions at once and costs nothing extra: the close check only ever asked whether anything was left.

`async_get_connection_info()` reports one entry per physical device, and `modbus/connections/list` serves it to an admin over the websocket API:

```json
{
  "connections": [
    {
      "endpoint": ["tcp", "device.local", 502],
      "connected": true,
      "units": {"01K...": [1], "01K...": [2]}
    }
  ]
}
```

Two entries on one device appear once, with both of them and the unit each is using.

The same registry change is on a branch offering these connections as an LLM API (#179936); the two carry it separately so either can land first.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: builds on #179658
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/54036

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
