### PR TITLE
Avoid a naive datetime.now() in monarch_money

### DIFF
--- a/homeassistant/components/monarch_money/coordinator.py
+++ b/homeassistant/components/monarch_money/coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import override
 
 from aiohttp import ClientResponseError
@@ -19,6 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import LOGGER
 
@@ -71,7 +72,7 @@ class MonarchMoneyDataUpdateCoordinator(DataUpdateCoordinator[MonarchData]):
     async def _async_update_data(self) -> MonarchData:
         """Fetch data for all accounts."""
 
-        now = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+        now = dt_util.now()
 
         account_data, cashflow_summary = await asyncio.gather(
             self.client.get_accounts_as_dict_with_id_key(),

--- a/tests/components/monarch_money/test_coordinator.py
+++ b/tests/components/monarch_money/test_coordinator.py
@@ -1,0 +1,33 @@
+"""Test the Monarch Money coordinator."""
+
+from unittest.mock import AsyncMock
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_cashflow_year_follows_configured_time_zone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_config_api: AsyncMock,
+) -> None:
+    """Test the cashflow window uses the year of the configured time zone.
+
+    The clock is stopped at a moment that is still 2025 in UTC but already 2026
+    in Pacific/Kiritimati, so a query built from the host clock would ask for
+    the wrong year.
+    """
+    await hass.config.async_set_time_zone("Pacific/Kiritimati")  # UTC+14
+    freezer.move_to("2025-12-31T12:00:00+00:00")
+
+    await setup_integration(hass, mock_config_entry)
+
+    mock_config_api.return_value.get_cashflow_summary.assert_called_with(
+        start_date="2026-01-01", end_date="2026-12-31"
+    )


### PR DESCRIPTION
## Proposed change

The value is only read for `now.year`, which bounds the cashflow query at `{year}-01-01` to `{year}-12-31`. Around New Year the year that matters is the one in the configured time zone rather than the one the host happens to be in, so `dt_util.now()` is the right source. Every other day of the year the result is identical.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177814
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
