### PR TITLE
Raise instead of dereferencing a vanished public light

### DIFF
--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -147,8 +147,8 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
         if (public := self._ufp_public_obj) is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="public_device_unavailable",
-                translation_placeholders={"name": self.device.display_name},
+                translation_key="light_not_available",
+                translation_placeholders={"light_name": self.device.display_name},
             )
         return cast(PublicLight, public)
 
@@ -168,8 +168,7 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
         else:
             _LOGGER.debug("Turning on light")
 
-        # The setter validates the level and writes through the light's own
-        # settings.
+        # led_level is range-checked by the setter, not by HA.
         await self._public_or_raise().set_light(True, led_level)
 
     @async_ufp_instance_command

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -13,12 +13,13 @@ from uiprotect.data.public_devices import PublicLight
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DEFAULT_BRAND
+from .const import DEFAULT_BRAND, DOMAIN
 from .data import ProtectData, ProtectDeviceType, UFPConfigEntry
 from .entity import ProtectDeviceEntity
 from .utils import async_ufp_instance_command
@@ -141,6 +142,16 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
             None if led_level is None else unifi_brightness_to_hass(led_level)
         )
 
+    def _public_or_raise(self) -> PublicLight:
+        """Return the public object, or raise if it vanished mid-command."""
+        if (public := self._ufp_public_obj) is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="public_device_unavailable",
+                translation_placeholders={"name": self.device.display_name},
+            )
+        return cast(PublicLight, public)
+
     @async_ufp_instance_command
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -157,13 +168,13 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
         else:
             _LOGGER.debug("Turning on light")
 
-        # Reachable only while available (public object present); the setter
-        # validates the level and writes through the light's own settings.
-        await cast(PublicLight, self._ufp_public_obj).set_light(True, led_level)
+        # The setter validates the level and writes through the light's own
+        # settings.
+        await self._public_or_raise().set_light(True, led_level)
 
     @async_ufp_instance_command
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         _LOGGER.debug("Turning off light")
-        await cast(PublicLight, self._ufp_public_obj).set_light(False)
+        await self._public_or_raise().set_light(False)

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -739,6 +739,9 @@
     "global_alarm_manager": {
       "message": "The alarm manager on this UniFi Protect NVR is set to Global mode and cannot be controlled locally."
     },
+    "light_not_available": {
+      "message": "Light {light_name} is no longer available"
+    },
     "motion_detection_public_only": {
       "message": "Motion detection cannot be changed over the public API; configure it in the UniFi Protect app"
     },
@@ -765,9 +768,6 @@
     },
     "public_bootstrap_failed": {
       "message": "Could not load the public API bootstrap for camera streams"
-    },
-    "public_device_unavailable": {
-      "message": "{name} is no longer available on the UniFi Protect controller"
     },
     "relay_not_available": {
       "message": "Relay is no longer available"

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -766,6 +766,9 @@
     "public_bootstrap_failed": {
       "message": "Could not load the public API bootstrap for camera streams"
     },
+    "public_device_unavailable": {
+      "message": "{name} is no longer available on the UniFi Protect controller"
+    },
     "relay_not_available": {
       "message": "Relay is no longer available"
     },

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .utils import (
@@ -322,6 +323,55 @@ async def test_light_added_during_gap_public_only(
     assert hass.states.get("light.gap_light") is not None
     # The resync re-offers the first light too; the dedup must drop it.
     assert "already exists" not in caplog.text
+
+
+async def test_light_command_when_public_object_vanishes(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """A light deleted mid-call raises a translated error, not AttributeError.
+
+    Service calls filter unavailable entities once up front and then run the
+    entity coroutines, so a delete frame landing after that check must not
+    reach the command path as a missing public object.
+    """
+
+    first = make_public_light(light)
+    second = make_public_light(light)
+    second.id = "vanishing-light"
+    second.mac = "FFEEDDCCBB03"
+    second.name = "Vanishing Light"
+    second.display_name = "Vanishing Light"
+
+    _use_public_only_bootstrap(ufp, first, second)
+
+    await init_entry(hass, ufp, [])
+    assert_entity_counts(hass, Platform.LIGHT, 2, 2)
+
+    def _delete_on_command(victim: Mock, result: Mock) -> AsyncMock:
+        """Delete ``victim`` while the other light's command is running."""
+
+        async def _run(*args: Any, **kwargs: Any) -> Mock:
+            ufp.api.public_bootstrap.lights.pop(victim.id, None)
+            msg = public_device_ws_message(victim)
+            msg.new_obj = None
+            msg.old_obj = victim
+            ufp.devices_ws_subscription(msg)
+            return result
+
+        return AsyncMock(side_effect=_run)
+
+    # Each light deletes the other, so whichever entity runs first, the second
+    # one meets a missing public object regardless of scheduling order.
+    first.set_light = _delete_on_command(second, first)
+    second.set_light = _delete_on_command(first, second)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "light",
+            "turn_off",
+            {ATTR_ENTITY_ID: ["light.test_light", "light.vanishing_light"]},
+            blocking=True,
+        )
 
 
 async def test_light_turn_on_with_brightness_public_only(

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -4,13 +4,14 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from uiprotect.data import DeviceState, Light, Permission, WSAction
+from uiprotect.data import DeviceState, Light, ModelType, Permission, WSAction
 from uiprotect.websocket import WebsocketState
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.unifiprotect.const import (
     DEFAULT_ATTRIBUTION,
     DEFAULT_BRAND,
+    DOMAIN,
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -325,8 +326,20 @@ async def test_light_added_during_gap_public_only(
     assert "already exists" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("service", "service_data"),
+    [
+        pytest.param("turn_off", {}, id="turn_off"),
+        pytest.param("turn_on", {}, id="turn_on"),
+        pytest.param("turn_on", {ATTR_BRIGHTNESS: 128}, id="turn_on_with_brightness"),
+    ],
+)
 async def test_light_command_when_public_object_vanishes(
-    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    light: Light,
+    service: str,
+    service_data: dict[str, Any],
 ) -> None:
     """A light deleted mid-call raises a translated error, not AttributeError.
 
@@ -348,7 +361,13 @@ async def test_light_command_when_public_object_vanishes(
     assert_entity_counts(hass, Platform.LIGHT, 2, 2)
 
     def _delete_on_command(victim: Mock, result: Mock) -> AsyncMock:
-        """Delete ``victim`` while the other light's command is running."""
+        """Delete ``victim`` while the other light's command is running.
+
+        Neither the deletion nor the WS dispatch below awaits, so this always
+        finishes before the other entity's deferred coroutine gets a turn -
+        that is what makes the outcome independent of which light HA runs
+        first, not the mutual-delete shape by itself.
+        """
 
         async def _run(*args: Any, **kwargs: Any) -> Mock:
             ufp.api.public_bootstrap.lights.pop(victim.id, None)
@@ -360,18 +379,93 @@ async def test_light_command_when_public_object_vanishes(
 
         return AsyncMock(side_effect=_run)
 
-    # Each light deletes the other, so whichever entity runs first, the second
-    # one meets a missing public object regardless of scheduling order.
     first.set_light = _delete_on_command(second, first)
     second.set_light = _delete_on_command(first, second)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "light",
+            service,
+            {
+                ATTR_ENTITY_ID: ["light.test_light", "light.vanishing_light"],
+                **service_data,
+            },
+            blocking=True,
+        )
+
+    # Which of the two runs first is HA's scheduling choice, not something
+    # this test controls, so this resolves the real outcome rather than a
+    # parametrized case.
+    ran, missed = (first, second) if first.set_light.call_count else (second, first)
+    assert ran.set_light.call_count == 1
+    assert missed.set_light.call_count == 0
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "light_not_available"
+    assert err.value.translation_placeholders == {"light_name": missed.display_name}
+
+
+async def test_light_command_when_public_object_vanishes_hybrid(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """The hybrid guard names the light from the private object, not the public one.
+
+    ``self.device`` is the private object in hybrid mode, whose ``display_name``
+    fallback (``name or market_name or type``) differs from the public
+    object's (``name or type``) - pin that the error uses it correctly here
+    rather than assuming the public-only case above is equivalent.
+    """
+
+    second_light = light.model_copy()
+    second_light.id = "vanishing-light"
+    second_light.mac = "FFEEDDCCBB04"
+    second_light.name = "Vanishing Light"
+
+    setup_public_light(ufp)
+    await init_entry(hass, ufp, [light, second_light])
+    assert_entity_counts(hass, Platform.LIGHT, 2, 2)
+
+    pb = ufp.api.public_bootstrap
+    first = pb.get(ModelType.LIGHT, light.id)
+    second = pb.get(ModelType.LIGHT, second_light.id)
+    # setup_public_light()'s lookup re-creates a public mirror from the
+    # private object whenever it's missing, which would silently heal the
+    # delete below; the real bootstrap has no such fallback, so drop it here
+    # to actually exercise a gone-for-good public object.
+    pb.get = lambda model, obj_id: (
+        pb.lights.get(obj_id) if model is ModelType.LIGHT else None
+    )
+
+    def _delete_on_command(victim: Mock, result: Mock) -> AsyncMock:
+        """Delete ``victim``'s public mirror while the other light's command runs."""
+
+        async def _run(*args: Any, **kwargs: Any) -> Mock:
+            pb.lights.pop(victim.id, None)
+            msg = public_device_ws_message(victim)
+            msg.new_obj = None
+            msg.old_obj = victim
+            ufp.devices_ws_subscription(msg)
+            return result
+
+        return AsyncMock(side_effect=_run)
+
+    first.set_light = _delete_on_command(second, first)
+    second.set_light = _delete_on_command(first, second)
+
+    with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
             "light",
             "turn_off",
             {ATTR_ENTITY_ID: ["light.test_light", "light.vanishing_light"]},
             blocking=True,
         )
+
+    # Same non-parametrized-order reasoning as the public-only test above.
+    missed_private = second_light if first.set_light.call_count else light
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "light_not_available"
+    assert err.value.translation_placeholders == {
+        "light_name": missed_private.display_name
+    }
 
 
 async def test_light_turn_on_with_brightness_public_only(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ProtectLight.async_turn_on`/`async_turn_off` dereferenced the entity's cached public object without checking it could be `None`. A public devices websocket delete frame landing between HA's once-up-front availability filter and a multi-entity service call's entity coroutines can null it out, so the command path raised an untranslated `AttributeError` instead of a translated error. This is new since the light platform's public-API migration (#176570) - the equivalent path there wrote through the private object, which is never `None`.

`_public_or_raise()` now guards both commands and raises a translated `HomeAssistantError` instead. Regression tests cover the public-only and hybrid cases, parametrized over turn_on/turn_off/turn_on-with-brightness, and pin the exact translation key and placeholders rather than just any `HomeAssistantError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
