### PR TITLE
Fix Tonewinner setup failing when device is in standby

### DIFF
--- a/homeassistant/components/tonewinner/config_flow.py
+++ b/homeassistant/components/tonewinner/config_flow.py
@@ -29,11 +29,24 @@ class TonewinnerConfigFlow(ConfigEntryFlow, domain=DOMAIN):
     """Handle the Tonewinner config flow."""
 
     async def _async_probe_receiver(self, port: str) -> str | None:
-        """Verify a receiver answers on the port and return its model."""
+        """Verify a receiver answers on the port and return its model.
+
+        A receiver in standby ignores the identity query but still answers
+        power polls, so an answered power poll verifies the port with the
+        model left for a later reconfigure once the device is awake.
+        """
         receiver = TonewinnerReceiver(port)
         try:
             await receiver.connect()
-            info: ReceiverInfo | None = await receiver.query_info()
+            power = await receiver.query_power()
+            if power is None:
+                msg = "Receiver did not answer the power query"
+                raise ConnectionError(msg) from None
+            # Standby devices ignore the identity query; only an awake
+            # receiver can report its model.
+            info: ReceiverInfo | None = None
+            if power:
+                info = await receiver.query_info()
         finally:
             await receiver.disconnect()
         return info.model if info else None

--- a/homeassistant/components/tonewinner/manifest.json
+++ b/homeassistant/components/tonewinner/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["tonewinner_rs232"],
   "quality_scale": "silver",
-  "requirements": ["tonewinner-rs232==1.1.0"]
+  "requirements": ["tonewinner-rs232==1.2.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3229,7 +3229,7 @@ togrill-bluetooth==0.9.0
 tololib==1.2.2
 
 # homeassistant.components.tonewinner
-tonewinner-rs232==1.1.0
+tonewinner-rs232==1.2.1
 
 # homeassistant.components.toon
 toonapi==0.3.0

--- a/tests/components/tonewinner/test_config_flow.py
+++ b/tests/components/tonewinner/test_config_flow.py
@@ -12,12 +12,21 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-def _mock_receiver(model: str | None = "AT-500") -> MagicMock:
-    """Return a mock receiver that answers info queries."""
+def _mock_receiver(
+    model: str | None = "AT-500", power: bool | None = True
+) -> MagicMock:
+    """Return a mock receiver that answers info and power queries."""
     mock_receiver = MagicMock()
     mock_receiver.connect = AsyncMock()
     mock_receiver.disconnect = AsyncMock()
-    mock_receiver.query_info = AsyncMock(return_value=MagicMock(model=model))
+    if model is None:
+        # A standby receiver ignores the identity query.
+        mock_receiver.query_info = AsyncMock(
+            side_effect=ConnectionError("No response for VER query")
+        )
+    else:
+        mock_receiver.query_info = AsyncMock(return_value=MagicMock(model=model))
+    mock_receiver.query_power = AsyncMock(return_value=power)
     return mock_receiver
 
 
@@ -57,14 +66,14 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
 async def test_form_unknown_model(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test setup falls back to a generic title when no model is reported."""
+    """Test setup falls back to a generic title for a standby receiver."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
         "homeassistant.components.tonewinner.config_flow.TonewinnerReceiver",
-        return_value=_mock_receiver(model=None),
+        return_value=_mock_receiver(model=None, power=False),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -394,7 +403,7 @@ async def test_reconfigure_unknown_model(
 
     with patch(
         "homeassistant.components.tonewinner.config_flow.TonewinnerReceiver",
-        return_value=_mock_receiver(model=None),
+        return_value=_mock_receiver(model=None, power=False),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/tonewinner/test_config_flow.py
+++ b/tests/components/tonewinner/test_config_flow.py
@@ -126,7 +126,7 @@ async def test_form_duplicate_serial_port(hass: HomeAssistant) -> None:
 async def test_form_cannot_connect(
     hass: HomeAssistant,
     connect_error: OSError | None,
-    answer_power: bool,
+    answer_power: bool | None,
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/tonewinner/test_config_flow.py
+++ b/tests/components/tonewinner/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.tonewinner.const import CONF_SERIAL_PORT, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -113,15 +115,27 @@ async def test_form_duplicate_serial_port(hass: HomeAssistant) -> None:
     mock_receiver_cls.assert_not_called()
 
 
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("connect_error", "answer_power"),
+    [
+        (OSError("Permission denied"), True),
+        (None, None),
+    ],
+    ids=["refused", "silent"],
+)
+async def test_form_cannot_connect(
+    hass: HomeAssistant,
+    connect_error: OSError | None,
+    answer_power: bool,
+) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_receiver = MagicMock()
-    mock_receiver.connect = AsyncMock(side_effect=OSError("Permission denied"))
-    mock_receiver.disconnect = AsyncMock()
+    mock_receiver = _mock_receiver(power=answer_power)
+    if connect_error is not None:
+        mock_receiver.connect = AsyncMock(side_effect=connect_error)
 
     with patch(
         "homeassistant.components.tonewinner.config_flow.TonewinnerReceiver",

--- a/tests/components/tonewinner/test_init.py
+++ b/tests/components/tonewinner/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from homeassistant.components.tonewinner.const import CONF_SERIAL_PORT, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_MODEL
@@ -38,14 +40,27 @@ async def test_setup_entry(
     mock_receiver.disconnect.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    ("connect_error", "query_error"),
+    [
+        (OSError("Permission denied"), None),
+        (None, ConnectionError("No response for POWER query")),
+    ],
+    ids=["refused", "no_answer"],
+)
 async def test_setup_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_receiver: MagicMock,
+    connect_error: OSError | None,
+    query_error: ConnectionError | None,
 ) -> None:
     """Test a failed connection raises ConfigEntryNotReady and cleans up."""
     mock_config_entry.add_to_hass(hass)
-    mock_receiver.connect.side_effect = OSError("Permission denied")
+    if connect_error is not None:
+        mock_receiver.connect.side_effect = connect_error
+    if query_error is not None:
+        mock_receiver.query_state.side_effect = query_error
 
     with (
         patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

At least for my AT-500 unit, when the receiver is in standby it only responds to power state queries, so relying on a query to get version/model info in the initialization causes the integration to fail to start if the device is in standby. Since Home Assistant users may want to be able to reboot without turning on their receiver beforehand, this makes the model info in initialization best-effort: we run a power state query, and if the receiver _is_ on, we can populate the `model` field; if it responds to the power state query but it's in standby, we just leave the `model` empty and proceed. This preserves the failures we do want to surface when the device isn't reachable, doesn't respond to the query format, or responds with an invalid value, but doesn't rely on a query that only works when the receiver is on.

If desired, a reconfigure later on when the device is on will pick up the device model.

This upgrades https://github.com/emma-sg/tonewinner-rs232 from `v1.1.0` to `v1.2.1`, which updates the `query_state` method to not block on unavailable info if the device is in standby. Full diff here: https://github.com/emma-sg/tonewinner-rs232/compare/v1.1.0...v1.2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47587
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
