### PR TITLE
Add binary sensor platform to Hot Spring integration

### DIFF
--- a/homeassistant/components/hotspring/__init__.py
+++ b/homeassistant/components/hotspring/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.SENSOR,
 ]

--- a/homeassistant/components/hotspring/binary_sensor.py
+++ b/homeassistant/components/hotspring/binary_sensor.py
@@ -28,6 +28,13 @@ class HotSpringBinarySensorEntityDescription(BinarySensorEntityDescription):
     is_on_fn: Callable[[Spa], bool | None]
 
 
+def _is_problem(spa: Spa) -> bool | None:
+    """Return False if OK, None if unavailable or unknown."""
+    if spa.diagnostics.spa_failure_state is SpaFailureState.OK:
+        return False
+    return None
+
+
 BINARY_SENSORS: tuple[HotSpringBinarySensorEntityDescription, ...] = (
     HotSpringBinarySensorEntityDescription(
         key="heating",
@@ -46,9 +53,7 @@ BINARY_SENSORS: tuple[HotSpringBinarySensorEntityDescription, ...] = (
         key="problem",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda spa: (
-            spa.diagnostics.spa_failure_state is not SpaFailureState.OK
-        ),
+        is_on_fn=_is_problem,
     ),
 )
 

--- a/homeassistant/components/hotspring/binary_sensor.py
+++ b/homeassistant/components/hotspring/binary_sensor.py
@@ -1,0 +1,87 @@
+"""Support for Hot Spring binary sensors."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from hotspring import Spa, SpaFailureState
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
+from .entity import HotSpringEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class HotSpringBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes Hot Spring binary sensor entity."""
+
+    is_on_fn: Callable[[Spa], bool | None]
+
+
+BINARY_SENSORS: tuple[HotSpringBinarySensorEntityDescription, ...] = (
+    HotSpringBinarySensorEntityDescription(
+        key="heating",
+        translation_key="heating",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        is_on_fn=lambda spa: spa.heater.is_on,
+    ),
+    HotSpringBinarySensorEntityDescription(
+        key="spa_connected",
+        translation_key="spa_connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        is_on_fn=lambda spa: spa.connection_status.spa_connected,
+    ),
+    HotSpringBinarySensorEntityDescription(
+        key="problem",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        is_on_fn=lambda spa: (
+            spa.diagnostics.spa_failure_state is not SpaFailureState.OK
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HotSpringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Hot Spring binary sensor entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        HotSpringBinarySensorEntity(coordinator, description)
+        for description in BINARY_SENSORS
+    )
+
+
+class HotSpringBinarySensorEntity(HotSpringEntity, BinarySensorEntity):
+    """Defines a Hot Spring binary sensor entity."""
+
+    entity_description: HotSpringBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HotSpringDataUpdateCoordinator,
+        description: HotSpringBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor entity."""
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/hotspring/strings.json
+++ b/homeassistant/components/hotspring/strings.json
@@ -26,6 +26,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "heating": {
+        "name": "Heating"
+      },
+      "spa_connected": {
+        "name": "Spa connected"
+      }
+    },
     "number": {
       "target_temperature": {
         "name": "Target temperature"

--- a/tests/components/hotspring/snapshots/test_binary_sensor.ambr
+++ b/tests/components/hotspring/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,154 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_heating-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_heating',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Heating',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Heating',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'heating',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_heating',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_heating-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Heating',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_heating',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_problem-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_problem',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Problem',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Problem',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:DD:EE:FF_problem',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_problem-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Problem',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_problem',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_spa_connected-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_spa_connected',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Spa connected',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Spa connected',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'spa_connected',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_spa_connected',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.connectedspa_ddeeff_spa_connected-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'connectivity',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Spa connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.connectedspa_ddeeff_spa_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/hotspring/test_binary_sensor.py
+++ b/tests/components/hotspring/test_binary_sensor.py
@@ -1,0 +1,26 @@
+"""Tests for the Hot Spring binary sensor platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_with_selected_platforms
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_hotspring")
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the binary sensor platform state."""
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.BINARY_SENSOR]
+    )
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/hotspring/test_binary_sensor.py
+++ b/tests/components/hotspring/test_binary_sensor.py
@@ -1,9 +1,12 @@
 """Tests for the Hot Spring binary sensor platform."""
 
+from unittest.mock import MagicMock
+
+from hotspring import Spa, SpaFailureState
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -24,3 +27,28 @@ async def test_binary_sensors(
         hass, mock_config_entry, [Platform.BINARY_SENSOR]
     )
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("failure_state", "expected_state"),
+    [
+        (SpaFailureState.OK, STATE_OFF),
+        (SpaFailureState.UNKNOWN, STATE_UNKNOWN),
+    ],
+)
+async def test_problem_binary_sensor_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    device_fixture: Spa,
+    failure_state: SpaFailureState,
+    expected_state: str,
+) -> None:
+    """Test problem binary sensor state mapping."""
+    device_fixture.diagnostics.spa_failure_state = failure_state
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.BINARY_SENSOR]
+    )
+    state = hass.states.get("binary_sensor.connectedspa_ddeeff_problem")
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/components/hotspring/test_binary_sensor.py
+++ b/tests/components/hotspring/test_binary_sensor.py
@@ -1,12 +1,9 @@
 """Tests for the Hot Spring binary sensor platform."""
 
-from unittest.mock import MagicMock
-
-from hotspring import Spa, SpaFailureState
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_OFF, STATE_UNKNOWN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -27,28 +24,3 @@ async def test_binary_sensors(
         hass, mock_config_entry, [Platform.BINARY_SENSOR]
     )
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
-
-
-@pytest.mark.parametrize(
-    ("failure_state", "expected_state"),
-    [
-        (SpaFailureState.OK, STATE_OFF),
-        (SpaFailureState.UNKNOWN, STATE_UNKNOWN),
-    ],
-)
-async def test_problem_binary_sensor_states(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_hotspring: MagicMock,
-    device_fixture: Spa,
-    failure_state: SpaFailureState,
-    expected_state: str,
-) -> None:
-    """Test problem binary sensor state mapping."""
-    device_fixture.diagnostics.spa_failure_state = failure_state
-    await setup_with_selected_platforms(
-        hass, mock_config_entry, [Platform.BINARY_SENSOR]
-    )
-    state = hass.states.get("binary_sensor.connectedspa_ddeeff_problem")
-    assert state is not None
-    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request adds the `binary_sensor` platform to the **Hot Spring** integration.

Implemented binary sensors:
- **Heating** (`heating`): `BinarySensorDeviceClass.RUNNING` indicating whether the spa heater is actively heating water.
- **Spa connected** (`spa_connected`): `BinarySensorDeviceClass.CONNECTIVITY` (`EntityCategory.DIAGNOSTIC`) indicating whether the wireless radio link between the Home Network Adapter (HNA) and the spa (SNA) is connected.
- **Problem** (`problem`): `BinarySensorDeviceClass.PROBLEM` (`EntityCategory.DIAGNOSTIC`) indicating whether an error or failure state is reported by the spa.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47595
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
