### PR TITLE
Update govee-local-api to 3.0.0

### DIFF
--- a/homeassistant/components/govee_light_local/light.py
+++ b/homeassistant/components/govee_light_local/light.py
@@ -129,7 +129,7 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
         """
         if not super().available:
             return False
-        return dt_util.naive_now() - self._device.lastseen < DEVICE_TIMEOUT
+        return dt_util.utcnow() - self._device.lastseen < DEVICE_TIMEOUT
 
     @property
     @override

--- a/homeassistant/components/govee_light_local/manifest.json
+++ b/homeassistant/components/govee_light_local/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/govee_light_local",
   "iot_class": "local_push",
-  "requirements": ["govee-local-api==2.4.0"]
+  "requirements": ["govee-local-api==3.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1177,7 +1177,7 @@ gotailwind==0.4.0
 govee-ble==1.4.0
 
 # homeassistant.components.govee_light_local
-govee-local-api==2.4.0
+govee-local-api==3.0.0
 
 # homeassistant.components.remote_rpi_gpio
 gpiozero==1.6.2


### PR DESCRIPTION
## Proposed change

Updates `govee-local-api` from 2.4.0 to 3.0.0.

The library resolves a device's capabilities from a hand-maintained SKU table
(`GOVEE_LIGHT_CAPABILITIES`). When the SKU is missing, `capabilities` is `None`,
the coordinator logs *"Device X is not supported. Only power control is
available"* and the light entity is created with `{ColorMode.ONOFF}` only, even
though the device speaks the full local protocol. 3.0.0 adds 80 SKUs to that
table (191 -> 262), among them H1250 and H1270.

One adaptation is required by the bump: in 3.0.0 `GoveeDevice.lastseen` is
timezone-aware (`datetime.now(timezone.utc)`), where 2.4.0 used a naive
`datetime.now()`. `GoveeLight.available` compares it with `dt_util.naive_now()`,
so with 3.0.0 every entity fails to be added with:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
  File "homeassistant/components/govee_light_local/light.py", line 132, in available
    return dt_util.naive_now() - self._device.lastseen < DEVICE_TIMEOUT
```

Switching to `dt_util.utcnow()` matches the library's aware UTC value and keeps
the `DEVICE_TIMEOUT` semantics unchanged.

Test results on this branch, `tests/components/govee_light_local`:

| | result |
|---|---|
| `dev` + govee-local-api 2.4.0 | 23 passed |
| `dev` + govee-local-api 3.0.0, without the `available` fix | 16 failed, 7 passed |
| this branch (3.0.0 + fix) | 23 passed |

Also verified on real hardware running this branch's integration code against
3.0.0: an H1250 and an H1270, previously on/off only, now expose
`['color_temp', 'rgb']` plus the scene effect list, and colour, brightness and
colour temperature set from Home Assistant were read back from the devices over
the Govee local UDP protocol.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Library diff: https://github.com/Galorhallen/govee-local-api/compare/v2.4.0...v3.0.0
Release notes: https://github.com/Galorhallen/govee-local-api/releases/tag/v3.0.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
