### PR TITLE
Bump pyIntesishome to 2.5.0

### DIFF
--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -217,6 +217,11 @@ class IntesisAC(ClimateEntity):
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
         self._controller.add_update_callback(self.async_update_callback)
 
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from event updates."""
+        self._controller.remove_update_callback(self.async_update_callback)
+
     @property
     @override
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -1,7 +1,6 @@
 """Support for IntesisHome and airconwithme Smart AC Controllers."""
 
 import logging
-from random import randrange
 from typing import Any, NamedTuple, override
 
 from pyintesishome import IHAuthenticationError, IHConnectionError, IntesisHome
@@ -33,7 +32,6 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
@@ -144,7 +142,9 @@ class IntesisAC(ClimateEntity):
     """Represents an Intesishome air conditioning device."""
 
     _attr_preset_modes = [PRESET_ECO, PRESET_COMFORT, PRESET_BOOST]
-    _attr_should_poll = False
+    # Availability depends on how long since the library's poller last got
+    # through, so it changes with the clock rather than with any event.
+    _attr_should_poll = True
     _attr_target_temperature_step = 1
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
@@ -155,7 +155,6 @@ class IntesisAC(ClimateEntity):
         self._ih_device = ih_device
         self._attr_name = ih_device.get("name")
         self._device_type = controller.device_type
-        self._connected = None
         self._attr_hvac_modes = []
         self._outdoor_temp = None
         self._hvac_mode = None
@@ -313,7 +312,6 @@ class IntesisAC(ClimateEntity):
     async def async_update(self) -> None:
         """Copy values from controller dictionary to climate device."""
         # Update values from controller's device dictionary
-        self._connected = self._controller.is_connected
         self._attr_current_temperature = self._controller.get_temperature(
             self._device_id
         )
@@ -362,28 +360,6 @@ class IntesisAC(ClimateEntity):
 
     async def async_update_callback(self, device_id=None):
         """Let HA know there has been an update from the controller."""
-        # Track changes in connection state
-        if not self._controller.is_connected and self._connected:
-            # Connection has dropped
-            self._connected = False
-            reconnect_minutes = 1 + randrange(10)
-            _LOGGER.error(
-                "Connection to %s API was lost. Reconnecting in %i minutes",
-                self._device_type,
-                reconnect_minutes,
-            )
-            # Schedule reconnection
-
-            async def try_connect(_now):
-                await self._controller.connect()
-
-            async_call_later(self.hass, reconnect_minutes * 60, try_connect)
-
-        if self._controller.is_connected and not self._connected:
-            # Connection has been restored
-            self._connected = True
-            _LOGGER.debug("Connection to %s API was restored", self._device_type)
-
         if not device_id or self._device_id == device_id:
             # Update all devices if no device_id was specified
             _LOGGER.debug(
@@ -410,8 +386,8 @@ class IntesisAC(ClimateEntity):
     @property
     @override
     def available(self) -> bool:
-        """If the device hasn't been able to connect, mark as unavailable."""
-        return self._connected or self._connected is None
+        """Return whether the controller still has a path to the device."""
+        return self._controller.is_available
 
     @property
     @override

--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -25,9 +25,10 @@ from homeassistant.const import (
     CONF_DEVICE,
     CONF_PASSWORD,
     CONF_USERNAME,
+    EVENT_HOMEASSISTANT_STOP,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -113,7 +114,7 @@ async def async_setup_platform(
         device_type=device_type,
     )
     try:
-        await controller.poll_status()
+        await controller.connect()
     except IHAuthenticationError:
         _LOGGER.error("Invalid username or password")
         return
@@ -122,6 +123,12 @@ async def async_setup_platform(
         raise PlatformNotReady from ex
 
     if ih_devices := controller.get_devices():
+        # The controller is shared by every entity, so it outlives any one of
+        # them and is only torn down with Home Assistant itself.
+        async def _async_stop_controller(event: Event) -> None:
+            await controller.stop()
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_controller)
         async_add_entities(
             [
                 IntesisAC(ih_device_id, device, controller)
@@ -209,11 +216,6 @@ class IntesisAC(ClimateEntity):
         """Subscribe to event updates."""
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
         self._controller.add_update_callback(self.async_update_callback)
-        try:
-            await self._controller.connect()
-        except IHConnectionError as ex:
-            _LOGGER.error("Exception connecting to IntesisHome: %s", ex)
-            raise PlatformNotReady from ex
 
     @property
     @override
@@ -344,11 +346,6 @@ class IntesisAC(ClimateEntity):
         self._power_consumption_cool = self._controller.get_cool_power_consumption(
             self._device_id
         )
-
-    @override
-    async def async_will_remove_from_hass(self) -> None:
-        """Shutdown the controller when the device is being removed."""
-        await self._controller.stop()
 
     @property
     @override

--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -149,9 +149,6 @@ class IntesisAC(ClimateEntity):
     """Represents an Intesishome air conditioning device."""
 
     _attr_preset_modes = [PRESET_ECO, PRESET_COMFORT, PRESET_BOOST]
-    # Availability depends on how long since the library's poller last got
-    # through, so it changes with the clock rather than with any event.
-    _attr_should_poll = True
     _attr_target_temperature_step = 1
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 

--- a/homeassistant/components/intesishome/manifest.json
+++ b/homeassistant/components/intesishome/manifest.json
@@ -3,8 +3,8 @@
   "name": "IntesisHome",
   "codeowners": ["@jnimmo"],
   "documentation": "https://www.home-assistant.io/integrations/intesishome",
-  "iot_class": "cloud_push",
+  "iot_class": "cloud_polling",
   "loggers": ["pyintesishome"],
   "quality_scale": "legacy",
-  "requirements": ["pyintesishome==2.0.3"]
+  "requirements": ["pyintesishome==2.5.0"]
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3373,7 +3373,7 @@
       "name": "IntesisHome",
       "integration_type": "hub",
       "config_flow": false,
-      "iot_class": "cloud_push"
+      "iot_class": "cloud_polling"
     },
     "iometer": {
       "name": "IOmeter",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2276,7 +2276,7 @@ pyinsteon==1.6.4
 pyintelliclima==0.4.1
 
 # homeassistant.components.intesishome
-pyintesishome==2.0.3
+pyintesishome==2.5.0
 
 # homeassistant.components.ipma
 pyipma==3.0.10

--- a/tests/components/intesishome/test_climate.py
+++ b/tests/components/intesishome/test_climate.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import PLATFORM_NOT_READY_BASE_WAIT_TIME
 from homeassistant.setup import async_setup_component
 
@@ -115,14 +116,34 @@ async def test_setup_platform_retries_on_connection_error(
     hass: HomeAssistant, mock_controller: MagicMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test an unreachable API leaves the platform to be set up again later."""
-    mock_controller.poll_status.side_effect = IHConnectionError
+    mock_controller.connect.side_effect = IHConnectionError
 
     await setup_platform(hass)
     assert hass.states.get(ENTITY_ID) is None
 
-    mock_controller.poll_status.side_effect = None
+    mock_controller.connect.side_effect = None
     freezer.tick(timedelta(seconds=PLATFORM_NOT_READY_BASE_WAIT_TIME))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert hass.states.get(ENTITY_ID) is not None
+
+
+async def test_removing_one_entity_keeps_controller_running(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the shared controller outlives the removal of a single entity."""
+    mock_controller.get_devices.return_value = {
+        "device-id": {"name": "Office"},
+        "other-device-id": {"name": "Lounge"},
+    }
+    await setup_platform(hass)
+
+    entity_registry.async_remove(ENTITY_ID)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID) is None
+    mock_controller.stop.assert_not_awaited()
+    assert hass.states.get("climate.lounge").state != STATE_UNAVAILABLE

--- a/tests/components/intesishome/test_climate.py
+++ b/tests/components/intesishome/test_climate.py
@@ -1,15 +1,32 @@
 """Tests for the IntesisHome climate platform."""
 
+from collections.abc import Generator
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
+from freezegun.api import FrozenDateTimeFactory
+from pyintesishome import IHConnectionError
+import pytest
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN, SCAN_INTERVAL
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_PLATFORM,
+    CONF_USERNAME,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import PLATFORM_NOT_READY_BASE_WAIT_TIME
 from homeassistant.setup import async_setup_component
 
+from tests.common import async_fire_time_changed
 
-async def test_setup_platform_registers_callback(hass: HomeAssistant) -> None:
-    """Test registering the synchronous library update callback during setup."""
+ENTITY_ID = "climate.office"
+
+
+@pytest.fixture
+def mock_controller() -> Generator[MagicMock]:
+    """Mock the pyintesishome controller."""
     with patch(
         "homeassistant.components.intesishome.climate.IntesisHome", autospec=True
     ) as intesis_home:
@@ -22,7 +39,7 @@ async def test_setup_platform_registers_callback(hass: HomeAssistant) -> None:
         controller.get_fan_speed_list.return_value = []
         controller.get_mode_list.return_value = []
         controller.add_update_callback = MagicMock()
-        controller.is_connected = True
+        controller.is_available = True
         controller.get_temperature.return_value = 22
         controller.get_fan_speed.return_value = None
         controller.is_on.return_value = False
@@ -38,21 +55,74 @@ async def test_setup_platform_registers_callback(hass: HomeAssistant) -> None:
         controller.get_horizontal_swing.return_value = "auto/stop"
         controller.get_heat_power_consumption.return_value = None
         controller.get_cool_power_consumption.return_value = None
+        yield controller
 
-        assert await async_setup_component(
-            hass,
-            CLIMATE_DOMAIN,
-            {
-                CLIMATE_DOMAIN: {
-                    CONF_PLATFORM: "intesishome",
-                    CONF_USERNAME: "user",
-                    CONF_PASSWORD: "password",
-                }
-            },
-        )
-        await hass.async_block_till_done()
 
-    assert hass.states.get("climate.office") is not None
-    controller.add_update_callback.assert_called_once()
-    assert callable(controller.add_update_callback.call_args.args[0])
-    controller.connect.assert_awaited_once_with()
+async def setup_platform(hass: HomeAssistant) -> None:
+    """Set up the IntesisHome climate platform."""
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: {
+                CONF_PLATFORM: "intesishome",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "password",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+async def test_setup_platform_registers_callback(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test registering the synchronous library update callback during setup."""
+    await setup_platform(hass)
+
+    assert hass.states.get(ENTITY_ID) is not None
+    mock_controller.add_update_callback.assert_called_once()
+    assert callable(mock_controller.add_update_callback.call_args.args[0])
+    mock_controller.connect.assert_awaited_once_with()
+
+
+async def test_availability_follows_controller(
+    hass: HomeAssistant, mock_controller: MagicMock, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test polling picks up availability changes with no library callback."""
+    await setup_platform(hass)
+    assert hass.states.get(ENTITY_ID).state != STATE_UNAVAILABLE
+
+    # Availability follows how long since the controller's poller last got
+    # through, so nothing calls back to announce either transition.
+    mock_controller.is_available = False
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
+
+    mock_controller.is_available = True
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID).state != STATE_UNAVAILABLE
+
+    # Recovered without reconnecting: connect() was only called during setup.
+    assert mock_controller.connect.await_count == 1
+
+
+async def test_setup_platform_retries_on_connection_error(
+    hass: HomeAssistant, mock_controller: MagicMock, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test an unreachable API leaves the platform to be set up again later."""
+    mock_controller.poll_status.side_effect = IHConnectionError
+
+    await setup_platform(hass)
+    assert hass.states.get(ENTITY_ID) is None
+
+    mock_controller.poll_status.side_effect = None
+    freezer.tick(timedelta(seconds=PLATFORM_NOT_READY_BASE_WAIT_TIME))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID) is not None

--- a/tests/components/intesishome/test_climate.py
+++ b/tests/components/intesishome/test_climate.py
@@ -40,6 +40,7 @@ def mock_controller() -> Generator[MagicMock]:
         controller.get_fan_speed_list.return_value = []
         controller.get_mode_list.return_value = []
         controller.add_update_callback = MagicMock()
+        controller.remove_update_callback = MagicMock()
         controller.is_available = True
         controller.get_temperature.return_value = 22
         controller.get_fan_speed.return_value = None
@@ -141,9 +142,21 @@ async def test_removing_one_entity_keeps_controller_running(
     }
     await setup_platform(hass)
 
+    registered_callbacks = [
+        call.args[0] for call in mock_controller.add_update_callback.call_args_list
+    ]
+    assert len(registered_callbacks) == 2
+
     entity_registry.async_remove(ENTITY_ID)
     await hass.async_block_till_done()
 
     assert hass.states.get(ENTITY_ID) is None
     mock_controller.stop.assert_not_awaited()
     assert hass.states.get("climate.lounge").state != STATE_UNAVAILABLE
+
+    # Only the removed entity detaches; the other keeps receiving updates.
+    removed_callbacks = [
+        call.args[0] for call in mock_controller.remove_update_callback.call_args_list
+    ]
+    assert len(removed_callbacks) == 1
+    assert removed_callbacks[0] in registered_callbacks


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps `pyintesishome` from 2.0.3 to 2.5.0, and adapts the `intesishome` climate platform to the transport change that comes with it. This is to improve connection reliability after HMS Networks have started limiting connections to the mobile API which was being used previously.

From 2.4.0 the library uses the socket opportunistically: connect() authenticates and starts an HTTP poller rather than dialling out, commands open a socket when they need one and fall back to the web portal if they can't, and state comes from pushes while a socket is up and from polling otherwise.

is_connected still means the raw socket state, so it is now False whenever nothing has needed a socket — no longer something an entity can gate availability on. is_available was added for that: true while either the socket is up or a poll got through recently enough that cached state is still trustworthy.

The entity now uses `is_available` and polls again — its `should_poll = False` override is gone, and `Entity.should_poll` already defaults to `True` — because availability is derived from how long it has been since the last successful poll and no callback announces that transition. `async_update` is a pure copy out of the controller's cached dicts, so polling costs no I/O. `iot_class` moves to `cloud_polling`, and the entity's old reconnect/connection-tracking block is gone — the library's poller retries on its own.

The controller's lifecycle is now scoped to the platform rather than to an entity. It is shared by every `IntesisAC`, so the old code was connecting once per entity and calling `stop()` whenever any single entity was removed, which left the remaining entities with a dead poller. `connect()` now runs once in `async_setup_platform` and `stop()` runs on `EVENT_HOMEASSISTANT_STOP`; each entity only attaches its own update callback on add and detaches it on removal.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Dependency diff and release notes:

- PyPI: https://pypi.org/project/pyintesishome/2.5.0/
- Full diff: https://github.com/jnimmo/pyIntesisHome/compare/v2.0.3...v2.5.0
- Releases: https://github.com/jnimmo/pyIntesisHome/releases

Tests added alongside the change:

- `test_setup_platform_registers_callback` checks that setup subscribes to the library's update callback.
- `test_availability_follows_controller` validates that the integration correctly tracks the availability status of the library.
- `test_setup_platform_retries_on_connection_error` checks that an unreachable API leaves the platform to retry setup again later.
- `test_removing_one_entity_keeps_controller_running` checks that removing a single entity detaches only that entity's callback and leaves the shared controller running for the rest.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

