### PR TITLE
Avoid a naive datetime.now() in nextbus

### DIFF
--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -1,6 +1,6 @@
 """NextBus data update coordinator."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 from typing import Any, override
 
@@ -9,6 +9,7 @@ from py_nextbus.client import NextBusFormatError, NextBusHTTPError
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .util import RouteStop
@@ -67,7 +68,9 @@ class NextBusDataUpdateCoordinator(
             # But only if we have a reset time to unthrottle
             and self.client.rate_limit_reset is not None
             # Unless we are after the reset time
-            and datetime.now() < self.client.rate_limit_reset  # pylint: disable=home-assistant-enforce-naive-now
+            # py_nextbus builds rate_limit_reset with datetime.fromtimestamp and
+            # no tzinfo, so it is a naive local time and needs one to compare to.
+            and dt_util.naive_now() < self.client.rate_limit_reset
         ):
             self.logger.debug(
                 "Rate limit threshold reached. Skipping updates for. Routes: %s",

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -68,8 +68,6 @@ class NextBusDataUpdateCoordinator(
             # But only if we have a reset time to unthrottle
             and self.client.rate_limit_reset is not None
             # Unless we are after the reset time
-            # py_nextbus builds rate_limit_reset with datetime.fromtimestamp and
-            # no tzinfo, so it is a naive local time and needs one to compare to.
             and dt_util.naive_now() < self.client.rate_limit_reset
         ):
             self.logger.debug(

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -1,7 +1,7 @@
 """The tests for the nexbus sensor component."""
 
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock
 from urllib.error import HTTPError
 
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from . import assert_setup_sensor
 from .const import (
@@ -135,7 +136,7 @@ async def test_verify_throttle(
     # Set rate limit past threshold, should be ignored for first request
     mock_client = mock_nextbus.return_value
     mock_client.rate_limit_percent = 99.0
-    mock_client.rate_limit_reset = datetime.now() + timedelta(seconds=30)  # pylint: disable=home-assistant-enforce-naive-now
+    mock_client.rate_limit_reset = dt_util.naive_now() + timedelta(seconds=30)
 
     # Do a request with the initial config and get predictions
     await assert_setup_sensor(hass, CONFIG_BASIC)


### PR DESCRIPTION
## Proposed change

The throttle check compares the current time against `client.rate_limit_reset`, which `py_nextbus` builds as:

```python
self._rate_limit_reset = (
    datetime.fromtimestamp(int(reset_time)) if reset_time else None
)
```

No tzinfo, so it is a naive local time and an aware value would not be comparable with it. `dt_util.naive_now()` keeps the comparison working and removes the suppression, here and in the test that builds the same kind of value.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177816
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
