### PR TITLE
Fix JSON serialization of date and time objects in llama_cpp

### DIFF
--- a/homeassistant/components/llama_cpp/entity.py
+++ b/homeassistant/components/llama_cpp/entity.py
@@ -37,6 +37,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import json_dumps
 
 from .api import api_error_handler
 from .const import (
@@ -102,7 +103,7 @@ def _convert_content_to_chat_message(
         return ChatCompletionToolMessageParam(
             role="tool",
             tool_call_id=content.tool_call_id,
-            content=json.dumps(content.tool_result),
+            content=json_dumps(content.tool_result),
         )
 
     role: Literal["user", "assistant", "system"] = content.role
@@ -123,7 +124,7 @@ def _convert_content_to_chat_message(
                     type="function",
                     id=tool_call.id,
                     function=Function(
-                        arguments=json.dumps(tool_call.tool_args),
+                        arguments=json_dumps(tool_call.tool_args),
                         name=tool_call.tool_name,
                     ),
                 )
@@ -175,7 +176,7 @@ def _convert_content_to_param(
         return ChatCompletionToolMessageParam(
             role="tool",
             tool_call_id=content.tool_call_id,
-            content=json.dumps(content.tool_result),
+            content=json_dumps(content.tool_result),
         )
     if not isinstance(content, conversation.AssistantContent) or not content.tool_calls:
         if isinstance(content, conversation.SystemContent):
@@ -195,7 +196,7 @@ def _convert_content_to_param(
             ChatCompletionMessageToolCallParam(
                 id=tool_call.id,
                 function=Function(
-                    arguments=json.dumps(tool_call.tool_args),
+                    arguments=json_dumps(tool_call.tool_args),
                     name=tool_call.tool_name,
                 ),
                 type="function",

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -26,7 +26,7 @@ class JSONEncoder(json.JSONEncoder):
 
         Hand other objects to the original method.
         """
-        if isinstance(o, datetime.datetime):
+        if isinstance(o, (datetime.date, datetime.time, datetime.datetime)):
             return o.isoformat()
         if isinstance(o, set):
             return list(o)
@@ -51,7 +51,7 @@ def json_encoder_default(obj: Any) -> Any:
         return obj.as_dict()
     if isinstance(obj, Path):
         return obj.as_posix()
-    if isinstance(obj, datetime.datetime):
+    if isinstance(obj, (datetime.date, datetime.time, datetime.datetime)):
         return obj.isoformat()
     raise TypeError
 

--- a/tests/components/llama_cpp/test_conversation.py
+++ b/tests/components/llama_cpp/test_conversation.py
@@ -1,6 +1,7 @@
 """Tests for the llama.cpp conversation platform."""
 
 from collections.abc import AsyncGenerator, Generator
+import datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -191,6 +192,102 @@ async def test_function_call(
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert mock_chat_log.content[1:] == snapshot
+
+
+@pytest.mark.parametrize(("config_entry_options"), [ASSIST_OPTIONS])
+async def test_function_call_with_datetime_tool_results(
+    hass: HomeAssistant,
+    mock_chat_log: MockChatLog,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test function call where tool result contains time/date/datetime objects."""
+    mock_chat_log.mock_tool_results(
+        {
+            "call_call_1": {
+                "speech_slots": {
+                    "time": datetime.time(12, 0),
+                    "date": datetime.date(2026, 8, 23),
+                    "datetime": datetime.datetime(2026, 8, 23, 12, 0),
+                }
+            },
+        }
+    )
+
+    def completion_result(
+        *args: Any, messages: list[dict[str, Any]] | list[Any], **kwargs: Any
+    ) -> ChatCompletion:
+        for message in messages:
+            role = message["role"] if isinstance(message, dict) else message.role
+            if role == "tool":
+                return ChatCompletion(
+                    id="chatcmpl-1234567890ZYXWVUTSRQPONMLKJIH",
+                    choices=[
+                        Choice(
+                            finish_reason="stop",
+                            index=0,
+                            message=ChatCompletionMessage(
+                                content="I have successfully called the function with time",
+                                role="assistant",
+                                function_call=None,
+                                tool_calls=None,
+                            ),
+                        )
+                    ],
+                    created=1700000000,
+                    model="gpt-4-1106-preview",
+                    object="chat.completion",
+                    system_fingerprint=None,
+                    usage=CompletionUsage(
+                        completion_tokens=9, prompt_tokens=8, total_tokens=17
+                    ),
+                )
+
+        return ChatCompletion(
+            id="chatcmpl-1234567890ABCDEFGHIJKLMNOPQRS",
+            choices=[
+                Choice(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content=None,
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_call_1",
+                                function=Function(
+                                    arguments='{"param1":"call1"}',
+                                    name="test_tool",
+                                ),
+                                type="function",
+                            )
+                        ],
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="gpt-4-1106-preview",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=9, prompt_tokens=8, total_tokens=17
+            ),
+        )
+
+    with patch(
+        "openai.resources.chat.completions.AsyncCompletions.create",
+        new_callable=AsyncMock,
+        side_effect=completion_result,
+    ):
+        result = await conversation.async_converse(
+            hass,
+            "Please call the test function",
+            mock_chat_log.conversation_id,
+            Context(),
+            agent_id="conversation.llama_cpp_conversation",
+        )
+
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
 
 @pytest.mark.parametrize(("config_entry_options"), [ASSIST_OPTIONS])

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -54,6 +54,17 @@ def test_json_encoder(hass: HomeAssistant, encoder: type[json.JSONEncoder]) -> N
     assert json_round_trip(default) == json_round_trip(state.as_dict())
 
 
+def test_default_json_encoder(hass: HomeAssistant) -> None:
+    """Test the default JSON encoder for date and time."""
+    ha_json_enc = DefaultHASSJSONEncoder()
+
+    today = datetime.date(2026, 8, 23)
+    assert ha_json_enc.default(today) == today.isoformat()
+
+    current_time = datetime.time(12, 0)
+    assert ha_json_enc.default(current_time) == current_time.isoformat()
+
+
 def test_json_encoder_raises(hass: HomeAssistant) -> None:
     """Test the JSON encoder raises on unsupported types."""
     ha_json_enc = DefaultHASSJSONEncoder()
@@ -145,6 +156,27 @@ def test_json_dumps_rgb_color_subclass() -> None:
     rgb = RGBColor(4, 2, 1)
 
     assert json_dumps(rgb) == "[4,2,1]"
+
+
+def test_json_dumps_date_time_subclasses() -> None:
+    """Test the json dumps with date and time subclasses."""
+
+    class CustomDate(datetime.date):
+        """Custom date subclass."""
+
+    class CustomTime(datetime.time):
+        """Custom time subclass."""
+
+    class CustomDatetime(datetime.datetime):
+        """Custom datetime subclass."""
+
+    d = CustomDate(2026, 8, 23)
+    t = CustomTime(12, 30, 45)
+    dt = CustomDatetime(2026, 8, 23, 12, 30, 45)
+
+    assert json_dumps({"date": d, "time": t, "datetime": dt}) == (
+        '{"date":"2026-08-23","time":"12:30:45","datetime":"2026-08-23T12:30:45"}'
+    )
 
 
 def test_json_fragments() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When intent execution returns responses containing time or date objects (such as a `time` slot in `speech_slots`), the conversation pipeline in `llama_cpp` crashes with `TypeError: Object of type time is not JSON serializable` because standard library `json.dumps` does not support temporal objects.

Using `homeassistant.helpers.json.json_dumps` aligns `llama_cpp` with other LLM integrations (`openai_conversation`, `anthropic`, etc.) that support Home Assistant and temporal types. Ensuring `homeassistant.helpers.json` explicitly handles `datetime.time` and `datetime.date` objects/subclasses prevents serialization crashes when these values are returned in tool results.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179914
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
