### PR TITLE
Bump pynintendoparental to 2.6.2

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/manifest.json
+++ b/homeassistant/components/nintendo_parental_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynintendoauth", "pynintendoparental"],
   "quality_scale": "bronze",
-  "requirements": ["pynintendoauth==1.0.3", "pynintendoparental==2.5.0"]
+  "requirements": ["pynintendoauth==1.0.3", "pynintendoparental==2.6.1"]
 }

--- a/homeassistant/components/nintendo_parental_controls/manifest.json
+++ b/homeassistant/components/nintendo_parental_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynintendoauth", "pynintendoparental"],
   "quality_scale": "bronze",
-  "requirements": ["pynintendoauth==1.0.3", "pynintendoparental==2.6.1"]
+  "requirements": ["pynintendoauth==1.0.3", "pynintendoparental==2.6.2"]
 }

--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -108,9 +108,9 @@ async def async_setup_entry(
     for device in entry.runtime_data.api.devices.values():
         entities.extend(
             NintendoParentalControlsPlayerSensorEntity(
-                entry.runtime_data, device, player_id, sensor
+                entry.runtime_data, device, player, sensor
             )
-            for player_id in device.players
+            for player in device.players
             for sensor in PLAYER_SENSOR_DESCRIPTIONS
         )
     async_add_entities(entities)
@@ -153,17 +153,18 @@ class NintendoParentalControlsPlayerSensorEntity(NintendoDevice, SensorEntity):
         self,
         coordinator: NintendoUpdateCoordinator,
         device: Device,
-        player_id: str,
+        player: Player,
         description: NintendoParentalControlsPlayerSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator, device=device, key=description.key)
         self.entity_description = description
-        self.player_id = player_id
-        player_obj = device.get_player(player_id)
-        nickname = player_obj.nickname or ""
+        self.player_id = player.player_id
+        nickname = player.nickname or ""
         self._attr_translation_placeholders = {"nickname": nickname}
-        self._attr_unique_id = f"{device.device_id}_{player_id}_{description.key}"
+        self._attr_unique_id = (
+            f"{device.device_id}_{player.player_id}_{description.key}"
+        )
 
     @property
     @override

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2414,7 +2414,7 @@ pynina==1.0.2
 pynintendoauth==1.0.3
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==2.6.1
+pynintendoparental==2.6.2
 
 # homeassistant.components.nobo_hub
 pynobo==1.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2414,7 +2414,7 @@ pynina==1.0.2
 pynintendoauth==1.0.3
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==2.5.0
+pynintendoparental==2.6.1
 
 # homeassistant.components.nobo_hub
 pynobo==1.9.0

--- a/tests/components/nintendo_parental_controls/conftest.py
+++ b/tests/components/nintendo_parental_controls/conftest.py
@@ -88,7 +88,6 @@ def mock_nintendo_device(
     mock.applications = applications
     mock.players = players
     mock.get_player = MagicMock(side_effect=players.get_player)
-    mock.get_player.return_value = mock_nintendo_player
     return mock
 
 

--- a/tests/components/nintendo_parental_controls/conftest.py
+++ b/tests/components/nintendo_parental_controls/conftest.py
@@ -5,9 +5,14 @@ from datetime import datetime, time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pynintendoparental import NintendoParental
+from pynintendoparental.application import (
+    Application,
+    ApplicationRegistry,
+    PlayedAppUsage,
+)
 from pynintendoparental.device import Device
 from pynintendoparental.enum import DeviceTimerMode
-from pynintendoparental.player import Player
+from pynintendoparental.player import Player, PlayerRegistry
 import pytest
 
 from homeassistant.components.nintendo_parental_controls.const import DOMAIN
@@ -28,30 +33,36 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_nintendo_player() -> Player:
+def mock_nintendo_app() -> Application:
+    """Return a mocked Nintendo application."""
+    mock_app = MagicMock(spec=Application)
+    mock_app.application_id = "testappid"
+    mock_app.name = "Test Game Name"
+    return mock_app
+
+
+@pytest.fixture
+def mock_nintendo_player(mock_nintendo_app: Application) -> Player:
     """Return a mocked player."""
     # This class has no async methods
     mock = MagicMock(spec=Player)
     mock.player_id = "testplayerid"
     mock.nickname = "HA Gamer"
-    mock.apps = [
-        {
-            "playingTime": 15,
-            "meta": {
-                "title": "Test Game Name",
-                "imageUri": {"medium": "http://localhost/medium.png"},
-                "shopUri": "http://localhost/shop-test-game-name",
-            },
-        }
-    ]
+    mock.apps = [PlayedAppUsage(application=mock_nintendo_app, playing_time=110)]
     mock.playing_time = 110
     mock.player_image = "http://localhost/image.png"
     return mock
 
 
 @pytest.fixture
-def mock_nintendo_device(mock_nintendo_player: Player) -> Device:
+def mock_nintendo_device(
+    mock_nintendo_app: Application, mock_nintendo_player: Player
+) -> Device:
     """Return a mocked device."""
+    applications = ApplicationRegistry()
+    players = PlayerRegistry()
+    applications.add_application(mock_nintendo_app)
+    players.add_player(mock_nintendo_player)
     mock = AsyncMock(spec=Device)
     mock.device_id = "testdevid"
     mock.name = "Home Assistant Test"
@@ -74,8 +85,9 @@ def mock_nintendo_device(mock_nintendo_player: Player) -> Device:
     mock.forced_termination_mode = True
     mock.model = "Test Model"
     mock.generation = "P00"
-    mock.players = {mock_nintendo_player.player_id: mock_nintendo_player}
-    mock.get_player = MagicMock()
+    mock.applications = applications
+    mock.players = players
+    mock.get_player = MagicMock(side_effect=players.get_player)
     mock.get_player.return_value = mock_nintendo_player
     return mock
 

--- a/tests/components/nintendo_parental_controls/test_sensor.py
+++ b/tests/components/nintendo_parental_controls/test_sensor.py
@@ -50,7 +50,7 @@ async def test_player_sensor_none_handling(
     assert state.state == "110"
     assert state.attributes["entity_picture"] == "http://localhost/image.png"
 
-    mock_nintendo_client.devices["testdevid"].players = {}
+    mock_nintendo_client.devices["testdevid"].players.remove_player("testplayerid")
     freezer.tick(60)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pynintendoparental to unblock #173160 and fix #179748

Some Python API structure changes have been made which I've accounted for as part of the bump (specifically around how `Device.players` returns data). For the most part old raw API responses have been replaced with proper classes and therefore application / player registries are used instead of plain dicts to help keep tidy up management.

Release: https://github.com/pantherale0/pynintendoparental/releases/tag/2.6.2
Diff: https://github.com/pantherale0/pynintendoparental/compare/2.5.0...2.6.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179748
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
