### PR TITLE
Complete action-exceptions quality scale rule for ouman_eh_800

### DIFF
--- a/homeassistant/components/ouman_eh_800/coordinator.py
+++ b/homeassistant/components/ouman_eh_800/coordinator.py
@@ -10,6 +10,7 @@ from ouman_eh_800_api import (
     L2BaseEndpoints,
     OumanClientAuthenticationError,
     OumanClientCommunicationError,
+    OumanClientError,
     OumanEh800Client,
     OumanEndpoint,
     OumanRegistrySet,
@@ -128,6 +129,8 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
             raise HomeAssistantError("Authentication failed") from err
         except OumanClientCommunicationError as err:
             raise HomeAssistantError("Error communicating with API") from err
+        except OumanClientError as err:
+            raise HomeAssistantError("Unexpected response from device") from err
 
         self.async_set_updated_data({**self.data, endpoint: result})
         # Separate refresh on all endpoints to catch cascading changes.

--- a/homeassistant/components/ouman_eh_800/quality_scale.yaml
+++ b/homeassistant/components/ouman_eh_800/quality_scale.yaml
@@ -32,9 +32,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions:
-    status: exempt
-    comment: Integration does not provide actions.
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done

--- a/tests/components/ouman_eh_800/test_climate.py
+++ b/tests/components/ouman_eh_800/test_climate.py
@@ -8,6 +8,7 @@ from ouman_eh_800_api import (
     OperationMode,
     OumanClientAuthenticationError,
     OumanClientCommunicationError,
+    OumanClientError,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -308,6 +309,11 @@ async def test_async_set_temperature_out_of_range(
             OumanClientCommunicationError("Network error: Connection refused"),
             "Error communicating with API",
             id="communication_failure",
+        ),
+        pytest.param(
+            OumanClientError("Endpoint ID missing from response"),
+            "Unexpected response from device",
+            id="unexpected_response",
         ),
     ],
 )

--- a/tests/components/ouman_eh_800/test_number.py
+++ b/tests/components/ouman_eh_800/test_number.py
@@ -10,6 +10,7 @@ from ouman_eh_800_api import (
     L1ThreePointCurve,
     OumanClientAuthenticationError,
     OumanClientCommunicationError,
+    OumanClientError,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -102,6 +103,11 @@ async def test_async_set_native_value(
             OumanClientCommunicationError("Network error: Connection refused"),
             "Error communicating with API",
             id="communication_failure",
+        ),
+        pytest.param(
+            OumanClientError("Endpoint ID missing from response"),
+            "Unexpected response from device",
+            id="unexpected_response",
         ),
     ],
 )

--- a/tests/components/ouman_eh_800/test_select.py
+++ b/tests/components/ouman_eh_800/test_select.py
@@ -10,6 +10,7 @@ from ouman_eh_800_api import (
     OperationMode,
     OumanClientAuthenticationError,
     OumanClientCommunicationError,
+    OumanClientError,
     PumpSummerStopControl,
     RelayControl,
     RelayPumpSummerStop,
@@ -125,6 +126,12 @@ async def test_async_select_option(
             HomeAssistantError,
             "Error communicating with API",
             id="communication_failure",
+        ),
+        pytest.param(
+            OumanClientError("Endpoint ID missing from response"),
+            HomeAssistantError,
+            "Unexpected response from device",
+            id="unexpected_response",
         ),
     ],
 )

--- a/tests/components/ouman_eh_800/test_valve.py
+++ b/tests/components/ouman_eh_800/test_valve.py
@@ -6,6 +6,7 @@ from ouman_eh_800_api import (
     L1BaseEndpoints,
     OumanClientAuthenticationError,
     OumanClientCommunicationError,
+    OumanClientError,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -95,6 +96,11 @@ async def test_async_set_valve_position(
             OumanClientCommunicationError("Network error: Connection refused"),
             "Error communicating with API",
             id="communication_failure",
+        ),
+        pytest.param(
+            OumanClientError("Endpoint ID missing from response"),
+            "Unexpected response from device",
+            id="unexpected_response",
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Complete the `action-exceptions` quality scale rule for the Ouman EH-800 integration.

The rule was previously marked `exempt` with "Integration does not provide actions", which is incorrect: the rule explicitly counts platform actions and allows no exemptions. The integration was already mostly compliant, since all entity actions route through a single coordinator method that raises `HomeAssistantError` on authentication and communication failures, and incorrect-usage cases are covered by Home Assistant's action schema and bounds validation.

The one gap was that the client library can raise its base `OumanClientError` on the set-value path when the device answers with a malformed or mismatching response (confirmation endpoint missing, unparseable confirmation value, or an echoed value that differs from the requested one). That escaped as a raw library exception; it is now wrapped in `HomeAssistantError` ("Unexpected response from device"), and each platform's action error tests gained a case for it. With that, the rule is marked `done` in `quality_scale.yaml`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
