### PR TITLE
Update add-on state from Supervisor state change events

### DIFF
--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -91,6 +91,7 @@ EVENT_ISSUE_CHANGED = "issue_changed"
 EVENT_ISSUE_REMOVED = "issue_removed"
 EVENT_JOB = "job"
 EVENT_STORE_RELOADED = "store_reloaded"
+EVENT_ADDON = "addon"
 
 UPDATE_KEY_SUPERVISOR = "supervisor"
 STARTUP_COMPLETE = "complete"

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -34,7 +34,7 @@ from aiohasupervisor.models import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_MANUFACTURER, ATTR_NAME
+from homeassistant.const import ATTR_MANUFACTURER, ATTR_NAME, ATTR_STATE
 from homeassistant.core import (
     CALLBACK_TYPE,
     HomeAssistant,
@@ -80,6 +80,7 @@ from .const import (
     DATA_SUPERVISOR_INFO,
     DATA_SUPERVISOR_STATS,
     DOMAIN,
+    EVENT_ADDON,
     EVENT_HEALTH_CHANGED,
     EVENT_ISSUE_CHANGED,
     EVENT_ISSUE_REMOVED,
@@ -1306,8 +1307,12 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
 
     @callback
     def _supervisor_event(self, event: dict[str, Any]) -> None:
-        """Refresh add-on data when Supervisor reloads the store."""
-        if event.get(ATTR_WS_EVENT) != EVENT_STORE_RELOADED:
+        """Handle Supervisor store reload and add-on state change events."""
+        ws_event = event.get(ATTR_WS_EVENT)
+        if ws_event == EVENT_ADDON:
+            self._update_addon_state_from_event(event)
+            return
+        if ws_event != EVENT_STORE_RELOADED:
             return
         # Without listeners there are no add-on entities to keep in sync.
         # Scheduled polling is paused in that case as well, so don't let
@@ -1316,6 +1321,40 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
             return
         self.config_entry.async_create_task(
             self.hass, self.async_refresh_after_store_reload()
+        )
+
+    @callback
+    def _update_addon_state_from_event(self, event: dict[str, Any]) -> None:
+        """Update cached add-on state from a Supervisor state change event."""
+        if self.data is None:
+            return
+        if (slug := event.get(ATTR_SLUG)) is None or (
+            addon_data := self.data.addons.get(slug)
+        ) is None:
+            return
+        try:
+            state = AddonState(event[ATTR_STATE])
+        except KeyError, ValueError:
+            return
+        if addon_data.addon.state == state:
+            return
+        updated_addon = replace(addon_data.addon, state=state)
+
+        # Keep the addon list used by legacy accessors and the stats
+        # coordinator in sync
+        addons_list: list[InstalledAddon] | None = self.hass.data.get(DATA_ADDONS_LIST)
+        if addons_list is not None:
+            self.hass.data[DATA_ADDONS_LIST] = [
+                updated_addon if addon.slug == slug else addon for addon in addons_list
+            ]
+
+        self.async_set_updated_data(
+            HassioAddonData(
+                addons={
+                    **self.data.addons,
+                    slug: replace(addon_data, addon=updated_addon),
+                }
+            )
         )
 
     @override

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -128,6 +128,106 @@ async def test_binary_sensor(
     assert state.state == expected
 
 
+async def test_addon_state_from_supervisor_event(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_supervisor_ws_client: WebSocketGenerator,
+) -> None:
+    """Test addon running binary sensor updates from Supervisor state events."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, DOMAIN, {"hassio": {}})
+    await hass.async_block_till_done()
+
+    # Enable the entity.
+    entity_id = "binary_sensor.test2_running"
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    client = await hass_supervisor_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "supervisor/event",
+            "data": {"event": "addon", "slug": "test2", "state": "started"},
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "supervisor/event",
+            "data": {"event": "addon", "slug": "test2", "state": "stopped"},
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
+@pytest.mark.parametrize(
+    "event_data",
+    [
+        pytest.param(
+            {"event": "addon", "slug": "not_installed", "state": "started"},
+            id="unknown_addon",
+        ),
+        pytest.param(
+            {"event": "addon", "slug": "test2", "state": "not_a_state"},
+            id="unknown_state",
+        ),
+        pytest.param({"event": "addon"}, id="missing_fields"),
+    ],
+)
+async def test_addon_state_event_ignored(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_supervisor_ws_client: WebSocketGenerator,
+    event_data: dict[str, str],
+) -> None:
+    """Test invalid Supervisor addon state events are ignored."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, DOMAIN, {"hassio": {}})
+    await hass.async_block_till_done()
+
+    # Enable the entity.
+    entity_id = "binary_sensor.test2_running"
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = await hass_supervisor_ws_client()
+    await client.send_json({"id": 1, "type": "supervisor/event", "data": event_data})
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
 async def test_mount_binary_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Supervisor pushes an `addon` websocket event whenever an add-on changes state, but the hassio add-on coordinator so far only picked up state changes through its regular poll. Since the coordinator split the poll interval is 15 minutes, so the add-on "Running" binary sensor could report a stale state for up to 15 minutes, e.g. after a Home Assistant restart while an add-on is still starting (see home-assistant/supervisor#7159).

Handle the add-on state change event in the add-on coordinator by patching the cached add-on state directly from the event payload, making the "Running" binary sensor update immediately without an additional Supervisor API call. The add-on list stored in `hass.data` is kept in sync as well, so the stats coordinator sees the current set of running add-ons.

This handles the legacy `addon` event only for now; support for the `app` event of the Supervisor websocket v2 API will be added for all events in one go in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/supervisor#7159
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
