### PR TITLE
Fix configured URLs after HTTP port changes

### DIFF
--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -77,7 +77,7 @@ def update_url_port(url: str | None, old_port: int, new_port: int) -> str | None
         return None
 
     parsed = URL(url)
-    if parsed.port != old_port or f":{old_port}" not in parsed.raw_authority:
+    if parsed.explicit_port != old_port:
         return url
 
     return str(parsed.with_port(new_port))

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -9,6 +9,7 @@ import os
 from typing import Any, Final, TypedDict, cast, override
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.const import SERVER_PORT
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
@@ -68,6 +69,18 @@ def default_server_port() -> int:
             default,
         )
         return default
+
+
+def update_url_port(url: str | None, old_port: int, new_port: int) -> str | None:
+    """Update an explicitly configured URL that used the old server port."""
+    if url is None:
+        return None
+
+    parsed = URL(url)
+    if parsed.port != old_port or f":{old_port}" not in parsed.raw_authority:
+        return url
+
+    return str(parsed.with_port(new_port))
 
 
 STORAGE_KEY: Final = DOMAIN

--- a/homeassistant/components/http/websocket_api.py
+++ b/homeassistant/components/http/websocket_api.py
@@ -12,7 +12,12 @@ from homeassistant.components.homeassistant import (
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from .config import HTTP_STORAGE_SCHEMA, ConfData, async_get_and_load_store
+from .config import (
+    HTTP_STORAGE_SCHEMA,
+    ConfData,
+    async_get_and_load_store,
+    update_url_port,
+)
 from .const import ATTR_CONFIG, CONF_SERVER_PORT
 from .server import async_verify_can_bind
 
@@ -106,6 +111,21 @@ async def websocket_set_config(
         except HomeAssistantError as err:
             connection.send_error(msg["id"], ERR_BIND_FAILED, str(err))
             return
+
+        old_port = hass.http.server_port
+        new_port = config[CONF_SERVER_PORT]
+        url_updates = {
+            attr: updated_url
+            for attr in ("internal_url", "external_url")
+            if (
+                updated_url := update_url_port(
+                    getattr(hass.config, attr), old_port, new_port
+                )
+            )
+            != getattr(hass.config, attr)
+        }
+        if url_updates:
+            await hass.config.async_update(**url_updates)
 
     store = await async_get_and_load_store(hass)
     previous_pending = store.pending

--- a/tests/components/http/test_config.py
+++ b/tests/components/http/test_config.py
@@ -1,0 +1,22 @@
+"""Tests for the HTTP configuration helpers."""
+
+from homeassistant.components.http.config import update_url_port
+
+
+def test_update_url_port_updates_explicit_old_port() -> None:
+    """Update a URL that explicitly uses the previous server port."""
+    assert update_url_port("http://homeassistant.local:8123", 8123, 9123) == (
+        "http://homeassistant.local:9123"
+    )
+
+
+def test_update_url_port_preserves_other_ports() -> None:
+    """Preserve URLs that point at a reverse proxy on another port."""
+    url = "https://proxy.example:8443"
+    assert update_url_port(url, 8123, 9123) == url
+
+
+def test_update_url_port_preserves_url_without_explicit_port() -> None:
+    """Do not add a port to a URL that did not explicitly contain one."""
+    url = "http://homeassistant.local"
+    assert update_url_port(url, 80, 9123) == url

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -2012,6 +2012,8 @@ async def test_websocket_http_config(
 
     # Staging a new config triggers a restart so the pending config is applied.
     restart_calls = async_mock_service(hass, "homeassistant", "restart")
+    hass.config.internal_url = "http://homeassistant.local:8123"
+    hass.config.external_url = "https://home.example:8123"
 
     # On a fresh setup the stable slot is seeded with the schema defaults and
     # there is no pending config.
@@ -2042,6 +2044,8 @@ async def test_websocket_http_config(
     response = await ws_client.receive_json()
     assert response["success"]
     assert response["result"] == {"restart": True}
+    assert hass.config.internal_url == "http://homeassistant.local:9123"
+    assert hass.config.external_url == "https://home.example:9123"
     assert hass_storage["http"]["data"]["pending"] == {
         **new_config,
         "created_at": created_at,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

This is not a breaking change.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The HTTP configuration WebSocket now updates explicitly configured `internal_url` and `external_url` values when their port matches the previous HTTP server port. URLs using another port, such as a reverse proxy, and URLs without an explicit port are preserved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180040
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
