### PR TITLE
Avoid a naive datetime.now() in sharkiq

### DIFF
--- a/homeassistant/components/sharkiq/coordinator.py
+++ b/homeassistant/components/sharkiq/coordinator.py
@@ -1,7 +1,7 @@
 """Data update coordinator for shark iq vacuums."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import override
 
 from sharkiq import (
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import API_TIMEOUT, DOMAIN, LOGGER, UPDATE_INTERVAL
 
@@ -72,7 +73,9 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
         try:
             if (
                 self.ayla_api.token_expiring_soon
-                or datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+                # The Ayla client builds auth_expiration from its own
+                # datetime.now(), so it is a naive local time.
+                or dt_util.naive_now()
                 > self.ayla_api.auth_expiration - timedelta(seconds=600)
             ):
                 await self.ayla_api.async_refresh_auth()

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -45,6 +45,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONFIG,
@@ -111,7 +112,7 @@ class MockAyla(AylaApi):
     @property
     def auth_expiration(self) -> datetime:
         """Sample expiration timestamp that is always 1200 seconds behind now()."""
-        return datetime.now() - timedelta(seconds=1200)  # pylint: disable=home-assistant-enforce-naive-now
+        return dt_util.naive_now() - timedelta(seconds=1200)
 
 
 class MockShark(SharkIqVacuum):


### PR DESCRIPTION
## Proposed change

The expiry check compares the current time against `ayla_api.auth_expiration`, which the client sets itself as:

```python
self._auth_expiration = datetime.now() + timedelta(seconds=login_result["expires_in"])
```

and compares internally the same way. It is a naive local time, so an aware value would not be comparable with it. `dt_util.naive_now()` keeps the check working and removes the suppression, here and in the test that fakes the same value.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177826
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
