### PR TITLE
Fix lutron_caseta warm dim level not being sent to the bridge

### DIFF
--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -188,7 +188,7 @@ class LutronCasetaLight(LutronCasetaUpdatableEntity, LightEntity):
             brightness = to_lutron_level(brightness)
 
         await self._smartbridge.set_warm_dim(
-            self.device_id, brightness, **set_warm_dim_kwargs
+            self.device_id, True, value=brightness, **set_warm_dim_kwargs
         )
 
     @override

--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -204,11 +204,12 @@ class MockBridge:
     async def set_warm_dim(
         self,
         device_id: str,
+        enabled: bool,
         value: int | None = None,
         fade_time: timedelta | None = None,
     ) -> None:
         """Mock changing the warm dim state and invoke callbacks."""
-        if device_id in self.devices and value is not None:
+        if device_id in self.devices and enabled and value is not None:
             self.devices[device_id]["current_state"] = value
             self.devices[device_id]["warm_dim"] = True
         self.call_subscribers(device_id)

--- a/tests/components/lutron_caseta/test_light.py
+++ b/tests/components/lutron_caseta/test_light.py
@@ -218,6 +218,38 @@ async def test_white_mode_turn_on_remembers_brightness(
     assert state.state == STATE_ON
 
 
+async def test_white_mode_turn_on_enables_warm_dim_with_level(
+    hass: HomeAssistant,
+) -> None:
+    """Test warm dim mode is enabled and the requested level is sent.
+
+    set_warm_dim()'s signature is (device_id, enabled: bool, value=None, ...).
+    Regression test for passing the brightness positionally into `enabled`,
+    which silently dropped the requested level (only enabled/disabled based on
+    the truthiness of the int).
+    """
+    mock_entry = await async_setup_integration(hass, MockBridgeWithColorLight)
+
+    entity_id = "light.kitchen_kitchen_spectrum_light"
+    bridge = mock_entry.runtime_data.bridge
+
+    with patch.object(
+        bridge, "set_warm_dim", wraps=bridge.set_warm_dim
+    ) as mock_set_warm_dim:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_WHITE: 100},
+            target={ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert mock_set_warm_dim.call_args is not None
+    assert mock_set_warm_dim.call_args.args[1] is True
+    assert mock_set_warm_dim.call_args.kwargs["value"] is not None
+
+
 async def test_async_update_syncs_previous_brightness(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Proposed change

`pylutron_caseta`'s `SmartBridge.set_warm_dim()` signature is `(device_id, enabled: bool, value=None, fade_time=None)`, but `LutronCasetaLight._async_set_warm_dim()` called it as `set_warm_dim(self.device_id, brightness, **kwargs)` — passing the converted brightness level positionally into `enabled` instead of `value`. Python doesn't enforce the type hint, so this runs without error; it just silently drops the requested level and only toggles warm dim on/off based on the truthiness of the int. `ATTR_WHITE`'s actual brightness value is never sent to the bridge.

This passes `enabled=True` explicitly and the level via the `value` keyword, matching the real library signature.

The test mock for `set_warm_dim()` in `tests/components/lutron_caseta/__init__.py` didn't require `enabled` either (it only had `value`/`fade_time`), which is how the existing test suite missed this — the buggy call happened to line up with the mock's own (also wrong) signature. Updated the mock to match the real library, and added a regression test that asserts on the actual call args, mirroring the existing `test_color_only_turn_on_preserves_brightness` pattern for `set_value()`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #172978
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (`test_white_mode_turn_on_enables_warm_dim_with_level` in `tests/components/lutron_caseta/test_light.py`).

## Test plan

- Reproduced the bug directly: constructing the entity and calling `_async_set_warm_dim(100)` against unmodified `dev` calls `set_warm_dim('801', 39)` — the level lands in the `enabled` parameter and no `value` is ever passed. With the fix: `set_warm_dim('801', True, value=39)`.
- `pytest tests/components/lutron_caseta/test_light.py` — all 8 tests pass (including the new one). Note: every test in this file (before and after this change, confirmed against unmodified `dev`) hits an unrelated `ERROR at teardown` from the `check_translations` autouse fixture in this local environment, due to a missing compiled-translations build step unrelated to this change — the actual test bodies all report `PASSED`.
- `ruff check` / `ruff format --check` clean on all three changed files.