### PR TITLE
Fix freezegun thread race dropping recorder events in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,10 @@ def pytest_runtest_setup() -> None:
 
     - Modified to not force lazily imported module attributes to be resolved
       when scanning the loaded modules for time related objects.
+
+    - Modified to tolerate a thread reading the time while another thread
+      stops freeze_time, which otherwise raises IndexError, see
+      https://github.com/spulec/freezegun/issues/345.
     """
     pytest_socket.socket_allow_hosts(["127.0.0.1"])
     pytest_socket.disable_socket(allow_unix_socket=True)
@@ -243,6 +247,8 @@ def pytest_runtest_setup() -> None:
     freezegun.api._get_module_attributes_hash = (  # type: ignore[attr-defined]
         patch_time.ha_get_module_attributes_hash
     )
+    freezegun.api._should_use_real_time = patch_time.ha_should_use_real_time  # type: ignore[attr-defined]
+    freezegun.api.get_current_time = patch_time.ha_get_current_time
 
     def adapt_datetime(val):
         return val.isoformat(" ")

--- a/tests/patch_time.py
+++ b/tests/patch_time.py
@@ -1,6 +1,7 @@
 """Patch time related functions."""
 
 import datetime
+import inspect
 import time
 import types
 from typing import Any
@@ -47,6 +48,71 @@ def ha_get_module_attributes_hash(module: types.ModuleType) -> str:
     return f"{id(module)}-{hash(frozenset(getattr(module, '__dict__', {})))}"
 
 
+def ha_should_use_real_time() -> bool:
+    """Return whether time patched by freezegun should return the real time.
+
+    Modified to read the ignore list atomically: freeze_time stop() in another
+    thread pops the freezegun stacks mid-check, and the upstream implementation
+    then raises IndexError, which for example makes the recorder thread drop
+    the event it is processing when a log timestamp hits the race.
+    See https://github.com/spulec/freezegun/issues/345.
+    """
+    if not freezegun.api.call_stack_inspection_limit:
+        return False
+
+    try:
+        ignore = freezegun.api.ignore_lists[-1]
+    except IndexError:
+        # Means stop() has already been called, so we can now return the real time
+        return True
+
+    if not ignore:
+        return False
+
+    # Keep the same call depth as the upstream implementation: the caller of
+    # the patched time function is two frames up.
+    frame = inspect.currentframe().f_back.f_back
+
+    for _ in range(freezegun.api.call_stack_inspection_limit):
+        module_name = frame.f_globals.get("__name__")
+        if module_name and module_name.startswith(ignore):
+            return True
+
+        frame = frame.f_back
+        if frame is None:
+            break
+
+    return False
+
+
+def ha_get_current_time() -> datetime.datetime:
+    """Return the frozen time as a naive UTC datetime.
+
+    Modified to fall back to the real time when freeze_time stop() in another
+    thread pops the factory stack mid-call, instead of raising IndexError.
+    See https://github.com/spulec/freezegun/issues/345.
+    """
+    try:
+        return freezegun.api.freeze_factories[-1]()
+    except IndexError:
+        # Means stop() has already been called, so we can now return the real time
+        return freezegun.api.real_datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+def _ha_tz_offset() -> datetime.timedelta:
+    """Return the frozen tz offset.
+
+    Modified to fall back to no offset when freeze_time stop() in another
+    thread pops the offset stack mid-call, instead of raising IndexError.
+    See https://github.com/spulec/freezegun/issues/345.
+    """
+    try:
+        return freezegun.api.tz_offsets[-1]
+    except IndexError:
+        # Means stop() has already been called, and real time has no offset
+        return datetime.timedelta(0)
+
+
 class HAFakeDateMeta(freezegun.api.FakeDateMeta):
     """Modified to override the string representation."""
 
@@ -56,7 +122,12 @@ class HAFakeDateMeta(freezegun.api.FakeDateMeta):
 
 
 class HAFakeDate(freezegun.api.FakeDate, metaclass=HAFakeDateMeta):  # type: ignore[name-defined]
-    """Modified to improve class str."""
+    """Modified to improve class str and tolerate a concurrent unfreeze."""
+
+    @classmethod
+    def _tz_offset(cls) -> datetime.timedelta:
+        """Return the frozen tz offset."""
+        return _ha_tz_offset()
 
 
 class HAFakeDatetimeMeta(freezegun.api.FakeDatetimeMeta):
@@ -71,7 +142,13 @@ class HAFakeDatetime(freezegun.api.FakeDatetime, metaclass=HAFakeDatetimeMeta): 
     """Modified to include basic fold support and improve class str.
 
     Fold support submitted to upstream in https://github.com/spulec/freezegun/pull/424.
+    Also modified to tolerate a concurrent unfreeze.
     """
+
+    @classmethod
+    def _tz_offset(cls) -> datetime.timedelta:
+        """Return the frozen tz offset."""
+        return _ha_tz_offset()
 
     @classmethod
     def now(cls, tz=None):

--- a/tests/test_patch_time.py
+++ b/tests/test_patch_time.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 import datetime
 import sys
+import time
 import types
 
 from freezegun import freeze_time
@@ -53,3 +54,33 @@ def test_freezing_time_rescans_a_changed_module(
         assert lazy_module.datetime.now() == real_datetime(2023, 1, 1)
 
     assert lazy_module.datetime is real_datetime
+
+
+def test_time_is_readable_after_unfreeze() -> None:
+    """Test stale patched time functions do not raise after time is unfrozen.
+
+    A thread which entered a patched time function, or still holds a patched
+    class, keeps using it while another thread stops freeze_time; the freezegun
+    stacks are then already empty, see
+    https://github.com/spulec/freezegun/issues/345.
+    """
+
+    def capture() -> tuple:
+        # Function locals, unlike module globals, are not restored by
+        # freezegun's unpatching, so these stay patched after the freeze ends.
+        with freeze_time("2023-01-01"):
+            return (
+                datetime.datetime,
+                datetime.date,
+                time.time,
+                time.time_ns,
+                time.monotonic,
+            )
+
+    fake_datetime, fake_date, fake_time, fake_time_ns, fake_monotonic = capture()
+
+    assert fake_datetime.now().year >= 2023
+    assert fake_date.today().year >= 2023
+    assert fake_time() > 0
+    assert fake_time_ns() > 0
+    assert fake_monotonic() >= 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes a class of CI flakes caused by a thread-safety bug in freezegun ([spulec/freezegun#345](https://github.com/spulec/freezegun/issues/345), open upstream, also present on master).

`freeze_time` `stop()` pops freezegun's module-global stacks (`ignore_lists`, `freeze_factories`, `tz_offsets`) without locking. A thread that reads the time at that moment can hit `IndexError` from `ignore_lists[-1]`, `freeze_factories[-1]` or `tz_offsets[-1]`.

This is how `test_compile_hourly_statistics_unavailable` failed in [this CI run](https://github.com/home-assistant/core/actions/runs/32726927898/job/97430864172): the recorder thread timestamped a log record (`time.time_ns()`) while the test's main thread exited a `freeze_time` context. The `IndexError` made the recorder drop the `state_changed` event it was processing, so one state was missing from history and the test failed with `assert 3 == 2`.

The fix adds thread-safe replacements for the three racy readers to `tests/patch_time.py`, next to the freezegun patches Home Assistant already maintains there. Each replacement falls back to the real time when the stacks are already empty, which matches what freezegun itself does once `stop()` has finished.

Verified with a stress test (freeze/unfreeze loop in the main thread, 4 threads hammering time calls): vanilla freezegun produced 28 `IndexError`s in 300 freeze cycles, spread over all three call sites; with the patch, 0 errors in 1500 cycles and 56M time reads. A regression test is included which fails with `IndexError` without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JugnJTGLR542uyRSCrp1og)_