### PR TITLE
Send the basic credentials as a header in the http auth tests

### DIFF
--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
-from aiohttp import BasicAuth, web
+from aiohttp import encode_basic_auth, web
 from aiohttp.web_exceptions import HTTPUnauthorized
 import jwt
 import pytest
@@ -164,13 +164,21 @@ async def test_basic_auth_does_not_work(
     await async_setup_auth(hass, app)
     client = await aiohttp_client(app)
 
-    req = await client.get("/", auth=BasicAuth("homeassistant", API_PASSWORD))
+    req = await client.get(
+        "/", headers={"Authorization": encode_basic_auth("homeassistant", API_PASSWORD)}
+    )
     assert req.status == HTTPStatus.UNAUTHORIZED
 
-    req = await client.get("/", auth=BasicAuth("wrong_username", API_PASSWORD))
+    req = await client.get(
+        "/",
+        headers={"Authorization": encode_basic_auth("wrong_username", API_PASSWORD)},
+    )
     assert req.status == HTTPStatus.UNAUTHORIZED
 
-    req = await client.get("/", auth=BasicAuth("homeassistant", "wrong password"))
+    req = await client.get(
+        "/",
+        headers={"Authorization": encode_basic_auth("homeassistant", "wrong password")},
+    )
     assert req.status == HTTPStatus.UNAUTHORIZED
 
     req = await client.get("/", headers={"authorization": "NotBasic abcdefg"})
@@ -285,7 +293,9 @@ async def test_auth_legacy_support_api_password_cannot_access(
     resp = await client.get("/", params={"api_password": API_PASSWORD})
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
-    req = await client.get("/", auth=BasicAuth("homeassistant", API_PASSWORD))
+    req = await client.get(
+        "/", headers={"Authorization": encode_basic_auth("homeassistant", API_PASSWORD)}
+    )
     assert req.status == HTTPStatus.UNAUTHORIZED
 
 


### PR DESCRIPTION

## Breaking change




## Proposed change


aiohttp deprecates both `BasicAuth` and the per-request `auth` argument, so each `client.get("/", auth=BasicAuth(...))` in these tests emits two warnings. The assertions only need a valid Basic header, so encode one directly.

Four call sites in `tests/components/http/test_auth.py`. No production code changes.

Warnings from this file in a full CI run ([run 354272](https://github.com/home-assistant/core/actions/runs/32696680914)):

| | Before | After |
| --- | --- | --- |
| `BasicAuth is deprecated` | 4 | 0 |
| `The 'auth' parameter is deprecated` | 4 | 0 |

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_