### PR TITLE
And new service helper to get device and config entry

### DIFF
--- a/homeassistant/components/alexa_devices/services.py
+++ b/homeassistant/components/alexa_devices/services.py
@@ -4,11 +4,14 @@ from aioamazondevices.const.metadata import ALEXA_INFO_SKILLS
 from aioamazondevices.const.sounds import SOUNDS_LIST
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    service,
+)
 
 from .const import DOMAIN, INFO_SKILLS_MAPPING
 from .coordinator import AmazonConfigEntry, alexa_api_call
@@ -42,29 +45,10 @@ def async_get_entry_id_for_service_call(
     call: ServiceCall,
 ) -> tuple[dr.DeviceEntry, AmazonConfigEntry]:
     """Get the entry ID related to a service call (by device ID)."""
-    device_id = call.data[ATTR_DEVICE_ID]
-    device, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        call.hass, device_id, domain=DOMAIN
+    config_entry: AmazonConfigEntry
+    device, config_entry = service.async_get_device_and_config_entry(
+        call.hass, DOMAIN, call.data[ATTR_DEVICE_ID]
     )
-    if device is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_device_id",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    if config_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="config_entry_not_found",
-            translation_placeholders={"device_id": device_id},
-        )
-    if config_entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="entry_not_loaded",
-            translation_placeholders={"entry": config_entry.title},
-        )
     return (device, config_entry)
 
 

--- a/homeassistant/components/alexa_devices/strings.json
+++ b/homeassistant/components/alexa_devices/strings.json
@@ -135,20 +135,11 @@
     "cannot_retrieve_data_with_error": {
       "message": "Error retrieving data: {error}"
     },
-    "config_entry_not_found": {
-      "message": "Config entry not found: {device_id}"
-    },
     "device_serial_number_missing": {
       "message": "Device serial number missing: {device_id}"
     },
-    "entry_not_loaded": {
-      "message": "Entry not loaded: {entry}"
-    },
     "invalid_auth": {
       "message": "Invalid authentication credentials: {error}"
-    },
-    "invalid_device_id": {
-      "message": "Invalid device ID specified: {device_id}"
     },
     "invalid_info_skill_value": {
       "message": "Invalid info skill {info_skill} specified"

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -63,6 +63,12 @@
     "service_config_entry_wrong_domain": {
       "message": "Config entry {entry_title} does not belong to integration {domain}."
     },
+    "service_device_not_found": {
+      "message": "Device with ID {device_id} was not found."
+    },
+    "service_device_wrong_domain": {
+      "message": "Device {device_name} does not belong to integration {domain}."
+    },
     "service_does_not_support_response": {
       "message": "An action which does not return responses can't be called with {return_response}."
     },

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1414,3 +1414,42 @@ def _async_get_single_loaded_config_entry(
             },
         )
     return config_entry
+
+
+@callback
+def async_get_device_and_config_entry(
+    hass: HomeAssistant, domain: str, device_id: str
+) -> tuple[device_registry.DeviceEntry, ConfigEntry]:
+    """Get and validate the device and the loaded config entry of the domain owning it.
+
+    Raises ServiceValidationError if the device is unknown, is not owned by a
+    config entry of the domain, or if that config entry is not loaded.
+    """
+    device, config_entry = device_registry.async_get_device_and_config_entry_for_domain(
+        hass, device_id, domain=domain
+    )
+    if device is None:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_device_not_found",
+            translation_placeholders={"device_id": device_id},
+        )
+    if config_entry is None:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_device_wrong_domain",
+            translation_placeholders={
+                "device_name": device.name_by_user or device.name or device_id,
+                "domain": domain,
+            },
+        )
+    if config_entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_config_entry_not_loaded",
+            translation_placeholders={
+                "domain": domain,
+                "entry_title": config_entry.title,
+            },
+        )
+    return device, config_entry

--- a/tests/components/alexa_devices/test_services.py
+++ b/tests/components/alexa_devices/test_services.py
@@ -13,7 +13,7 @@ from homeassistant.components.alexa_devices.services import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
@@ -128,17 +128,25 @@ async def test_send_text_service(
 
 
 @pytest.mark.parametrize(
-    ("sound", "device_id", "translation_key", "translation_placeholders"),
+    (
+        "sound",
+        "device_id",
+        "translation_domain",
+        "translation_key",
+        "translation_placeholders",
+    ),
     [
         (
             "bell_02",
             "fake_device_id",
-            "invalid_device_id",
+            HOMEASSISTANT_DOMAIN,
+            "service_device_not_found",
             {"device_id": "fake_device_id"},
         ),
         (
             "wrong_sound_name",
             TEST_DEVICE_1_ID,
+            DOMAIN,
             "invalid_sound_value",
             {
                 "sound": "wrong_sound_name",
@@ -152,6 +160,7 @@ async def test_invalid_parameters(
     mock_config_entry: MockConfigEntry,
     sound: str,
     device_id: str,
+    translation_domain: str,
     translation_key: str,
     translation_placeholders: dict[str, str],
 ) -> None:
@@ -180,23 +189,31 @@ async def test_invalid_parameters(
             blocking=True,
         )
 
-    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_domain == translation_domain
     assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_placeholders == translation_placeholders
 
 
 @pytest.mark.parametrize(
-    ("info_skill", "device_id", "translation_key", "translation_placeholders"),
+    (
+        "info_skill",
+        "device_id",
+        "translation_domain",
+        "translation_key",
+        "translation_placeholders",
+    ),
     [
         (
             "tell_joke",
             "fake_device_id",
-            "invalid_device_id",
+            HOMEASSISTANT_DOMAIN,
+            "service_device_not_found",
             {"device_id": "fake_device_id"},
         ),
         (
             "wrong_info_skill_name",
             TEST_DEVICE_1_ID,
+            DOMAIN,
             "invalid_info_skill_value",
             {
                 "info_skill": "wrong_info_skill_name",
@@ -210,6 +227,7 @@ async def test_invalid_info_skillparameters(
     mock_config_entry: MockConfigEntry,
     info_skill: str,
     device_id: str,
+    translation_domain: str,
     translation_key: str,
     translation_placeholders: dict[str, str],
 ) -> None:
@@ -238,7 +256,7 @@ async def test_invalid_info_skillparameters(
             blocking=True,
         )
 
-    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_domain == translation_domain
     assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_placeholders == translation_placeholders
 
@@ -275,9 +293,12 @@ async def test_config_entry_not_loaded(
             blocking=True,
         )
 
-    assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == "entry_not_loaded"
-    assert exc_info.value.translation_placeholders == {"entry": mock_config_entry.title}
+    assert exc_info.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert exc_info.value.translation_key == "service_config_entry_not_loaded"
+    assert exc_info.value.translation_placeholders == {
+        "domain": DOMAIN,
+        "entry_title": mock_config_entry.title,
+    }
 
 
 async def test_invalid_config_entry(
@@ -309,9 +330,12 @@ async def test_invalid_config_entry(
             blocking=True,
         )
 
-    assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == "config_entry_not_found"
-    assert exc_info.value.translation_placeholders == {"device_id": TEST_DEVICE_1_ID}
+    assert exc_info.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert exc_info.value.translation_key == "service_device_wrong_domain"
+    assert exc_info.value.translation_placeholders == {
+        "device_name": TEST_DEVICE_1_ID,
+        "domain": DOMAIN,
+    }
 
 
 async def test_missing_config_entry(
@@ -348,6 +372,9 @@ async def test_missing_config_entry(
             blocking=True,
         )
 
-    assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == "config_entry_not_found"
-    assert exc_info.value.translation_placeholders == {"device_id": device_entry.id}
+    assert exc_info.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert exc_info.value.translation_key == "service_device_wrong_domain"
+    assert exc_info.value.translation_placeholders == {
+        "device_name": device_entry.name,
+        "domain": DOMAIN,
+    }

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3420,3 +3420,43 @@ async def test_get_service_config_entry_none(hass: HomeAssistant) -> None:
     with pytest.raises(exceptions.ServiceValidationError) as err:
         service.async_get_config_entry(hass, domain, None)
     assert err.value.translation_key == "service_config_entry_not_loaded"
+
+
+async def test_get_service_device_and_config_entry(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that we can get a device and its config entry."""
+    domain = "mock_integration"
+    entry = MockConfigEntry(domain=domain)
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(domain, "unique_id")},
+        name="Mock device",
+    )
+
+    assert service.async_get_device_and_config_entry(hass, domain, device.id) == (
+        device,
+        entry,
+    )
+
+    # Device doesn't exist
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.async_get_device_and_config_entry(hass, domain, "unknown_device_id")
+    assert err.value.translation_key == "service_device_not_found"
+
+    # Device exists, but is not owned by a config entry of the domain
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.async_get_device_and_config_entry(hass, "another_domain", device.id)
+    assert err.value.translation_key == "service_device_wrong_domain"
+    assert err.value.translation_placeholders == {
+        "device_name": "Mock device",
+        "domain": "another_domain",
+    }
+
+    # Device exists, but its config entry is not loaded
+    entry.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.async_get_device_and_config_entry(hass, domain, device.id)
+    assert err.value.translation_key == "service_config_entry_not_loaded"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on discussion in #180103

The current `dr.async_get_device_and_config_entry_for_domain` helper method in the device_registry helper always returns a `device`/`config_entry` pair and leaves the consumer to validate the result (both `device` and `config_entry` can be `None`)

In the case of service calls, I think it makes sense to offload the validation to a service helper.

cc @emontnemery

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
