### PR TITLE
Require UniFi Protect 7.2.105

### DIFF
--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -309,15 +309,16 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
         if self._private is not None:
             super()._async_set_device_info()
             return
-        # public-only: no market_name/firmware_version/protect_url, and
-        # ``type`` only on newer firmware, so device identity is limited. The
-        # NVR link is omitted — an API-key-only client has no private
-        # bootstrap to read the NVR mac from, and resolving it publicly is
-        # async; the public-only config mode wires it at setup instead.
+        # public-only: no market_name/firmware_version/protect_url, so device
+        # identity is limited. The NVR link is omitted — an API-key-only client
+        # has no private bootstrap to read the NVR mac from, and resolving it
+        # publicly is async; the public-only config mode wires it at setup
+        # instead.
         public = self._public
         self._attr_device_info = DeviceInfo(
             name=public.display_name,
             model=public.type,
+            model_id=public.type,
             manufacturer=DEFAULT_BRAND,
             connections={(dr.CONNECTION_NETWORK_MAC, public.mac)},
         )

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -55,7 +55,7 @@ DEVICES_FOR_SUBSCRIBE = DEVICES_WITH_ENTITIES | {ModelType.EVENT}
 # the public API devices WebSocket.
 DEVICES_WS_SUBSCRIBED_MODELS: set[ModelType] = set()
 
-MIN_REQUIRED_PROTECT_V = Version("7.1.0")
+MIN_REQUIRED_PROTECT_V = Version("7.2.105")
 OUTDATED_LOG_MESSAGE = (
     "You are running v%s of UniFi Protect. Minimum required version is v%s. Please"
     " upgrade UniFi Protect and then retry"

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -123,6 +123,7 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
         self._attr_device_info = DeviceInfo(
             name=public.display_name,
             model=public.type,
+            model_id=public.type,
             manufacturer=DEFAULT_BRAND,
             connections={(dr.CONNECTION_NETWORK_MAC, public.mac)},
         )

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -11,7 +11,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cloud_user": "Ubiquiti Cloud users are not supported. Please use a local user instead.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "protect_version": "Minimum required version is v7.1.0. Please upgrade UniFi Protect and then retry."
+      "protect_version": "Minimum required version is v7.2.105. Please upgrade UniFi Protect and then retry."
     },
     "flow_title": "{name} ({ip_address})",
     "step": {

--- a/tests/components/unifiprotect/fixtures/sample_nvr.json
+++ b/tests/components/unifiprotect/fixtures/sample_nvr.json
@@ -5,7 +5,7 @@
   "canAutoUpdate": true,
   "isStatsGatheringEnabled": true,
   "timezone": "America/New_York",
-  "version": "7.1.0",
+  "version": "7.2.105",
   "ucoreVersion": "2.3.26",
   "firmwareVersion": "2.3.10",
   "uiVersion": null,

--- a/tests/components/unifiprotect/snapshots/test_diagnostics.ambr
+++ b/tests/components/unifiprotect/snapshots/test_diagnostics.ambr
@@ -603,7 +603,7 @@
         'uptime': 1191516000,
         'vaultCameras': list([
         ]),
-        'version': '7.1.0',
+        'version': '7.2.105',
         'wanIp': None,
       }),
       'ringtones': list([

--- a/tests/components/unifiprotect/snapshots/test_init.ambr
+++ b/tests/components/unifiprotect/snapshots/test_init.ambr
@@ -29,7 +29,7 @@
     'name': 'UnifiProtect',
     'name_by_user': None,
     'serial_number': None,
-    'sw_version': '7.1.0',
+    'sw_version': '7.2.105',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -446,6 +446,7 @@ async def test_public_only_camera(
     assert device.via_device_id is None
     assert device.name == camera.display_name
     assert device.model == camera.type
+    assert device.model_id == camera.type
 
     assert (
         await async_get_stream_source(hass, entity_id)

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -1626,7 +1626,7 @@ async def test_reconfigure_outdated_version(
 
     # Set up NVR with outdated version
     old_nvr = nvr.model_copy()
-    old_nvr.version = Version("5.0.0")  # Below MIN_REQUIRED_PROTECT_V (7.1.0)
+    old_nvr.version = Version("5.0.0")  # Below MIN_REQUIRED_PROTECT_V (7.2.105)
     bootstrap.nvr = old_nvr
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -8,7 +8,10 @@ from uiprotect.data import DeviceState, Light, Permission, WSAction
 from uiprotect.websocket import WebsocketState
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
+from homeassistant.components.unifiprotect.const import (
+    DEFAULT_ATTRIBUTION,
+    DEFAULT_BRAND,
+)
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ENTITY_ID,
@@ -18,7 +21,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .utils import (
     MockUFPFixture,
@@ -212,6 +215,7 @@ async def test_light_turn_off(
 
 async def test_light_setup_public_only(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     ufp: MockUFPFixture,
     light: Light,
@@ -232,6 +236,13 @@ async def test_light_setup_public_only(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_OFF
+
+    # Device identity comes from the public object alone.
+    device = device_registry.async_get(entity.device_id)
+    assert device
+    assert device.model == public.type
+    assert device.model_id == public.type
+    assert device.manufacturer == DEFAULT_BRAND
 
 
 async def test_light_added_after_setup_public_only(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

UniFi Protect 7.2.105 or later is now required. On older versions the integration stops setting up and tells you to update; update UniFi Protect, then reload the integration.

7.2 is the first version whose public API always reports the NVR mac and the device type, which the integration now relies on instead of carrying a fallback for each.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raises the minimum Protect version from 7.1.0 to 7.2.105.

7.2 always reports the NVR mac and the device `type` on the public API; on 7.1 both are optional and need a fallback everywhere they are read.

Sense entities already depend on 7.2 in practice: the sensor capability map that decides which of them exist is only reported from 7.2, and which entities a user got was a source of confusion in 2026.8. Requiring 7.2 makes that predictable instead of version-dependent.

With `type` guaranteed, the public-only device info sets `model_id` like the hybrid path already does, so a device no longer reports a `model_id` in one mode and none in the other. The remaining pre-7.2 fallbacks are dropped in follow-ups.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47575
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
