### PR TITLE
Fix NINA device registry calls

### DIFF
--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -276,12 +276,10 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         removed_regions = set(self.data[CONF_REGIONS]) - set(user_input[CONF_REGIONS])
 
         for region in removed_regions:
-            if device := device_registry.async_get_device(
-                identifiers={(DOMAIN, region)}
+            if device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, region), self.config_entry.entry_id
             ):
-                device_registry.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_registry.async_remove_device(device.id)
 
     async def remove_unused_entities(self, user_input: dict[str, Any]) -> None:
         """Remove entities which are not used anymore."""


### PR DESCRIPTION
## Breaking change



## Proposed change

The NINA options flow removed devices for deselected regions with two deprecated device registry calls, which now raise `RuntimeError` for core integrations:

- `device_registry.async_get_device(identifiers=...)` — identifiers are no longer unique across config entries, so the lookup is replaced with `async_get_device_by_identifier((DOMAIN, region), self.config_entry.entry_id)`.
- `device_registry.async_update_device(..., remove_config_entry_id=...)` — a device now belongs to a single config entry, so detaching the config entry is equivalent to removing the device; this is replaced with `async_remove_device(device.id)`.
- This recently merged PR added the deprecated calls: https://github.com/home-assistant/core/pull/176834

This surfaced as `tests/components/nina/test_config_flow.py::test_options_flow_init` and `::test_options_flow_device_removal` failing on `dev`, for example in [this run](https://github.com/home-assistant/core/actions/runs/32776764218/job/97590776338).

The existing tests cover the behaviour and pass unchanged.

## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9vk1fEMgqoTQjz6nuQ9p8)_