### PR TITLE
Ignore the TLS 1.0 deprecation the airOS helper opts into

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,6 +458,10 @@ filterwarnings = [
   # Modify app state for testing
   "ignore:Changing state of started or joined application is deprecated:DeprecationWarning:tests.components.http.test_ban",
 
+  # -- HomeAssistant - design choice
+  # airOS 6 firmware negotiates nothing newer than TLS 1.0
+  "ignore:ssl.TLSVersion.TLSv1 is deprecated:DeprecationWarning:homeassistant.components.airos.helpers",
+
   # -- DeprecationWarning already fixed in our codebase
   # https://github.com/kurtmckee/feedparser/ - 6.0.12
   "ignore:.*a temporary mapping .* from `updated_parsed` to `published_parsed` if `updated_parsed` doesn't exist:DeprecationWarning:feedparser.util",


### PR DESCRIPTION

## Breaking change




## Proposed change


`build_legacy_context` deliberately lowers `minimum_version` for airOS 6 firmware, which negotiates nothing newer than TLS 1.0:

```python
ctx.minimum_version = ssl.TLSVersion.TLSv1
```

Python 3.14 deprecates that TLS version. The warning fires on the assignment, not on the attribute access, so there is no alternative spelling — `ssl.TLSVersion(769)` warns the same way, and raising the minimum would drop support for the devices the helper exists for.

`pyproject.toml` already carries this exact ignore for `elkm1_lib.util` under "design choice 3rd party". This adds the same one for our module, in its own group since the choice is ours rather than a dependency's.

`ssl.TLSVersion.TLSv1 is deprecated` warnings in a full CI run ([run 354272](https://github.com/home-assistant/core/actions/runs/32696680914)):

| Before | After |
| --- | --- |
| 2 | 0 |

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmnu5HiXQUaHcHnNCvBSU)_