### PR TITLE
Avoid a naive datetime.now() in yale

### DIFF
--- a/homeassistant/components/yale/util.py
+++ b/homeassistant/components/yale/util.py
@@ -1,6 +1,6 @@
 """Yale util functions."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import partial
 
 import aiohttp
@@ -11,6 +11,7 @@ from yalexs.manager.const import ACTIVITY_UPDATE_INTERVAL
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import aiohttp_client
+from homeassistant.util import dt as dt_util
 
 from . import YaleData
 
@@ -61,7 +62,9 @@ def _activity_time_based(latest: Activity) -> Activity | None:
     """Get the latest state of the sensor."""
     start = latest.activity_start_time
     end = latest.activity_end_time + TIME_TO_DECLARE_DETECTION
-    if start <= datetime.now() <= end:  # pylint: disable=home-assistant-enforce-naive-now
+    # yalexs builds these from datetime.fromtimestamp without a tzinfo, so they
+    # are naive local times and have to be compared against one.
+    if start <= dt_util.naive_now() <= end:
         return latest
     return None
 


### PR DESCRIPTION
## Proposed change

The two values on either side of this comparison come from `yalexs`, which builds them with `datetime.fromtimestamp` and no tzinfo. Its docstring is explicit about that:

> Convert epoch to a naive local-time datetime.
>
> Callers pass the result through `as_utc_from_local` to obtain UTC; introducing tzinfo here would double-shift those conversions.

So the comparison is between naive local times and an aware value would not be comparable with them. `dt_util.naive_now()` keeps the current behaviour and removes the suppression.

Same change as #179182, which did this for the identical code in `august`.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177845
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
