### PR TITLE
Fix Tibber coordinator unhandled exception

### DIFF
--- a/homeassistant/components/tibber/coordinator.py
+++ b/homeassistant/components/tibber/coordinator.py
@@ -477,5 +477,7 @@ class TibberDataAPICoordinator(TibberCoordinator[dict[str, TibberDevice]]):
                 f"Rate limit exceeded, retry after {err.retry_after} seconds",
                 retry_after=err.retry_after,
             ) from err
+        except tibber.exceptions.HttpExceptionError as err:
+            raise UpdateFailed(f"Error communicating with API ({err})") from err
         self._build_sensor_lookup(devices)
         return devices

--- a/tests/components/tibber/test_coordinator.py
+++ b/tests/components/tibber/test_coordinator.py
@@ -1,7 +1,7 @@
 """Tests for the Tibber coordinators."""
 
 from datetime import date, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .conftest import create_tibber_home
+from .conftest import create_tibber_device, create_tibber_home
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -39,6 +39,28 @@ async def _async_setup_price_sensor(
     await hass.async_block_till_done()
 
     entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, home.home_id)
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+    return entity_id
+
+
+async def _async_setup_data_api_sensor(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    data_api_client_mock: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> str:
+    """Set up the Tibber config entry and return a Data API sensor entity id."""
+    device = create_tibber_device(state_of_charge=72.0)
+    data_api_client_mock.get_all_devices = AsyncMock(return_value={"device-id": device})
+    data_api_client_mock.update_devices = AsyncMock(return_value={"device-id": device})
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "external-id_storage.stateOfCharge"
+    )
     assert entity_id is not None
     assert hass.states.get(entity_id) is not None
     return entity_id
@@ -206,6 +228,59 @@ async def test_price_fetch_refresh_handles_update_exceptions(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_message"),
+    [
+        pytest.param(
+            tibber.RetryableHttpExceptionError(500, "Internal Server Error"),
+            "Error communicating with API (Internal Server Error)",
+            id="retryable_http_error",
+        ),
+        pytest.param(
+            tibber.exceptions.HttpExceptionError(503, "Service unavailable"),
+            "Error communicating with API (Service unavailable)",
+            id="http_error",
+        ),
+        pytest.param(
+            tibber.exceptions.RateLimitExceededError(
+                429, "Too many requests", "RATE_LIMIT", 123
+            ),
+            "Rate limit exceeded, retry after 123 seconds",
+            id="rate_limit",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("recorder_mock", "setup_credentials")
+async def test_data_api_refresh_handles_update_exceptions(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    data_api_client_mock: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    exception: Exception,
+    expected_message: str,
+) -> None:
+    """Test handled exceptions during Data API coordinator refresh."""
+    entity_id = await _async_setup_data_api_sensor(
+        hass, config_entry, data_api_client_mock, entity_registry
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    data_api_client_mock.update_devices.side_effect = exception
+
+    await _async_fire_coordinator_update(hass, freezer, timedelta(minutes=1))
+
+    assert f"Error fetching {DOMAIN} Data API data: {expected_message}" in caplog.text
+    assert "Unexpected error fetching" not in caplog.text
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_price_sensor_unavailable_when_cached_prices_run_out(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle a known exception in the Tibber data API coordinator refresh.

```
Unexpected error fetching tibber Data API data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 433, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tibber/coordinator.py", line 410, in _async_update_data
    devices: dict[str, TibberDevice] = await client.data_api.update_devices()
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/tibber/data_api.py", line 296, in update_devices
    raise result
  File "/usr/local/lib/python3.14/site-packages/tibber/data_api.py", line 263, in get_device
    response = await self._make_request("GET", f"/v1/homes/{home_id}/devices/{device_id}")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/tibber/data_api.py", line 136, in _make_request
    await self._handle_error_response(response)
  File "/usr/local/lib/python3.14/site-packages/tibber/data_api.py", line 216, in _handle_error_response
    raise RetryableHttpExceptionError(status, detail, extension_code)
tibber.exceptions.RetryableHttpExceptionError: Internal Server Error
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
