### PR TITLE
Improve recorder tests for purging states of a group entity

### DIFF
--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,6 +1,6 @@
 """Test data purging."""
 
-from collections.abc import Generator
+from collections.abc import Awaitable, Callable, Generator
 from datetime import datetime, timedelta
 import json
 import sqlite3
@@ -33,8 +33,14 @@ from homeassistant.components.recorder.services import (
 )
 from homeassistant.components.recorder.tasks import PurgeTask
 from homeassistant.components.recorder.util import session_scope
-from homeassistant.const import EVENT_STATE_CHANGED, EVENT_THEMES_UPDATED, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_STATE_CHANGED,
+    EVENT_THEMES_UPDATED,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from .common import (
@@ -1661,56 +1667,113 @@ async def test_purge_entities(hass: HomeAssistant, recorder_mock: Recorder) -> N
         assert states_meta_remain.count() == 4
 
 
+async def _setup_removed_group(hass: HomeAssistant) -> None:
+    """Set up nothing: the purged group entity no longer exists."""
+
+
+async def _setup_legacy_group(hass: HomeAssistant) -> None:
+    """Set up a live legacy group state with a wired member."""
+    hass.states.async_set(
+        "group.purge_group", STATE_ON, {ATTR_ENTITY_ID: ["sensor.member"]}
+    )
+
+
+async def _setup_lock_group(hass: HomeAssistant) -> None:
+    """Set up a live lock group backed by helpers.group.GenericGroup."""
+    assert await async_setup_component(
+        hass,
+        "lock",
+        {
+            "lock": {
+                "platform": "group",
+                "entities": ["lock.member"],
+                "name": "Purge group",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+def _count_states_before(session: Session, entity_id: str, cutoff: datetime) -> int:
+    """Count the states recorded before cutoff for entity_id."""
+    return (
+        session.query(States)
+        .join(StatesMeta, States.metadata_id == StatesMeta.metadata_id)
+        .filter(StatesMeta.entity_id == entity_id)
+        .filter(States.last_updated_ts < cutoff.timestamp())
+        .count()
+    )
+
+
+@pytest.mark.parametrize(
+    ("setup_group", "group_entity_id", "member_entity_id"),
+    [
+        pytest.param(
+            _setup_removed_group, "group.purge_group", "sensor.member", id="legacy-dead"
+        ),
+        pytest.param(
+            _setup_legacy_group, "group.purge_group", "sensor.member", id="legacy-live"
+        ),
+        pytest.param(
+            _setup_lock_group, "lock.purge_group", "lock.member", id="modern-lock-live"
+        ),
+    ],
+)
 async def test_purge_entities_group_entity_id(
-    hass: HomeAssistant, recorder_mock: Recorder
+    hass: HomeAssistant,
+    recorder_mock: Recorder,
+    setup_group: Callable[[HomeAssistant], Awaitable[None]],
+    group_entity_id: str,
+    member_entity_id: str,
 ) -> None:
-    """Test purge_entities purges a group.* entity without purging everything else."""
+    """Test purge_entities purges a group entity itself without expanding it."""
+    await setup_group(hass)
+    await async_wait_recording_done(hass)
+
+    # Seeded rows are two days old; live states recorded during setup are newer
+    # than this cutoff, so the assertions only see the seeded rows.
+    cutoff = dt_util.utcnow() - timedelta(days=1)
     with session_scope(hass=hass) as session:
         timestamp = dt_util.utcnow() - timedelta(days=2)
         for event_id in range(1000, 1010):
             _add_state_with_state_attributes(
-                session,
-                "group.purge_group",
-                "purgeme",
-                timestamp,
-                event_id,
+                session, group_entity_id, "purgeme", timestamp, event_id
             )
         for event_id in range(2000, 2010):
             _add_state_with_state_attributes(
-                session,
-                "sensor.keep",
-                "keep",
-                timestamp,
-                event_id,
+                session, member_entity_id, "keep", timestamp, event_id
+            )
+        for event_id in range(3000, 3010):
+            _add_state_with_state_attributes(
+                session, "sensor.keep", "keep", timestamp, event_id
             )
         convert_pending_states_to_meta(recorder_mock, session)
         convert_pending_events_to_event_types(recorder_mock, session)
 
     with session_scope(hass=hass, read_only=True) as session:
-        states = session.query(States)
-        assert states.count() == 20
+        assert _count_states_before(session, group_entity_id, cutoff) == 10
+        assert _count_states_before(session, member_entity_id, cutoff) == 10
+        assert _count_states_before(session, "sensor.keep", cutoff) == 10
 
     await hass.services.async_call(
-        DOMAIN,
-        SERVICE_PURGE_ENTITIES,
-        {"entity_id": "group.purge_group", "domains": [], "entity_globs": []},
+        DOMAIN, SERVICE_PURGE_ENTITIES, {"entity_id": group_entity_id}
     )
     await hass.async_block_till_done()
     await async_recorder_block_till_done(hass)
     await async_wait_purge_done(hass)
 
     with session_scope(hass=hass, read_only=True) as session:
+        # The group must not be expanded: the member keeps its history and the
+        # group's own history is purged.
+        assert _count_states_before(session, member_entity_id, cutoff) == 10
+        assert _count_states_before(session, group_entity_id, cutoff) == 0
+        # An unrelated entity is untouched, i.e. a group id which cannot be
+        # expanded did not result in the whole database being purged.
+        assert _count_states_before(session, "sensor.keep", cutoff) == 10
         states_meta_remain = session.query(StatesMeta).filter(
-            StatesMeta.entity_id == "group.purge_group"
+            StatesMeta.entity_id == "sensor.keep"
         )
-        assert states_meta_remain.count() == 0
-
-        states_sensor_kept = (
-            session.query(States)
-            .outerjoin(StatesMeta, States.metadata_id == StatesMeta.metadata_id)
-            .filter(StatesMeta.entity_id == "sensor.keep")
-        )
-        assert states_sensor_kept.count() == 10
+        assert states_meta_remain.count() == 1
 
 
 async def _add_test_states(hass: HomeAssistant, wait_recording_done: bool = True):

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1767,6 +1767,12 @@ async def test_purge_entities_group_entity_id(
         # group's own history is purged.
         assert _count_states_before(session, member_entity_id, cutoff) == 10
         assert _count_states_before(session, group_entity_id, cutoff) == 0
+        # A zero states count can leave an orphaned StatesMeta row, so assert the
+        # group's metadata row is removed too.
+        states_meta_group = session.query(StatesMeta).filter(
+            StatesMeta.entity_id == group_entity_id
+        )
+        assert states_meta_group.count() == 0
         # An unrelated entity is untouched, i.e. a group id which cannot be
         # expanded did not result in the whole database being purged.
         assert _count_states_before(session, "sensor.keep", cutoff) == 10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This improves the test added in https://github.com/home-assistant/core/pull/180024, which only tested the degenerate test where a group entity expanded to no entities (for example if the group was removed) by also adding parametrizations for modern and legacy group which can be expanded to their members.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
