### PR TITLE
Fix undefined DeviceEntry name in Netatmo device removal

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
-from homeassistant.helpers.device_registry import AnyDeviceEntry
+from homeassistant.helpers.device_registry import AnyDeviceEntry, DeviceEntry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_started
@@ -159,7 +159,7 @@ async def async_remove_config_entry_device(
     # the inventory check. Its descendants keep their own disabler, hence a walk.
     unpolled_home_ids = account.all_home_names.keys() - account.homes.keys()
     device_registry = dr.async_get(hass)
-    device: DeviceEntry | None = device_entry
+    device: AnyDeviceEntry | None = device_entry
     while device is not None:
         if any(
             identifier[1] in unpolled_home_ids
@@ -169,7 +169,7 @@ async def async_remove_config_entry_device(
             return False
         device = (
             device_registry.async_get(device.via_device_id, include_child_devices=False)
-            if device.via_device_id
+            if isinstance(device, DeviceEntry) and device.via_device_id
             else None
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

CI is red on `dev`. The device walk added in #178742 annotates its loop variable with `DeviceEntry`, which the module never imports:

```
ruff: homeassistant/components/netatmo/__init__.py:162:13: F821 Undefined name `DeviceEntry`
mypy: homeassistant/components/netatmo/__init__.py:162: error: Name "DeviceEntry" is not defined  [name-defined]
```

This fails both the `Run prek checks` and `Check mypy` jobs on every push to `dev` and on every open PR ([example run](https://github.com/home-assistant/core/actions/runs/32810532731)). PEP 649 evaluates annotations lazily, which is why the tests never caught it at runtime.

The value assigned is the `AnyDeviceEntry` that `async_remove_config_entry_device` receives, so the annotation becomes `AnyDeviceEntry | None`. Importing `DeviceEntry` alone would not be enough — mypy then rejects the assignment.

`via_device_id` exists only on `DeviceEntry`, not on `ChildDeviceEntry`, so the walk needs a guard for the union. Netatmo registers no child devices, so the walk simply ends if one is ever passed in. The behaviour of the walk is otherwise unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Verified locally against the same commands CI runs:

- `mypy --num-workers=4 homeassistant pylint` → `Success: no issues found in 10014 source files`
- `prek run --all-files` with CI's `PREK_SKIP` → all hooks pass
- `pytest tests/components/netatmo` → 213 passed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNeLoz2N3D86aTutCqcjuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNeLoz2N3D86aTutCqcjuu)_