### PR TITLE
Disconnect the Litter-Robot account when Home Assistant stops

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -6,8 +6,13 @@ import logging
 from pylitterbot import Account
 from pylitterbot.exceptions import LitterRobotException
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import AnyDeviceEntry
@@ -84,6 +89,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: LitterRobotConfigEntry) 
     coordinator = LitterRobotDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    # Entries are not unloaded at shutdown, so the account is only reachable here.
+    async def _async_disconnect_account(event: Event) -> None:
+        await coordinator.account.disconnect()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_disconnect_account)
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LitterRobotConfigEntry) 
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
-    # Entries are not unloaded at shutdown, so the account is only reachable here.
+    # Entries are not unloaded at shutdown, so async_unload_entry does not run there.
     async def _async_disconnect_account(event: Event) -> None:
         await coordinator.account.disconnect()
 

--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -87,10 +87,9 @@ async def async_migrate_entry(
 async def async_setup_entry(hass: HomeAssistant, entry: LitterRobotConfigEntry) -> bool:
     """Set up Litter-Robot from a config entry."""
     coordinator = LitterRobotDataUpdateCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
-    entry.runtime_data = coordinator
 
-    # Entries are not unloaded at shutdown, so async_unload_entry does not run there.
+    # Entries are not unloaded at shutdown, and the first refresh already starts
+    # the account's WebSocket monitor.
     async def _async_disconnect_account(event: Event) -> None:
         await coordinator.account.disconnect()
 
@@ -98,6 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LitterRobotConfigEntry) 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_disconnect_account)
     )
 
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -1,6 +1,7 @@
 """Test Litter-Robot setup process."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -57,6 +58,22 @@ async def test_shutdown_disconnects_account(
     await setup_integration(hass, mock_account, VACUUM_DOMAIN)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    mock_account.disconnect.assert_awaited_once()
+
+
+async def test_shutdown_during_first_refresh_disconnects_account(
+    hass: HomeAssistant, mock_account: MagicMock
+) -> None:
+    """Test a stop during the first refresh still disconnects the account."""
+
+    async def _stop_during_refresh(**kwargs: Any) -> None:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+
+    mock_account.load_robots.side_effect = _stop_during_refresh
+
+    await setup_integration(hass, mock_account, VACUUM_DOMAIN)
     await hass.async_block_till_done()
 
     mock_account.disconnect.assert_awaited_once()

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -15,7 +15,11 @@ from homeassistant.components.vacuum import (
     VacuumActivity,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STOP,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -44,6 +48,23 @@ async def test_unload_entry(hass: HomeAssistant, mock_account: MagicMock) -> Non
     mock_account.robots[0].start_cleaning.assert_called_once()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_shutdown_disconnects_account(
+    hass: HomeAssistant, mock_account: MagicMock
+) -> None:
+    """Home Assistant stopping disconnects the account.
+
+    Entries are not unloaded at shutdown, so the stop event is the only place
+    the account is reached. An account left connected keeps its WebSocket
+    monitor running until the shared session is detached under it.
+    """
+    await setup_integration(hass, mock_account, VACUUM_DOMAIN)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    mock_account.disconnect.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -53,12 +53,7 @@ async def test_unload_entry(hass: HomeAssistant, mock_account: MagicMock) -> Non
 async def test_shutdown_disconnects_account(
     hass: HomeAssistant, mock_account: MagicMock
 ) -> None:
-    """Home Assistant stopping disconnects the account.
-
-    Entries are not unloaded at shutdown, so the stop event is the only place
-    the account is reached. An account left connected keeps its WebSocket
-    monitor running until the shared session is detached under it.
-    """
+    """Test the account is disconnected when Home Assistant stops."""
     await setup_integration(hass, mock_account, VACUUM_DOMAIN)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

`pylitterbot`'s WebSocket monitor logs an error and a full traceback on every Home Assistant restart:

```
ERROR (MainThread) [pylitterbot.transport] Unexpected error in WebSocket monitor; reconnecting in 1.0s
Traceback (most recent call last):
  File ".../pylitterbot/transport.py", line 155, in _run
    await self._connect()
  File ".../pylitterbot/transport.py", line 189, in _connect
    async with session.ws_connect(**config) as ws:
  File ".../aiohttp/client.py", line 581, in _request
    raise RuntimeError("Session is closed")
RuntimeError: Session is closed
```

Config entries are not unloaded when Home Assistant stops. `ConfigEntries._async_shutdown` calls `entry.async_shutdown()`, which only cancels the retry-setup timer, so the `await account.disconnect()` in `async_unload_entry` never runs at shutdown. The account's monitor task is created inside the library with a bare `asyncio.create_task`, so it is not one of the background tasks Home Assistant cancels either. It is still running at `EVENT_HOMEASSISTANT_CLOSE`, when the shared aiohttp session is detached underneath it.

`EVENT_HOMEASSISTANT_STOP` fires two stages earlier, while the session is still usable, so listening for it disconnects the account cleanly and the error no longer occurs.

This matches the pattern already used by `zwave_js`, `unifiprotect`, `smartthings` and `homekit_controller`.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The same class of bug is being fixed for `onvif` in #174152, and was discussed for Shelly in #121511.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
