### PR TITLE
Add Fronius Modbus TCP (SunSpec) support

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -4,13 +4,22 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 from typing import Final
+from urllib.parse import urlsplit
 
+from fronius_modbus import (
+    GEN24_UNIT_ID,
+    FroniusModbusInverter,
+    SunSpecError,
+    datamanager_unit_id,
+)
+from modbus_connection import ModbusError, ModbusTcpParams
 from pyfronius import Fronius, FroniusError
 
+from homeassistant.components.modbus import async_get_unit
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_MODEL, ATTR_SW_VERSION, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -18,17 +27,21 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
+    CONF_MODBUS_PORT,
+    DEFAULT_MODBUS_PORT,
     DOMAIN,
     SOLAR_NET_DISCOVERY_NEW,
     SOLAR_NET_ID_SYSTEM,
     SOLAR_NET_RESCAN_TIMER,
     FroniusDeviceInfo,
+    SolarNetId,
 )
 from .coordinator import (
     FroniusCoordinatorBase,
     FroniusInverterUpdateCoordinator,
     FroniusLoggerUpdateCoordinator,
     FroniusMeterUpdateCoordinator,
+    FroniusModbusInverterUpdateCoordinator,
     FroniusOhmpilotUpdateCoordinator,
     FroniusPowerFlowUpdateCoordinator,
     FroniusStorageUpdateCoordinator,
@@ -57,6 +70,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: FroniusConfigEntry) -> b
 
     entry.runtime_data = solar_net
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: FroniusConfigEntry) -> bool:
+    """Migrate old config entries."""
+    if entry.minor_version < 2:
+        # add the Modbus port setting
+        data = {CONF_MODBUS_PORT: DEFAULT_MODBUS_PORT, **entry.data}
+        hass.config_entries.async_update_entry(entry, data=data, minor_version=2)
     return True
 
 
@@ -98,6 +120,12 @@ class FroniusSolarNet:
         self.ohmpilot_coordinator: FroniusOhmpilotUpdateCoordinator | None = None
         self.power_flow_coordinator: FroniusPowerFlowUpdateCoordinator | None = None
         self.storage_coordinator: FroniusStorageUpdateCoordinator | None = None
+
+        self.modbus_inverter_coordinators: list[
+            FroniusModbusInverterUpdateCoordinator
+        ] = []
+        # one hold on the shared connection per inverter, kept across re-scans
+        self.modbus_inverters: dict[SolarNetId, FroniusModbusInverter] = {}
 
     async def init_devices(self) -> None:
         """Initialize DataUpdateCoordinators for SolarNet devices."""
@@ -230,6 +258,11 @@ class FroniusSolarNet:
                 _inverter_info.unique_id,
             )
 
+        # an inverter that was asleep answers nothing, so retry the ones
+        # still without Modbus data on every re-scan
+        for inverter_coordinator in self.inverter_coordinators:
+            await self._init_modbus_inverter(inverter_coordinator.inverter_info)
+
     async def _get_inverter_infos(self) -> list[FroniusDeviceInfo]:
         """Get information about the inverters in the SolarNet system."""
         inverter_infos: list[FroniusDeviceInfo] = []
@@ -281,6 +314,94 @@ class FroniusSolarNet:
                 unique_id,
             )
         return inverter_infos
+
+    def _modbus_params(self) -> ModbusTcpParams | None:
+        """Return the Modbus link settings, or None for an unusable host."""
+        # the configured host may be a bare host name or a full URL
+        url = self.host if "://" in self.host else f"//{self.host}"
+        if (modbus_host := urlsplit(url).hostname) is None:
+            return None
+        return ModbusTcpParams(
+            host=modbus_host, port=self.config_entry.data[CONF_MODBUS_PORT]
+        )
+
+    async def _init_modbus_inverter(self, inverter_info: FroniusDeviceInfo) -> None:
+        """Set up a Modbus coordinator for an inverter exposing SunSpec MPPT data."""
+        if inverter_info.solar_net_id in [
+            coordinator.inverter_info.solar_net_id
+            for coordinator in self.modbus_inverter_coordinators
+        ]:
+            return
+        if (unit_id := self._modbus_unit_id(inverter_info.solar_net_id)) is None:
+            return
+        if (
+            modbus_inverter := self.modbus_inverters.get(inverter_info.solar_net_id)
+        ) is None:
+            if (params := self._modbus_params()) is None:
+                return
+            try:
+                unit = async_get_unit(self.hass, self.config_entry, params, unit_id)
+            except HomeAssistantError as err:
+                # another integration holds the device on different link settings
+                _LOGGER.debug("No Modbus unit for inverter %s: %s", unit_id, err)
+                return
+            modbus_inverter = FroniusModbusInverter(unit)
+            self.modbus_inverters[inverter_info.solar_net_id] = modbus_inverter
+
+        try:
+            await modbus_inverter.discover()
+        except (ModbusError, SunSpecError) as err:
+            _LOGGER.debug(
+                "No SunSpec data for inverter %s at Modbus unit %s: %s",
+                inverter_info.solar_net_id,
+                unit_id,
+                err,
+            )
+            return
+        if modbus_inverter.mppt is None:
+            _LOGGER.debug(
+                "No MPPT model exposed by inverter %s at Modbus unit %s",
+                inverter_info.solar_net_id,
+                unit_id,
+            )
+            return
+
+        coordinator = FroniusModbusInverterUpdateCoordinator(
+            hass=self.hass,
+            solar_net=self,
+            logger=_LOGGER,
+            name=f"{DOMAIN}_modbus_inverter_{inverter_info.solar_net_id}_{self.host}",
+            inverter_info=inverter_info,
+            modbus_inverter=modbus_inverter,
+            config_entry=self.config_entry,
+        )
+        if self.config_entry.state is ConfigEntryState.LOADED:
+            await coordinator.async_refresh()
+        else:
+            try:
+                await coordinator.async_config_entry_first_refresh()
+            except ConfigEntryNotReady:
+                # never fail the whole entry for optional Modbus data
+                return
+        self.modbus_inverter_coordinators.append(coordinator)
+
+        # Only for re-scans. Initial setup adds entities
+        # through sensor.async_setup_entry
+        if self.config_entry.state is ConfigEntryState.LOADED:
+            async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, coordinator)
+
+        _LOGGER.debug(
+            "Modbus enabled for inverter %s (UID: %s, unit ID: %s)",
+            inverter_info.solar_net_id,
+            inverter_info.unique_id,
+            unit_id,
+        )
+
+    def _modbus_unit_id(self, solar_net_id: str) -> int | None:
+        """Return the Modbus unit ID for an inverter."""
+        if not self.config_entry.data["is_logger"]:
+            return GEN24_UNIT_ID
+        return datamanager_unit_id(solar_net_id)
 
     @staticmethod
     async def _init_optional_coordinator[_FroniusCoordinatorT: FroniusCoordinatorBase](

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -14,11 +14,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DOMAIN, FroniusConfigEntryData
+from .const import CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT, DOMAIN, FroniusConfigEntryData
 
 _LOGGER: Final = logging.getLogger(__name__)
 
 DHCP_REQUEST_DELAY: Final = 60
+
+MODBUS_PORT_SELECTOR: Final = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
 
 
 def create_title(info: FroniusConfigEntryData) -> str:
@@ -30,7 +32,7 @@ def create_title(info: FroniusConfigEntryData) -> str:
 
 
 async def validate_host(
-    hass: HomeAssistant, host: str
+    hass: HomeAssistant, host: str, modbus_port: int = DEFAULT_MODBUS_PORT
 ) -> tuple[str, FroniusConfigEntryData]:
     """Validate the user input allows us to connect."""
     fronius = Fronius(async_get_clientsession(hass, verify_ssl=False), host)
@@ -45,6 +47,7 @@ async def validate_host(
         return logger_uid, FroniusConfigEntryData(
             host=host,
             is_logger=True,
+            modbus_port=modbus_port,
         )
     # Gen24 devices don't provide GetLoggerInfo
     try:
@@ -57,6 +60,7 @@ async def validate_host(
     return first_inverter_uid, FroniusConfigEntryData(
         host=host,
         is_logger=False,
+        modbus_port=modbus_port,
     )
 
 
@@ -64,6 +68,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Fronius."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize flow."""
@@ -78,7 +83,11 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                unique_id, info = await validate_host(self.hass, user_input[CONF_HOST])
+                unique_id, info = await validate_host(
+                    self.hass,
+                    user_input[CONF_HOST],
+                    modbus_port=user_input[CONF_MODBUS_PORT],
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -92,7 +101,14 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST): str,
+                    vol.Required(
+                        CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT
+                    ): MODBUS_PORT_SELECTOR,
+                }
+            ),
             errors=errors,
         )
 
@@ -146,7 +162,11 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                unique_id, info = await validate_host(self.hass, user_input[CONF_HOST])
+                unique_id, info = await validate_host(
+                    self.hass,
+                    user_input[CONF_HOST],
+                    modbus_port=user_input[CONF_MODBUS_PORT],
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -159,9 +179,17 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_reload_and_abort(reconfigure_entry, data=info)
 
         host = reconfigure_entry.data[CONF_HOST]
+        modbus_port = reconfigure_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=host): str,
+                    vol.Required(
+                        CONF_MODBUS_PORT, default=modbus_port
+                    ): MODBUS_PORT_SELECTOR,
+                }
+            ),
             description_placeholders={"device": reconfigure_entry.title},
             errors=errors,
         )

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -8,6 +8,9 @@ from homeassistant.helpers.typing import StateType
 
 DOMAIN: Final = "fronius"
 
+CONF_MODBUS_PORT: Final = "modbus_port"
+DEFAULT_MODBUS_PORT: Final = 502
+
 type SolarNetId = str
 SOLAR_NET_DISCOVERY_NEW: Final = "fronius_discovery_new"
 SOLAR_NET_ID_POWER_FLOW: SolarNetId = "power_flow"
@@ -20,6 +23,7 @@ class FroniusConfigEntryData(TypedDict):
 
     host: str
     is_logger: bool
+    modbus_port: int
 
 
 class FroniusDeviceInfo(NamedTuple):

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -219,20 +219,22 @@ class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from the Modbus interface."""
         mppt = await self._update_mppt()
-        data: dict[str, Any] = {}
-        for index, module in enumerate(mppt.modules, start=1):
-            data[f"mppt_{index}_current_dc"] = {"value": module.current}
-            data[f"mppt_{index}_voltage_dc"] = {"value": module.voltage}
-            data[f"mppt_{index}_power_dc"] = {"value": module.power}
-            data[f"mppt_{index}_energy_dc"] = {"value": module.energy}
-        data["energy_total_pv"] = {"value": mppt.pv_energy_total}
-        data["storage_energy_charged_total"] = {
-            "value": mppt.storage_charge_energy_total
+        values: dict[str, float | None] = {
+            "energy_total_pv": mppt.pv_energy_total,
+            "storage_energy_charged_total": mppt.storage_charge_energy_total,
+            "storage_energy_discharged_total": mppt.storage_discharge_energy_total,
         }
-        data["storage_energy_discharged_total"] = {
-            "value": mppt.storage_discharge_energy_total
+        for number, module in enumerate(mppt.modules, start=1):
+            values[f"mppt_{number}_current_dc"] = module.current
+            values[f"mppt_{number}_voltage_dc"] = module.voltage
+            values[f"mppt_{number}_power_dc"] = module.power
+            values[f"mppt_{number}_energy_dc"] = module.energy
+        # entities read the SolarAPI's {"value": ...} shape, so match it here
+        return {
+            self.inverter_info.solar_net_id: {
+                key: {"value": value} for key, value in values.items()
+            }
         }
-        return {self.inverter_info.solar_net_id: data}
 
     async def _update_mppt(self) -> Mppt:
         """Refresh the MPPT model, re-discovering once on a register map shift."""

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -5,6 +5,13 @@ from collections.abc import Mapping, Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, override
 
+from fronius_modbus import (
+    FroniusModbusInverter,
+    Mppt,
+    SunSpecError,
+    SunSpecMapShiftError,
+)
+from modbus_connection import ModbusError
 from pyfronius import BadStatusError, FroniusError
 
 from homeassistant.const import Platform
@@ -25,6 +32,7 @@ from .sensor import (
     INVERTER_ENTITY_DESCRIPTIONS,
     LOGGER_ENTITY_DESCRIPTIONS,
     METER_ENTITY_DESCRIPTIONS,
+    MODBUS_INVERTER_ENTITY_DESCRIPTIONS,
     OHMPILOT_ENTITY_DESCRIPTIONS,
     POWER_FLOW_ENTITY_DESCRIPTIONS,
     STORAGE_ENTITY_DESCRIPTIONS,
@@ -43,6 +51,7 @@ class FroniusCoordinatorBase(
     default_interval: timedelta
     error_interval: timedelta
     valid_descriptions: Mapping[Platform, Sequence[FroniusEntityDescription]]
+    update_exceptions: tuple[type[Exception], ...] = (FroniusError,)
 
     MAX_FAILED_UPDATES = 3
 
@@ -64,30 +73,34 @@ class FroniusCoordinatorBase(
     async def _async_update_data(self) -> dict[SolarNetId, Any]:
         """Fetch the latest data from the source."""
         async with self.solar_net.coordinator_lock:
-            try:
-                data = await self._update_method()
-            except FroniusError as err:
-                self._failed_update_count += 1
-                if self._failed_update_count == self.MAX_FAILED_UPDATES:
-                    self.update_interval = self.error_interval
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="update_failed",
-                    translation_placeholders={"fronius_error": str(err)},
-                ) from err
+            return await self._do_update()
 
-            if self._failed_update_count != 0:
-                self._failed_update_count = 0
-                self.update_interval = self.default_interval
+    async def _do_update(self) -> dict[SolarNetId, Any]:
+        """Fetch the latest data and keep track of seen conditions."""
+        try:
+            data = await self._update_method()
+        except self.update_exceptions as err:
+            self._failed_update_count += 1
+            if self._failed_update_count == self.MAX_FAILED_UPDATES:
+                self.update_interval = self.error_interval
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"fronius_error": str(err)},
+            ) from err
 
-            for solar_net_id in data:
-                if solar_net_id not in self.unregistered_descriptors:
-                    # id seen for the first time
-                    self.unregistered_descriptors[solar_net_id] = {
-                        platform: list(descriptions)
-                        for platform, descriptions in self.valid_descriptions.items()
-                    }
-            return data
+        if self._failed_update_count != 0:
+            self._failed_update_count = 0
+            self.update_interval = self.default_interval
+
+        for solar_net_id in data:
+            if solar_net_id not in self.unregistered_descriptors:
+                # id seen for the first time
+                self.unregistered_descriptors[solar_net_id] = {
+                    platform: list(descriptions)
+                    for platform, descriptions in self.valid_descriptions.items()
+                }
+        return data
 
     @callback
     def add_entities_for_seen_keys[_FroniusEntityT: FroniusEntity](
@@ -170,6 +183,71 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
         # wrap a single devices data in a dict with solar_net_id key for
         # FroniusCoordinatorBase _async_update_data and add_entities_for_seen_keys
         return {self.inverter_info.solar_net_id: data}
+
+
+class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
+    """Query SunSpec data from an inverters Modbus interface."""
+
+    default_interval = timedelta(minutes=1)
+    error_interval = timedelta(minutes=10)
+    valid_descriptions = {Platform.SENSOR: MODBUS_INVERTER_ENTITY_DESCRIPTIONS}
+    update_exceptions = (ModbusError, SunSpecError)
+
+    def __init__(
+        self,
+        *args: Any,
+        inverter_info: FroniusDeviceInfo,
+        modbus_inverter: FroniusModbusInverter,
+        **kwargs: Any,
+    ) -> None:
+        """Set up a Fronius Modbus inverter device scope coordinator."""
+        super().__init__(*args, **kwargs)
+        self.inverter_info = inverter_info
+        self.modbus_inverter = modbus_inverter
+
+    @override
+    async def _async_update_data(self) -> dict[SolarNetId, Any]:
+        """Fetch the latest data from the source.
+
+        The coordinator_lock rate-limits requests to the SolarAPI HTTP endpoint.
+        Modbus requests use a separate transport which serializes its requests
+        internally, so the lock is not needed here.
+        """
+        return await self._do_update()
+
+    @override
+    async def _update_method(self) -> dict[SolarNetId, Any]:
+        """Return data per solar net id from the Modbus interface."""
+        mppt = await self._update_mppt()
+        data: dict[str, Any] = {}
+        for index, module in enumerate(mppt.modules, start=1):
+            data[f"mppt_{index}_current_dc"] = {"value": module.current}
+            data[f"mppt_{index}_voltage_dc"] = {"value": module.voltage}
+            data[f"mppt_{index}_power_dc"] = {"value": module.power}
+            data[f"mppt_{index}_energy_dc"] = {"value": module.energy}
+        data["energy_total_pv"] = {"value": mppt.pv_energy_total}
+        data["storage_energy_charged_total"] = {
+            "value": mppt.storage_charge_energy_total
+        }
+        data["storage_energy_discharged_total"] = {
+            "value": mppt.storage_discharge_energy_total
+        }
+        return {self.inverter_info.solar_net_id: data}
+
+    async def _update_mppt(self) -> Mppt:
+        """Refresh the MPPT model, re-discovering once on a register map shift."""
+        if (mppt := self.modbus_inverter.mppt) is None:
+            raise SunSpecError("Multiple MPPT model not available")
+        try:
+            await mppt.async_update()
+        except SunSpecMapShiftError:
+            # The register map shifts when the data type setting is changed on
+            # the device. Re-discover once at the new addresses and retry.
+            await self.modbus_inverter.discover()
+            if (mppt := self.modbus_inverter.mppt) is None:
+                raise
+            await mppt.async_update()
+        return mppt
 
 
 class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):

--- a/homeassistant/components/fronius/diagnostics.py
+++ b/homeassistant/components/fronius/diagnostics.py
@@ -43,4 +43,23 @@ async def async_get_config_entry_diagnostics(
         solar_net.storage_coordinator.data if solar_net.storage_coordinator else None
     )
 
+    diag["modbus"] = {
+        "inverters": {
+            coordinator.inverter_info.solar_net_id: {
+                "float_mode": coordinator.modbus_inverter.float_mode,
+                "has_storage": coordinator.modbus_inverter.has_storage,
+                "model_chain": [
+                    {
+                        "model_id": model.model_id,
+                        "address": model.address,
+                        "length": model.length,
+                    }
+                    for model in coordinator.modbus_inverter.model_chain
+                ],
+                "data": coordinator.data,
+            }
+            for coordinator in solar_net.modbus_inverter_coordinators
+        },
+    }
+
     return async_redact_data(diag, TO_REDACT)

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -30,11 +30,23 @@
       "energy_reactive_ac_produced": {
         "default": "mdi:lightning-bolt-outline"
       },
+      "energy_total_pv": {
+        "default": "mdi:solar-power"
+      },
+      "modbus_mppt_current_dc": {
+        "default": "mdi:current-dc"
+      },
       "relative_autonomy": {
         "default": "mdi:home-circle-outline"
       },
       "relative_self_consumption": {
         "default": "mdi:solar-power"
+      },
+      "storage_energy_charged_total": {
+        "default": "mdi:battery-plus"
+      },
+      "storage_energy_discharged_total": {
+        "default": "mdi:battery-minus"
       },
       "voltage_dc": {
         "default": "mdi:current-dc"

--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -12,7 +12,7 @@
   "documentation": "https://www.home-assistant.io/integrations/fronius",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["fronius_modbus", "modbus_connection", "pyfronius", "tmodbus"],
+  "loggers": ["fronius_modbus", "modbus_connection", "pyfronius"],
   "quality_scale": "platinum",
   "requirements": ["PyFronius==0.8.2", "fronius-modbus==0.2.0"]
 }

--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -3,6 +3,7 @@
   "name": "Fronius",
   "codeowners": ["@farmio"],
   "config_flow": true,
+  "dependencies": ["modbus"],
   "dhcp": [
     {
       "macaddress": "0003AC*"
@@ -11,7 +12,7 @@
   "documentation": "https://www.home-assistant.io/integrations/fronius",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["pyfronius"],
+  "loggers": ["fronius_modbus", "modbus_connection", "pyfronius", "tmodbus"],
   "quality_scale": "platinum",
-  "requirements": ["PyFronius==0.8.2"]
+  "requirements": ["PyFronius==0.8.2", "fronius-modbus==0.2.0"]
 }

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -55,7 +55,8 @@ rules:
     status: done
     comment: |
       Coordinators are used and asyncio.Lock mutex across them ensure proper
-      rate limiting. Platforms are read-only.
+      rate limiting. Modbus coordinators use a separate transport that
+      serializes its requests internally. Platforms are read-only.
   reauthentication-flow:
     status: exempt
     comment: |

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         FroniusInverterUpdateCoordinator,
         FroniusLoggerUpdateCoordinator,
         FroniusMeterUpdateCoordinator,
+        FroniusModbusInverterUpdateCoordinator,
         FroniusOhmpilotUpdateCoordinator,
         FroniusPowerFlowUpdateCoordinator,
         FroniusStorageUpdateCoordinator,
@@ -73,6 +74,10 @@ async def async_setup_entry(
         inverter_coordinator.add_entities_for_seen_keys(
             async_add_entities, Platform.SENSOR, InverterSensor
         )
+    for modbus_inverter_coordinator in solar_net.modbus_inverter_coordinators:
+        modbus_inverter_coordinator.add_entities_for_seen_keys(
+            async_add_entities, Platform.SENSOR, ModbusInverterSensor
+        )
     if solar_net.logger_coordinator is not None:
         solar_net.logger_coordinator.add_entities_for_seen_keys(
             async_add_entities, Platform.SENSOR, LoggerSensor
@@ -95,10 +100,15 @@ async def async_setup_entry(
         )
 
     @callback
-    def async_add_new_entities(coordinator: FroniusInverterUpdateCoordinator) -> None:
+    def async_add_new_entities(coordinator: FroniusCoordinatorBase) -> None:
         """Add newly found inverter entities."""
+        constructor = (
+            ModbusInverterSensor
+            if coordinator in solar_net.modbus_inverter_coordinators
+            else InverterSensor
+        )
         coordinator.add_entities_for_seen_keys(
-            async_add_entities, Platform.SENSOR, InverterSensor
+            async_add_entities, Platform.SENSOR, constructor
         )
 
     config_entry.async_on_unload(
@@ -279,6 +289,80 @@ INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         key="led_color",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+    ),
+]
+
+
+def _modbus_mppt_descriptions(
+    mppt_no: int,
+) -> list[FroniusSensorEntityDescription]:
+    """Create entity descriptions for one MPPT module of SunSpec model 160."""
+    return [
+        FroniusSensorEntityDescription(
+            key=f"mppt_{mppt_no}_current_dc",
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+            translation_key="modbus_mppt_current_dc",
+            translation_placeholders={"mppt_no": str(mppt_no)},
+        ),
+        FroniusSensorEntityDescription(
+            key=f"mppt_{mppt_no}_voltage_dc",
+            native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+            translation_key="modbus_mppt_voltage_dc",
+            translation_placeholders={"mppt_no": str(mppt_no)},
+        ),
+        FroniusSensorEntityDescription(
+            key=f"mppt_{mppt_no}_power_dc",
+            native_unit_of_measurement=UnitOfPower.WATT,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            translation_key="modbus_mppt_power_dc",
+            translation_placeholders={"mppt_no": str(mppt_no)},
+        ),
+        FroniusSensorEntityDescription(
+            key=f"mppt_{mppt_no}_energy_dc",
+            native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+            device_class=SensorDeviceClass.ENERGY,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            invalid_when_falsy=True,
+            translation_key="modbus_mppt_energy_dc",
+            translation_placeholders={"mppt_no": str(mppt_no)},
+        ),
+    ]
+
+
+MODBUS_INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    # SunSpec model 160 supports up to 4 MPPT modules (GEN24 hybrid, Tauro)
+    *(
+        description
+        for mppt_no in range(1, 5)
+        for description in _modbus_mppt_descriptions(mppt_no)
+    ),
+    FroniusSensorEntityDescription(
+        key="energy_total_pv",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        invalid_when_falsy=True,
+    ),
+    FroniusSensorEntityDescription(
+        key="storage_energy_charged_total",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        invalid_when_falsy=True,
+    ),
+    FroniusSensorEntityDescription(
+        key="storage_energy_discharged_total",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        invalid_when_falsy=True,
     ),
 ]
 
@@ -810,6 +894,24 @@ class InverterSensor(_FroniusSensorEntity):
         self._attr_device_info = coordinator.inverter_info.device_info
         self._attr_unique_id = (
             f"{coordinator.inverter_info.unique_id}-{description.key}"
+        )
+
+
+class ModbusInverterSensor(_FroniusSensorEntity):
+    """Defines a Fronius Modbus inverter device sensor entity."""
+
+    def __init__(
+        self,
+        coordinator: FroniusModbusInverterUpdateCoordinator,
+        description: FroniusSensorEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius Modbus inverter sensor."""
+        super().__init__(coordinator, description, solar_net_id)
+        # attach to the same device as the SolarAPI inverter sensors
+        self._attr_device_info = coordinator.inverter_info.device_info
+        self._attr_unique_id = (
+            f"{coordinator.inverter_info.unique_id}-modbus-{description.key}"
         )
 
 

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -17,19 +17,23 @@
       },
       "reconfigure": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "modbus_port": "[%key:component::fronius::config::step::user::data::modbus_port%]"
         },
         "data_description": {
-          "host": "[%key:component::fronius::config::step::user::data_description::host%]"
+          "host": "[%key:component::fronius::config::step::user::data_description::host%]",
+          "modbus_port": "[%key:component::fronius::config::step::user::data_description::modbus_port%]"
         },
         "description": "Update your configuration information for {device}."
       },
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "modbus_port": "Modbus port"
         },
         "data_description": {
-          "host": "The IP address or hostname of your Fronius device."
+          "host": "The IP address or hostname of your Fronius device.",
+          "modbus_port": "Port of the device's Modbus TCP interface. Only used when Modbus is enabled on the device's web interface."
         },
         "description": "Configure your Fronius SolarAPI device."
       }
@@ -104,6 +108,9 @@
       },
       "energy_total": {
         "name": "Total energy"
+      },
+      "energy_total_pv": {
+        "name": "PV energy total"
       },
       "energy_year": {
         "name": "Energy year"
@@ -240,6 +247,18 @@
       "meter_mode": {
         "name": "Meter mode"
       },
+      "modbus_mppt_current_dc": {
+        "name": "MPPT {mppt_no} DC current"
+      },
+      "modbus_mppt_energy_dc": {
+        "name": "MPPT {mppt_no} DC energy"
+      },
+      "modbus_mppt_power_dc": {
+        "name": "MPPT {mppt_no} DC power"
+      },
+      "modbus_mppt_voltage_dc": {
+        "name": "MPPT {mppt_no} DC voltage"
+      },
       "power_ac": {
         "name": "AC power"
       },
@@ -353,6 +372,12 @@
           "standby": "[%key:common::state::standby%]",
           "startup": "Startup"
         }
+      },
+      "storage_energy_charged_total": {
+        "name": "Battery charging energy total"
+      },
+      "storage_energy_discharged_total": {
+        "name": "Battery discharging energy total"
       },
       "temperature_cell": {
         "name": "[%key:component::sensor::entity_component::temperature::name%]"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1067,6 +1067,9 @@ fressnapftracker==0.2.2
 # homeassistant.components.fritzbox_callmonitor
 fritzconnection[qr]==1.15.1
 
+# homeassistant.components.fronius
+fronius-modbus==0.2.0
+
 # homeassistant.components.fumis
 fumis==0.4.0
 

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -18,9 +18,16 @@ MOCK_UID = "123.4567890"
 
 
 async def setup_fronius_integration(
-    hass: HomeAssistant, is_logger: bool = True, unique_id: str = MOCK_UID
+    hass: HomeAssistant,
+    is_logger: bool = True,
+    unique_id: str = MOCK_UID,
+    modbus_port: int | None = None,
 ) -> ConfigEntry:
-    """Create the Fronius integration."""
+    """Create the Fronius integration.
+
+    Without ``modbus_port`` an old config entry is created to exercise
+    the migration adding the default port.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         entry_id="f1e2b9837e8adaed6fa682acaa216fd8",
@@ -28,7 +35,9 @@ async def setup_fronius_integration(
         data={
             CONF_HOST: MOCK_HOST,
             "is_logger": is_logger,
+            **({"modbus_port": modbus_port} if modbus_port is not None else {}),
         },
+        minor_version=1 if modbus_port is None else 2,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/fronius/conftest.py
+++ b/tests/components/fronius/conftest.py
@@ -1,0 +1,43 @@
+"""Fixtures for the Fronius integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+from modbus_connection import ModbusConnectionError
+from modbus_connection.mock import MockModbusConnection
+import pytest
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture(autouse=True)
+def mock_modbus_unavailable(
+    mock_modbus_connection: MockModbusConnection,
+) -> Generator[MagicMock]:
+    """Refuse every Modbus request by default so tests run HTTP-only."""
+
+    def _refusing_unit(
+        hass: HomeAssistant, entry: ConfigEntry, params: object, unit_id: int
+    ) -> object:
+        unit = mock_modbus_connection.for_unit(unit_id)
+        unit.fail_requests(ModbusConnectionError("Modbus disabled in tests"))
+        return unit
+
+    with patch(
+        "homeassistant.components.fronius.async_get_unit",
+        MagicMock(side_effect=_refusing_unit),
+    ) as mock_get_unit:
+        yield mock_get_unit
+
+
+@pytest.fixture
+def mock_fronius_modbus(
+    mock_modbus_unavailable: MagicMock,
+    mock_modbus_connection: MockModbusConnection,
+) -> MockModbusConnection:
+    """Answer Modbus requests from the mock connection."""
+    mock_modbus_unavailable.side_effect = lambda hass, entry, params, unit_id: (
+        mock_modbus_connection.for_unit(unit_id)
+    )
+    return mock_modbus_connection

--- a/tests/components/fronius/snapshots/test_diagnostics.ambr
+++ b/tests/components/fronius/snapshots/test_diagnostics.ambr
@@ -5,13 +5,14 @@
       'data': dict({
         'host': 'http://fronius',
         'is_logger': True,
+        'modbus_port': 502,
       }),
       'disabled_by': None,
       'discovery_keys': dict({
       }),
       'domain': 'fronius',
       'entry_id': 'f1e2b9837e8adaed6fa682acaa216fd8',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -368,6 +369,420 @@
       }),
       'timestamp': dict({
         'value': '2021-10-07T13:41:00+02:00',
+      }),
+    }),
+    'modbus': dict({
+      'inverters': dict({
+      }),
+    }),
+  })
+# ---
+# name: test_diagnostics_modbus
+  dict({
+    'config_entry': dict({
+      'data': dict({
+        'host': 'http://fronius',
+        'is_logger': False,
+        'modbus_port': 502,
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'fronius',
+      'entry_id': 'f1e2b9837e8adaed6fa682acaa216fd8',
+      'minor_version': 2,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'Mock Title',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+    'coordinators': dict({
+      'inverters': dict({
+        '1': dict({
+          'current_ac': dict({
+            'unit': 'A',
+            'value': 0.15894582867622375,
+          }),
+          'current_dc': dict({
+            'unit': 'A',
+            'value': 0.07832378149032593,
+          }),
+          'current_dc_2': dict({
+            'unit': 'A',
+            'value': 0.07539909332990646,
+          }),
+          'current_dc_3': dict({
+            'unit': 'A',
+            'value': None,
+          }),
+          'energy_day': dict({
+            'unit': 'Wh',
+            'value': None,
+          }),
+          'energy_total': dict({
+            'unit': 'Wh',
+            'value': 1530193.42,
+          }),
+          'energy_year': dict({
+            'unit': 'Wh',
+            'value': None,
+          }),
+          'error_code': dict({
+            'value': 0,
+          }),
+          'frequency_ac': dict({
+            'unit': 'Hz',
+            'value': 49.99169921875,
+          }),
+          'inverter_state': dict({
+            'value': 'Running',
+          }),
+          'power_ac': dict({
+            'unit': 'W',
+            'value': 37.32044982910156,
+          }),
+          'status': dict({
+            'Code': 0,
+            'Reason': '',
+            'UserMessage': '',
+          }),
+          'status_code': dict({
+            'value': 7,
+          }),
+          'timestamp': dict({
+            'value': '2021-11-26T11:07:53+00:00',
+          }),
+          'voltage_ac': dict({
+            'unit': 'V',
+            'value': 234.91676330566406,
+          }),
+          'voltage_dc': dict({
+            'unit': 'V',
+            'value': 411.3810729980469,
+          }),
+          'voltage_dc_2': dict({
+            'unit': 'V',
+            'value': 403.4312438964844,
+          }),
+          'voltage_dc_3': dict({
+            'unit': 'V',
+            'value': None,
+          }),
+        }),
+      }),
+      'logger': None,
+      'meter': dict({
+        '0': dict({
+          'current_ac_phase_1': dict({
+            'unit': 'A',
+            'value': 1.145,
+          }),
+          'current_ac_phase_2': dict({
+            'unit': 'A',
+            'value': 2.33,
+          }),
+          'current_ac_phase_3': dict({
+            'unit': 'A',
+            'value': 1.825,
+          }),
+          'enable': dict({
+            'value': 1,
+          }),
+          'energy_reactive_ac_consumed': dict({
+            'unit': 'VArh',
+            'value': 88221.0,
+          }),
+          'energy_reactive_ac_produced': dict({
+            'unit': 'VArh',
+            'value': 1989125.0,
+          }),
+          'energy_real_ac_minus': dict({
+            'unit': 'Wh',
+            'value': 3863340.0,
+          }),
+          'energy_real_ac_plus': dict({
+            'unit': 'Wh',
+            'value': 2013105.0,
+          }),
+          'energy_real_consumed': dict({
+            'unit': 'Wh',
+            'value': 2013105.0,
+          }),
+          'energy_real_produced': dict({
+            'unit': 'Wh',
+            'value': 3863340.0,
+          }),
+          'frequency_phase_average': dict({
+            'unit': 'Hz',
+            'value': 49.9,
+          }),
+          'manufacturer': dict({
+            'value': 'Fronius',
+          }),
+          'meter_location': dict({
+            'value': 0.0,
+          }),
+          'model': dict({
+            'value': 'Smart Meter TS 65A-3',
+          }),
+          'power_apparent': dict({
+            'unit': 'VA',
+            'value': 868.0,
+          }),
+          'power_apparent_phase_1': dict({
+            'unit': 'VA',
+            'value': 243.3,
+          }),
+          'power_apparent_phase_2': dict({
+            'unit': 'VA',
+            'value': 323.4,
+          }),
+          'power_apparent_phase_3': dict({
+            'unit': 'VA',
+            'value': 301.2,
+          }),
+          'power_factor': dict({
+            'value': 0.828,
+          }),
+          'power_factor_phase_1': dict({
+            'value': 0.441,
+          }),
+          'power_factor_phase_2': dict({
+            'value': 0.934,
+          }),
+          'power_factor_phase_3': dict({
+            'value': 0.832,
+          }),
+          'power_reactive': dict({
+            'unit': 'VAr',
+            'value': -517.4,
+          }),
+          'power_reactive_phase_1': dict({
+            'unit': 'VAr',
+            'value': -218.6,
+          }),
+          'power_reactive_phase_2': dict({
+            'unit': 'VAr',
+            'value': -132.8,
+          }),
+          'power_reactive_phase_3': dict({
+            'unit': 'VAr',
+            'value': -166.0,
+          }),
+          'power_real': dict({
+            'unit': 'W',
+            'value': 653.1,
+          }),
+          'power_real_phase_1': dict({
+            'unit': 'W',
+            'value': 106.8,
+          }),
+          'power_real_phase_2': dict({
+            'unit': 'W',
+            'value': 294.9,
+          }),
+          'power_real_phase_3': dict({
+            'unit': 'W',
+            'value': 251.3,
+          }),
+          'serial': '**REDACTED**',
+          'visible': dict({
+            'value': 1.0,
+          }),
+          'voltage_ac_phase_1': dict({
+            'unit': 'V',
+            'value': 235.9,
+          }),
+          'voltage_ac_phase_2': dict({
+            'unit': 'V',
+            'value': 236.1,
+          }),
+          'voltage_ac_phase_3': dict({
+            'unit': 'V',
+            'value': 236.9,
+          }),
+          'voltage_ac_phase_to_phase_12': dict({
+            'unit': 'V',
+            'value': 408.7,
+          }),
+          'voltage_ac_phase_to_phase_23': dict({
+            'unit': 'V',
+            'value': 409.6,
+          }),
+          'voltage_ac_phase_to_phase_31': dict({
+            'unit': 'V',
+            'value': 409.4,
+          }),
+        }),
+      }),
+      'ohmpilot': None,
+      'power_flow': dict({
+        'power_flow': dict({
+          'backup_mode': dict({
+            'value': False,
+          }),
+          'battery_mode': dict({
+            'value': 'disabled',
+          }),
+          'battery_standby': dict({
+            'value': False,
+          }),
+          'energy_day': dict({
+            'unit': 'Wh',
+            'value': None,
+          }),
+          'energy_total': dict({
+            'unit': 'Wh',
+            'value': 1530193.42,
+          }),
+          'energy_year': dict({
+            'unit': 'Wh',
+            'value': None,
+          }),
+          'meter_location': dict({
+            'value': 'grid',
+          }),
+          'meter_mode': dict({
+            'value': 'meter',
+          }),
+          'power_battery': dict({
+            'unit': 'W',
+            'value': None,
+          }),
+          'power_grid': dict({
+            'unit': 'W',
+            'value': 658.4,
+          }),
+          'power_load': dict({
+            'unit': 'W',
+            'value': -695.6827491760254,
+          }),
+          'power_photovoltaics': dict({
+            'unit': 'W',
+            'value': 62.94814872741699,
+          }),
+          'relative_autonomy': dict({
+            'unit': '%',
+            'value': 5.3591596485874495,
+          }),
+          'relative_self_consumption': dict({
+            'unit': '%',
+            'value': 100.0,
+          }),
+          'state_of_charge': dict({
+            'unit': '%',
+            'value': 0.0,
+          }),
+          'status': dict({
+            'Code': 0,
+            'Reason': '',
+            'UserMessage': '',
+          }),
+          'timestamp': dict({
+            'value': '2021-11-26T11:07:53+00:00',
+          }),
+        }),
+      }),
+      'storage': None,
+    }),
+    'inverter_info': dict({
+      'inverters': list([
+        dict({
+          'custom_name': dict({
+            'value': 'Inverter name',
+          }),
+          'device_id': dict({
+            'value': '1',
+          }),
+          'device_type': dict({
+            'manufacturer': 'Fronius',
+            'model': 'Gen24',
+            'value': 1,
+          }),
+          'error_code': dict({
+            'value': 0,
+          }),
+          'pv_power': dict({
+            'unit': 'W',
+            'value': 9360,
+          }),
+          'show': dict({
+            'value': 1,
+          }),
+          'status_code': dict({
+            'value': 7,
+          }),
+          'unique_id': '**REDACTED**',
+        }),
+      ]),
+      'status': dict({
+        'Code': 0,
+        'Reason': '',
+        'UserMessage': '',
+      }),
+      'timestamp': dict({
+        'value': '2021-11-26T11:07:53+00:00',
+      }),
+    }),
+    'modbus': dict({
+      'inverters': dict({
+        '1': dict({
+          'data': dict({
+            '1': dict({
+              'energy_total_pv': dict({
+                'value': 1000000,
+              }),
+              'mppt_1_current_dc': dict({
+                'value': 8.2,
+              }),
+              'mppt_1_energy_dc': dict({
+                'value': 1000000,
+              }),
+              'mppt_1_power_dc': dict({
+                'value': 3300,
+              }),
+              'mppt_1_voltage_dc': dict({
+                'value': 402.1,
+              }),
+              'storage_energy_charged_total': dict({
+                'value': None,
+              }),
+              'storage_energy_discharged_total': dict({
+                'value': None,
+              }),
+            }),
+          }),
+          'float_mode': True,
+          'has_storage': False,
+          'model_chain': list([
+            dict({
+              'address': 40002,
+              'length': 66,
+              'model_id': 1,
+            }),
+            dict({
+              'address': 40070,
+              'length': 60,
+              'model_id': 113,
+            }),
+            dict({
+              'address': 40132,
+              'length': 24,
+              'model_id': 123,
+            }),
+            dict({
+              'address': 40158,
+              'length': 28,
+              'model_id': 160,
+            }),
+          ]),
+        }),
       }),
     }),
   })

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -63,6 +63,7 @@ async def assert_finish_flow_with_logger(hass: HomeAssistant, flow_id: str) -> N
     assert result["data"] == {
         "host": "10.9.8.1",
         "is_logger": True,
+        "modbus_port": 502,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -120,6 +121,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
             result["flow_id"],
             {
                 "host": "10.9.1.1",
+                "modbus_port": 1502,
             },
         )
         await hass.async_block_till_done()
@@ -129,6 +131,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
     assert result2["data"] == {
         "host": "10.9.1.1",
         "is_logger": False,
+        "modbus_port": 1502,
     }
     assert result2["result"].unique_id == "1234567"
 
@@ -252,6 +255,7 @@ async def test_config_flow_already_configured(
     assert entries[0].data == {
         "host": old_host,  # not updated from config flow - only from reconfigure flow
         "is_logger": True,
+        "modbus_port": 502,  # added by migration
     }
 
 
@@ -278,6 +282,7 @@ async def test_dhcp(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) ->
     assert result["data"] == {
         "host": MOCK_DHCP_DATA.ip,
         "is_logger": True,
+        "modbus_port": 502,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -357,6 +362,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input={
                 "host": new_host,
+                "modbus_port": 1502,
             },
         )
         await hass.async_block_till_done()
@@ -366,6 +372,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
     assert entry.data == {
         "host": new_host,
         "is_logger": False,
+        "modbus_port": 1502,
     }
 
 

--- a/tests/components/fronius/test_diagnostics.py
+++ b/tests/components/fronius/test_diagnostics.py
@@ -1,5 +1,7 @@
 """Tests for the diagnostics data provided by the Fronius integration."""
 
+from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
+from modbus_connection.mock import MockModbusConnection
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -21,6 +23,37 @@ async def test_diagnostics(
     """Test diagnostics."""
     mock_responses(aioclient_mock)
     entry = await setup_fronius_integration(hass)
+
+    assert await get_diagnostics_for_config_entry(
+        hass,
+        hass_client,
+        entry,
+    ) == snapshot(exclude=props("created_at", "modified_at"))
+
+
+async def test_diagnostics_modbus(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics with Modbus enabled."""
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(
+            [
+                MpptModuleSpec(
+                    id_str="String 1",
+                    current=82,
+                    voltage=4021,
+                    power=3300,
+                    energy=1_000_000,
+                ),
+            ]
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24")
+    entry = await setup_fronius_integration(hass, is_logger=False)
 
     assert await get_diagnostics_for_config_entry(
         hass,

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -39,6 +39,18 @@ async def test_unload_config_entry(
     assert not hass.data.get(DOMAIN)
 
 
+async def test_migrate_config_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test migration adds the default Modbus port to old config entries."""
+    mock_responses(aioclient_mock)
+    entry = await setup_fronius_integration(hass)
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert entry.data["modbus_port"] == 502
+
+
 async def test_logger_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -1,0 +1,413 @@
+"""Tests for the Fronius Modbus TCP (SunSpec) support."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
+from modbus_connection.mock import MockModbusConnection
+import pytest
+
+from homeassistant.components.fronius.const import SOLAR_NET_RESCAN_TIMER
+from homeassistant.components.fronius.coordinator import (
+    FroniusModbusInverterUpdateCoordinator,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import mock_responses, setup_fronius_integration
+
+from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+# module names as reported by real GEN24 hybrid inverters
+GEN24_HYBRID_MODULES = [
+    MpptModuleSpec(
+        id_str="MPPT 1", current=82, voltage=4021, power=3300, energy=1_000_000
+    ),
+    MpptModuleSpec(
+        id_str="MPPT 2", current=41, voltage=4022, power=1650, energy=500_000
+    ),
+    MpptModuleSpec(id_str="StCha 3", current=0, voltage=0, power=0, energy=200_000),
+    MpptModuleSpec(
+        id_str="StDisCha 4", current=12, voltage=3990, power=480, energy=150_000
+    ),
+]
+
+
+def assert_state(
+    hass: HomeAssistant, entity_id: str, expected_state: str | float
+) -> None:
+    """Assert the state of an entity."""
+    state = hass.states.get(entity_id)
+    assert state, f"State for {entity_id} not found"
+    assert state.state == str(expected_state)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    "float_mode",
+    [pytest.param(True, id="float"), pytest.param(False, id="int_sf")],
+)
+async def test_gen24_storage_mppt(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    entity_registry: er.EntityRegistry,
+    float_mode: bool,
+) -> None:
+    """Test MPPT entities of a GEN24 hybrid inverter for both data types."""
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(
+            GEN24_HYBRID_MODULES, float_mode=float_mode, storage_wcha_max=5000
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_current", 8.2)
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_voltage", 402.1)
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_energy", 1000000)
+    assert_state(hass, "sensor.gen24_storage_mppt_2_dc_power", 1650)
+    assert_state(hass, "sensor.gen24_storage_mppt_3_dc_power", 0)
+    assert_state(hass, "sensor.gen24_storage_mppt_4_dc_power", 480)
+
+    # derived totals: PV strings only, charge/discharge from storage modules
+    assert_state(hass, "sensor.gen24_storage_pv_energy_total", 1500000)
+    assert_state(hass, "sensor.gen24_storage_battery_charging_energy_total", 200000)
+    assert_state(hass, "sensor.gen24_storage_battery_discharging_energy_total", 150000)
+
+    entity_entry = entity_registry.async_get("sensor.gen24_storage_mppt_1_dc_power")
+    assert entity_entry
+    assert entity_entry.unique_id == "12345678-modbus-mppt_1_power_dc"
+
+    solar_net = config_entry.runtime_data
+    assert len(solar_net.modbus_inverter_coordinators) == 1
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("storage_id_str", "expected_pv_energy_total"),
+    [
+        # a bidirectional storage module is excluded from the PV total
+        pytest.param("Battery 1", 1000000, id="storage_matched_by_id_str"),
+        # 2-module inverters default to PV even with a detected storage -
+        # safe since Symo Hybrid doesn't support lifetime energy anyway
+        pytest.param("String 2", 1500000, id="inconclusive_defaults_to_pv"),
+    ],
+)
+async def test_hybrid_bidirectional_storage(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    storage_id_str: str,
+    expected_pv_energy_total: int,
+) -> None:
+    """Test 2-module inverters with a detected storage.
+
+    No separate charge/discharge energy is available in either case.
+    """
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(
+            [
+                MpptModuleSpec(
+                    id_str="String 1",
+                    current=82,
+                    voltage=4021,
+                    power=3300,
+                    energy=1_000_000,
+                ),
+                MpptModuleSpec(
+                    id_str=storage_id_str,
+                    current=41,
+                    voltage=4022,
+                    power=1650,
+                    energy=500_000,
+                ),
+            ],
+            storage_wcha_max=5000,
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        await setup_fronius_integration(hass, is_logger=False, unique_id="12345678")
+
+    assert_state(hass, "sensor.gen24_storage_pv_energy_total", expected_pv_energy_total)
+    assert_state(hass, "sensor.gen24_storage_mppt_2_dc_power", 1650)
+    # no separable charge/discharge energy without dedicated modules
+    assert hass.states.get("sensor.gen24_storage_battery_charging_energy_total") is None
+    assert (
+        hass.states.get("sensor.gen24_storage_battery_discharging_energy_total") is None
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_datamanager_multiple_inverters(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test Modbus entities for multiple inverters behind a Datamanager."""
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(
+            [
+                MpptModuleSpec(
+                    id_str="String 1",
+                    current=82,
+                    voltage=4021,
+                    power=3300,
+                    energy=1_000_000,
+                ),
+                MpptModuleSpec(
+                    id_str="String 2",
+                    current=41,
+                    voltage=4022,
+                    power=1650,
+                    energy=500_000,
+                ),
+            ]
+        )
+    )
+    mock_fronius_modbus.for_unit(2).holding.update(
+        build_sunspec_map(
+            [
+                MpptModuleSpec(
+                    id_str="String 1",
+                    current=50,
+                    voltage=3000,
+                    power=1500,
+                    energy=250_000,
+                ),
+            ]
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="primo_s0", inverter_ids=[1, 2])
+    await setup_fronius_integration(hass, is_logger=True)
+
+    assert_state(hass, "sensor.primo_5_0_1_mppt_1_dc_power", 3300)
+    assert_state(hass, "sensor.primo_5_0_1_mppt_2_dc_power", 1650)
+    assert_state(hass, "sensor.primo_5_0_1_pv_energy_total", 1500000)
+    assert_state(hass, "sensor.primo_3_0_1_mppt_1_dc_power", 1500)
+    assert_state(hass, "sensor.primo_3_0_1_pv_energy_total", 250000)
+    # no storage in this system - no charge/discharge entities
+    assert hass.states.get("sensor.primo_5_0_1_battery_charging_energy_total") is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_custom_modbus_port(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    mock_modbus_unavailable: MagicMock,
+) -> None:
+    """Test the unit is asked for on the configured Modbus port."""
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(GEN24_HYBRID_MODULES, storage_wcha_max=5000)
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678", modbus_port=1502
+        )
+
+    params = mock_modbus_unavailable.call_args.args[2]
+    assert params.host == "fronius"
+    assert params.port == 1502
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+
+
+async def test_modbus_unavailable(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the entry loads HTTP-only when the Modbus probe is refused."""
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    config_entry = await setup_fronius_integration(
+        hass, is_logger=False, unique_id="12345678"
+    )
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert not config_entry.runtime_data.modbus_inverter_coordinators
+    assert not [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        if "-modbus-" in entry.unique_id
+    ]
+
+
+async def test_no_mppt_model(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a SunSpec device without MPPT model creates no Modbus entities."""
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map([], include_mppt_model=False)
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    config_entry = await setup_fronius_integration(
+        hass, is_logger=False, unique_id="12345678"
+    )
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert config_entry.runtime_data.modbus_inverter_coordinators == []
+    assert not [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        if "-modbus-" in entry.unique_id
+    ]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_not_implemented_values(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test not-implemented sentinel values don't create entities."""
+    modules = [
+        MpptModuleSpec(
+            id_str="String 1", current=82, voltage=4021, power=3300, energy=1_000_000
+        ),
+        # all values not implemented
+        MpptModuleSpec(id_str="String 2"),
+    ]
+    unit = mock_fronius_modbus.for_unit(1)
+    unit.holding.update(build_sunspec_map(modules))
+    mock_responses(aioclient_mock, fixture_set="gen24")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        await setup_fronius_integration(hass, is_logger=False)
+
+    assert_state(hass, "sensor.inverter_name_mppt_1_dc_power", 3300)
+    assert hass.states.get("sensor.inverter_name_mppt_2_dc_power") is None
+    assert hass.states.get("sensor.inverter_name_mppt_2_dc_energy") is None
+    # PV total unknown when a PV module doesn't report energy
+    assert hass.states.get("sensor.inverter_name_pv_energy_total") is None
+
+    # an implemented value turning into a sentinel becomes unknown
+    modules[0].energy = 0
+    unit.holding.clear()
+    unit.holding.update(build_sunspec_map(modules))
+    freezer.tick(FroniusModbusInverterUpdateCoordinator.default_interval)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert_state(hass, "sensor.inverter_name_mppt_1_dc_energy", "unknown")
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_data_type_changed_at_runtime(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test re-discovery when the register map shifts due to a data type change."""
+    unit = mock_fronius_modbus.for_unit(1)
+    unit.holding.update(build_sunspec_map(GEN24_HYBRID_MODULES, float_mode=True))
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        await setup_fronius_integration(hass, is_logger=False, unique_id="12345678")
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+
+    # switching int+SF shifts the model 160 address
+    unit.holding.clear()
+    unit.holding.update(build_sunspec_map(GEN24_HYBRID_MODULES, float_mode=False))
+    freezer.tick(FroniusModbusInverterUpdateCoordinator.default_interval)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+
+    # a broken register map makes the update fail and entities unavailable
+    unit.holding.clear()
+    freezer.tick(FroniusModbusInverterUpdateCoordinator.default_interval)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", "unavailable")
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_connection_lost_recovers(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a dropped Modbus link heals without reloading the entry.
+
+    The connection re-establishes a dropped link on the next request, so
+    entities recover on the next poll.
+    """
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(GEN24_HYBRID_MODULES)
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+    assert config_entry.runtime_data.modbus_inverter_coordinators
+
+    mock_fronius_modbus.simulate_connection_lost()
+    await hass.async_block_till_done()
+
+    freezer.tick(FroniusModbusInverterUpdateCoordinator.default_interval)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # the entry was not reloaded and the values are back
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data.modbus_inverter_coordinators
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+
+
+async def test_modbus_retried_after_setup(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_modbus_unavailable: MagicMock,
+    mock_modbus_connection: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an inverter asleep at setup time gets its Modbus entities later.
+
+    An inverter without a grid-powered datalogger answers nothing while it is
+    powered down, so discovery fails and the re-scan has to try again.
+    """
+    unit = mock_modbus_connection.for_unit(1)
+    unit.holding.update(build_sunspec_map(GEN24_HYBRID_MODULES))
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+    assert not config_entry.runtime_data.modbus_inverter_coordinators
+    assert hass.states.get("sensor.gen24_storage_mppt_1_dc_power") is None
+
+    # the inverter wakes up and starts answering
+    mock_modbus_unavailable.side_effect = lambda hass, entry, params, unit_id: (
+        mock_modbus_connection.for_unit(unit_id)
+    )
+    unit.fail_requests(None)
+
+    freezer.tick(timedelta(minutes=SOLAR_NET_RESCAN_TIMER, seconds=1))
+    async_fire_time_changed(hass)
+    # the re-scan refreshes the new coordinator in a background task
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert config_entry.runtime_data.modbus_inverter_coordinators
+    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
+    # the hold on the shared connection is taken once, not once per re-scan
+    assert mock_modbus_unavailable.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds **Modbus TCP (SunSpec)** sensors to the Fronius integration, for per-string data the HTTP Solar API does not expose:

- **Per MPP tracker**: DC current, voltage, power and lifetime energy (SunSpec Multiple MPPT model 160).
- **Derived lifetime totals**: PV-only energy, and battery charged / discharged energy — separable because a GEN24 hybrid exposes its storage as dedicated MPPT modules (`StCha 3` / `StDisCha 4`), which the library classifies by ID string with a positional fallback.

Modbus is entirely **optional and additive**. The integration probes the host on setup; if Modbus is disabled on the device, or the inverter is powered down, the probe fails, it is logged at debug level and the entry loads exactly as before. Nothing existing changes.

Both device generations are supported: **GEN24 / Tauro**, which serve Modbus themselves on unit ID 1, and **SnapINverter behind a Datamanager 2.0**, where the unit ID is the SolarNet inverter number. The register map is discovered at runtime, so the device's *float* vs *int + SF* setting is detected automatically and no register configuration is needed — enabling Modbus in the device's web UI is all a user has to do.

A **Modbus port** setting (default 502) is added to the config and reconfigure flows, with a minor-version config entry migration.

### Where the protocol code lives

Per the [architecture direction](https://github.com/home-assistant/architecture/discussions/1418), the SunSpec handling is a standalone library — [`fronius-modbus`](https://github.com/farmio/fronius-modbus) — built on `modbus-connection`; the integration only consumes a `ModbusUnit`.

Units come from the `modbus` integration via `async_get_unit`, so a device polled by more than one integration is reached over a single shared connection rather than competing sockets — which matters here, as a GEN24 accepts only a few simultaneous Modbus sessions. There is no connection lifecycle to manage: `modbus` closes it when the last entry holding a unit unloads. The hold is taken once per inverter and kept across re-scans.

Because the link is established lazily by the first request, there is no separate probe. Discovery runs per inverter, and one that answers nothing — Modbus not enabled, or a datalogger that sleeps with the inverter — simply gets no Modbus entities and is retried on the SolarNet re-scan.

### Tested on hardware

- **Symo GEN24 10.0 Plus SC** (fw 1.41.11-1) with BYD storage, int + SF encoding — 4 MPPT modules, storage auto-detected. Cross-checked: the module powers sum to the inverter's own `DCW`, and the lifetime energies imply a plausible 96.7 % DC→AC efficiency.
- **Symo 5.0-3-M behind a Datamanager 2.0**, float encoding — read during production and after dark.

Read-only for now; the library's write support (power limiting, battery control) is deliberately not exposed here.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


### Dependencies

- **`fronius-modbus==0.2.0`** — new. [Repository](https://github.com/farmio/fronius-modbus) · [Releases](https://github.com/farmio/fronius-modbus/releases) · [0.1.0…0.2.0](https://github.com/farmio/fronius-modbus/compare/0.1.0...0.2.0)
- `modbus-connection` is **not** a direct requirement: it arrives through `fronius-modbus`, and the `modbus` dependency supplies the pinned `modbus-connection[tmodbus]==4.8.1` along with the shared connection.

### Known upstream issue

A device that is offline produces one ERROR-level traceback per poll from `tmodbus`, which logs the failure *and* raises it, so an integration that handles `ModbusConnectionError` still fills the user's log. Reported as [wlcrs/tmodbus#111](https://github.com/wlcrs/tmodbus/issues/111). It affects any consumer of `modbus-connection` whose device goes away, not this integration specifically.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47610
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


