### PR TITLE
Bump modbus-connection to 4.10.0

### DIFF
--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -7,7 +7,7 @@
   "loggers": ["pymodbus"],
   "requirements": [
     "pymodbus==3.13.1",
-    "modbus-connection[tmodbus]==4.9.0",
-    "tmodbus==0.5.2"
+    "modbus-connection[tmodbus]==4.10.0",
+    "tmodbus==0.6.1"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1613,7 +1613,7 @@ mitsubishi-comfort==0.5.2
 moat-ble==0.1.1
 
 # homeassistant.components.modbus
-modbus-connection[tmodbus]==4.9.0
+modbus-connection[tmodbus]==4.10.0
 
 # homeassistant.components.moehlenhoff_alpha2
 moehlenhoff-alpha2==1.4.0
@@ -3223,7 +3223,7 @@ tilt-pi==0.2.1
 tmb==0.0.4
 
 # homeassistant.components.modbus
-tmodbus==0.5.2
+tmodbus==0.6.1
 
 # homeassistant.components.todoist
 todoist-api-python==3.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump modbus-connection from 4.9.0 to 4.10.0 and tmodbus from 0.5.2 to 0.6.1. The modbus-connection release implements the diagnostics (FC08), comm-event counter (FC0B), and comm-event log (FC0C) function codes on its tmodbus backend, which raised `NotImplementedError` for them before. It requires tmodbus 0.6.1, which is what the second pin follows.

The integration itself does not call those three operations, so this is a no-op for `modbus` beyond the newer libraries. tmodbus 0.6.0 renamed parts of its pre-1.0 API, but only on the server side and on PDU classes that modbus-connection consumes; core never imports tmodbus directly.

- [PyPI release](https://pypi.org/project/modbus-connection/4.10.0/)
- [Release notes](https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.10.0)
- [Diff 4.9.0...4.10.0](https://github.com/home-assistant-libs/modbus-connection/compare/4.9.0...4.10.0)
- [tmodbus 0.6.1 on PyPI](https://pypi.org/project/tmodbus/0.6.1/) — [release notes](https://github.com/wlcrs/tmodbus/releases/tag/v0.6.1), [diff v0.5.2...v0.6.1](https://github.com/wlcrs/tmodbus/compare/v0.5.2...v0.6.1)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
