### PR TITLE
Close the connection when the sqlite database is corrupt

### DIFF
--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -284,7 +284,6 @@ def validate_sqlite_database(dbpath: str) -> bool:
     import sqlite3  # noqa: PLC0415
 
     try:
-        # closing() so a corrupt database does not leak the connection
         with contextlib.closing(sqlite3.connect(dbpath)) as conn:
             run_checks_on_open_db(dbpath, conn.cursor())
     except sqlite3.DatabaseError:

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -284,9 +284,9 @@ def validate_sqlite_database(dbpath: str) -> bool:
     import sqlite3  # noqa: PLC0415
 
     try:
-        conn = sqlite3.connect(dbpath)
-        run_checks_on_open_db(dbpath, conn.cursor())
-        conn.close()
+        # closing() so a corrupt database does not leak the connection
+        with contextlib.closing(sqlite3.connect(dbpath)) as conn:
+            run_checks_on_open_db(dbpath, conn.cursor())
     except sqlite3.DatabaseError:
         _LOGGER.exception("The database at %s is corrupt or malformed", dbpath)
         return False

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -100,6 +100,29 @@ async def test_recorder_bad_execute(hass: HomeAssistant, setup_recorder: None) -
     assert e_mock.call_count == 2
 
 
+def test_validate_sqlite_database_closes_corrupt_database(tmp_path: Path) -> None:
+    """Test a corrupt database does not leave its connection open."""
+    test_db_file = f"{tmp_path}/broken.db"
+    with open(test_db_file, "w", encoding="utf8") as fhandle:
+        fhandle.write("I am not a database")
+
+    opened: list[sqlite3.Connection] = []
+    real_connect = sqlite3.connect
+
+    def track_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        conn = real_connect(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    with patch("sqlite3.connect", side_effect=track_connect):
+        assert util.validate_sqlite_database(test_db_file) is False
+
+    assert opened
+    for conn in opened:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
 def test_validate_or_move_away_sqlite_database(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -100,29 +100,6 @@ async def test_recorder_bad_execute(hass: HomeAssistant, setup_recorder: None) -
     assert e_mock.call_count == 2
 
 
-def test_validate_sqlite_database_closes_corrupt_database(tmp_path: Path) -> None:
-    """Test a corrupt database does not leave its connection open."""
-    test_db_file = f"{tmp_path}/broken.db"
-    with open(test_db_file, "w", encoding="utf8") as fhandle:
-        fhandle.write("I am not a database")
-
-    opened: list[sqlite3.Connection] = []
-    real_connect = sqlite3.connect
-
-    def track_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
-        conn = real_connect(*args, **kwargs)
-        opened.append(conn)
-        return conn
-
-    with patch("sqlite3.connect", side_effect=track_connect):
-        assert util.validate_sqlite_database(test_db_file) is False
-
-    assert opened
-    for conn in opened:
-        with pytest.raises(sqlite3.ProgrammingError):
-            conn.execute("SELECT 1")
-
-
 def test_validate_or_move_away_sqlite_database(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION

## Breaking change




## Proposed change


`validate_sqlite_database` closed the connection only on the success path:

```python
conn = sqlite3.connect(dbpath)
run_checks_on_open_db(dbpath, conn.cursor())
conn.close()
```

`run_checks_on_open_db` raises `sqlite3.DatabaseError` for a corrupt or malformed database, which is the case this function exists to detect, so `conn.close()` never ran and every such check leaked a connection. `contextlib.closing` closes it on both paths.

The leak surfaced as `ResourceWarning: unclosed database` at whichever `gc.collect()` happened to run next, which is why CI reported it against `tests/conftest.py` in unrelated tests rather than against the recorder.

Reproduced against a file that is not a database, counting the warnings after a forced collection:

| Before | After |
| --- | --- |
| 1 | 0 |

## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_