### PR TITLE
Let config flows temporarily hold a Modbus unit

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
-from .connection import async_get_unit
+from .connection import async_get_temporary_unit, async_get_unit
 from .const import DOMAIN
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
 from .schemas import CONFIG_SCHEMA
@@ -17,6 +17,7 @@ from .schemas import CONFIG_SCHEMA
 __all__ = [
     "CONFIG_SCHEMA",
     "ModbusHub",
+    "async_get_temporary_unit",
     "async_get_unit",
     "get_hub",
 ]

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -66,7 +66,7 @@ def _async_acquire(
 
     shared.consumers += 1
 
-    async def _release() -> None:
+    async def release() -> None:
         """Give up this hold, closing behind the last one."""
         shared.consumers -= 1
         if shared.consumers or connections.get(endpoint) is not shared:
@@ -75,7 +75,7 @@ def _async_acquire(
         _LOGGER.debug("Closing the Modbus connection to %s", endpoint)
         await shared.connection.close()
 
-    return shared, _release
+    return shared, release
 
 
 @callback

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -46,7 +46,7 @@ class _SharedConnection:
 @callback
 def _async_acquire(
     hass: HomeAssistant, params: ModbusParams
-) -> tuple[_SharedConnection, Callable[[], Coroutine[Any, Any, None]]]:
+) -> tuple[ModbusConnection, Callable[[], Coroutine[Any, Any, None]]]:
     """Take a hold on the connection these credentials describe.
 
     Raises `HomeAssistantError` if the device is already in use over different
@@ -75,7 +75,7 @@ def _async_acquire(
         _LOGGER.debug("Closing the Modbus connection to %s", endpoint)
         await shared.connection.close()
 
-    return shared, release
+    return shared.connection, release
 
 
 @callback
@@ -94,9 +94,9 @@ def async_get_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    shared, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params)
     entry.async_on_unload(release)
-    return shared.connection.for_unit(unit_id)
+    return connection.for_unit(unit_id)
 
 
 @asynccontextmanager
@@ -114,8 +114,8 @@ async def async_get_temporary_unit(
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
     """
-    shared, release = _async_acquire(hass, params)
+    connection, release = _async_acquire(hass, params)
     try:
-        yield shared.connection.for_unit(unit_id)
+        yield connection.for_unit(unit_id)
     finally:
         await release()

--- a/homeassistant/components/modbus/connection.py
+++ b/homeassistant/components/modbus/connection.py
@@ -1,7 +1,10 @@
 """Hand out Modbus units over connections shared between integrations."""
 
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from modbus_connection import (
     ModbusSerialParams,
@@ -41,17 +44,10 @@ class _SharedConnection:
 
 
 @callback
-def async_get_unit(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    params: ModbusParams,
-    unit_id: int,
-) -> ModbusUnit:
-    """Return a unit on the connection these credentials describe.
-
-    Consumers of one device share a connection, so their requests serialize
-    behind its lock. It is closed when the last config entry holding a unit on
-    it unloads.
+def _async_acquire(
+    hass: HomeAssistant, params: ModbusParams
+) -> tuple[_SharedConnection, Callable[[], Coroutine[Any, Any, None]]]:
+    """Take a hold on the connection these credentials describe.
 
     Raises `HomeAssistantError` if the device is already in use over different
     link settings, which cannot both be honoured on one connection.
@@ -79,5 +75,47 @@ def async_get_unit(
         _LOGGER.debug("Closing the Modbus connection to %s", endpoint)
         await shared.connection.close()
 
-    entry.async_on_unload(_release)
+    return shared, _release
+
+
+@callback
+def async_get_unit(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    params: ModbusParams,
+    unit_id: int,
+) -> ModbusUnit:
+    """Return a unit on the connection these credentials describe.
+
+    Consumers of one device share a connection, so their requests serialize
+    behind its lock. It is closed when the last config entry holding a unit on
+    it unloads.
+
+    Raises `HomeAssistantError` if the device is already in use over different
+    link settings, which cannot both be honoured on one connection.
+    """
+    shared, release = _async_acquire(hass, params)
+    entry.async_on_unload(release)
     return shared.connection.for_unit(unit_id)
+
+
+@asynccontextmanager
+async def async_get_temporary_unit(
+    hass: HomeAssistant,
+    params: ModbusParams,
+    unit_id: int,
+) -> AsyncIterator[ModbusUnit]:
+    """Hold a unit on the connection these credentials describe for the context.
+
+    For config flows, which have no config entry yet to tie a hold to. A
+    connection already held by a config entry is shared and stays up; one
+    opened here is closed on exit.
+
+    Raises `HomeAssistantError` if the device is already in use over different
+    link settings, which cannot both be honoured on one connection.
+    """
+    shared, release = _async_acquire(hass, params)
+    try:
+        yield shared.connection.for_unit(unit_id)
+    finally:
+        await release()

--- a/tests/components/modbus/test_connection.py
+++ b/tests/components/modbus/test_connection.py
@@ -4,10 +4,12 @@ from collections.abc import Callable, Generator
 from unittest.mock import AsyncMock, patch
 
 from modbus_connection import ModbusSerialParams, ModbusTcpParams
+from modbus_connection.tmodbus import ModbusConnection
 import pytest
 
 from homeassistant.components.modbus.connection import (
     DATA_MODBUS_CONNECTIONS,
+    async_get_temporary_unit,
     async_get_unit,
 )
 from homeassistant.config_entries import ConfigFlow
@@ -188,3 +190,70 @@ async def test_reloading_an_entry_reopens_the_connection(
     [second] = hass.data[DATA_MODBUS_CONNECTIONS].values()
 
     assert second.connection is not first.connection
+
+
+async def test_a_temporary_unit_closes_the_connection_on_exit(
+    hass: HomeAssistant,
+) -> None:
+    """A config flow's hold ends with the context, not with a config entry."""
+    with patch.object(ModbusConnection, "close") as close:
+        async with async_get_temporary_unit(
+            hass, ModbusTcpParams(host="1.2.3.4", port=502), 1
+        ):
+            [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+            assert shared.consumers == 1
+
+    assert close.called
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_a_temporary_unit_releases_when_the_context_raises(
+    hass: HomeAssistant,
+) -> None:
+    """A flow step failing must not leak the connection it probed over."""
+    with patch.object(ModbusConnection, "close") as close, pytest.raises(ValueError):
+        async with async_get_temporary_unit(
+            hass, ModbusTcpParams(host="1.2.3.4", port=502), 1
+        ):
+            raise ValueError
+
+    assert close.called
+    assert not hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_a_temporary_unit_shares_a_connection_an_entry_holds(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """A flow probing a device an entry already talks to joins its connection.
+
+    The connection outlives the flow because the entry still holds it.
+    """
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    params = ModbusTcpParams(host="1.2.3.4", port=502)
+    async_get_unit(hass, entry, params, 1)
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+
+    async with async_get_temporary_unit(hass, params, 2):
+        assert shared.consumers == 2
+
+    assert shared.consumers == 1
+    assert hass.data[DATA_MODBUS_CONNECTIONS]
+
+
+async def test_a_temporary_unit_cannot_clash_with_held_link_settings(
+    hass: HomeAssistant, consumer: ConsumerFactory
+) -> None:
+    """A flow gets told about a link settings clash when entering the context."""
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="1.2.3.4", port=502), 1)
+
+    with pytest.raises(HomeAssistantError, match="different link settings"):
+        async with async_get_temporary_unit(
+            hass, ModbusTcpParams(host="1.2.3.4", port=502, framer="rtu"), 2
+        ):
+            pass
+
+    [shared] = hass.data[DATA_MODBUS_CONNECTIONS].values()
+    assert shared.consumers == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`async_get_unit` ties the hold on a shared Modbus connection to a config entry's unload. A config flow that wants to probe a device has no config entry yet, so it cannot use it.

This adds `async_get_temporary_unit`, an async context manager that holds a unit for the duration of the context. A connection a config entry already holds is shared and stays up on exit. A connection the flow opened itself is closed on exit, including when the flow step raises.

The acquire/release logic is shared with `async_get_unit` through a private helper. The behavior of `async_get_unit` is unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: builds on the shared-connection work in https://github.com/home-assistant/core/pull/179933
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr