### PR TITLE
Reuse the Vizio base entity in the sensor platforms

### DIFF
--- a/homeassistant/components/vizio/binary_sensor.py
+++ b/homeassistant/components/vizio/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from vizaio import ChargingStatus
 
@@ -13,12 +13,10 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-from .coordinator import VizioConfigEntry, VizioDeviceCoordinator, VizioDeviceData
+from .coordinator import VizioConfigEntry, VizioDeviceData
+from .entity import VizioDescriptionEntity
 
 PARALLEL_UPDATES = 0
 
@@ -57,32 +55,14 @@ async def async_setup_entry(
         return
 
     async_add_entities(
-        VizioBinarySensor(config_entry, coordinator, description)
-        for description in BINARY_SENSORS
+        VizioBinarySensor(config_entry, description) for description in BINARY_SENSORS
     )
 
 
-class VizioBinarySensor(CoordinatorEntity[VizioDeviceCoordinator], BinarySensorEntity):
+class VizioBinarySensor(VizioDescriptionEntity, BinarySensorEntity):
     """Binary sensor entity for battery-powered Vizio SmartCast devices."""
 
-    _attr_has_entity_name = True
     entity_description: VizioBinarySensorEntityDescription
-
-    def __init__(
-        self,
-        config_entry: VizioConfigEntry,
-        coordinator: VizioDeviceCoordinator,
-        description: VizioBinarySensorEntityDescription,
-    ) -> None:
-        """Initialize the binary sensor entity."""
-        super().__init__(coordinator)
-        self.entity_description = description
-        unique_id = config_entry.unique_id
-        # Guard against config entries missing unique_id, which should never happen
-        if TYPE_CHECKING:
-            assert unique_id is not None
-        self._attr_unique_id = f"{unique_id}_{description.key}"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
 
     @property
     @override

--- a/homeassistant/components/vizio/entity.py
+++ b/homeassistant/components/vizio/entity.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -24,3 +25,15 @@ class VizioEntity(CoordinatorEntity[VizioDeviceCoordinator]):
             assert unique_id is not None
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
         self._device = coordinator.device
+
+
+class VizioDescriptionEntity(VizioEntity):
+    """Base class for Vizio entities described by an entity description."""
+
+    def __init__(
+        self, config_entry: VizioConfigEntry, description: EntityDescription
+    ) -> None:
+        """Initialize the Vizio entity from its description."""
+        super().__init__(config_entry)
+        self.entity_description = description
+        self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"

--- a/homeassistant/components/vizio/sensor.py
+++ b/homeassistant/components/vizio/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -12,12 +12,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-from .coordinator import VizioConfigEntry, VizioDeviceCoordinator, VizioDeviceData
+from .coordinator import VizioConfigEntry, VizioDeviceData
+from .entity import VizioDescriptionEntity
 
 PARALLEL_UPDATES = 0
 
@@ -52,31 +50,14 @@ async def async_setup_entry(
         return
 
     async_add_entities(
-        VizioSensor(config_entry, coordinator, description) for description in SENSORS
+        VizioSensor(config_entry, description) for description in SENSORS
     )
 
 
-class VizioSensor(CoordinatorEntity[VizioDeviceCoordinator], SensorEntity):
+class VizioSensor(VizioDescriptionEntity, SensorEntity):
     """Sensor entity for battery-powered Vizio SmartCast devices."""
 
-    _attr_has_entity_name = True
     entity_description: VizioSensorEntityDescription
-
-    def __init__(
-        self,
-        config_entry: VizioConfigEntry,
-        coordinator: VizioDeviceCoordinator,
-        description: VizioSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor entity."""
-        super().__init__(coordinator)
-        self.entity_description = description
-        unique_id = config_entry.unique_id
-        # Guard against config entries missing unique_id, which should never happen
-        if TYPE_CHECKING:
-            assert unique_id is not None
-        self._attr_unique_id = f"{unique_id}_{description.key}"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
 
     @property
     @override


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


`sensor.py` and `binary_sensor.py` each extended `CoordinatorEntity` directly and re-implemented
`_attr_has_entity_name`, `_attr_unique_id` and `_attr_device_info`, duplicating the logic that
already lives in `VizioEntity`. `media_player.py` and `remote.py` already use the base entity.

`VizioEntity` could not be reused as-is because it sets `_attr_unique_id` to the config entry's
unique ID with no suffix, which is right for the single-entity platforms but not for
description-driven ones. This adds a `VizioDescriptionEntity` subclass in `entity.py` that assigns
`entity_description` and appends the description key, so both sensor platforms drop their
`__init__` entirely.

Unique IDs are unchanged: `media_player`/`remote` keep `<entry.unique_id>`, and the sensor
platforms keep `<entry.unique_id>_<description.key>`. The existing entity registry snapshots
(`testid_battery_level`, `testid_battery_charging`) are untouched and still pass, which is what
verifies no entity is orphaned.

Net -26 lines. No behaviour change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
