### PR TITLE
Implement reauthentication flow for Anglian Water integration

### DIFF
--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -117,7 +117,6 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _async_validate_mfa(self, code: str) -> str | None:
         """Validate the provided MFA code."""
         if TYPE_CHECKING:
-            # This can never not be None at this point.
             assert self.authenticator
         try:
             await self.authenticator.send_mfa_request(code)

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -9,10 +9,12 @@ from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
     ConsentRequiredError,
+    ExpiredAccessTokenError,
     InvalidAccountIdError,
     MFARequiredError,
     SelfAssertedError,
     SmartMeterUnavailableError,
+    UnknownEndpointError,
 )
 import voluptuous as vol
 
@@ -127,6 +129,20 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
             return "unknown"
         return None
 
+    async def _async_get_accounts(self) -> str | None:
+        """Retrieve the list of accounts associated with the authenticated user."""
+        if TYPE_CHECKING:
+            assert self.authenticator
+        try:
+            self.accounts = await get_accounts(self.authenticator)
+        except ExpiredAccessTokenError, UnknownEndpointError:
+            _LOGGER.exception("Error retrieving accounts")
+            return "cannot_connect"
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            return "unknown"
+        return None
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -142,9 +158,12 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_mfa()
                 errors["base"] = validation_response
             else:
-                self.accounts = await get_accounts(self.authenticator)
-                self.user_input = user_input
-                return await self.async_step_select_account()
+                account_error = await self._async_get_accounts()
+                if account_error:
+                    errors["base"] = account_error
+                else:
+                    self.user_input = user_input
+                    return await self.async_step_select_account()
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -162,8 +181,11 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
             if error:
                 errors["base"] = error
             else:
-                self.accounts = await get_accounts(self.authenticator)
-                return await self.async_step_select_account()
+                account_error = await self._async_get_accounts()
+                if account_error:
+                    errors["base"] = account_error
+                else:
+                    return await self.async_step_select_account()
         return self.async_show_form(
             step_id="mfa", data_schema=STEP_MFA_DATA_SCHEMA, errors=errors
         )
@@ -271,9 +293,16 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert self.authenticator
         entry = self._get_reauth_entry()
-        accounts = await get_accounts(self.authenticator)
+        account_error = await self._async_get_accounts()
+        if account_error:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=STEP_USER_DATA_SCHEMA,
+                errors={"base": account_error},
+            )
         if not any(
-            account["value"] == entry.data[CONF_ACCOUNT_NUMBER] for account in accounts
+            account["value"] == entry.data[CONF_ACCOUNT_NUMBER]
+            for account in self.accounts
         ):
             return self.async_show_form(
                 step_id="reauth_confirm",

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -245,10 +245,7 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_reauth_mfa()
                 errors["base"] = validation_response
             else:
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(),
-                    data_updates={CONF_ACCESS_TOKEN: self.authenticator.refresh_token},
-                )
+                return await self._async_finish_reauth()
         return self.async_show_form(
             step_id="reauth_confirm", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
@@ -265,10 +262,26 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
             if error:
                 errors["base"] = error
             else:
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(),
-                    data_updates={CONF_ACCESS_TOKEN: self.authenticator.refresh_token},
-                )
+                return await self._async_finish_reauth()
         return self.async_show_form(
             step_id="reauth_mfa", data_schema=STEP_MFA_DATA_SCHEMA, errors=errors
+        )
+
+    async def _async_finish_reauth(self) -> ConfigFlowResult:
+        """Verify the account and update its access token."""
+        if TYPE_CHECKING:
+            assert self.authenticator
+        entry = self._get_reauth_entry()
+        accounts = await get_accounts(self.authenticator)
+        if not any(
+            account["value"] == entry.data[CONF_ACCOUNT_NUMBER] for account in accounts
+        ):
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=STEP_USER_DATA_SCHEMA,
+                errors={"base": "account_not_found"},
+            )
+        return self.async_update_reload_and_abort(
+            entry,
+            data_updates={CONF_ACCESS_TOKEN: self.authenticator.refresh_token},
         )

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the Anglian Water integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import TYPE_CHECKING, Any, override
 
@@ -102,6 +103,31 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         self.accounts: list[selector.SelectOptionDict] = []
         self.user_input: dict[str, Any] | None = None
 
+    def _create_authenticator(self, user_input: dict[str, Any]) -> MSOB2CAuth:
+        """Create an MSOB2CAuth instance with the provided user input."""
+        return MSOB2CAuth(
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+            session=async_create_clientsession(
+                self.hass,
+                cookie_jar=CookieJar(quote_cookie=False),
+            ),
+        )
+
+    async def _async_validate_mfa(self, code: str) -> str | None:
+        """Validate the provided MFA code."""
+        if TYPE_CHECKING:
+            # This can never not be None at this point.
+            assert self.authenticator
+        try:
+            await self.authenticator.send_mfa_request(code)
+        except MFARequiredError:
+            return "invalid_code"
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            return "unknown"
+        return None
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -109,14 +135,7 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            self.authenticator = MSOB2CAuth(
-                username=user_input[CONF_USERNAME],
-                password=user_input[CONF_PASSWORD],
-                session=async_create_clientsession(
-                    self.hass,
-                    cookie_jar=CookieJar(quote_cookie=False),
-                ),
-            )
+            self.authenticator = self._create_authenticator(user_input)
             validation_response = await validate_credentials(self.authenticator)
             if isinstance(validation_response, str):
                 if validation_response == "mfa_required":
@@ -140,13 +159,9 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if TYPE_CHECKING:
                 assert self.authenticator
-            try:
-                await self.authenticator.send_mfa_request(user_input[CONF_CODE])
-            except MFARequiredError:
-                errors["base"] = "invalid_code"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            error = await self._async_validate_mfa(user_input[CONF_CODE])
+            if error:
+                errors["base"] = error
             else:
                 self.accounts = await get_accounts(self.authenticator)
                 return await self.async_step_select_account()
@@ -208,4 +223,52 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=user_input[CONF_ACCOUNT_NUMBER],
             data=config_entry_data,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Initial configuration step via reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle receiving username/password."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self.authenticator = self._create_authenticator(user_input)
+            validation_response = await validate_credentials(self.authenticator)
+            if isinstance(validation_response, str):
+                if validation_response == "mfa_required":
+                    self.user_input = user_input
+                    return await self.async_step_reauth_mfa()
+                errors["base"] = validation_response
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_ACCESS_TOKEN: self.authenticator.refresh_token},
+                )
+        return self.async_show_form(
+            step_id="reauth_confirm", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth_mfa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the MFA step during reauthentication."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if TYPE_CHECKING:
+                assert self.authenticator
+            error = await self._async_validate_mfa(user_input[CONF_CODE])
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_ACCESS_TOKEN: self.authenticator.refresh_token},
+                )
+        return self.async_show_form(
+            step_id="reauth_mfa", data_schema=STEP_MFA_DATA_SCHEMA, errors=errors
         )

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -48,7 +48,7 @@ STEP_MFA_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def validate_credentials(auth: MSOB2CAuth) -> str | MSOB2CAuth:
+async def validate_credentials(auth: MSOB2CAuth) -> str | None:
     """Validate the provided credentials."""
     try:
         await auth.send_login_request()
@@ -61,7 +61,7 @@ async def validate_credentials(auth: MSOB2CAuth) -> str | MSOB2CAuth:
     except Exception:
         _LOGGER.exception("Unexpected exception")
         return "unknown"
-    return auth
+    return None
 
 
 def humanize_account_data(account: dict) -> str:
@@ -86,14 +86,14 @@ async def get_accounts(auth: MSOB2CAuth) -> list[selector.SelectOptionDict]:
     ]
 
 
-async def validate_account(auth: MSOB2CAuth, account_number: str) -> str | MSOB2CAuth:
+async def validate_account(auth: MSOB2CAuth, account_number: str) -> str | None:
     """Validate the provided account number."""
     _aw = AnglianWater(authenticator=auth)
     try:
         await _aw.validate_smart_meter(account_number)
     except InvalidAccountIdError, SmartMeterUnavailableError:
         return "smart_meter_unavailable"
-    return auth
+    return None
 
 
 class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -151,19 +151,18 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             self.authenticator = self._create_authenticator(user_input)
-            validation_response = await validate_credentials(self.authenticator)
-            if isinstance(validation_response, str):
-                if validation_response == "mfa_required":
-                    self.user_input = user_input
-                    return await self.async_step_mfa()
-                errors["base"] = validation_response
+            validation_error = await validate_credentials(self.authenticator)
+            if validation_error == "mfa_required":
+                self.user_input = user_input
+                return await self.async_step_mfa()
+            if validation_error:
+                errors["base"] = validation_error
             else:
                 account_error = await self._async_get_accounts()
-                if account_error:
-                    errors["base"] = account_error
-                else:
+                if not account_error:
                     self.user_input = user_input
                     return await self.async_step_select_account()
+                errors["base"] = account_error
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -182,10 +181,9 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = error
             else:
                 account_error = await self._async_get_accounts()
-                if account_error:
-                    errors["base"] = account_error
-                else:
+                if not account_error:
                     return await self.async_step_select_account()
+                errors["base"] = account_error
         return self.async_show_form(
             step_id="mfa", data_schema=STEP_MFA_DATA_SCHEMA, errors=errors
         )
@@ -209,10 +207,9 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.authenticator,
                 user_input[CONF_ACCOUNT_NUMBER],
             )
-            if isinstance(validation_result, str):
-                errors["base"] = validation_result
-            else:
+            if not validation_result:
                 return await self.async_step_complete(user_input)
+            errors["base"] = validation_result
         return self.async_show_form(
             step_id="select_account",
             data_schema=vol.Schema(
@@ -260,13 +257,12 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.authenticator = self._create_authenticator(user_input)
             validation_response = await validate_credentials(self.authenticator)
-            if isinstance(validation_response, str):
-                if validation_response == "mfa_required":
-                    self.user_input = user_input
-                    return await self.async_step_reauth_mfa()
-                errors["base"] = validation_response
-            else:
+            if not validation_response:
                 return await self._async_finish_reauth()
+            if validation_response == "mfa_required":
+                self.user_input = user_input
+                return await self.async_step_reauth_mfa()
+            errors["base"] = validation_response
         return self.async_show_form(
             step_id="reauth_confirm", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
@@ -280,10 +276,9 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
             if TYPE_CHECKING:
                 assert self.authenticator
             error = await self._async_validate_mfa(user_input[CONF_CODE])
-            if error:
-                errors["base"] = error
-            else:
+            if not error:
                 return await self._async_finish_reauth()
+            errors["base"] = error
         return self.async_show_form(
             step_id="reauth_mfa", data_schema=STEP_MFA_DATA_SCHEMA, errors=errors
         )

--- a/homeassistant/components/anglian_water/quality_scale.yaml
+++ b/homeassistant/components/anglian_water/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -5,6 +5,7 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
+      "account_not_found": "These credentials do not have access to the configured billing account.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "consent_required": "You need to accept the terms and conditions for your Anglian Water account before using this integration. Log in to their website for further information.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -29,19 +29,19 @@
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
-          "password": "Your password",
-          "username": "Username or email used to log in to the Anglian Water website."
+          "password": "[%key:component::anglian_water::config::step::user::data_description::password%]",
+          "username": "[%key:component::anglian_water::config::step::user::data_description::username%]"
         },
-        "description": "Enter your Anglian Water account credentials to connect to Home Assistant."
+        "description": "[%key:component::anglian_water::config::step::user::description%]"
       },
       "reauth_mfa": {
         "data": {
-          "code": "Security code"
+          "code": "[%key:component::anglian_water::config::step::mfa::data::code%]"
         },
         "data_description": {
-          "code": "The security code sent to your email."
+          "code": "[%key:component::anglian_water::config::step::mfa::data_description::code%]"
         },
-        "description": "Two-factor authentication is enabled on your account. Check your email for the security code. It will come from `no-reply@anglianwater.co.uk`."
+        "description": "[%key:component::anglian_water::config::step::mfa::description%]"
       },
       "select_account": {
         "data": {

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -13,6 +14,26 @@
     },
     "step": {
       "mfa": {
+        "data": {
+          "code": "Security code"
+        },
+        "data_description": {
+          "code": "The security code sent to your email."
+        },
+        "description": "Two-factor authentication is enabled on your account. Check your email for the security code. It will come from `no-reply@anglianwater.co.uk`."
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "Your password",
+          "username": "Username or email used to log in to the Anglian Water website."
+        },
+        "description": "Enter your Anglian Water account credentials to connect to Home Assistant."
+      },
+      "reauth_mfa": {
         "data": {
           "code": "Security code"
         },

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -413,6 +413,8 @@ async def test_reauth_flow(
 ) -> None:
     """Test the reauth flow."""
     mock_config_entry.add_to_hass(hass)
+    mock_anglian_water_authenticator.refresh_token = "new_access_token"
+    original_data = dict(mock_config_entry.data)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -436,6 +438,10 @@ async def test_reauth_flow(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {
+        **original_data,
+        CONF_ACCESS_TOKEN: "new_access_token",
+    }
 
 
 async def test_reauth_flow_invalid_credentials(

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -444,13 +444,22 @@ async def test_reauth_flow(
     }
 
 
-async def test_reauth_flow_invalid_credentials(
+@pytest.mark.parametrize(
+    ("exception_type", "expected_error"),
+    [
+        (SelfAssertedError, "invalid_auth"),
+        (ConsentRequiredError, "consent_required"),
+    ],
+)
+async def test_reauth_flow_auth_exception(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_anglian_water_authenticator: AsyncMock,
     mock_anglian_water_client: AsyncMock,
+    exception_type: type[Exception],
+    expected_error: str,
 ) -> None:
-    """Test the reauth flow with invalid credentials."""
+    """Test that the reauth flow can recover from an auth exception."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -465,7 +474,7 @@ async def test_reauth_flow_invalid_credentials(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    mock_anglian_water_authenticator.send_login_request.side_effect = ValueError
+    mock_anglian_water_authenticator.send_login_request.side_effect = exception_type
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -477,7 +486,7 @@ async def test_reauth_flow_invalid_credentials(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
-    assert result["errors"] == {"base": "unknown"}
+    assert result["errors"] == {"base": expected_error}
 
     mock_anglian_water_authenticator.send_login_request.side_effect = None
 
@@ -590,13 +599,22 @@ async def test_reauth_flow_mfa_required(
     assert result["reason"] == "reauth_successful"
 
 
-async def test_reauth_flow_mfa_required_invalid_code(
+@pytest.mark.parametrize(
+    ("exception_type", "expected_error"),
+    [
+        (MFARequiredError, "invalid_code"),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_reauth_flow_mfa_exception(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_anglian_water_authenticator: AsyncMock,
     mock_anglian_water_client: AsyncMock,
+    exception_type: type[Exception],
+    expected_error: str,
 ) -> None:
-    """Test the reauth flow with MFA required and an invalid code."""
+    """Test that the reauth flow can recover from an MFA exception."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -624,7 +642,7 @@ async def test_reauth_flow_mfa_required_invalid_code(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_mfa"
 
-    mock_anglian_water_authenticator.send_mfa_request.side_effect = ValueError
+    mock_anglian_water_authenticator.send_mfa_request.side_effect = exception_type
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -635,7 +653,7 @@ async def test_reauth_flow_mfa_required_invalid_code(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_mfa"
-    assert result["errors"] == {"base": "unknown"}
+    assert result["errors"] == {"base": expected_error}
 
     mock_anglian_water_authenticator.send_mfa_request.side_effect = None
 

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -4,10 +4,12 @@ from unittest.mock import AsyncMock
 
 from pyanglianwater.exceptions import (
     ConsentRequiredError,
+    ExpiredAccessTokenError,
     InvalidAccountIdError,
     MFARequiredError,
     SelfAssertedError,
     SmartMeterUnavailableError,
+    UnknownEndpointError,
 )
 import pytest
 
@@ -667,3 +669,51 @@ async def test_reauth_flow_mfa_exception(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (ExpiredAccessTokenError, "cannot_connect"),
+        (
+            UnknownEndpointError(status=500, response="Service Unavailable"),
+            "cannot_connect",
+        ),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_reauth_flow_account_fetch_exception(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+    exception: Exception,
+    expected_error: str,
+) -> None:
+    """Test that reauth handles account-fetch exceptions."""
+    mock_config_entry.add_to_hass(hass)
+    original_data = dict(mock_config_entry.data)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    mock_anglian_water_client.api.get_associated_accounts.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": expected_error}
+    assert mock_config_entry.data == original_data

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -403,3 +403,189 @@ async def test_account_recover_exception(
     assert result["data"][CONF_ACCESS_TOKEN] == ACCESS_TOKEN
     assert result["data"][CONF_ACCOUNT_NUMBER] == ACCOUNT_NUMBER
     assert result["result"].unique_id == ACCOUNT_NUMBER
+
+
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test the reauth flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+async def test_reauth_flow_invalid_credentials(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test the reauth flow with invalid credentials."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_anglian_water_authenticator.send_login_request.side_effect = ValueError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "unknown"}
+
+    mock_anglian_water_authenticator.send_login_request.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+async def test_reauth_flow_mfa_required(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test the reauth flow with MFA required."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_anglian_water_authenticator.send_login_request.side_effect = MFARequiredError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_mfa"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CODE: "123456",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+async def test_reauth_flow_mfa_required_invalid_code(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test the reauth flow with MFA required and an invalid code."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_anglian_water_authenticator.send_login_request.side_effect = MFARequiredError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_mfa"
+
+    mock_anglian_water_authenticator.send_mfa_request.side_effect = ValueError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CODE: "123456",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_mfa"
+    assert result["errors"] == {"base": "unknown"}
+
+    mock_anglian_water_authenticator.send_mfa_request.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CODE: "123456",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -492,6 +492,59 @@ async def test_reauth_flow_invalid_credentials(
     assert result["reason"] == "reauth_successful"
 
 
+async def test_reauth_flow_account_not_found(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test that reauth does not update an entry for another account."""
+    mock_config_entry.add_to_hass(hass)
+    original_data = dict(mock_config_entry.data)
+    mock_anglian_water_client.api.get_associated_accounts.return_value = {
+        "result": {"active": []}
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+    assert result is not None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "account_not_found"}
+    assert mock_config_entry.data == original_data
+
+    mock_anglian_water_client.api.get_associated_accounts.return_value = (
+        await async_load_json_object_fixture(
+            hass, "multi_associated_accounts.json", DOMAIN
+        )
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
 async def test_reauth_flow_mfa_required(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -449,6 +449,7 @@ async def test_reauth_flow(
     [
         (SelfAssertedError, "invalid_auth"),
         (ConsentRequiredError, "consent_required"),
+        (ValueError, "unknown"),
     ],
 )
 async def test_reauth_flow_auth_exception(

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -234,6 +234,98 @@ async def test_single_account_flow_with_mfa_exception(
     assert result["result"].unique_id == ACCOUNT_NUMBER
 
 
+@pytest.mark.parametrize(
+    ("exception_type", "expected_error"),
+    [
+        (ExpiredAccessTokenError, "cannot_connect"),
+        (
+            UnknownEndpointError(status=500, response="Service Unavailable"),
+            "cannot_connect",
+        ),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_account_fetch_exception(
+    hass: HomeAssistant,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+    exception_type: Exception,
+    expected_error: str,
+) -> None:
+    """Test that the flow handles account-fetch exceptions."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    mock_anglian_water_client.api.get_associated_accounts.side_effect = exception_type
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "expected_error"),
+    [
+        (ExpiredAccessTokenError, "cannot_connect"),
+        (
+            UnknownEndpointError(status=500, response="Service Unavailable"),
+            "cannot_connect",
+        ),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_mfa_account_fetch_exception(
+    hass: HomeAssistant,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+    exception_type: Exception,
+    expected_error: str,
+) -> None:
+    """Test that the MFA flow handles account-fetch exceptions."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result is not None
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    mock_anglian_water_authenticator.send_login_request.side_effect = MFARequiredError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "mfa"
+
+    mock_anglian_water_client.api.get_associated_accounts.side_effect = exception_type
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_CODE: "123456"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "mfa"
+    assert result["errors"] == {"base": expected_error}
+
+
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_already_configured(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, I think this should now bring AW to silver status on the quality scale?

A small bit of refactoring was done just to tidy up and deduplicate the necessary code in the config flow class.

Username/password is not retained because the integration uses the refresh token to authenticate.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173437
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
