### PR TITLE
Use translation key for UpdateFailed in TechnoVE coordinator

### DIFF
--- a/homeassistant/components/technove/coordinator.py
+++ b/homeassistant/components/technove/coordinator.py
@@ -2,7 +2,12 @@
 
 from typing import override
 
-from technove import Station as TechnoVEStation, TechnoVE, TechnoVEError
+from technove import (
+    Station as TechnoVEStation,
+    TechnoVE,
+    TechnoVEConnectionError,
+    TechnoVEError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
@@ -39,7 +44,15 @@ class TechnoVEDataUpdateCoordinator(DataUpdateCoordinator[TechnoVEStation]):
         """Fetch data from TechnoVE."""
         try:
             station = await self.technove.update()
+        except TechnoVEConnectionError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error
         except TechnoVEError as error:
-            raise UpdateFailed(f"Invalid response from API: {error}") from error
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_response",
+            ) from error
 
         return station

--- a/tests/components/technove/test_init.py
+++ b/tests/components/technove/test_init.py
@@ -25,10 +25,10 @@ async def test_async_setup_entry(
 
 
 @pytest.mark.parametrize(
-    "exception",
+    ("exception", "reason"),
     [
-        TechnoVEConnectionError,
-        TechnoVEError,
+        (TechnoVEConnectionError, "Error communicating with TechnoVE API"),
+        (TechnoVEError, "Invalid response from TechnoVE API"),
     ],
 )
 async def test_async_setup_error(
@@ -36,6 +36,7 @@ async def test_async_setup_error(
     mock_technove: MagicMock,
     mock_config_entry: MockConfigEntry,
     exception: type[Exception],
+    reason: str,
 ) -> None:
     """Test a connection or update error during setup."""
     mock_technove.update.side_effect = exception
@@ -43,3 +44,4 @@ async def test_async_setup_error(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.reason == reason

--- a/tests/components/technove/test_init.py
+++ b/tests/components/technove/test_init.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import MagicMock
 
-from technove import TechnoVEConnectionError
+import pytest
+from technove import TechnoVEConnectionError, TechnoVEError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -23,13 +24,21 @@ async def test_async_setup_entry(
     assert init_integration.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_async_setup_connection_error(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        TechnoVEConnectionError,
+        TechnoVEError,
+    ],
+)
+async def test_async_setup_error(
     hass: HomeAssistant,
     mock_technove: MagicMock,
     mock_config_entry: MockConfigEntry,
+    exception: type[Exception],
 ) -> None:
-    """Test a connection error after setup."""
-    mock_technove.update.side_effect = TechnoVEConnectionError
+    """Test a connection or update error during setup."""
+    mock_technove.update.side_effect = exception
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use translation domain and keys when raising `UpdateFailed` in the TechnoVE coordinator. Specifically, map `TechnoVEConnectionError` to `"communication_error"` and generic `TechnoVEError` to `"invalid_response"`, matching the exception translations already defined in strings.json and used by entity helpers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179455
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
