### PR TITLE
Fix Z-Wave value updated trigger KeyError

### DIFF
--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -115,19 +115,23 @@ async def async_attach_trigger(
 
     @callback
     def async_on_value_updated(
-        value: Value, device: dr.DeviceEntry, event: dict
+        value_id: str, device: dr.DeviceEntry, event: dict
     ) -> None:
         """Handle value update."""
         event_value: Value = event["value"]
-        if event_value != value:
+        if event_value.value_id != value_id:
             return
 
         # Get previous value and its state value if it exists
         prev_value_raw = event["args"]["prevValue"]
-        prev_value = value.metadata.states.get(str(prev_value_raw), prev_value_raw)
+        prev_value = event_value.metadata.states.get(
+            str(prev_value_raw), prev_value_raw
+        )
         # Get current value and its state value if it exists
         curr_value_raw = event["args"]["newValue"]
-        curr_value = value.metadata.states.get(str(curr_value_raw), curr_value_raw)
+        curr_value = event_value.metadata.states.get(
+            str(curr_value_raw), curr_value_raw
+        )
         # Check from and to values against previous and current values respectively
         for value_to_eval, raw_value_to_eval, match in (
             (prev_value, prev_value_raw, from_value),
@@ -140,17 +144,17 @@ async def async_attach_trigger(
                 return
 
         device_name = device.name_by_user or device.name
-        description = f"Z-Wave value {value.value_id} updated on {device_name}"
+        description = f"Z-Wave value {event_value.value_id} updated on {device_name}"
         payload = {
             ATTR_DEVICE_ID: device.id,
-            ATTR_NODE_ID: value.node.node_id,
-            ATTR_COMMAND_CLASS: value.command_class,
-            ATTR_COMMAND_CLASS_NAME: value.command_class_name,
-            ATTR_PROPERTY: value.property_,
-            ATTR_PROPERTY_NAME: value.property_name,
+            ATTR_NODE_ID: event_value.node.node_id,
+            ATTR_COMMAND_CLASS: event_value.command_class,
+            ATTR_COMMAND_CLASS_NAME: event_value.command_class_name,
+            ATTR_PROPERTY: event_value.property_,
+            ATTR_PROPERTY_NAME: event_value.property_name,
             ATTR_ENDPOINT: endpoint,
-            ATTR_PROPERTY_KEY: value.property_key,
-            ATTR_PROPERTY_KEY_NAME: value.property_key_name,
+            ATTR_PROPERTY_KEY: event_value.property_key,
+            ATTR_PROPERTY_KEY_NAME: event_value.property_key_name,
             ATTR_PREVIOUS_VALUE: prev_value,
             ATTR_PREVIOUS_VALUE_RAW: prev_value_raw,
             ATTR_CURRENT_VALUE: curr_value,
@@ -185,12 +189,10 @@ async def async_attach_trigger(
             value_id = get_value_id_str(
                 node, command_class, property_, endpoint, property_key
             )
-            value = node.values[value_id]
-            # We need to store the current value and device for the callback
             unsubs.append(
                 node.on(
                     EVENT_VALUE_UPDATED,
-                    functools.partial(async_on_value_updated, value, device),
+                    functools.partial(async_on_value_updated, value_id, device),
                 )
             )
 

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -1,5 +1,6 @@
 """The tests for Z-Wave JS automation triggers."""
 
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -1320,6 +1321,105 @@ async def test_server_reconnect_value_updated(
 
     # Make sure the old listener is no longer referenced
     assert old_listener not in new_node._listeners.get(event_name, [])
+
+
+async def test_server_reconnect_value_updated_missing_value(
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    lock_schlage_be469_state,
+    integration,
+) -> None:
+    """Test value_updated trigger re-registers when value is absent at reconnect."""
+    trigger_type = f"{DOMAIN}.value_updated"
+
+    no_value_filter = async_capture_events(hass, "no_value_filter")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": trigger_type,
+                        "options": {
+                            "entity_id": SCHLAGE_BE469_LOCK_ENTITY,
+                            "command_class": CommandClass.DOOR_LOCK.value,
+                            "property": "latchStatus",
+                        },
+                    },
+                    "action": {
+                        "event": "no_value_filter",
+                    },
+                },
+            ]
+        },
+    )
+
+    # Remove the node so we can re-add it without the target value, simulating the
+    # reconnect race where node.values is not yet fully populated when
+    # _create_zwave_listeners runs.
+    node_removed_event = Event(
+        type="node removed",
+        data={
+            "source": "controller",
+            "event": "node removed",
+            "reason": 0,
+            "node": lock_schlage_be469_state,
+        },
+    )
+    client.driver.controller.receive_event(node_removed_event)
+    assert 20 not in client.driver.controller.nodes
+    await hass.async_block_till_done()
+
+    partial_state = copy.deepcopy(lock_schlage_be469_state)
+    partial_state["values"] = [
+        v for v in partial_state["values"] if v.get("propertyName") != "latchStatus"
+    ]
+    node_added_event = Event(
+        type="node added",
+        data={
+            "source": "controller",
+            "event": "node added",
+            "node": partial_state,
+            "result": {},
+        },
+    )
+    client.driver.controller.receive_event(node_added_event)
+    await hass.async_block_till_done()
+
+    # Reload the integration, which fires the connected_to_server signal that causes
+    # _create_zwave_listeners to re-register listeners on the new node. With the old
+    # code the missing latchStatus value would raise a KeyError and leave the trigger
+    # without a listener.
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    # Fire a value updated event on the new node — the trigger must fire even though
+    # the value was absent when _create_zwave_listeners ran.
+    new_node = client.driver.controller.nodes[20]
+    value_updated_event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": new_node.node_id,
+            "args": {
+                "commandClassName": "Door Lock",
+                "commandClass": CommandClass.DOOR_LOCK.value,
+                "endpoint": 0,
+                "property": "latchStatus",
+                "newValue": "boo",
+                "prevValue": "hiss",
+                "propertyName": "latchStatus",
+            },
+        },
+    )
+    new_node.receive_event(value_updated_event)
+    await hass.async_block_till_done()
+
+    assert len(no_value_filter) == 1
 
 
 async def test_zwave_js_old_syntax(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle a missing value for a Z-Wave trigger during reconnect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179968
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
