### PR TITLE
Improve Google Health config flow error messages

### DIFF
--- a/homeassistant/components/google_health/config_flow.py
+++ b/homeassistant/components/google_health/config_flow.py
@@ -8,7 +8,8 @@ from google_health_api import GoogleHealthApi
 from google_health_api.const import HealthApiScope
 from google_health_api.exceptions import (
     GoogleHealthApiError,
-    HealthApiForbiddenException,
+    HealthApiScopeInsufficientException,
+    HealthApiServiceDisabledException,
 )
 
 from homeassistant.config_entries import (
@@ -81,19 +82,22 @@ class OAuth2FlowHandler(
 
         try:
             identity = await api.get_identity()
-        except HealthApiForbiddenException as err:
+        except HealthApiServiceDisabledException as err:
             _LOGGER.error("Error getting Google Health identity: %s", err)
             return self.async_abort(
                 reason="api_not_enabled",
                 description_placeholders={"url": API_CONSOLE_URL},
             )
+        except HealthApiScopeInsufficientException as err:
+            _LOGGER.error("Error getting Google Health identity: %s", err)
+            return self.async_abort(reason="missing_profile_scope")
         except GoogleHealthApiError as err:
             _LOGGER.error("Error getting Google Health identity: %s", err)
             return self.async_abort(reason="cannot_connect")
 
         if not identity.health_user_id:
             _LOGGER.error("Google Health identity has no health_user_id")
-            return self.async_abort(reason="cannot_connect")
+            return self.async_abort(reason="missing_profile_scope")
 
         await self.async_set_unique_id(identity.health_user_id)
         if self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
@@ -110,7 +114,7 @@ class OAuth2FlowHandler(
             try:
                 userinfo = await api.get_user_info()
                 display_name = userinfo.given_name or userinfo.name
-            except Exception as err:  # pylint: disable=broad-except # noqa: BLE001
+            except GoogleHealthApiError as err:
                 _LOGGER.warning("Error fetching user profile name: %s", err)
 
         return self.async_create_entry(

--- a/homeassistant/components/google_health/strings.json
+++ b/homeassistant/components/google_health/strings.json
@@ -10,7 +10,7 @@
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "cannot_connect": "Failed to connect.",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
-      "missing_profile_scope": "Missing required Google Health profile read permission.",
+      "missing_profile_scope": "Missing required Google Health profile read permission. Please try again and select the right permission.",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",

--- a/tests/components/google_health/test_config_flow.py
+++ b/tests/components/google_health/test_config_flow.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, patch
 from google_health_api.const import HealthApiScope
 from google_health_api.exceptions import (
     GoogleHealthApiError,
-    HealthApiForbiddenException,
+    HealthApiScopeInsufficientException,
+    HealthApiServiceDisabledException,
 )
 from google_health_api.model import Identity
 import pytest
@@ -243,8 +244,8 @@ async def test_config_flow_api_not_enabled(
     mock_google_health_client: AsyncMock,
 ) -> None:
     """Test config flow aborts if the Google Health API is not enabled."""
-    mock_google_health_client.get_identity.side_effect = HealthApiForbiddenException(
-        "Forbidden"
+    mock_google_health_client.get_identity.side_effect = (
+        HealthApiServiceDisabledException
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -278,6 +279,50 @@ async def test_config_flow_api_not_enabled(
     assert result["description_placeholders"] == {
         "url": "https://console.developers.google.com/apis/api/health.googleapis.com/overview"
     }
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "mock_setup_entry", "setup_credentials"
+)
+async def test_config_flow_scope_insufficient(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_google_health_client: AsyncMock,
+) -> None:
+    """Test config flow aborts if the OAuth token has insufficient scope."""
+    mock_google_health_client.get_identity.side_effect = (
+        HealthApiScopeInsufficientException
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "scope": " ".join(OAUTH_SCOPES),
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_profile_scope"
 
 
 @pytest.mark.usefixtures(
@@ -321,7 +366,7 @@ async def test_config_flow_missing_health_user_id(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
+    assert result["reason"] == "missing_profile_scope"
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve Google Health config flow error messages using the improved exception tree.


Detailed changes:
- Catch `HealthApiServiceDisabledException` specifically to abort with `api_not_enabled`.
- Catch `HealthApiScopeInsufficientException` specifically to abort with `missing_profile_scope`.
- Abort with `missing_profile_scope` when `health_user_id` is not returned.
- Update `missing_profile_scope` message to guide the user to select the right permissions during authentication.
- Fallback to `cannot_connect` for generic `GoogleHealthApiError`.
- Narrow profile name lookup error handling from broad `Exception` to `GoogleHealthApiError`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178711
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
