### PR TITLE
Add service to download all images from an entity at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -1,5 +1,7 @@
 """Constants for the Home Connect integration."""
 
+from typing import Final
+
 from aiohomeconnect.model import EventKey, OptionKey, ProgramKey, SettingKey, StatusKey
 
 from homeassistant.const import UnitOfTemperature, UnitOfTime, UnitOfVolume
@@ -70,6 +72,9 @@ ATTR_AFFECTS_TO = "affects_to"
 ATTR_KEY = "key"
 ATTR_PROGRAM = "program"
 ATTR_VALUE = "value"
+ATTR_FOLDER_NAME: Final = "folder_name"
+ATTR_FROM: Final = "from"
+ATTR_TO: Final = "to"
 
 AFFECTS_TO_ACTIVE_PROGRAM = "active_program"
 AFFECTS_TO_SELECTED_PROGRAM = "selected_program"

--- a/homeassistant/components/home_connect/icons.json
+++ b/homeassistant/components/home_connect/icons.json
@@ -245,6 +245,9 @@
     "change_setting": {
       "service": "mdi:cog"
     },
+    "download_images": {
+      "service": "mdi:download"
+    },
     "set_program_and_options": {
       "service": "mdi:form-select"
     },

--- a/homeassistant/components/home_connect/services.py
+++ b/homeassistant/components/home_connect/services.py
@@ -1,8 +1,10 @@
 """Custom actions (previously known as services) for the Home Connect integration."""
 
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from functools import partial
 import logging
+import os
 from typing import Any, cast
 
 from aiohomeconnect.client import Client as HomeConnectClient
@@ -17,18 +19,26 @@ from aiohomeconnect.model.error import HomeConnectError, NoProgramActiveError
 from aiohomeconnect.model.program import Program, ProgramDefinition
 import voluptuous as vol
 
+from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
 from homeassistant.const import ATTR_DEVICE_ID, UnitOfTemperature
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    service,
+)
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
     AFFECTS_TO_ACTIVE_PROGRAM,
     AFFECTS_TO_SELECTED_PROGRAM,
     ATTR_AFFECTS_TO,
+    ATTR_FOLDER_NAME,
+    ATTR_FROM,
     ATTR_KEY,
     ATTR_PROGRAM,
+    ATTR_TO,
     ATTR_VALUE,
     DOMAIN,
     PROGRAM_ENUM_OPTIONS,
@@ -38,6 +48,7 @@ from .const import (
     TRANSLATION_KEYS_PROGRAMS_MAP,
 )
 from .coordinator import HomeConnectConfigEntry
+from .image import HomeConnectImageEntity
 from .utils import bsh_key_to_translation_key, get_dict_from_home_connect_error
 
 LOGGER = logging.getLogger(__name__)
@@ -422,6 +433,63 @@ async def async_service_start_selected_program(call: ServiceCall) -> None:
         ) from err
 
 
+async def async_handle_download_images_service(
+    image_entity: HomeConnectImageEntity, service_call: ServiceCall
+) -> None:
+    """Handle download images services calls."""
+    hass = image_entity.hass
+    folder_name: str = service_call.data[ATTR_FOLDER_NAME]
+    from_time: datetime | None = service_call.data.get(ATTR_FROM)
+    to_time: datetime | None = service_call.data.get(ATTR_TO)
+
+    # check if we allow to access to that file
+    if not hass.config.is_allowed_path(folder_name):
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_access_to_path",
+            translation_placeholders={"target": folder_name},
+        )
+
+    def _write_image(to_file: str, image_data: bytes) -> None:
+        """Executor helper to write image."""
+        os.makedirs(os.path.dirname(to_file), exist_ok=True)
+        with open(to_file, "wb") as img_file:
+            img_file.write(image_data)
+
+    client = image_entity.appliance_coordinator.client
+    for image_info in (
+        await client.get_images(image_entity.appliance.info.ha_id)
+    ).images:
+        if image_info.key != image_entity.entity_description.key:
+            continue
+        timestamp = datetime.fromtimestamp(image_info.timestamp / 1000)
+        if from_time and timestamp < from_time:
+            continue
+        if to_time and timestamp > to_time:
+            continue
+        try:
+            image_data = await client.get_image(
+                image_entity.appliance.info.ha_id, image_key=image_info.image_key
+            )
+        except HomeConnectError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="fetch_image_error",
+                translation_placeholders=get_dict_from_home_connect_error(err),
+            ) from err
+        try:
+            await hass.async_add_executor_job(
+                _write_image,
+                f"{folder_name}/{timestamp.strftime('%Y%m%d_%H%M%S')}.jpg",
+                image_data,
+            )
+        except OSError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="cannot_write",
+            ) from err
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register custom actions."""
@@ -440,4 +508,16 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_START_SELECTED_PROGRAM,
         async_service_start_selected_program,
         schema=SERVICE_START_SELECTED_PROGRAM_SCHEMA,
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        "download_images",
+        func=async_handle_download_images_service,
+        entity_domain=IMAGE_DOMAIN,
+        schema={
+            vol.Required(ATTR_FOLDER_NAME): cv.string,
+            vol.Optional(ATTR_FROM): cv.datetime,
+            vol.Optional(ATTR_TO): cv.datetime,
+        },
     )

--- a/homeassistant/components/home_connect/services.yaml
+++ b/homeassistant/components/home_connect/services.yaml
@@ -804,3 +804,23 @@ start_selected_program:
           step: 1
           mode: box
           unit_of_measurement: s
+
+download_images:
+  target:
+    entity:
+      integration: home_connect
+      domain: image
+  fields:
+    folder_name:
+      required: true
+      example: "/tmp/fridge_interior"
+      selector:
+        text:
+    from:
+      example: "2023-01-01T00:00:00Z"
+      selector:
+        datetime:
+    to:
+      example: "2023-01-31T23:59:59Z"
+      selector:
+        datetime:

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1602,6 +1602,9 @@
     "auth_error": {
       "message": "Authentication error: {error}. Please, re-authenticate your account"
     },
+    "cannot_write": {
+      "message": "Can't write to file, check logs for details."
+    },
     "config_entry_not_found": {
       "message": "Config entry for device ID {device_id} not found"
     },
@@ -1619,6 +1622,9 @@
     },
     "fetch_program_error": {
       "message": "Error obtaining the selected or active program: {error}"
+    },
+    "no_access_to_path": {
+      "message": "Can't write to directory {target}, no access to path!"
     },
     "no_program_to_start": {
       "message": "No program to start"
@@ -2209,6 +2215,24 @@
         "value": { "description": "Value of the setting.", "name": "Value" }
       },
       "name": "Change setting"
+    },
+    "download_images": {
+      "description": "Downloads images from the appliance. Files names will contain the date of the image.",
+      "fields": {
+        "folder_name": {
+          "description": "Name of the folder to save the images to.",
+          "name": "Folder name"
+        },
+        "from": {
+          "description": "Start time for the image range (UTC).",
+          "name": "From"
+        },
+        "to": {
+          "description": "End time for the image range (UTC).",
+          "name": "To"
+        }
+      },
+      "name": "Download images"
     },
     "set_program_and_options": {
       "description": "Starts or selects a program with options or sets the options for the active or the selected program.",

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -1,8 +1,10 @@
 """Tests for the Home Connect actions."""
 
 from collections.abc import Awaitable, Callable
+from datetime import datetime
+from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohomeconnect.model import (
     HomeAppliance,
@@ -14,6 +16,7 @@ from aiohomeconnect.model import (
     SettingKey,
 )
 from aiohomeconnect.model.error import HomeConnectError, NoProgramActiveError
+from aiohomeconnect.model.image import ArrayOfImages, Image
 from aiohomeconnect.model.program import ProgramDefinitionOption
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -28,6 +31,7 @@ from homeassistant.components.home_connect.const import (
 from homeassistant.components.home_connect.services import PROGRAM_OPTIONS
 from homeassistant.components.home_connect.utils import bsh_key_to_translation_key
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -56,6 +60,16 @@ SERVICE_APPLIANCE_METHOD_MAPPING = {
 SERVICE_VALIDATION_ERROR_MAPPING = {
     "change_setting": r"Error.*assigning.*value.*setting.*",
 }
+
+IMAGE_ENTITY_ID = "image.fridgefreezer_interior_right_camera"
+
+
+@pytest.fixture
+def platforms(request: pytest.FixtureRequest) -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    if hasattr(request, "param") and request.param:
+        return request.param
+    return []
 
 
 SERVICES_SET_PROGRAM_AND_OPTIONS = [
@@ -1072,3 +1086,268 @@ async def test_temperature_options_convert_api_error(
         kwargs.get("options") or kwargs["array_of_options"].options
     )
     assert call_options[0].value == 35
+
+
+@pytest.mark.parametrize("platforms", [[Platform.IMAGE]], indirect=True)
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_download_images_service(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    tmp_path: Path,
+) -> None:
+    """Test downloading images for matching image entity key."""
+    images = [
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_1",
+            preview_image_key="preview_image_key_1",
+            timestamp=1785974400000,
+            quality="good",
+        ),
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.DoorRightRC",
+            image_key="image_key_2",
+            preview_image_key="preview_image_key_2",
+            timestamp=1785978000000,
+            quality="good",
+        ),
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_3",
+            preview_image_key="preview_image_key_3",
+            timestamp=1785981600000,
+            quality="good",
+        ),
+    ]
+    image_data = {
+        "image_key_1": b"image_data_1",
+        "image_key_3": b"image_data_3",
+    }
+
+    async def mock_get_image(_: str, *, image_key: str) -> bytes:
+        return image_data[image_key]
+
+    client.get_images = AsyncMock(return_value=ArrayOfImages(images))
+    client.get_image = AsyncMock(wraps=mock_get_image)
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+    client.get_images.reset_mock()
+    client.get_image.reset_mock()
+
+    with patch.object(hass.config, "is_allowed_path", return_value=True):
+        await hass.services.async_call(
+            DOMAIN,
+            "download_images",
+            {
+                "entity_id": IMAGE_ENTITY_ID,
+                "folder_name": str(tmp_path),
+            },
+            blocking=True,
+        )
+
+    client.get_images.assert_awaited_once_with(appliance.ha_id)
+    assert client.get_image.await_count == 2
+    client.get_image.assert_any_call(appliance.ha_id, image_key="image_key_1")
+    client.get_image.assert_any_call(appliance.ha_id, image_key="image_key_3")
+
+    expected_files = {
+        f"{datetime.fromtimestamp(image.timestamp / 1000).strftime('%Y%m%d_%H%M%S')}.jpg"
+        for image in images
+        if image.key == "Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC"
+    }
+    assert {path.name for path in tmp_path.glob("*.jpg")} == expected_files
+
+
+@pytest.mark.parametrize("platforms", [[Platform.IMAGE]], indirect=True)
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_download_images_service_with_time_filters(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    tmp_path: Path,
+) -> None:
+    """Test downloading images with from/to filters."""
+    images = [
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_1",
+            preview_image_key="preview_image_key_1",
+            timestamp=1785974400000,
+            quality="good",
+        ),
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_2",
+            preview_image_key="preview_image_key_2",
+            timestamp=1785978000000,
+            quality="good",
+        ),
+    ]
+
+    client.get_images = AsyncMock(return_value=ArrayOfImages(images))
+    client.get_image = AsyncMock(return_value=b"image_data_2")
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+    client.get_images.reset_mock()
+    client.get_image.reset_mock()
+
+    with patch.object(hass.config, "is_allowed_path", return_value=True):
+        await hass.services.async_call(
+            DOMAIN,
+            "download_images",
+            {
+                "entity_id": IMAGE_ENTITY_ID,
+                "folder_name": str(tmp_path),
+                "from": datetime.fromtimestamp(images[1].timestamp / 1000),
+                "to": datetime.fromtimestamp(images[1].timestamp / 1000),
+            },
+            blocking=True,
+        )
+
+    client.get_images.assert_awaited_once_with(appliance.ha_id)
+    client.get_image.assert_awaited_once_with(appliance.ha_id, image_key="image_key_2")
+
+    expected_filename = f"{datetime.fromtimestamp(images[1].timestamp / 1000).strftime('%Y%m%d_%H%M%S')}.jpg"
+    assert {path.name for path in tmp_path.glob("*.jpg")} == {expected_filename}
+
+
+@pytest.mark.parametrize("platforms", [[Platform.IMAGE]], indirect=True)
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_download_images_service_no_access_to_path(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+) -> None:
+    """Test download_images fails when target path is not allowlisted."""
+    images = [
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_1",
+            preview_image_key="preview_image_key_1",
+            timestamp=1785974400000,
+            quality="good",
+        )
+    ]
+
+    client.get_images = AsyncMock(return_value=ArrayOfImages(images))
+    client.get_image = AsyncMock(return_value=b"image_data_1")
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+    client.get_images.reset_mock()
+
+    with (
+        patch.object(hass.config, "is_allowed_path", return_value=False),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "download_images",
+            {
+                "entity_id": IMAGE_ENTITY_ID,
+                "folder_name": "/forbidden",
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "no_access_to_path"
+    client.get_images.assert_not_awaited()
+
+
+@pytest.mark.parametrize("platforms", [[Platform.IMAGE]], indirect=True)
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_download_images_service_get_image_error(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    tmp_path: Path,
+) -> None:
+    """Test download_images handles API errors when fetching image bytes."""
+    images = [
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_1",
+            preview_image_key="preview_image_key_1",
+            timestamp=1785974400000,
+            quality="good",
+        )
+    ]
+
+    client.get_images = AsyncMock(return_value=ArrayOfImages(images))
+    client.get_image = AsyncMock(side_effect=HomeConnectError("error.key"))
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+    client.get_images.reset_mock()
+    client.get_image.reset_mock()
+
+    with (
+        patch.object(hass.config, "is_allowed_path", return_value=True),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "download_images",
+            {
+                "entity_id": IMAGE_ENTITY_ID,
+                "folder_name": str(tmp_path),
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "fetch_image_error"
+
+
+@pytest.mark.parametrize("platforms", [[Platform.IMAGE]], indirect=True)
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_download_images_service_cannot_write(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    tmp_path: Path,
+) -> None:
+    """Test download_images handles filesystem write errors."""
+    images = [
+        Image(
+            key="Refrigeration.Common.EnumType.Compartment.Type.InteriorRightRC",
+            image_key="image_key_1",
+            preview_image_key="preview_image_key_1",
+            timestamp=1785974400000,
+            quality="good",
+        )
+    ]
+
+    client.get_images = AsyncMock(return_value=ArrayOfImages(images))
+    client.get_image = AsyncMock(return_value=b"image_data_1")
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+    client.get_images.reset_mock()
+    client.get_image.reset_mock()
+
+    with (
+        patch.object(hass.config, "is_allowed_path", return_value=True),
+        patch.object(hass, "async_add_executor_job", side_effect=OSError),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "download_images",
+            {
+                "entity_id": IMAGE_ENTITY_ID,
+                "folder_name": str(tmp_path),
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "cannot_write"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add service action that allows downloading images from Home Connect API. 
Image entities show only the latest images, but users might be interested on seeing other images different from the last one, then this service can be used for that.

The service action includes time filters so that not all the images need to be downloaded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
