### PR TITLE
Use async_get_device_and_config_entry service helper in switchbot

### DIFF
--- a/homeassistant/components/switchbot/services.py
+++ b/homeassistant/components/switchbot/services.py
@@ -2,11 +2,10 @@
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, CONF_SENSOR_TYPE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, service
 
 from .const import DOMAIN, SupportedModels
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
@@ -31,31 +30,8 @@ def _async_get_switchbot_entry_for_device_id(
     hass: HomeAssistant, device_id: str
 ) -> SwitchbotConfigEntry:
     """Return the loaded SwitchBot config entry for a device id."""
-    config_entry: SwitchbotConfigEntry | None
-    device, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        hass, device_id, domain=DOMAIN
-    )
-    if device is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_device_id",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    if config_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="device_not_belonging",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    if config_entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="device_entry_not_loaded",
-            translation_placeholders={"device_id": device_id},
-        )
-
+    config_entry: SwitchbotConfigEntry
+    _, config_entry = service.async_get_device_and_config_entry(hass, DOMAIN, device_id)
     return config_entry
 
 

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -431,20 +431,11 @@
     "advertising_state_error": {
       "message": "{address} is not advertising state"
     },
-    "device_entry_not_loaded": {
-      "message": "The device ID {device_id} is not loaded."
-    },
-    "device_not_belonging": {
-      "message": "The device ID {device_id} does not belong to SwitchBot integration."
-    },
     "device_not_found_error": {
       "message": "Could not find Switchbot {sensor_type} with address {address}: {reason}"
     },
     "device_without_config_entry": {
       "message": "The device ID {device_id} is not associated with a config entry."
-    },
-    "invalid_device_id": {
-      "message": "The device ID {device_id} is not a valid device ID."
     },
     "not_keypad_vision_device": {
       "message": "This service is only supported for SwitchBot Keypad Vision devices."

--- a/tests/components/switchbot/test_services.py
+++ b/tests/components/switchbot/test_services.py
@@ -12,7 +12,7 @@ from homeassistant.components.switchbot.services import (
     async_setup_services,
 )
 from homeassistant.const import ATTR_DEVICE_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
@@ -100,8 +100,8 @@ async def test_device_not_found(
                 blocking=True,
             )
 
-        assert err.value.translation_domain == DOMAIN
-        assert err.value.translation_key == "invalid_device_id"
+        assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+        assert err.value.translation_key == "service_device_not_found"
         assert err.value.translation_placeholders == {"device_id": "nonexistent_device"}
 
 
@@ -142,9 +142,12 @@ async def test_device_not_belonging(
             blocking=True,
         )
 
-    assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "device_not_belonging"
-    assert err.value.translation_placeholders == {"device_id": device_entry.id}
+    assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert err.value.translation_key == "service_device_wrong_domain"
+    assert err.value.translation_placeholders == {
+        "device_name": "Other device",
+        "domain": DOMAIN,
+    }
 
 
 async def test_device_entry_not_loaded(
@@ -184,9 +187,12 @@ async def test_device_entry_not_loaded(
             blocking=True,
         )
 
-    assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "device_entry_not_loaded"
-    assert err.value.translation_placeholders == {"device_id": device_entry.id}
+    assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert err.value.translation_key == "service_config_entry_not_loaded"
+    assert err.value.translation_placeholders == {
+        "domain": DOMAIN,
+        "entry_title": second_entry.title,
+    }
 
 
 async def test_service_unsupported_device(
@@ -245,6 +251,6 @@ async def test_device_without_config_entry_id(
             blocking=True,
         )
 
-    assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "invalid_device_id"
+    assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert err.value.translation_key == "service_device_not_found"
     assert err.value.translation_placeholders == {"device_id": "abc"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new helper introduced in #180132

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
