### PR TITLE
Handle all TechnoVE API errors in config flow

### DIFF
--- a/homeassistant/components/technove/config_flow.py
+++ b/homeassistant/components/technove/config_flow.py
@@ -2,7 +2,7 @@
 
 from typing import Any, override
 
-from technove import Station as TechnoVEStation, TechnoVE, TechnoVEConnectionError
+from technove import Station as TechnoVEStation, TechnoVE, TechnoVEError
 import voluptuous as vol
 
 from homeassistant.components import onboarding
@@ -34,7 +34,7 @@ class TechnoVEConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 station = await self._async_get_station(user_input[CONF_HOST])
-            except TechnoVEConnectionError:
+            except TechnoVEError:
                 errors["base"] = "cannot_connect"
             else:
                 await self.async_set_unique_id(
@@ -98,7 +98,7 @@ class TechnoVEConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovered_host = discovery_info.host
         try:
             self.discovered_station = await self._async_get_station(discovery_info.host)
-        except TechnoVEConnectionError:
+        except TechnoVEError:
             return self.async_abort(reason="cannot_connect")
 
         await self.async_set_unique_id(self.discovered_station.info.mac_address)

--- a/tests/components/technove/test_config_flow.py
+++ b/tests/components/technove/test_config_flow.py
@@ -5,7 +5,7 @@ from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from technove import TechnoVEConnectionError
+from technove import TechnoVEConnectionError, TechnoVEError
 
 from homeassistant.components.technove.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
@@ -63,9 +63,18 @@ async def test_user_device_exists_abort(
     assert result.get("reason") == "already_configured"
 
 
-async def test_connection_error(hass: HomeAssistant, mock_technove: MagicMock) -> None:
-    """Test we show user form on TechnoVE connection error."""
-    mock_technove.update.side_effect = TechnoVEConnectionError
+@pytest.mark.parametrize(
+    "error",
+    [
+        TechnoVEConnectionError,
+        TechnoVEError,
+    ],
+)
+async def test_connection_error(
+    hass: HomeAssistant, mock_technove: MagicMock, error: type[Exception]
+) -> None:
+    """Test we show user form on TechnoVE error."""
+    mock_technove.update.side_effect = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -83,12 +92,19 @@ async def test_connection_error(hass: HomeAssistant, mock_technove: MagicMock) -
     assert result.get("errors") == {"base": "cannot_connect"}
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        TechnoVEConnectionError,
+        TechnoVEError,
+    ],
+)
 @pytest.mark.usefixtures("mock_setup_entry", "mock_technove")
 async def test_full_user_flow_with_error(
-    hass: HomeAssistant, mock_technove: MagicMock
+    hass: HomeAssistant, mock_technove: MagicMock, error: type[Exception]
 ) -> None:
     """Test the full manual user flow with some errors in the middle."""
-    mock_technove.update.side_effect = TechnoVEConnectionError
+    mock_technove.update.side_effect = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -187,11 +203,18 @@ async def test_zeroconf_during_onboarding(
     assert len(mock_onboarding.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        TechnoVEConnectionError,
+        TechnoVEError,
+    ],
+)
 async def test_zeroconf_connection_error(
-    hass: HomeAssistant, mock_technove: MagicMock
+    hass: HomeAssistant, mock_technove: MagicMock, error: type[Exception]
 ) -> None:
     """Test we abort zeroconf flow on TechnoVE connection error."""
-    mock_technove.update.side_effect = TechnoVEConnectionError
+    mock_technove.update.side_effect = error
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -333,16 +356,24 @@ async def test_full_reconfigure_flow_unique_id_mismatch(
     assert result.get("reason") == "unique_id_mismatch"
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        TechnoVEConnectionError,
+        TechnoVEError,
+    ],
+)
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_reconfigure_flow_connection_error_and_success(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_technove: MagicMock,
+    error: type[Exception],
 ) -> None:
     """Test reconfigure flow with connection error, then successful recovery."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_technove.update.side_effect = TechnoVEConnectionError
+    mock_technove.update.side_effect = error
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle all expected TechnoVE API failures in the config flow. `TechnoVE.update()` can raise `TechnoVEError` for HTTP error responses or empty data, but the user, reconfigure, and zeroconf paths only caught `TechnoVEConnectionError`. Catching `TechnoVEError` ensures all API failures produce a recoverable flow error (`cannot_connect`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179455
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
