### PR TITLE
Fix intents targeting unexposed entities and non-light entities in HassLightSet

### DIFF
--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -45,6 +45,7 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
                 ),
             },
             description="Sets the brightness percentage or color of a light",
+            required_domains={DOMAIN},
             platforms={DOMAIN},
         ),
     )

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -272,6 +272,7 @@ class WyomingConversationEntity(
                                     intent_slots,
                                     text_input=user_input.text,
                                     language=user_input.language,
+                                    assistant=conversation.DOMAIN,
                                     satellite_id=user_input.satellite_id,
                                     device_id=user_input.device_id,
                                 )

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -1,12 +1,19 @@
 """Tests for the light intents."""
 
+import pytest
+
 from homeassistant.components import light
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.intent import async_handle
+from homeassistant.helpers import area_registry as ar, entity_registry as er
+from homeassistant.helpers.intent import MatchFailedError, async_handle
+from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
+
+ASSISTANT = "conversation"
 
 
 async def test_intent_set_color(hass: HomeAssistant) -> None:
@@ -89,3 +96,79 @@ async def test_intent_set_temperature(hass: HomeAssistant) -> None:
     assert call.service == SERVICE_TURN_ON
     assert call.data.get(ATTR_ENTITY_ID) == "light.test"
     assert call.data.get(light.ATTR_COLOR_TEMP_KELVIN) == 2000
+
+
+async def test_intent_set_area_only_targets_lights(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that only lights are targeted when an area is used without a domain slot."""
+    kitchen = area_registry.async_create("Kitchen")
+    for domain, unique_id in (("light", "l1"), ("switch", "s1"), ("sensor", "t1")):
+        entry = entity_registry.async_get_or_create(domain, "test", unique_id)
+        entity_registry.async_update_entity(entry.entity_id, area_id=kitchen.id)
+        hass.states.async_set(entry.entity_id, "off")
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET,
+        {"area": {"value": "Kitchen"}, "brightness": {"value": "20"}},
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get(ATTR_ENTITY_ID) == "light.test_l1"
+    assert calls[0].data.get(light.ATTR_BRIGHTNESS_PCT) == 20
+
+
+async def test_intent_set_without_name_or_area_skips_unexposed(
+    hass: HomeAssistant,
+) -> None:
+    """Test that unexposed lights are not targeted when no name or area is given."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    hass.states.async_set("light.exposed", "off")
+    hass.states.async_set("light.hidden", "off")
+    async_expose_entity(hass, ASSISTANT, "light.hidden", False)
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET,
+        {"brightness": {"value": "20"}},
+        assistant=ASSISTANT,
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get(ATTR_ENTITY_ID) == "light.exposed"
+
+
+async def test_intent_set_without_name_or_area_all_unexposed(
+    hass: HomeAssistant,
+) -> None:
+    """Test that no lights are targeted when none are exposed."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    hass.states.async_set("light.hidden", "off")
+    async_expose_entity(hass, ASSISTANT, "light.hidden", False)
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    with pytest.raises(MatchFailedError):
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET,
+            {"brightness": {"value": "20"}},
+            assistant=ASSISTANT,
+        )
+
+    assert not calls

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -64,6 +64,8 @@ async def test_intent(
             assert intent_obj.slots.get("entity", {}).get("value") == "value"
             assert intent_obj.satellite_id == satellite_id
             assert intent_obj.device_id == device_id
+            # Entities must be filtered by exposure to the conversation assistant
+            assert intent_obj.assistant == conversation.DOMAIN
             response = intent_obj.create_response()
 
             # Add parts to test response rendering


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A `HassLightSet` intent with no `name` and no `area` set the brightness of every light in the house, including lights that were not exposed to Assist. Two separate bugs combined to allow that.

**1. The Wyoming conversation agent bypassed exposure filtering entirely**

`async_match_targets` only applies the exposure filter when `constraints.assistant` is set:

```python
if constraints.assistant:
    # Check exposure
    candidates = [c for c in candidates if c.is_exposed]
```

`WyomingConversationEntity` called `intent.async_handle` without `assistant`, unlike the default agent and `llm.IntentTool`, so every intent recognized by a Wyoming intent service ran with exposure checks disabled and could target unexposed entities. This now passes `assistant=conversation.DOMAIN`.

**2. `HassLightSet` was missing `required_domains`**

It was the only domain intent handler without `required_domains={DOMAIN}` — `fan`, `vacuum`, `lawn_mower`, and all six `media_player` handlers set it. Two consequences, both covered by new tests:

- With an `area` but no `domain` slot, `constraints.domains` was `None`, so `hass.states.async_all(None)` returned every entity and `light.turn_on` was then called on each one in that area. A repro with a light, a switch, and a sensor in the same area produced service calls for all three.
- Without a domain constraint, `has_constraints` was `False`, so a request with no `name`/`area` (and `name: all`) raised `IntentHandleError("Service handler cannot target all devices")`. It only worked in practice because the intents package injects `slots: {domain: light}` into the area/floor sentence groups.

Adding `required_domains={DOMAIN}` fixes the cross-domain service calls and makes an unconstrained `HassLightSet` target all lights, matching `HassFanSetSpeed`. The exposure filter is what keeps that scoped, which is why the two changes belong together.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
