### PR TITLE
Add esphome/get_device_capabilities websocket command

### DIFF
--- a/homeassistant/components/esphome/websocket_api.py
+++ b/homeassistant/components/esphome/websocket_api.py
@@ -33,8 +33,23 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, get_device_capabilities)
 
 
-def _serial_port_type_name(port_type: SerialProxyPortType | int) -> str | None:
+def _is_main_esphome_device(device: dr.DeviceEntry, mac_address: str | None) -> bool:
+    """Return True if device is the MAC-connected ESPHome node."""
+    if mac_address is None:
+        return any(
+            conn_type == dr.CONNECTION_NETWORK_MAC
+            for conn_type, _ in device.connections
+        )
+    return (
+        dr.CONNECTION_NETWORK_MAC,
+        dr.format_mac(mac_address),
+    ) in device.connections
+
+
+def _serial_port_type_name(port_type: SerialProxyPortType | int | None) -> str | None:
     """Return the SerialProxyPortType name, or None if unknown."""
+    if port_type is None:
+        return None
     try:
         return SerialProxyPortType(port_type).name
     except ValueError:
@@ -106,16 +121,33 @@ def get_device_capabilities(
         )
         return
 
-    if entry.state is not ConfigEntryState.LOADED:
-        connection.send_result(msg["id"], _UNAVAILABLE_CAPABILITIES)
+    # Sub-devices share the config entry but not node-level proxy capabilities.
+    if not isinstance(device, dr.DeviceEntry):
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_FOUND,
+            "Device is not the main ESPHome device",
+        )
         return
 
-    entry_data = entry.runtime_data
-    device_info = entry_data.device_info
+    device_info = None
+    if entry.state is ConfigEntryState.LOADED:
+        device_info = entry.runtime_data.device_info
+
+    mac_address = device_info.mac_address if device_info is not None else None
+    if not _is_main_esphome_device(device, mac_address):
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_FOUND,
+            "Device is not the main ESPHome device",
+        )
+        return
+
     if device_info is None:
         connection.send_result(msg["id"], _UNAVAILABLE_CAPABILITIES)
         return
 
+    entry_data = entry.runtime_data
     connection.send_result(
         msg["id"],
         {

--- a/homeassistant/components/esphome/websocket_api.py
+++ b/homeassistant/components/esphome/websocket_api.py
@@ -1,26 +1,44 @@
 """ESPHome websocket API."""
 
-import logging
-from typing import Any
+from typing import Any, cast
 
+from aioesphomeapi.model import SerialProxyPortType
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_NOISE_PSK
-
-_LOGGER = logging.getLogger(__name__)
-
+from .const import CONF_NOISE_PSK, DOMAIN
+from .entry_data import ESPHomeConfigEntry
+from .serial_proxy import build_url
 
 TYPE = "type"
 ENTRY_ID = "entry_id"
+DEVICE_ID = "device_id"
+
+_UNAVAILABLE_CAPABILITIES: dict[str, Any] = {
+    "available": False,
+    "bluetooth_proxy": {"supported": False},
+    "zwave_proxy": {"supported": False, "home_id": 0},
+    "serial_proxies": [],
+}
 
 
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the websocket API."""
     websocket_api.async_register_command(hass, get_encryption_key)
+    websocket_api.async_register_command(hass, get_device_capabilities)
+
+
+def _serial_port_type_name(port_type: SerialProxyPortType | int) -> str | None:
+    """Return the SerialProxyPortType name, or None if unknown."""
+    try:
+        return SerialProxyPortType(port_type).name
+    except ValueError:
+        return None
 
 
 @callback
@@ -48,5 +66,78 @@ def get_encryption_key(
         msg["id"],
         {
             "encryption_key": entry.data.get(CONF_NOISE_PSK),
+        },
+    )
+
+
+@callback
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "esphome/get_device_capabilities",
+        vol.Required(DEVICE_ID): str,
+    }
+)
+def get_device_capabilities(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return cached ESPHome DeviceInfo capabilities for the device page."""
+    device = dr.async_get(hass).async_get(msg[DEVICE_ID])
+    if device is None:
+        connection.send_error(
+            msg["id"], websocket_api.ERR_NOT_FOUND, "Device not found"
+        )
+        return
+
+    entry: ESPHomeConfigEntry | None = None
+    for entry_id in device.config_entries:
+        candidate = hass.config_entries.async_get_entry(entry_id)
+        if candidate is not None and candidate.domain == DOMAIN:
+            entry = cast(ESPHomeConfigEntry, candidate)
+            break
+
+    if entry is None:
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_NOT_FOUND,
+            "Device is not an ESPHome device",
+        )
+        return
+
+    if entry.state is not ConfigEntryState.LOADED:
+        connection.send_result(msg["id"], _UNAVAILABLE_CAPABILITIES)
+        return
+
+    entry_data = entry.runtime_data
+    device_info = entry_data.device_info
+    if device_info is None:
+        connection.send_result(msg["id"], _UNAVAILABLE_CAPABILITIES)
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "available": entry_data.available,
+            "bluetooth_proxy": {
+                "supported": bool(
+                    device_info.bluetooth_proxy_feature_flags_compat(
+                        entry_data.api_version
+                    )
+                ),
+            },
+            "zwave_proxy": {
+                "supported": bool(device_info.zwave_proxy_feature_flags),
+                "home_id": device_info.zwave_home_id or 0,
+            },
+            "serial_proxies": [
+                {
+                    "name": proxy.name,
+                    "port_type": _serial_port_type_name(proxy.port_type),
+                    "url": str(build_url(entry.entry_id, proxy.name)),
+                }
+                for proxy in device_info.serial_proxies
+            ],
         },
     )

--- a/tests/components/esphome/test_websocket_api.py
+++ b/tests/components/esphome/test_websocket_api.py
@@ -1,9 +1,9 @@
 """Tests for ESPHome websocket API."""
 
 from aioesphomeapi import APIClient
-from aioesphomeapi.model import SerialProxyInfo, SerialProxyPortType
+from aioesphomeapi.model import SerialProxyInfo, SerialProxyPortType, SubDeviceInfo
 
-from homeassistant.components.esphome.const import CONF_NOISE_PSK
+from homeassistant.components.esphome.const import CONF_NOISE_PSK, DOMAIN
 from homeassistant.components.esphome.serial_proxy import build_url
 from homeassistant.components.esphome.websocket_api import DEVICE_ID, ENTRY_ID, TYPE
 from homeassistant.core import HomeAssistant
@@ -70,6 +70,7 @@ async def test_get_device_capabilities(
                 SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL),
                 SerialProxyInfo(name="amp", port_type=SerialProxyPortType.RS232),
                 SerialProxyInfo(name="bus", port_type=SerialProxyPortType.RS485),
+                SerialProxyInfo(name="unknown", port_type=None),
             ],
         },
     )
@@ -106,6 +107,11 @@ async def test_get_device_capabilities(
                 "name": "bus",
                 "port_type": "RS485",
                 "url": str(build_url(device.entry.entry_id, "bus")),
+            },
+            {
+                "name": "unknown",
+                "port_type": None,
+                "url": str(build_url(device.entry.entry_id, "unknown")),
             },
         ],
     }
@@ -158,6 +164,42 @@ async def test_get_device_capabilities_wrong_domain(
     assert response["error"]["message"] == "Device is not an ESPHome device"
 
 
+async def test_get_device_capabilities_sub_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test capabilities are not exposed on ESPHome sub-devices."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "devices": [
+                SubDeviceInfo(device_id=11111111, name="Motion Sensor", area_id=0),
+            ],
+        },
+    )
+
+    sub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
+    )
+    assert sub_device is not None
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: sub_device.id,
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is False
+    assert response["error"]["code"] == "not_found"
+    assert response["error"]["message"] == "Device is not the main ESPHome device"
+
+
 async def test_get_device_capabilities_unavailable(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -175,7 +217,7 @@ async def test_get_device_capabilities_unavailable(
             "zwave_home_id": 1234567890,
         },
     )
-    await device.mock_disconnect(expected_disconnect=False)
+    device.entry.runtime_data.available = False
 
     websocket_client = await hass_ws_client()
     await websocket_client.send_json_auto_id(

--- a/tests/components/esphome/test_websocket_api.py
+++ b/tests/components/esphome/test_websocket_api.py
@@ -1,12 +1,31 @@
 """Tests for ESPHome websocket API."""
 
 from aioesphomeapi import APIClient
+from aioesphomeapi.model import SerialProxyInfo, SerialProxyPortType
 
 from homeassistant.components.esphome.const import CONF_NOISE_PSK
-from homeassistant.components.esphome.websocket_api import ENTRY_ID, TYPE
+from homeassistant.components.esphome.serial_proxy import build_url
+from homeassistant.components.esphome.websocket_api import DEVICE_ID, ENTRY_ID, TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .conftest import MockESPHomeDeviceType
 
 from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
+
+
+def _device_id_for_mac(
+    device_registry: dr.DeviceRegistry,
+    entry: MockConfigEntry,
+    mac: str = "11:22:33:44:55:aa",
+) -> str:
+    """Return the device registry id for an ESPHome MAC."""
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mac), entry.entry_id
+    )
+    assert device is not None
+    return device.id
 
 
 async def test_get_encryption_key(
@@ -29,4 +48,180 @@ async def test_get_encryption_key(
     assert response["success"] is True
     assert response["result"] == {
         "encryption_key": mock_config_entry.data.get(CONF_NOISE_PSK)
+    }
+
+
+async def test_get_device_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test capabilities from cached DeviceInfo."""
+    mock_client.connected_address = "192.168.1.2"
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "bluetooth_proxy_feature_flags": 1,
+            "zwave_proxy_feature_flags": 1,
+            "zwave_home_id": 1234567890,
+            "serial_proxies": [
+                SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL),
+                SerialProxyInfo(name="amp", port_type=SerialProxyPortType.RS232),
+                SerialProxyInfo(name="bus", port_type=SerialProxyPortType.RS485),
+            ],
+        },
+    )
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: _device_id_for_mac(device_registry, device.entry),
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is True
+    assert response["result"] == {
+        "available": True,
+        "bluetooth_proxy": {"supported": True},
+        "zwave_proxy": {
+            "supported": True,
+            "home_id": 1234567890,
+        },
+        "serial_proxies": [
+            {
+                "name": "uart0",
+                "port_type": "TTL",
+                "url": str(build_url(device.entry.entry_id, "uart0")),
+            },
+            {
+                "name": "amp",
+                "port_type": "RS232",
+                "url": str(build_url(device.entry.entry_id, "amp")),
+            },
+            {
+                "name": "bus",
+                "port_type": "RS485",
+                "url": str(build_url(device.entry.entry_id, "bus")),
+            },
+        ],
+    }
+
+
+async def test_get_device_capabilities_device_not_found(
+    init_integration: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test get_device_capabilities when the device registry id is unknown."""
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: "not-a-device",
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is False
+    assert response["error"]["code"] == "not_found"
+    assert response["error"]["message"] == "Device not found"
+
+
+async def test_get_device_capabilities_wrong_domain(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test get_device_capabilities when the device is not ESPHome."""
+    other_entry = MockConfigEntry(domain="switch", data={})
+    other_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")},
+    )
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: device.id,
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is False
+    assert response["error"]["code"] == "not_found"
+    assert response["error"]["message"] == "Device is not an ESPHome device"
+
+
+async def test_get_device_capabilities_unavailable(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test cached capabilities are returned when the device is unavailable."""
+    mock_client.connected_address = "192.168.1.2"
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "bluetooth_proxy_feature_flags": 1,
+            "zwave_proxy_feature_flags": 1,
+            "zwave_home_id": 1234567890,
+        },
+    )
+    await device.mock_disconnect(expected_disconnect=False)
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: _device_id_for_mac(device_registry, device.entry),
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is True
+    assert response["result"] == {
+        "available": False,
+        "bluetooth_proxy": {"supported": True},
+        "zwave_proxy": {"supported": True, "home_id": 1234567890},
+        "serial_proxies": [],
+    }
+
+
+async def test_get_device_capabilities_no_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a useful empty payload when cached DeviceInfo is missing."""
+    device = await mock_esphome_device(mock_client=mock_client)
+    device.entry.runtime_data.device_info = None
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json_auto_id(
+        {
+            TYPE: "esphome/get_device_capabilities",
+            DEVICE_ID: _device_id_for_mac(device_registry, device.entry),
+        }
+    )
+
+    response = await websocket_client.receive_json()
+    assert response["success"] is True
+    assert response["result"] == {
+        "available": False,
+        "bluetooth_proxy": {"supported": False},
+        "zwave_proxy": {
+            "supported": False,
+            "home_id": 0,
+        },
+        "serial_proxies": [],
     }


### PR DESCRIPTION
## Proposed change

Add an admin websocket command that returns the cached ESPHome DeviceInfo flags the device page needs for a setup checklist: whether Bluetooth proxy and Z-Wave proxy are compiled in, the Z-Wave home ID, and advertised serial proxy ports.

Audio is not included. The frontend can tell that from `media_player` entities on the device.

Related: OpenHomeFoundation/roadmap#191, OpenHomeFoundation/ux-design#59, home-assistant/frontend#54245

Frontend: home-assistant/frontend#53781

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: OpenHomeFoundation/roadmap#191. Related to home-assistant/frontend#54245
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request: home-assistant/frontend#53781

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
