### PR TITLE
Bump probatio to 0.11.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -51,7 +51,7 @@ orjson==3.12.0
 packaging>=23.1
 paho-mqtt==2.1.0
 Pillow==12.3.0
-probatio==0.11.1
+probatio==0.11.2
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
   "ulid-transform==2.2.9",
   "urllib3>=2.0",
   "uv==0.12.5",
-  "probatio==0.11.1",
+  "probatio==0.11.2",
   "yarl==1.24.5",
   "webrtc-models==0.3.0",
   "zeroconf==0.150.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ mutagen==1.48.1
 orjson==3.12.0
 packaging>=23.1
 Pillow==12.3.0
-probatio==0.11.1
+probatio==0.11.2
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `probatio` from 0.11.1 to 0.11.2, the data validation engine used by Home Assistant Core.

This is a bug fix release. Probatio's compiled path laid out a validated mapping in schema declaration order instead of the order the input came in. Under the default `AUTO` build policy a schema validates interpreted and switches to generated code after 50 calls, so the same schema returned the same data with a different key order depending on how often it happened to have been called earlier in the process.

That is what caused the flaky `test_save_blueprint` in `tests/components/blueprint/test_websocket_api.py`. `NumberSelector` declares `step` before `mode`, so a blueprint supplying only `mode` validated to `{"mode": ..., "step": ...}` early in a process and `{"step": ..., "mode": ...}` once the schema went hot. Home Assistant dumps that validated config back to YAML and writes it to disk, which made the key order of a saved blueprint, and the test asserting it, depend on how warm the process was. Thanks @epenet for the report.

The generated code now seeds its result from the input, so every key keeps the slot the input gave it and defaulted keys land after them. No Home Assistant changes are needed beyond the version bump.

Verified locally: with 0.11.1 the reproduction from the release notes returns both key orders over 200 calls, with 0.11.2 it returns one.

- PyPI: https://pypi.org/project/probatio/0.11.2/
- Release notes: https://github.com/frenck/probatio/releases/tag/v0.11.2
- Full diff: https://github.com/frenck/probatio/compare/v0.11.1...v0.11.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
