### PR TITLE
Add ha-merge-queue skill for merge-ready PR detection

### DIFF
--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ha-merge-queue
-description: Finds open Home Assistant pull requests that are genuinely ready to merge, checking CI, the merge-gate statuses, code-owner approval, merge conflicts and unresolved review threads. Use when looking for PRs to merge, doing merge-queue triage, or asking for "quick wins" from the open PR backlog.
+description: Finds open Home Assistant pull requests that are genuinely ready to merge, checking CI, the merge-gate statuses, code-owner approval, merge conflicts, requested changes and unresolved review threads. Use when looking for PRs to merge, doing merge-queue triage, or asking for "quick wins" from the open PR backlog.
 ---
 
 # Find Ready-to-Merge Pull Requests
@@ -27,7 +27,7 @@ verify every finalist with the per-PR checks below.
 
 ## Verify each finalist
 
-Check all four. A PR fails the shortlist if any one fails.
+Check all five. A PR fails the shortlist if any one fails.
 
 1. **Merge-gate statuses** — fetch the combined commit status. This is the cheapest and
    most informative call, and it is what actually blocks the merge button. Five contexts
@@ -56,7 +56,16 @@ Check all four. A PR fails the shortlist if any one fails.
      `homeassistant/generated/integrations.json` conflicts constantly, so PRs adding
      integrations go stale fast.
 
-4. **Review threads** — fetch review threads and read `is_resolved`. Judge a thread by
+4. **Review submissions** — fetch the reviews, not just the threads. A `CHANGES_REQUESTED`
+   review is returned here and nowhere else, and a reviewer can request changes with only a
+   top-level body and no inline comments — such a PR has zero open review threads and looks
+   clean to the check above. Take the latest submission per reviewer: a standing
+   `CHANGES_REQUESTED` that no later `APPROVED` from the same person supersedes disqualifies
+   the PR. Do not lean on the `-review:changes_requested` search qualifier instead — the
+   index is stale, and `mergeable_state: blocked` does not distinguish "needs an approval"
+   from "changes were requested".
+
+5. **Review threads** — fetch review threads and read `is_resolved`. Judge a thread by
    whether it is resolved or substantively addressed, never by who wrote it: an unresolved
    finding from `copilot-pull-request-reviewer` is a bug report and can be a real defect,
    so read it on its merits before discounting it. For every thread still open, say which
@@ -75,6 +84,7 @@ recurring ones:
 - A failing test unrelated to the diff — name the test, say re-run the job.
 - `required-labels` red — name the label to add (`bugfix`, `new-feature`, …).
 - Awaiting code-owner approval — name the code owner from `manifest.json`.
+- A standing `CHANGES_REQUESTED` review — name the reviewer, and say what they asked for.
 - `dirty` — the author must merge `dev` and regenerate any generated files.
 
 Call out mismatches worth a maintainer's attention: a PR whose body declares a breaking

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -15,7 +15,7 @@ Search open PRs, excluding those that are structurally not mergeable:
 
 ```
 repo:home-assistant/core is:open is:pr draft:false status:success -review:changes_requested
-  -label:"awaiting-frontend" -label:"needs-more-info" -label:"stale" -label:"cla-needed"
+  -label:"awaiting-frontend" -label:"stale" -label:"cla-needed"
 ```
 
 Add `label:"small-pr"` for quick wins, or `label:"code-owner-approved"` / `review:approved`

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -31,7 +31,7 @@ Check all five. A PR fails the shortlist if any one fails.
 
 1. **Merge-gate statuses** — fetch the combined commit status. This is the cheapest and
    most informative call, and it is what actually blocks the merge button. Five contexts
-   matter: `code-owner-approval` (required for Gold and Platinum integrations),
+   matter: `code-owner-approval` (required for Platinum integrations),
    `required-labels` (red when the author checked no "Type of change" box),
    `docs-missing` (red when a user-facing change has no documentation PR), `cla-bot`, and
    `blocking-label-awaiting-frontend`.

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -29,6 +29,11 @@ verify every finalist with the per-PR checks below.
 
 Check all five. A PR fails the shortlist if any one fails.
 
+Paginate every list response before deciding. Check runs, reviews and review threads are all
+paged, typically 30 per page, and a full-suite Home Assistant PR runs to 40-odd check runs —
+so page one shows a green subset while a failure or a standing review sits on page two.
+Compare the returned count against the reported total and keep fetching until they match.
+
 1. **Merge-gate statuses** — fetch the combined commit status. This is the cheapest and
    most informative call, and it is what actually blocks the merge button. Five contexts
    matter: `code-owner-approval` (required for Platinum integrations),
@@ -48,13 +53,21 @@ Check all five. A PR fails the shortlist if any one fails.
    the request after that can still return `unknown`. Poll with bounded retries — a few
    attempts, pausing between them — and treat an `unknown` that never resolves as not
    ready, rather than assuming it is fine.
-   - `clean` — approved and mergeable; merge now
-   - `blocked` — mergeable, no conflict, waiting on an approving review (the normal state)
+   - `clean` — every merge requirement met; merge now
+   - `blocked` — some branch-protection requirement is unmet. It does not specifically mean
+     "waiting on an approval", so do not report it that way by default: use the other four
+     checks to establish which requirement is missing, and only call it awaiting review once
+     they all come back clean.
+   - `behind` — the base branch has moved on. Actionable and often a one-click update, so
+     surface it rather than dropping the PR.
+   - `unstable` — a non-required check is failing. Find out which one before shortlisting.
    - `dirty` — merge conflict. The author needs to merge `dev` into the branch. Do not tell
      them to rebase: `AGENTS.md` forbids rewriting history on a PR branch once the PR is
      open, because reviewers need to see what changed since their last review.
      `homeassistant/generated/integrations.json` conflicts constantly, so PRs adding
      integrations go stale fast.
+   - anything else (`draft`, `has_hooks`, a value not listed here) — do not guess at what it
+     means. Treat the PR as not ready and report the value you got.
 
 4. **Review submissions** — fetch the reviews, not just the threads. A `CHANGES_REQUESTED`
    review is returned here and nowhere else, and a reviewer can request changes with only a
@@ -80,8 +93,10 @@ Check all five. A PR fails the shortlist if any one fails.
 ## Report
 
 Rank by how little work each PR needs: `clean` first, then `blocked` with everything else
-green. For each PR give the number as a full markdown link, the integration, one line on
-what it does, and its blocking state.
+green. For each PR give the number as a full markdown link, the integration or core area,
+one line on what it does, and its blocking state. Plenty of `home-assistant/core` PRs touch
+helpers, the framework, the recorder or repo tooling and have no integration at all — name
+what they touch instead, rather than dropping them or inventing one.
 
 Then list the near-misses separately, each with the one action that unblocks it. The
 recurring ones:

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -61,16 +61,21 @@ Check all five. A PR fails the shortlist if any one fails.
    top-level body and no inline comments — such a PR has zero open review threads and looks
    clean to the check above. Take the latest submission per reviewer: a standing
    `CHANGES_REQUESTED` that no later `APPROVED` from the same person supersedes disqualifies
-   the PR. Do not lean on the `-review:changes_requested` search qualifier instead — the
+   the PR, regardless of whether its inline threads have since been resolved — resolving a
+   thread does not withdraw the review. Do not lean on the `-review:changes_requested`
+   search qualifier instead — the
    index is stale, and `mergeable_state: blocked` does not distinguish "needs an approval"
    from "changes were requested".
 
 5. **Review threads** — fetch review threads and read `is_resolved`. Judge a thread by
    whether it is resolved or substantively addressed, never by who wrote it: an unresolved
    finding from `copilot-pull-request-reviewer` is a bug report and can be a real defect,
-   so read it on its merits before discounting it. For every thread still open, say which
-   kind it is — an answered question, a nit the author passed on, or an open design debate
-   — because only the last of those should hold up a merge.
+   so read it on its merits before discounting it. Every thread still open counts against
+   the PR until you have read it and concluded it needs no change — the question was
+   answered, the suggestion was considered and declined, the point was fixed elsewhere in
+   the diff. Say for each open thread what it is and why it does or does not block. Never
+   discount one for the category it appears to fall into; an unaddressed defect is a
+   blocker whether or not anyone is arguing about it.
 
 ## Report
 

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ha-merge-queue
+description: Finds open Home Assistant pull requests that are genuinely ready to merge, checking CI, the merge-gate statuses, code-owner approval, merge conflicts and unresolved review threads. Use when looking for PRs to merge, doing merge-queue triage, or asking for "quick wins" from the open PR backlog.
+---
+
+# Find Ready-to-Merge Pull Requests
+
+Produce a shortlist of open PRs a maintainer can approve and merge immediately, plus a
+short list of near-misses that each need one specific nudge. Default to 10 candidates
+unless the user asks for a different number.
+
+## Gather candidates
+
+Search open PRs, excluding those that are structurally not mergeable:
+
+```
+repo:home-assistant/core is:open is:pr draft:false status:success -review:changes_requested
+  -label:"awaiting-frontend" -label:"needs-more-info" -label:"stale" -label:"cla-needed"
+```
+
+Add `label:"small-pr"` for quick wins, or `label:"code-owner-approved"` / `review:approved`
+for PRs already carrying an approval. Run several searches and pool the results — no single
+query surfaces everything.
+
+The search index lags reality by hours. Treat `status:` as a rough filter, never as proof;
+verify every finalist with the per-PR checks below.
+
+## Verify each finalist
+
+Check all four. A PR fails the shortlist if any one fails.
+
+1. **Merge-gate statuses** — fetch the combined commit status. This is the cheapest and
+   most informative call, and it is what actually blocks the merge button. Five contexts
+   matter: `code-owner-approval` (required for Gold and Platinum integrations),
+   `required-labels` (red when the author checked no "Type of change" box),
+   `docs-missing` (red when a user-facing change has no documentation PR), `cla-bot`, and
+   `blocking-label-awaiting-frontend`.
+
+2. **Check runs** — the commit statuses do not cover GitHub Actions. Fetch the check runs
+   and look for any job with conclusion `failure`. Ignore `skipped`. A green combined
+   status with a red test job is common.
+
+3. **Merge conflicts** — read `mergeable_state`. GitHub computes it lazily: the first
+   request usually returns `unknown` and kicks off the computation, so **request it a
+   second time** and use that value.
+   - `clean` — approved and mergeable; merge now
+   - `blocked` — mergeable, no conflict, waiting on an approving review (the normal state)
+   - `dirty` — merge conflict; the author must rebase. `homeassistant/generated/integrations.json`
+     conflicts constantly, so PRs adding integrations go stale fast.
+
+4. **Review threads** — fetch review threads and read `is_resolved`. Only unresolved
+   threads from humans block. Resolved threads, and long chains from
+   `copilot-pull-request-reviewer`, do not. Watch for an unresolved thread that is really
+   an answered question versus one that is an open design debate — say which it is.
+
+## Report
+
+Rank by how little work each PR needs: `clean` first, then `blocked` with everything else
+green. For each PR give the number as a full markdown link, the integration, one line on
+what it does, and its blocking state.
+
+Then list the near-misses separately, each with the one action that unblocks it. The
+recurring ones:
+
+- A failing test unrelated to the diff — name the test, say re-run the job.
+- `required-labels` red — name the label to add (`bugfix`, `new-feature`, …).
+- Awaiting code-owner approval — name the code owner from `manifest.json`.
+- `dirty` — the author must merge `dev` and regenerate any generated files.
+
+Call out mismatches worth a maintainer's attention: a PR whose body declares a breaking
+change but carries no `breaking-change` label will silently miss the release notes.
+
+## IMPORTANT
+
+- Only report in the CONSOLE. DO NOT ACT ON GITHUB — no comments, no reviews, no merges,
+  no pushes to contributor branches. Per `AI_POLICY.md`, a human decides and acts.
+- Never call a PR ready on green CI alone. Read the diff of every PR you shortlist; CI
+  cannot tell you whether the change is correct or wanted.

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -37,21 +37,31 @@ Check all four. A PR fails the shortlist if any one fails.
    `blocking-label-awaiting-frontend`.
 
 2. **Check runs** — the commit statuses do not cover GitHub Actions. Fetch the check runs
-   and look for any job with conclusion `failure`. Ignore `skipped`. A green combined
-   status with a red test job is common.
+   and require every one to have reached an acceptable terminal result: `status` must be
+   `completed`, and `conclusion` must be `success`, `skipped` or `neutral`. Everything else
+   disqualifies — `failure`, `cancelled`, `timed_out`, `action_required` and `stale`, and
+   any run still `queued` or `in_progress`. A green combined status sitting on top of a red
+   or still-running test job is common, so the status list alone is never enough.
 
-3. **Merge conflicts** — read `mergeable_state`. GitHub computes it lazily: the first
-   request usually returns `unknown` and kicks off the computation, so **request it a
-   second time** and use that value.
+3. **Merge conflicts** — read `mergeable_state`. GitHub computes it asynchronously: a
+   request that finds no cached answer returns `unknown` and starts the computation, and
+   the request after that can still return `unknown`. Poll with bounded retries — a few
+   attempts, pausing between them — and treat an `unknown` that never resolves as not
+   ready, rather than assuming it is fine.
    - `clean` — approved and mergeable; merge now
    - `blocked` — mergeable, no conflict, waiting on an approving review (the normal state)
-   - `dirty` — merge conflict; the author must rebase. `homeassistant/generated/integrations.json`
-     conflicts constantly, so PRs adding integrations go stale fast.
+   - `dirty` — merge conflict. The author needs to merge `dev` into the branch. Do not tell
+     them to rebase: `AGENTS.md` forbids rewriting history on a PR branch once the PR is
+     open, because reviewers need to see what changed since their last review.
+     `homeassistant/generated/integrations.json` conflicts constantly, so PRs adding
+     integrations go stale fast.
 
-4. **Review threads** — fetch review threads and read `is_resolved`. Only unresolved
-   threads from humans block. Resolved threads, and long chains from
-   `copilot-pull-request-reviewer`, do not. Watch for an unresolved thread that is really
-   an answered question versus one that is an open design debate — say which it is.
+4. **Review threads** — fetch review threads and read `is_resolved`. Judge a thread by
+   whether it is resolved or substantively addressed, never by who wrote it: an unresolved
+   finding from `copilot-pull-request-reviewer` is a bug report and can be a real defect,
+   so read it on its merits before discounting it. For every thread still open, say which
+   kind it is — an answered question, a nit the author passed on, or an open design debate
+   — because only the last of those should hold up a merge.
 
 ## Report
 


### PR DESCRIPTION
## Proposed change

Add a `ha-merge-queue` skill that finds open pull requests which are genuinely ready to merge, so maintainer merge-queue triage does not have to be re-derived from scratch each time.

The skill exists because "green CI" is not the same as "mergeable" in this repository, and the difference is not obvious.

The skill also codifies the near-miss triage that turns a red PR into a one-action fix and it flags PRs whose body declares a breaking change but carry no `breaking-change` label, since those silently miss the release notes.

It follows the console-only posture of the existing `ha-pr-*` skills and restates the `AI_POLICY.md` constraint explicitly: report, never act on GitHub.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Adds one file, `.claude/skills/ha-merge-queue/SKILL.md`. No runtime code, no dependencies,
no effect on any integration.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaK4ZPZZ3aFvNwWRcQKhiL