### PR TITLE
Fix recorder.purge_entities dropping group entities from the purge set

### DIFF
--- a/homeassistant/components/recorder/services.py
+++ b/homeassistant/components/recorder/services.py
@@ -100,7 +100,10 @@ async def _async_handle_purge_service(service: ServiceCall) -> None:
 
 async def _async_handle_purge_entities_service(service: ServiceCall) -> None:
     """Handle calls to the purge entities service."""
-    entity_ids = await async_extract_entity_ids(service)
+    # Purge the entity_ids exactly as given instead of expanding group
+    # members, otherwise a targeted group.* entity is dropped from the
+    # purge set instead of having its own history purged.
+    entity_ids = await async_extract_entity_ids(service, expand_group=False)
     domains = service.data.get(ATTR_DOMAINS, [])
     keep_days = service.data.get(ATTR_KEEP_DAYS, 0)
     entity_globs = service.data.get(ATTR_ENTITY_GLOBS, [])

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1661,6 +1661,65 @@ async def test_purge_entities(hass: HomeAssistant, recorder_mock: Recorder) -> N
         assert states_meta_remain.count() == 4
 
 
+async def test_purge_entities_group_entity_id(
+    hass: HomeAssistant, recorder_mock: Recorder
+) -> None:
+    """Test purge_entities purges a group.* entity_id instead of dropping it.
+
+    A group.* entity_id must not be expanded to its (non-existent) group
+    members, or it is silently dropped from the purge target set entirely.
+    That in turn leaves `entity_id`/`domains`/`entity_globs` all empty, which
+    generate_filter() treats as "no filter" and purges every entity in the
+    database instead of just the one requested. See issue #162615.
+    """
+    with session_scope(hass=hass) as session:
+        timestamp = dt_util.utcnow() - timedelta(days=2)
+        for event_id in range(1000, 1010):
+            _add_state_with_state_attributes(
+                session,
+                "group.purge_group",
+                "purgeme",
+                timestamp,
+                event_id,
+            )
+        for event_id in range(2000, 2010):
+            _add_state_with_state_attributes(
+                session,
+                "sensor.keep",
+                "keep",
+                timestamp,
+                event_id,
+            )
+        convert_pending_states_to_meta(recorder_mock, session)
+        convert_pending_events_to_event_types(recorder_mock, session)
+
+    with session_scope(hass=hass, read_only=True) as session:
+        states = session.query(States)
+        assert states.count() == 20
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        {"entity_id": "group.purge_group", "domains": [], "entity_globs": []},
+    )
+    await hass.async_block_till_done()
+    await async_recorder_block_till_done(hass)
+    await async_wait_purge_done(hass)
+
+    with session_scope(hass=hass, read_only=True) as session:
+        states_meta_remain = session.query(StatesMeta).filter(
+            StatesMeta.entity_id == "group.purge_group"
+        )
+        assert states_meta_remain.count() == 0
+
+        states_sensor_kept = (
+            session.query(States)
+            .outerjoin(StatesMeta, States.metadata_id == StatesMeta.metadata_id)
+            .filter(StatesMeta.entity_id == "sensor.keep")
+        )
+        assert states_sensor_kept.count() == 10
+
+
 async def _add_test_states(hass: HomeAssistant, wait_recording_done: bool = True):
     """Add multiple states to the db for testing."""
     utcnow = dt_util.utcnow()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A — this is not a breaking change.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`recorder.purge_entities` silently fails to purge the history of any
`group.*` entity, and — more importantly — can end up purging the history
of *every* entity in the database instead.

`_async_handle_purge_entities_service` calls `async_extract_entity_ids()`
with its default `expand_group=True`. For an `entity_id` starting with
`group.`, `homeassistant.helpers.group.expand_entity_ids()` tries to
replace it with its live group members. If there is no live state for that
group (a common case for `purge_entities`, since you're often purging
history for something that was renamed or removed), it's replaced with
nothing — the `group.*` id is dropped entirely, not preserved.

When that's the only `entity_id` passed, `entity_id`/`domains`/
`entity_globs` all end up empty. `generate_filter()` treats "nothing
specified" as no filter, i.e. "match everything" — so the purge call
deletes history for every entity in the database, not just the one that
was requested. This matches the behavior reported in #162615, where a
call with a single `group.*` entity purged 12 unrelated metadata IDs.

Fix: pass `expand_group=False`, so `purge_entities` purges exactly the
`entity_id`(s) given, the same way it already treats `domains` and
`entity_globs` as literal matches instead of expanding them.

## Type of change

- [ ]  Dependency upgrade
- [x]  Bugfix (non-breaking change which fixes an issue)
- [ ]  New integration (thank you!)
- [ ]  New feature (which adds functionality to an existing integration)
- [ ]  Deprecation (breaking change to happen in the future)
- [ ]  Breaking change (fix/feature causing existing functionality to break)
- [ ]  Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #162615
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
