### PR TITLE
Deprecate passing created or modified_at when creating devices

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -130,13 +130,11 @@ class DeviceInfo(TypedDict, total=False):
 
     configuration_url: str | URL | None
     connections: set[tuple[str, str]]
-    created_at: str
     entry_type: DeviceEntryType | None
     identifiers: set[tuple[str, str]]
     manufacturer: str | None
     model: str | None
     model_id: str | None
-    modified_at: str
     name: str | None
     serial_number: str | None
     suggested_area: str | None
@@ -155,9 +153,7 @@ class ChildDeviceInfo(TypedDict, total=False):
     entry, and must belong to the same config subentry.
     """
 
-    created_at: str
     identifiers: Required[set[tuple[str, str]]]
-    modified_at: str
     name: str | None
     parent_device_id: Required[str]
     suggested_area: str | None
@@ -263,11 +259,14 @@ def _validate_device_info(
 
 
 # Deprecated `async_get_or_create` parameters, mapped to the HA Core version they are
-# removed in.
-_DEPRECATED_DEVICE_INFO_PARAMETERS = {
+# removed in and the replacement parameter, or `None` if the parameter is ignored and
+# has no replacement.
+_DEPRECATED_DEVICE_INFO_PARAMETERS: dict[str, tuple[str, str | None]] = {
+    "created_at": ("2027.9.0", None),
     "default_manufacturer": ("2027.9.0", "manufacturer"),
     "default_model": ("2027.9.0", "model"),
     "default_name": ("2027.9.0", "name"),
+    "modified_at": ("2027.9.0", None),
     "via_device": ("2027.8.0", "via_device_id"),
 }
 
@@ -2214,7 +2213,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         config_subentry_id: str | UndefinedType | None = UNDEFINED,
         configuration_url: str | URL | UndefinedType | None = UNDEFINED,
         connections: set[tuple[str, str]] | UndefinedType | None = UNDEFINED,
-        created_at: str | datetime | UndefinedType = UNDEFINED,  # will be ignored
         # To disable a device if it gets created, does not affect existing devices
         disabled_by: DeviceEntryDisabler | UndefinedType | None = UNDEFINED,
         entry_type: DeviceEntryType | UndefinedType | None = UNDEFINED,
@@ -2223,7 +2221,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         manufacturer: str | UndefinedType | None = UNDEFINED,
         model: str | UndefinedType | None = UNDEFINED,
         model_id: str | UndefinedType | None = UNDEFINED,
-        modified_at: str | datetime | UndefinedType = UNDEFINED,  # will be ignored
         name: str | UndefinedType | None = UNDEFINED,
         serial_number: str | UndefinedType | None = UNDEFINED,
         suggested_area: str | UndefinedType | None = UNDEFINED,
@@ -2241,9 +2238,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         """
         # Extract deprecated parameters, and reject any other unexpected keyword
         # argument.
+        created_at = kwargs.pop("created_at", UNDEFINED)
         default_manufacturer = kwargs.pop("default_manufacturer", UNDEFINED)
         default_model = kwargs.pop("default_model", UNDEFINED)
         default_name = kwargs.pop("default_name", UNDEFINED)
+        modified_at = kwargs.pop("modified_at", UNDEFINED)
         via_device = kwargs.pop("via_device", UNDEFINED)
         if kwargs:
             raise TypeError(
@@ -2286,18 +2285,24 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             )
         # Report the deprecated parameters here, before any registry mutation.
         deprecated_values = {
+            "created_at": created_at,
             "default_manufacturer": default_manufacturer,
             "default_model": default_model,
             "default_name": default_name,
+            "modified_at": modified_at,
             "via_device": via_device,
         }
         for parameter, deprecation in _DEPRECATED_DEVICE_INFO_PARAMETERS.items():
             if deprecated_values[parameter] is UNDEFINED:
                 continue
             version, replacement = deprecation
+            if replacement is None:
+                advice = ", which is ignored"
+            else:
+                advice = f"; use `{replacement}` instead"
             report_usage(
                 "calls `device_registry.async_get_or_create` with a deprecated "
-                f"`{parameter}` parameter; use `{replacement}` instead",
+                f"`{parameter}` parameter{advice}",
                 core_behavior=ReportBehavior.ERROR,
                 core_integration_behavior=ReportBehavior.ERROR,
                 breaks_in_ha_version=version,
@@ -2598,10 +2603,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         *,
         config_entry_id: str,
         config_subentry_id: str | UndefinedType | None = UNDEFINED,
-        created_at: str | datetime | UndefinedType = UNDEFINED,  # will be ignored
         disabled_by: DeviceEntryDisabler | UndefinedType | None = UNDEFINED,
         identifiers: set[tuple[str, str]],
-        modified_at: str | datetime | UndefinedType = UNDEFINED,  # will be ignored
         name: str | UndefinedType | None = UNDEFINED,
         parent_device_id: str,
         suggested_area: str | UndefinedType | None = UNDEFINED,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4529,9 +4529,11 @@ async def test_async_get_device_deprecated(
 @pytest.mark.parametrize(
     ("parameter", "value", "replacement"),
     [
+        ("created_at", "2024-01-01T00:00:00+00:00", None),
         ("default_manufacturer", "manufacturer", "manufacturer"),
         ("default_model", "model", "model"),
         ("default_name", "name", "name"),
+        ("modified_at", "2024-01-01T00:00:00+00:00", None),
         ("via_device", ("some_domain", "via_id"), "via_device_id"),
     ],
 )
@@ -4562,7 +4564,7 @@ async def test_async_get_or_create_deprecated_parameters(
     caplog: pytest.LogCaptureFixture,
     parameter: str,
     value: Any,
-    replacement: str,
+    replacement: str | None,
     expectation: AbstractContextManager,
     expected_log: int,
 ) -> None:
@@ -4576,9 +4578,13 @@ async def test_async_get_or_create_deprecated_parameters(
         config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
     )
 
+    if replacement is None:
+        advice = ", which is ignored"
+    else:
+        advice = f"; use `{replacement}` instead"
     what = (
         "calls `device_registry.async_get_or_create` with a deprecated "
-        f"`{parameter}` parameter; use `{replacement}` instead"
+        f"`{parameter}` parameter{advice}"
     )
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
         device_registry.async_get_or_create(
@@ -4593,9 +4599,11 @@ async def test_async_get_or_create_deprecated_parameters(
 @pytest.mark.parametrize(
     ("parameter", "value"),
     [
+        ("created_at", "2024-01-01T00:00:00+00:00"),
         ("default_manufacturer", "manufacturer"),
         ("default_model", "model"),
         ("default_name", "name"),
+        ("modified_at", "2024-01-01T00:00:00+00:00"),
         ("via_device", ("some_domain", "via_id")),
     ],
 )
@@ -10477,6 +10485,33 @@ async def test_child_device_parent_in_other_config_entry(
     # Validation precedes mutation, so no child device is created
     assert not device_registry.child_devices
     assert len(device_registry.devices) == 1
+
+
+@pytest.mark.parametrize("parameter", ["created_at", "modified_at"])
+@pytest.mark.usefixtures("hass")
+async def test_async_get_or_create_child_rejects_removed_parameters(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    parameter: str,
+) -> None:
+    """Test async_get_or_create_child no longer accepts created_at / modified_at."""
+    parent = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("test", "strip")},
+        name="Power strip",
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=f"unexpected keyword argument '{parameter}'",
+    ):
+        device_registry.async_get_or_create_child(
+            config_entry_id=mock_config_entry.entry_id,
+            identifiers={("test", "strip_outlet_1")},
+            parent_device_id=parent.id,
+            name="Outlet 1",
+            **{parameter: "2024-01-01T00:00:00+00:00"},
+        )
 
 
 @pytest.mark.usefixtures("hass")

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4527,14 +4527,14 @@ async def test_async_get_device_deprecated(
 
 
 @pytest.mark.parametrize(
-    ("parameter", "value", "replacement"),
+    ("parameter", "value", "advice"),
     [
-        ("created_at", "2024-01-01T00:00:00+00:00", None),
-        ("default_manufacturer", "manufacturer", "manufacturer"),
-        ("default_model", "model", "model"),
-        ("default_name", "name", "name"),
-        ("modified_at", "2024-01-01T00:00:00+00:00", None),
-        ("via_device", ("some_domain", "via_id"), "via_device_id"),
+        ("created_at", "2024-01-01T00:00:00+00:00", ", which is ignored"),
+        ("default_manufacturer", "manufacturer", "; use `manufacturer` instead"),
+        ("default_model", "model", "; use `model` instead"),
+        ("default_name", "name", "; use `name` instead"),
+        ("modified_at", "2024-01-01T00:00:00+00:00", ", which is ignored"),
+        ("via_device", ("some_domain", "via_id"), "; use `via_device_id` instead"),
     ],
 )
 @pytest.mark.parametrize(
@@ -4564,7 +4564,7 @@ async def test_async_get_or_create_deprecated_parameters(
     caplog: pytest.LogCaptureFixture,
     parameter: str,
     value: Any,
-    replacement: str | None,
+    advice: str,
     expectation: AbstractContextManager,
     expected_log: int,
 ) -> None:
@@ -4578,10 +4578,6 @@ async def test_async_get_or_create_deprecated_parameters(
         config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
     )
 
-    if replacement is None:
-        advice = ", which is ignored"
-    else:
-        advice = f"; use `{replacement}` instead"
     what = (
         "calls `device_registry.async_get_or_create` with a deprecated "
         f"`{parameter}` parameter{advice}"
@@ -10485,33 +10481,6 @@ async def test_child_device_parent_in_other_config_entry(
     # Validation precedes mutation, so no child device is created
     assert not device_registry.child_devices
     assert len(device_registry.devices) == 1
-
-
-@pytest.mark.parametrize("parameter", ["created_at", "modified_at"])
-@pytest.mark.usefixtures("hass")
-async def test_async_get_or_create_child_rejects_removed_parameters(
-    device_registry: dr.DeviceRegistry,
-    mock_config_entry: MockConfigEntry,
-    parameter: str,
-) -> None:
-    """Test async_get_or_create_child no longer accepts created_at / modified_at."""
-    parent = device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        identifiers={("test", "strip")},
-        name="Power strip",
-    )
-
-    with pytest.raises(
-        TypeError,
-        match=f"unexpected keyword argument '{parameter}'",
-    ):
-        device_registry.async_get_or_create_child(
-            config_entry_id=mock_config_entry.entry_id,
-            identifiers={("test", "strip_outlet_1")},
-            parent_device_id=parent.id,
-            name="Outlet 1",
-            **{parameter: "2024-01-01T00:00:00+00:00"},
-        )
 
 
 @pytest.mark.usefixtures("hass")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate passing `created_at` or `modified_at` to `DeviceRegistry.async_get_or_create`; passing it will warn until 2027.9 when it will instead raise.

Immediately raise if passed to `DeviceRegistry.async_get_or_create_child`

The functionality is not used by core, and I can not find any case where it's used by custom integrations either.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
