### PR TITLE
Fix for working location calendar in some scenarios when "ignore availability" is unset

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -179,6 +179,7 @@ def _get_entity_descriptions(
                     event_type=EventTypeEnum.BIRTHDAY,
                     name=None,
                     entity_id=None,
+                    ignore_availability=True,
                 )
             )
             # Create an optional disabled by default entity for Work Location
@@ -191,6 +192,7 @@ def _get_entity_descriptions(
                     name=None,
                     entity_id=None,
                     entity_registry_enabled_default=False,
+                    ignore_availability=True,
                 )
             )
     return entity_descriptions

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1499,6 +1499,192 @@ async def test_working_location_entity(
     assert state.attributes.get("message") == expected_event_message
 
 
+@pytest.mark.parametrize("calendar_is_primary", [True])
+async def test_working_location_get_events(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
+    mock_events_list_items: Callable[[list[dict[str, Any]]], None],
+    component_setup: ComponentSetup,
+) -> None:
+    """Test get_events for working location entity with recurring and single events from diagnostics."""
+    events = [
+        {
+            **TEST_EVENT,
+            "id": "event-home",
+            "iCalUID": "event-home@google.com",
+            "summary": "Home",
+            "start": {"date": "2026-08-24"},
+            "end": {"date": "2026-08-25"},
+            "transparency": "transparent",
+            "status": "confirmed",
+            "eventType": "workingLocation",
+            "visibility": "public",
+            "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+        },
+        {
+            **TEST_EVENT,
+            "id": "event-office",
+            "iCalUID": "event-office@google.com",
+            "summary": "Office",
+            "start": {"date": "2026-08-25"},
+            "end": {"date": "2026-08-26"},
+            "transparency": "transparent",
+            "status": "confirmed",
+            "eventType": "workingLocation",
+            "visibility": "public",
+        },
+    ]
+    mock_events_list_items(events)
+    assert await component_setup()
+
+    entity_registry.async_update_entity(
+        entity_id="calendar.working_location", disabled_by=None
+    )
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + datetime.timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Query events via calendar.get_events action
+    response = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "start_date_time": "2026-08-24T00:00:00Z",
+            "end_date_time": "2026-09-01T00:00:00Z",
+        },
+        target={"entity_id": "calendar.working_location"},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {
+        "calendar.working_location": {
+            "events": [
+                {
+                    "start": "2026-08-24",
+                    "end": "2026-08-25",
+                    "summary": "Home",
+                    "description": "test event",
+                    "location": "Test Cases",
+                },
+                {
+                    "start": "2026-08-25",
+                    "end": "2026-08-26",
+                    "summary": "Office",
+                    "description": "test event",
+                    "location": "Test Cases",
+                },
+                {
+                    "start": "2026-08-31",
+                    "end": "2026-09-01",
+                    "summary": "Home",
+                    "description": "test event",
+                    "location": "Test Cases",
+                },
+            ]
+        }
+    }
+
+
+@pytest.mark.parametrize("calendar_is_primary", [True])
+@pytest.mark.parametrize(
+    "calendars_config",
+    [
+        [
+            {
+                "cal_id": CALENDAR_ID,
+                "entities": [
+                    {
+                        "device_id": "primary",
+                        "name": "Primary",
+                        "ignore_availability": False,
+                        "track": True,
+                    }
+                ],
+            }
+        ]
+    ],
+)
+async def test_working_location_ignore_availability_false(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_calendars_yaml: None,
+    mock_events_list_items: Callable[[list[dict[str, Any]]], None],
+    component_setup: ComponentSetup,
+) -> None:
+    """Test working location entity when primary calendar has ignore_availability=False in YAML reproduces empty events issue."""
+    event = {
+        **TEST_EVENT,
+        "id": "event-home",
+        "iCalUID": "event-home@google.com",
+        "summary": "Home",
+        "start": {"date": "2026-08-24"},
+        "end": {"date": "2026-08-25"},
+        "transparency": "transparent",
+        "status": "confirmed",
+        "eventType": "workingLocation",
+        "visibility": "public",
+    }
+    mock_events_list_items([event])
+    assert await component_setup()
+
+    entity_entry = entity_registry.async_get("calendar.working_location")
+    assert entity_entry
+    assert entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+
+    entity_registry.async_update_entity(
+        entity_id="calendar.working_location", disabled_by=None
+    )
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + datetime.timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Query events via calendar.get_events action on working location entity
+    response = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "start_date_time": "2026-08-24T00:00:00Z",
+            "end_date_time": "2026-08-26T00:00:00Z",
+        },
+        target={"entity_id": "calendar.working_location"},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {
+        "calendar.working_location": {
+            "events": [
+                {
+                    "start": "2026-08-24",
+                    "end": "2026-08-25",
+                    "summary": "Home",
+                    "description": "test event",
+                    "location": "Test Cases",
+                }
+            ]
+        }
+    }
+
+    # Query events via calendar.get_events action on primary calendar entity
+    primary_response = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "start_date_time": "2026-08-24T00:00:00Z",
+            "end_date_time": "2026-08-26T00:00:00Z",
+        },
+        target={"entity_id": "calendar.primary"},
+        blocking=True,
+        return_response=True,
+    )
+    # The primary calendar filters out transparent events because ignore_availability is False
+    assert primary_response == {"calendar.primary": {"events": []}}
+
+
 @pytest.mark.parametrize("calendar_is_primary", [False])
 async def test_no_working_location_entity(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Explicitly set `ignore_availability=True` when generating entity descriptions for dedicated sub-entities (`birthdays` and `working_location`) in the Google Calendar integration. This is meant to always show working location events since they are always transparent.

Google Calendar `workingLocation` and `birthday` events are status events that are inherently non-opaque / transparent (`transparency: "transparent"`). If the primary calendar was configured with `ignore_availability: False` (e.g. via YAML configuration), the sub-entities inherited that setting and filtered out all transparent events, causing `calendar.working_location` and `calendar.birthdays` to return empty event lists. Setting `ignore_availability=True` ensures these dedicated event-type entities always process their events properly regardless of the primary calendar's availability configuration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179779
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an  in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr