### PR TITLE
Bump powerfox to v2.1.3

### DIFF
--- a/homeassistant/components/powerfox/manifest.json
+++ b/homeassistant/components/powerfox/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "quality_scale": "silver",
-  "requirements": ["powerfox==2.1.1"],
+  "requirements": ["powerfox==2.1.3"],
   "zeroconf": [
     {
       "name": "powerfox*",

--- a/homeassistant/components/powerfox_local/manifest.json
+++ b/homeassistant/components/powerfox_local/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "platinum",
-  "requirements": ["powerfox==2.1.1"],
+  "requirements": ["powerfox==2.1.3"],
   "zeroconf": [
     {
       "name": "powerfox*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1891,7 +1891,7 @@ poolsense==0.0.8
 
 # homeassistant.components.powerfox
 # homeassistant.components.powerfox_local
-powerfox==2.1.1
+powerfox==2.1.3
 
 # homeassistant.components.prana
 prana-api-client==0.12.0


### PR DESCRIPTION
## Proposed change

Bump the shared `powerfox` dependency from 2.1.1 to 2.1.3 for both the Powerfox Cloud and Powerfox Local integrations.

Powerfox 2.1.3 reuses its Mashumaro JSON decoders instead of constructing new decoders and dynamically generated classes for every poll. This prevents the continuous memory growth reported for both integrations.

Upstream changes:

- [Powerfox v2.1.3 release notes](https://github.com/klaasnicolaas/python-powerfox/releases/tag/v2.1.3)
- [Full v2.1.1...v2.1.3 diff](https://github.com/klaasnicolaas/python-powerfox/compare/v2.1.1...v2.1.3)
- [Upstream memory leak fix](https://github.com/klaasnicolaas/python-powerfox/pull/827)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179133
- This PR is related to issue: #177533, https://github.com/klaasnicolaas/python-powerfox/issues/813
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [X] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.