### PR TITLE
Allow conditions and triggers to raise issues during validation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -381,6 +381,12 @@ class BaseAutomationEntity(ToggleEntity, ABC):
     ) -> ScriptRunResult | None:
         """Trigger automation."""
 
+    @callback
+    def async_refresh_validation_findings(
+        self, findings: list[ValidationFinding]
+    ) -> None:
+        """Refresh repair issues when kept across a reload with unchanged config."""
+
 
 class UnavailableAutomationEntity(BaseAutomationEntity):
     """A non-functional automation entity with its state set to unavailable.
@@ -666,6 +672,14 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         if enable_automation:
             await self._async_enable()
 
+        self._async_create_validation_issues()
+
+    @callback
+    def _async_create_validation_issues(self) -> None:
+        """Materialize repair issues for this automation's validation findings."""
+        edit_url = (
+            f"/config/automation/edit/{self.unique_id}" if self.unique_id else None
+        )
         for finding in self._validation_findings:
             self._validation_issue_ids.add(
                 async_create_validation_issue(
@@ -675,9 +689,22 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
                     owner_key=self.unique_id or self.entity_id,
                     name=self._attr_name or self.entity_id,
                     entity_id=self.entity_id,
-                    edit_url=f"/config/automation/edit/{self.unique_id}",
+                    edit_url=edit_url,
                 )
             )
+
+    @override
+    @callback
+    def async_refresh_validation_findings(
+        self, findings: list[ValidationFinding]
+    ) -> None:
+        """Re-materialize repair issues when kept across a reload."""
+        if findings == self._validation_findings:
+            return
+        async_clear_validation_issues(self.hass, self._validation_issue_ids)
+        self._validation_issue_ids = set()
+        self._validation_findings = findings
+        self._async_create_validation_issues()
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -1148,15 +1175,15 @@ async def _async_process_config(
     def find_matches(
         automations: list[BaseAutomationEntity],
         automation_configs: list[AutomationEntityConfig],
-    ) -> tuple[set[int], set[int]]:
+    ) -> list[tuple[int, int]]:
         """Find matches between automation entities and configurations.
 
         An automation or configuration is only allowed to match at most once to handle
         the case of multiple automations with identical configuration.
 
-        Returns a tuple of sets of indices: ({automation_matches}, {config_matches})
+        Returns a list of matched (automation_idx, config_idx) index pairs.
         """
-        automation_matches: set[int] = set()
+        matches: list[tuple[int, int]] = []
         config_matches: set[int] = set()
         automation_configs_with_id: dict[str, tuple[int, AutomationEntityConfig]] = {}
         automation_configs_without_id: list[tuple[int, AutomationEntityConfig]] = []
@@ -1178,8 +1205,7 @@ async def _async_process_config(
                     automation.unique_id
                 )
                 if automation_matches_config(automation, automation_config):
-                    automation_matches.add(automation_idx)
-                    config_matches.add(config_idx)
+                    matches.append((automation_idx, config_idx))
                 continue
 
             for config_idx, automation_config in automation_configs_without_id:
@@ -1187,18 +1213,27 @@ async def _async_process_config(
                     # Only allow an automation config to match at most once
                     continue
                 if automation_matches_config(automation, automation_config):
-                    automation_matches.add(automation_idx)
+                    matches.append((automation_idx, config_idx))
                     config_matches.add(config_idx)
                     # Only allow an automation to match at most once
                     break
 
-        return automation_matches, config_matches
+        return matches
 
     automation_configs = await _prepare_automation_config(hass, config, None)
     automations: list[BaseAutomationEntity] = list(component.entities)
 
     # Find automations and configurations which have matches
-    automation_matches, config_matches = find_matches(automations, automation_configs)
+    matches = find_matches(automations, automation_configs)
+    automation_matches = {automation_idx for automation_idx, _ in matches}
+    config_matches = {config_idx for _, config_idx in matches}
+
+    # A matched automation is kept as-is, but its registry-dependent findings may have
+    # changed even when the config text is unchanged, so refresh its repair issues.
+    for automation_idx, config_idx in matches:
+        automations[automation_idx].async_refresh_validation_findings(
+            automation_configs[config_idx].validation_findings
+        )
 
     # Remove automations which have changed config or no longer exist
     tasks = [
@@ -1245,6 +1280,11 @@ async def _async_process_single_config(
     automation_config = automation_configs[0] if automation_configs else None
 
     if _automation_matches_config(automation, automation_config):
+        # Kept as-is, but refresh registry-dependent findings that may have changed
+        # even though the config text is unchanged.
+        cast(BaseAutomationEntity, automation).async_refresh_validation_findings(
+            cast(AutomationEntityConfig, automation_config).validation_findings
+        )
         return
 
     if automation:

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -49,6 +49,11 @@ from homeassistant.helpers import (
     config_validation as cv,
     trigger as trigger_helper,
 )
+from homeassistant.helpers.automation import (
+    ValidationFinding,
+    async_clear_validation_issues,
+    async_create_validation_issue,
+)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.issue_registry import (
@@ -492,6 +497,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         raw_config: ConfigType | None,
         blueprint_inputs: ConfigType | None,
         trace_config: ConfigType,
+        validation_findings: list[ValidationFinding],
     ) -> None:
         """Initialize an automation entity."""
         self._attr_name = name
@@ -509,6 +515,8 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         self._blueprint_inputs = blueprint_inputs
         self._trace_config = trace_config
         self._attr_unique_id = automation_id
+        self._validation_findings = validation_findings
+        self._validation_issue_ids: set[str] = set()
 
     @property
     @override
@@ -657,6 +665,19 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
 
         if enable_automation:
             await self._async_enable()
+
+        for finding in self._validation_findings:
+            self._validation_issue_ids.add(
+                async_create_validation_issue(
+                    self.hass,
+                    finding,
+                    issue_domain=DOMAIN,
+                    owner_key=self.unique_id or self.entity_id,
+                    name=self._attr_name or self.entity_id,
+                    entity_id=self.entity_id,
+                    edit_url=f"/config/automation/edit/{self.unique_id}",
+                )
+            )
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -821,6 +842,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Remove listeners when removing automation from Home Assistant."""
         await super().async_will_remove_from_hass()
+        async_clear_validation_issues(self.hass, self._validation_issue_ids)
         if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
             # Entity ID change, do not unload the script or conditions as they will
             # be reused.
@@ -983,6 +1005,7 @@ class AutomationEntityConfig:
     raw_config: ConfigType | None
     validation_error: str | None
     validation_status: ValidationStatus
+    validation_findings: list[ValidationFinding]
 
 
 async def _prepare_automation_config(
@@ -1004,6 +1027,9 @@ async def _prepare_automation_config(
         raw_blueprint_inputs = cast(AutomationConfig, config_block).raw_blueprint_inputs
         validation_error = cast(AutomationConfig, config_block).validation_error
         validation_status = cast(AutomationConfig, config_block).validation_status
+        validation_findings = (
+            cast(AutomationConfig, config_block).validation_findings or []
+        )
         automation_configs.append(
             AutomationEntityConfig(
                 config_block,
@@ -1012,6 +1038,7 @@ async def _prepare_automation_config(
                 raw_config,
                 validation_error,
                 validation_status,
+                validation_findings,
             )
         )
 
@@ -1098,6 +1125,7 @@ async def _create_automation_entities(
             automation_config.raw_config,
             automation_config.raw_blueprint_inputs,
             config_block[CONF_TRACE],
+            automation_config.validation_findings,
         )
         entities.append(entity)
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -522,7 +522,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         self._trace_config = trace_config
         self._attr_unique_id = automation_id
         self._validation_findings = validation_findings
-        self._validation_issue_ids: set[str] = set()
+        self._validation_issue_ids: set[tuple[str, str]] = set()
 
     @property
     @override

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, script
+from homeassistant.helpers.automation import ValidationFinding
 from homeassistant.helpers.condition import async_validate_conditions_config
 from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.helpers.typing import ConfigType
@@ -214,9 +215,11 @@ async def _async_validate_config_item(  # noqa: C901
     automation_config.raw_blueprint_inputs = raw_blueprint_inputs
     automation_config.raw_config = raw_config
 
+    findings: list[ValidationFinding] = []
+
     try:
         automation_config[CONF_TRIGGERS] = await async_validate_trigger_config(
-            hass, validated_config[CONF_TRIGGERS]
+            hass, validated_config[CONF_TRIGGERS], issue_reporter=findings.append
         )
     except (
         vol.Invalid,
@@ -235,7 +238,9 @@ async def _async_validate_config_item(  # noqa: C901
     if CONF_CONDITIONS in validated_config:
         try:
             automation_config[CONF_CONDITIONS] = await async_validate_conditions_config(
-                hass, validated_config[CONF_CONDITIONS]
+                hass,
+                validated_config[CONF_CONDITIONS],
+                issue_reporter=findings.append,
             )
         except (
             vol.Invalid,
@@ -256,7 +261,7 @@ async def _async_validate_config_item(  # noqa: C901
 
     try:
         automation_config[CONF_ACTIONS] = await script.async_validate_actions_config(
-            hass, validated_config[CONF_ACTIONS]
+            hass, validated_config[CONF_ACTIONS], issue_reporter=findings.append
         )
     except (
         vol.Invalid,
@@ -271,6 +276,8 @@ async def _async_validate_config_item(  # noqa: C901
             automation_config, ValidationStatus.FAILED_ACTIONS, err, validated_config
         )
         return automation_config
+
+    automation_config.validation_findings = findings
 
     return automation_config
 
@@ -293,6 +300,7 @@ class AutomationConfig(dict):
     raw_blueprint_inputs: dict[str, Any] | None = None
     validation_status: ValidationStatus = ValidationStatus.OK
     validation_error: str | None = None
+    validation_findings: list[ValidationFinding] | None = None
 
 
 async def _try_async_validate_config_item(

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -179,6 +179,10 @@
       "description": "The automation or script \"{name}\" (`{entity_id}`) has an event trigger that filters on device `{device_id}`. This device was split into one device per integration and no longer exists, so the trigger can no longer fire.\n\nTo fix this issue, [edit it]({edit}) to filter on one of these devices instead: {devices}. Then save and reload the configuration.",
       "title": "Event trigger uses a device that no longer exists"
     },
+    "event_trigger_composite_device_id_no_edit": {
+      "description": "The automation or script \"{name}\" (`{entity_id}`) has an event trigger that filters on device `{device_id}`. This device was split into one device per integration and no longer exists, so the trigger can no longer fire.\n\nTo fix this issue, edit it to filter on one of these devices instead: {devices}. Then save and reload the configuration.",
+      "title": "[%key:component::homeassistant::issues::event_trigger_composite_device_id::title%]"
+    },
     "historic_currency": {
       "description": "The currency {currency} is no longer in use, please reconfigure the currency configuration.",
       "title": "The configured currency is no longer in use"

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -175,6 +175,10 @@
       "description": "Configuring {integration_title} using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
       "title": "The {integration_title} YAML configuration is being removed"
     },
+    "event_trigger_composite_device_id": {
+      "description": "The automation or script \"{name}\" (`{entity_id}`) has an event trigger that filters on device `{device_id}`. This device was split into one device per integration and no longer exists, so the trigger can no longer fire.\n\nTo fix this issue, [edit it]({edit}) to filter on one of these devices instead: {devices}. Then save and reload the configuration.",
+      "title": "Event trigger uses a device that no longer exists"
+    },
     "historic_currency": {
       "description": "The currency {currency} is no longer in use, please reconfigure the currency configuration.",
       "title": "The configured currency is no longer in use"

--- a/homeassistant/components/homeassistant/trigger.py
+++ b/homeassistant/components/homeassistant/trigger.py
@@ -4,6 +4,10 @@ from typing import cast
 
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.automation import (
+    ValidationIssueReporter,
+    async_call_platform_validator,
+)
 from homeassistant.helpers.importlib import async_import_module
 from homeassistant.helpers.trigger import (
     TriggerActionType,
@@ -24,12 +28,17 @@ async def _async_get_trigger_platform(
 
 
 async def async_validate_trigger_config(
-    hass: HomeAssistant, config: ConfigType
+    hass: HomeAssistant,
+    config: ConfigType,
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> ConfigType:
     """Validate config."""
     platform = await _async_get_trigger_platform(hass, config[CONF_PLATFORM])
     if hasattr(platform, "async_validate_trigger_config"):
-        return await platform.async_validate_trigger_config(hass, config)
+        return await async_call_platform_validator(
+            platform.async_validate_trigger_config, hass, config, issue_reporter
+        )
 
     return platform.TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
 

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     template,
 )
+from homeassistant.helpers.automation import ValidationFinding, ValidationIssueReporter
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import yaml as yaml_util
@@ -27,6 +28,10 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_EVENT_TYPE = "event_type"
 CONF_EVENT_CONTEXT = "context"
+
+# Base translation key (in the homeassistant integration) of the repair raised when an event
+# trigger filters on a pre-migration composite device id.
+COMPOSITE_DEVICE_ID_ISSUE = "event_trigger_composite_device_id"
 
 
 def _validate_event_types(value: Any) -> Any:
@@ -53,13 +58,19 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
 
 
 async def async_validate_trigger_config(
-    hass: HomeAssistant, config: ConfigType
+    hass: HomeAssistant,
+    config: ConfigType,
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> ConfigType:
     """Validate trigger config.
 
-    Warn if the trigger filters event_data.device_id on a pre-migration composite device
-    id - a device that was split into one device per config entry.
+    Detects when the trigger filters event_data.device_id on a pre-migration composite
+    device id - a device that was split into one device per config entry.
     A templated device id is a Template (not a plain string) and is left alone.
+
+    When an ``issue_reporter`` is provided the problem is reported as a finding to be
+    materialized as a repair issue. Otherwise it is logged as a warning.
     """
     validated_config: ConfigType = TRIGGER_SCHEMA(config)
     if (
@@ -73,8 +84,28 @@ async def async_validate_trigger_config(
             ).async_get_devices_for_composite_device_id(device_id)
         )
     ):
-        _log_composite_device_id_warning(hass, config, device_id, split_devices)
+        if issue_reporter is not None:
+            issue_reporter(
+                ValidationFinding(
+                    finding_type=COMPOSITE_DEVICE_ID_ISSUE,
+                    issue_key=device_id,
+                    placeholders={
+                        "device_id": device_id,
+                        "devices": _composite_device_names(split_devices),
+                    },
+                )
+            )
+        else:
+            _log_composite_device_id_warning(hass, config, device_id, split_devices)
     return validated_config
+
+
+def _composite_device_names(split_devices: list[dr.DeviceEntry]) -> str:
+    """Return a human readable list of the devices a composite id was split into."""
+    return ", ".join(
+        f"{device.name_by_user or device.name or device.id} ({device.id})"
+        for device in split_devices
+    )
 
 
 @callback

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -68,7 +68,7 @@ async def async_validate_trigger_config(
     A templated device id is a Template (not a plain string) and is left alone.
 
     When an ``issue_reporter`` is provided the problem is reported as a finding to be
-    materialized as a repair issue. Otherwise it is logged as a warning.
+    materialized as a repair issue. It is always logged as a warning.
     """
     validated_config: ConfigType = TRIGGER_SCHEMA(config)
     if (
@@ -82,6 +82,9 @@ async def async_validate_trigger_config(
             ).async_get_devices_for_composite_device_id(device_id)
         )
     ):
+        # Log the original (pre-schema) config so the dumped YAML has no Template
+        # objects, which cannot be serialized.
+        _log_composite_device_id_warning(hass, config, device_id, split_devices)
         if issue_reporter is not None:
             issue_reporter(
                 ValidationFinding(
@@ -93,8 +96,6 @@ async def async_validate_trigger_config(
                     },
                 )
             )
-        else:
-            _log_composite_device_id_warning(hass, config, device_id, split_devices)
     return validated_config
 
 

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -29,8 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_EVENT_TYPE = "event_type"
 CONF_EVENT_CONTEXT = "context"
 
-# Base translation key (in the homeassistant integration) of the repair raised when an event
-# trigger filters on a pre-migration composite device id.
 COMPOSITE_DEVICE_ID_ISSUE = "event_trigger_composite_device_id"
 
 

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -12,7 +12,14 @@ from homeassistant.const import (
     CONF_PLATFORM,
     EVENT_STATE_REPORTED,
 )
-from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    Event,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
@@ -89,6 +96,8 @@ async def async_validate_trigger_config(
             issue_reporter(
                 ValidationFinding(
                     finding_type=COMPOSITE_DEVICE_ID_ISSUE,
+                    translation_domain=HOMEASSISTANT_DOMAIN,
+                    translation_key=COMPOSITE_DEVICE_ID_ISSUE,
                     issue_key=device_id,
                     placeholders={
                         "device_id": device_id,

--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -1,14 +1,21 @@
 """Helpers for automation."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Coroutine, Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Final, Self
+import functools
+import inspect
+from typing import Any, Final, Protocol, Self
 
 import voluptuous as vol
 
 from homeassistant.const import CONF_OPTIONS
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    HomeAssistant,
+    callback,
+    split_entity_id,
+)
 
 from .entity import get_device_class_or_undefined
 from .typing import UNDEFINED, ConfigType, UndefinedType
@@ -162,3 +169,106 @@ class ThresholdConfig:
             entity = config["entity"]
 
         return cls(numerical=numerical, number=number, entity=entity, unit=unit)
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class ValidationFinding:
+    """A non-fatal problem detected while validating a trigger, condition or action config.
+
+    A validator reports findings through the optional ``issue_reporter`` passed to config
+    validation (e.g. ``async_validate_trigger_config``). The validator does not know which
+    automation, script or template entity owns the config; the code that initiated the
+    validation adds that owner context and materializes a repair issue via
+    ``async_create_validation_issue``.
+
+    ``finding_type`` is the base translation key of the repair issue - its strings live in
+    the ``homeassistant`` integration, which the issue is filed under. ``issue_key``
+    discriminates findings of the same type within one owner (e.g. the offending device
+    id). ``placeholders`` are the finding-specific translation placeholders.
+    """
+
+    finding_type: str
+    issue_key: str
+    placeholders: Mapping[str, str]
+
+
+class ValidationIssueReporter(Protocol):
+    """Reports a non-fatal problem found while validating a config."""
+
+    @callback
+    def __call__(self, finding: ValidationFinding, /) -> None:
+        """Report a validation finding."""
+
+
+@functools.cache
+def _validator_accepts_issue_reporter(validator: Callable[..., Any]) -> bool:
+    """Return True if a platform validator opts in to an ``issue_reporter``."""
+    try:
+        return "issue_reporter" in inspect.signature(validator).parameters
+    except TypeError, ValueError:
+        return False
+
+
+async def async_call_platform_validator(
+    validator: Callable[..., ConfigType | Coroutine[Any, Any, ConfigType]],
+    hass: HomeAssistant,
+    conf: ConfigType,
+    issue_reporter: ValidationIssueReporter | None,
+) -> ConfigType:
+    """Call a platform config validator, forwarding the reporter if opted in.
+
+    The validator may be a coroutine function or a plain function.
+    """
+    if issue_reporter is not None and _validator_accepts_issue_reporter(validator):
+        result = validator(hass, conf, issue_reporter=issue_reporter)
+    else:
+        result = validator(hass, conf)
+    if isinstance(result, Coroutine):
+        return await result
+    return result
+
+
+@callback
+def async_create_validation_issue(
+    hass: HomeAssistant,
+    finding: ValidationFinding,
+    *,
+    issue_domain: str,
+    owner_key: str,
+    name: str,
+    entity_id: str,
+    edit_url: str | None,
+) -> str:
+    """Materialize a repair issue for a validation finding.
+
+    Returns the created issue id.
+    """
+    from .issue_registry import IssueSeverity, async_create_issue  # noqa: PLC0415
+
+    issue_id = f"{finding.finding_type}_{owner_key}_{finding.issue_key}"
+    placeholders = {"name": name, "entity_id": entity_id, **finding.placeholders}
+    translation_key = finding.finding_type
+    if edit_url is not None:
+        placeholders["edit"] = edit_url
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        issue_id,
+        is_fixable=False,
+        issue_domain=issue_domain,
+        severity=IssueSeverity.ERROR,
+        translation_key=translation_key,
+        translation_placeholders=placeholders,
+    )
+    return issue_id
+
+
+@callback
+def async_clear_validation_issues(
+    hass: HomeAssistant, issue_ids: Iterable[str]
+) -> None:
+    """Delete repair issues previously created from validation findings."""
+    from .issue_registry import async_delete_issue  # noqa: PLC0415
+
+    for issue_id in issue_ids:
+        async_delete_issue(hass, HOMEASSISTANT_DOMAIN, issue_id)

--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -215,9 +215,12 @@ async def async_call_platform_validator(
     conf: ConfigType,
     issue_reporter: ValidationIssueReporter | None,
 ) -> ConfigType:
-    """Call a platform config validator, forwarding the reporter if opted in.
+    """Call a platform config validator, making the ``issue_reporter`` opt-in.
 
-    The validator may be a coroutine function or a plain function.
+    This helper exists solely so ``issue_reporter`` can be an optional parameter of
+    platform validators: the reporter is forwarded only to validators that declare it,
+    leaving legacy two-argument validators (including those in custom integrations)
+    called unchanged. The validator may be a coroutine function or a plain function.
     """
     if issue_reporter is not None and _validator_accepts_issue_reporter(validator):
         result = validator(hass, conf, issue_reporter=issue_reporter)
@@ -245,11 +248,13 @@ def async_create_validation_issue(
     """
     from .issue_registry import IssueSeverity, async_create_issue  # noqa: PLC0415
 
-    issue_id = f"{finding.finding_type}_{owner_key}_{finding.issue_key}"
+    issue_id = f"{issue_domain}_{finding.finding_type}_{owner_key}_{finding.issue_key}"
     placeholders = {"name": name, "entity_id": entity_id, **finding.placeholders}
-    translation_key = finding.finding_type
     if edit_url is not None:
+        translation_key = finding.finding_type
         placeholders["edit"] = edit_url
+    else:
+        translation_key = f"{finding.finding_type}_no_edit"
     async_create_issue(
         hass,
         HOMEASSISTANT_DOMAIN,

--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -10,12 +10,7 @@ from typing import Any, Final, Protocol, Self
 import voluptuous as vol
 
 from homeassistant.const import CONF_OPTIONS
-from homeassistant.core import (
-    DOMAIN as HOMEASSISTANT_DOMAIN,
-    HomeAssistant,
-    callback,
-    split_entity_id,
-)
+from homeassistant.core import HomeAssistant, callback, split_entity_id
 
 from .entity import get_device_class_or_undefined
 from .typing import UNDEFINED, ConfigType, UndefinedType
@@ -181,13 +176,18 @@ class ValidationFinding:
     validation adds that owner context and materializes a repair issue via
     ``async_create_validation_issue``.
 
-    ``finding_type`` is the base translation key of the repair issue - its strings live in
-    the ``homeassistant`` integration, which the issue is filed under. ``issue_key``
-    discriminates findings of the same type within one owner (e.g. the offending device
-    id). ``placeholders`` are the finding-specific translation placeholders.
+    ``finding_type`` is a stable identifier for the kind of problem; it is part of the
+    repair issue id so different finding types from one owner do not collide.
+    ``translation_domain`` and ``translation_key`` locate the repair issue's strings (in
+    that integration's ``strings.json``); the issue is filed under ``translation_domain`` so
+    its translations resolve. ``issue_key`` discriminates findings of the same type within
+    one owner (e.g. the offending device id). ``placeholders`` are the finding-specific
+    translation placeholders.
     """
 
     finding_type: str
+    translation_domain: str
+    translation_key: str
     issue_key: str
     placeholders: Mapping[str, str]
 
@@ -241,23 +241,23 @@ def async_create_validation_issue(
     name: str,
     entity_id: str,
     edit_url: str | None,
-) -> str:
+) -> tuple[str, str]:
     """Materialize a repair issue for a validation finding.
 
-    Returns the created issue id.
+    Returns the ``(translation_domain, issue_id)`` pair the issue was filed under.
     """
     from .issue_registry import IssueSeverity, async_create_issue  # noqa: PLC0415
 
     issue_id = f"{issue_domain}_{finding.finding_type}_{owner_key}_{finding.issue_key}"
     placeholders = {"name": name, "entity_id": entity_id, **finding.placeholders}
     if edit_url is not None:
-        translation_key = finding.finding_type
+        translation_key = finding.translation_key
         placeholders["edit"] = edit_url
     else:
-        translation_key = f"{finding.finding_type}_no_edit"
+        translation_key = f"{finding.translation_key}_no_edit"
     async_create_issue(
         hass,
-        HOMEASSISTANT_DOMAIN,
+        finding.translation_domain,
         issue_id,
         is_fixable=False,
         issue_domain=issue_domain,
@@ -265,15 +265,19 @@ def async_create_validation_issue(
         translation_key=translation_key,
         translation_placeholders=placeholders,
     )
-    return issue_id
+    return finding.translation_domain, issue_id
 
 
 @callback
 def async_clear_validation_issues(
-    hass: HomeAssistant, issue_ids: Iterable[str]
+    hass: HomeAssistant, issues: Iterable[tuple[str, str]]
 ) -> None:
-    """Delete repair issues previously created from validation findings."""
+    """Delete repair issues previously created from validation findings.
+
+    Each item is a ``(translation_domain, issue_id)`` pair as returned by
+    ``async_create_validation_issue``.
+    """
     from .issue_registry import async_delete_issue  # noqa: PLC0415
 
-    for issue_id in issue_ids:
-        async_delete_issue(hass, HOMEASSISTANT_DOMAIN, issue_id)
+    for translation_domain, issue_id in issues:
+        async_delete_issue(hass, translation_domain, issue_id)

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -87,6 +87,8 @@ from . import config_validation as cv, entity_registry as er, selector
 from .automation import (
     DomainSpec,
     ThresholdConfig,
+    ValidationIssueReporter,
+    async_call_platform_validator,
     filter_by_domain_specs,
     get_absolute_description_key,
     get_relative_description_key,
@@ -1993,7 +1995,10 @@ def state_validate_config(hass: HomeAssistant, config: ConfigType) -> ConfigType
 
 
 async def async_validate_condition_config(
-    hass: HomeAssistant, config: ConfigType | str
+    hass: HomeAssistant,
+    config: ConfigType | str,
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> ConfigType:
     """Validate config."""
     if isinstance(config, str):
@@ -2006,7 +2011,9 @@ async def async_validate_condition_config(
     if condition_key in ("and", "not", "or"):
         conditions = []
         for sub_cond in config["conditions"]:
-            sub_cond = await async_validate_condition_config(hass, sub_cond)
+            sub_cond = await async_validate_condition_config(
+                hass, sub_cond, issue_reporter=issue_reporter
+            )
             conditions.append(sub_cond)
         config["conditions"] = conditions
         return config
@@ -2020,7 +2027,9 @@ async def async_validate_condition_config(
         )
         if not (condition_class := condition_descriptors.get(relative_condition_key)):
             raise vol.Invalid(f"Invalid condition '{condition_key}' specified")
-        return await condition_class.async_validate_complete_config(hass, config)
+        return await async_call_platform_validator(
+            condition_class.async_validate_complete_config, hass, config, issue_reporter
+        )
 
     config = move_options_fields_to_top_level(config, _CONDITION_BASE_SCHEMA)
 
@@ -2031,18 +2040,29 @@ async def async_validate_condition_config(
                 sys.modules[__name__], VALIDATE_CONFIG_FORMAT.format(condition_key)
             ),
         )
-        return validator(hass, config)
+        return await async_call_platform_validator(
+            validator, hass, config, issue_reporter
+        )
 
     return config
 
 
 async def async_validate_conditions_config(
-    hass: HomeAssistant, conditions: list[ConfigType]
+    hass: HomeAssistant,
+    conditions: list[ConfigType],
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> list[ConfigType | Template]:
-    """Validate config."""
+    """Validate config.
+
+    See ``async_validate_condition_config`` for the ``issue_reporter`` behavior.
+    """
     # No gather here because async_validate_condition_config is unlikely
     # to suspend and the overhead of creating many tasks is not worth it
-    return [await async_validate_condition_config(hass, cond) for cond in conditions]
+    return [
+        await async_validate_condition_config(hass, cond, issue_reporter=issue_reporter)
+        for cond in conditions
+    ]
 
 
 async def async_conditions_from_config(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -90,6 +90,7 @@ from . import (
     template,
     trigger as trigger_helper,
 )
+from .automation import ValidationIssueReporter, async_call_platform_validator
 from .condition import ConditionChecker, trace_condition_function
 from .dispatcher import async_dispatcher_connect, async_dispatcher_send_internal
 from .event import async_call_later, async_track_template
@@ -321,16 +322,25 @@ REPEAT_TERMINATE_ITERATIONS = 10000
 
 
 async def async_validate_actions_config(
-    hass: HomeAssistant, actions: list[ConfigType]
+    hass: HomeAssistant,
+    actions: list[ConfigType],
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> list[ConfigType]:
     """Validate a list of actions."""
     # No gather here because async_validate_action_config is unlikely
     # to suspend and the overhead of creating many tasks is not worth it
-    return [await async_validate_action_config(hass, action) for action in actions]
+    return [
+        await async_validate_action_config(hass, action, issue_reporter=issue_reporter)
+        for action in actions
+    ]
 
 
 async def async_validate_action_config(
-    hass: HomeAssistant, config: ConfigType
+    hass: HomeAssistant,
+    config: ConfigType,
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> ConfigType:
     """Validate config."""
     action_type = cv.determine_script_action(config)
@@ -339,67 +349,73 @@ async def async_validate_action_config(
         pass
 
     elif action_type == cv.SCRIPT_ACTION_DEVICE_AUTOMATION:
-        config = await device_action.async_validate_action_config(hass, config)
+        config = await async_call_platform_validator(
+            device_action.async_validate_action_config, hass, config, issue_reporter
+        )
 
     elif action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
-        config = await condition.async_validate_condition_config(hass, config)
+        config = await condition.async_validate_condition_config(
+            hass, config, issue_reporter=issue_reporter
+        )
 
     elif action_type == cv.SCRIPT_ACTION_WAIT_FOR_TRIGGER:
         config[
             CONF_WAIT_FOR_TRIGGER
         ] = await trigger_helper.async_validate_trigger_config(
-            hass, config[CONF_WAIT_FOR_TRIGGER]
+            hass, config[CONF_WAIT_FOR_TRIGGER], issue_reporter=issue_reporter
         )
 
     elif action_type == cv.SCRIPT_ACTION_REPEAT:
         if CONF_UNTIL in config[CONF_REPEAT]:
             conditions = await condition.async_validate_conditions_config(
-                hass, config[CONF_REPEAT][CONF_UNTIL]
+                hass, config[CONF_REPEAT][CONF_UNTIL], issue_reporter=issue_reporter
             )
             config[CONF_REPEAT][CONF_UNTIL] = conditions
         if CONF_WHILE in config[CONF_REPEAT]:
             conditions = await condition.async_validate_conditions_config(
-                hass, config[CONF_REPEAT][CONF_WHILE]
+                hass, config[CONF_REPEAT][CONF_WHILE], issue_reporter=issue_reporter
             )
             config[CONF_REPEAT][CONF_WHILE] = conditions
         config[CONF_REPEAT][CONF_SEQUENCE] = await async_validate_actions_config(
-            hass, config[CONF_REPEAT][CONF_SEQUENCE]
+            hass, config[CONF_REPEAT][CONF_SEQUENCE], issue_reporter=issue_reporter
         )
 
     elif action_type == cv.SCRIPT_ACTION_CHOOSE:
         if CONF_DEFAULT in config:
             config[CONF_DEFAULT] = await async_validate_actions_config(
-                hass, config[CONF_DEFAULT]
+                hass, config[CONF_DEFAULT], issue_reporter=issue_reporter
             )
 
         for choose_conf in config[CONF_CHOOSE]:
             conditions = await condition.async_validate_conditions_config(
-                hass, choose_conf[CONF_CONDITIONS]
+                hass, choose_conf[CONF_CONDITIONS], issue_reporter=issue_reporter
             )
             choose_conf[CONF_CONDITIONS] = conditions
             choose_conf[CONF_SEQUENCE] = await async_validate_actions_config(
-                hass, choose_conf[CONF_SEQUENCE]
+                hass, choose_conf[CONF_SEQUENCE], issue_reporter=issue_reporter
             )
 
     elif action_type == cv.SCRIPT_ACTION_IF:
         config[CONF_IF] = await condition.async_validate_conditions_config(
-            hass, config[CONF_IF]
+            hass, config[CONF_IF], issue_reporter=issue_reporter
         )
-        config[CONF_THEN] = await async_validate_actions_config(hass, config[CONF_THEN])
+        config[CONF_THEN] = await async_validate_actions_config(
+            hass, config[CONF_THEN], issue_reporter=issue_reporter
+        )
         if CONF_ELSE in config:
             config[CONF_ELSE] = await async_validate_actions_config(
-                hass, config[CONF_ELSE]
+                hass, config[CONF_ELSE], issue_reporter=issue_reporter
             )
 
     elif action_type == cv.SCRIPT_ACTION_PARALLEL:
         for parallel_conf in config[CONF_PARALLEL]:
             parallel_conf[CONF_SEQUENCE] = await async_validate_actions_config(
-                hass, parallel_conf[CONF_SEQUENCE]
+                hass, parallel_conf[CONF_SEQUENCE], issue_reporter=issue_reporter
             )
 
     elif action_type == cv.SCRIPT_ACTION_SEQUENCE:
         config[CONF_SEQUENCE] = await async_validate_actions_config(
-            hass, config[CONF_SEQUENCE]
+            hass, config[CONF_SEQUENCE], issue_reporter=issue_reporter
         )
 
     else:

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -74,6 +74,8 @@ from . import config_validation as cv, selector
 from .automation import (
     DomainSpec,
     ThresholdConfig,
+    ValidationIssueReporter,
+    async_call_platform_validator,
     filter_by_domain_specs,
     get_absolute_description_key,
     get_relative_description_key,
@@ -1649,7 +1651,10 @@ async def _async_get_trigger_platform(
 
 
 async def async_validate_trigger_config(
-    hass: HomeAssistant, trigger_config: list[ConfigType]
+    hass: HomeAssistant,
+    trigger_config: list[ConfigType],
+    *,
+    issue_reporter: ValidationIssueReporter | None = None,
 ) -> list[ConfigType]:
     """Validate triggers."""
     config = []
@@ -1663,10 +1668,14 @@ async def async_validate_trigger_config(
             )
             if not (trigger := trigger_descriptors.get(relative_trigger_key)):
                 raise vol.Invalid(f"Invalid trigger '{trigger_key}' specified")
-            conf = await trigger.async_validate_complete_config(hass, conf)
+            conf = await async_call_platform_validator(
+                trigger.async_validate_complete_config, hass, conf, issue_reporter
+            )
         elif hasattr(platform, "async_validate_trigger_config"):
             conf = move_options_fields_to_top_level(conf, cv.TRIGGER_BASE_SCHEMA)
-            conf = await platform.async_validate_trigger_config(hass, conf)
+            conf = await async_call_platform_validator(
+                platform.async_validate_trigger_config, hass, conf, issue_reporter
+            )
         else:
             conf = move_options_fields_to_top_level(conf, cv.TRIGGER_BASE_SCHEMA)
             conf = platform.TRIGGER_SCHEMA(conf)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -4537,7 +4537,9 @@ async def test_not_triggered_trace_isolated_from_chained_run(
 
 
 COMPOSITE_ID = "composite00000000000000000000ab"
-COMPOSITE_ISSUE_ID = f"event_trigger_composite_device_id_composite_auto_{COMPOSITE_ID}"
+COMPOSITE_ISSUE_ID = (
+    f"automation_event_trigger_composite_device_id_composite_auto_{COMPOSITE_ID}"
+)
 
 
 @pytest.fixture
@@ -4744,6 +4746,118 @@ async def test_event_trigger_composite_device_id_kept_on_unchanged_reload(
     _assert_composite_issue(issues[0])
 
 
+@pytest.mark.parametrize(
+    (
+        "setup_composite_id",
+        "issues_after_setup",
+        "reload_composite_id",
+        "issues_after_reload",
+    ),
+    [
+        pytest.param(COMPOSITE_ID, 1, None, 0, id="stops_being_composite_clears_issue"),
+        pytest.param(None, 0, COMPOSITE_ID, 1, id="becomes_composite_creates_issue"),
+    ],
+)
+async def test_event_trigger_composite_device_id_refreshed_on_unchanged_reload(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    setup_composite_id: str | None,
+    issues_after_setup: int,
+    reload_composite_id: str | None,
+    issues_after_reload: int,
+) -> None:
+    """Test the repair is refreshed when a device's composite status changes.
+
+    The automation config text is identical across the reload, so the entity is
+    reused, but the trigger's finding depends on the device registry which changed.
+    """
+    e1 = MockConfigEntry(domain="itg1")
+    e1.add_to_hass(hass)
+    e2 = MockConfigEntry(domain="itg2")
+    e2.add_to_hass(hass)
+    d1 = device_registry.async_get_or_create(
+        config_entry_id=e1.entry_id, identifiers={("itg1", "1")}, name="Split device 1"
+    )
+    d2 = device_registry.async_get_or_create(
+        config_entry_id=e2.entry_id, identifiers={("itg2", "1")}, name="Split device 2"
+    )
+
+    def _set_composite_id(composite_id: str | None) -> None:
+        device_registry._devices[d1.id] = attr.evolve(
+            device_registry._devices[d1.id], composite_device_id=composite_id
+        )
+        device_registry._devices[d2.id] = attr.evolve(
+            device_registry._devices[d2.id], composite_device_id=composite_id
+        )
+
+    _set_composite_id(setup_composite_id)
+
+    config = {
+        automation.DOMAIN: {
+            "id": "composite_auto",
+            "alias": "Composite automation",
+            "triggers": {
+                "platform": "event",
+                "event_type": "test_event",
+                "event_data": {"device_id": COMPOSITE_ID},
+            },
+            "actions": {"action": "test.automation"},
+        }
+    }
+    assert await async_setup_component(hass, automation.DOMAIN, config)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == issues_after_setup
+
+    _set_composite_id(reload_composite_id)
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value=config,
+    ):
+        await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == issues_after_reload
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_event_trigger_composite_device_id_idless_no_edit(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test an id-less automation gets the no-edit repair (no /edit/None link)."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "Composite automation",
+                "triggers": {
+                    "platform": "event",
+                    "event_type": "test_event",
+                    "event_data": {"device_id": COMPOSITE_ID},
+                },
+                "actions": {"action": "test.automation"},
+            }
+        },
+    )
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue["issue_domain"] == "automation"
+    assert issue["translation_key"] == "event_trigger_composite_device_id_no_edit"
+    # Id-less automations have no editor deep link, so no edit placeholder is set.
+    assert "edit" not in issue["translation_placeholders"]
+    # The owner key falls back to the entity_id when there is no unique id.
+    assert issue["issue_id"] == (
+        "automation_event_trigger_composite_device_id_"
+        f"automation.composite_automation_{COMPOSITE_ID}"
+    )
+
+
 _MOCK_CONDITION_FINDING = ValidationFinding(
     finding_type="mock_condition_finding",
     issue_key="mock_key",
@@ -4833,7 +4947,9 @@ async def test_condition_validation_finding_raises_issue(
     # Translations live in the homeassistant integration; attributed to automation.
     assert issue["domain"] == "homeassistant"
     assert issue["issue_domain"] == "automation"
-    assert issue["issue_id"] == "mock_condition_finding_mock_cond_auto_mock_key"
+    assert (
+        issue["issue_id"] == "automation_mock_condition_finding_mock_cond_auto_mock_key"
+    )
     assert issue["translation_key"] == "mock_condition_finding"
     assert issue["is_fixable"] is False
     assert issue["severity"] == "error"

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 from unittest.mock import ANY, Mock, patch
 
+import attr
 import pytest
 import voluptuous as vol
 
@@ -48,6 +49,8 @@ from homeassistant.exceptions import (
     Unauthorized,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.automation import ValidationFinding, ValidationIssueReporter
+from homeassistant.helpers.condition import Condition
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.script import (
     SCRIPT_MODE_CHOICES,
@@ -4531,3 +4534,311 @@ async def test_not_triggered_trace_isolated_from_chained_run(
     child_trace = await _get_only_trace("child")
     assert child_trace["not_triggered"] is True
     assert set(child_trace["trace"]) == {"trigger/0"}
+
+
+COMPOSITE_ID = "composite00000000000000000000ab"
+COMPOSITE_ISSUE_ID = f"event_trigger_composite_device_id_composite_auto_{COMPOSITE_ID}"
+
+
+@pytest.fixture
+def split_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> tuple[dr.DeviceEntry, dr.DeviceEntry]:
+    """Register two devices that a composite device was split into."""
+    e1 = MockConfigEntry(domain="itg1")
+    e1.add_to_hass(hass)
+    e2 = MockConfigEntry(domain="itg2")
+    e2.add_to_hass(hass)
+    d1 = device_registry.async_get_or_create(
+        config_entry_id=e1.entry_id,
+        identifiers={("itg1", "1")},
+        name="Split device 1",
+    )
+    d2 = device_registry.async_get_or_create(
+        config_entry_id=e2.entry_id,
+        identifiers={("itg2", "1")},
+        name="Split device 2",
+    )
+    device_registry._devices[d1.id] = attr.evolve(d1, composite_device_id=COMPOSITE_ID)
+    device_registry._devices[d2.id] = attr.evolve(d2, composite_device_id=COMPOSITE_ID)
+    return device_registry._devices[d1.id], device_registry._devices[d2.id]
+
+
+def _assert_composite_issue(issue: dict[str, Any]) -> None:
+    """Assert an issue is the composite event-trigger repair for the test automation."""
+    # Translations live in the homeassistant integration; attributed to automation.
+    assert issue["domain"] == "homeassistant"
+    assert issue["issue_domain"] == "automation"
+    assert issue["issue_id"] == COMPOSITE_ISSUE_ID
+    assert issue["translation_key"] == "event_trigger_composite_device_id"
+    assert issue["is_fixable"] is False
+    assert issue["severity"] == "error"
+    placeholders = issue["translation_placeholders"]
+    assert placeholders["name"] == "Composite automation"
+    assert placeholders["entity_id"] == "automation.composite_automation"
+    assert placeholders["device_id"] == COMPOSITE_ID
+    assert placeholders["edit"] == "/config/automation/edit/composite_auto"
+    assert "Split device 1" in placeholders["devices"]
+    assert "Split device 2" in placeholders["devices"]
+
+
+@pytest.mark.usefixtures("split_devices")
+@pytest.mark.parametrize(
+    "automation_config",
+    [
+        pytest.param(
+            {
+                "id": "composite_auto",
+                "alias": "Composite automation",
+                "triggers": {
+                    "platform": "event",
+                    "event_type": "test_event",
+                    "event_data": {"device_id": COMPOSITE_ID},
+                },
+                "actions": {"action": "test.automation"},
+            },
+            id="top_level_trigger",
+        ),
+        pytest.param(
+            {
+                "id": "composite_auto",
+                "alias": "Composite automation",
+                "triggers": {"platform": "event", "event_type": "test_event"},
+                "actions": {
+                    "wait_for_trigger": {
+                        "platform": "event",
+                        "event_type": "wait_event",
+                        "event_data": {"device_id": COMPOSITE_ID},
+                    }
+                },
+            },
+            id="wait_for_trigger",
+        ),
+    ],
+)
+async def test_event_trigger_composite_device_id_raises_issue(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    automation_config: dict[str, Any],
+) -> None:
+    """Test an event trigger filtering on a composite device id raises a repair issue."""
+    assert await async_setup_component(
+        hass, automation.DOMAIN, {automation.DOMAIN: [automation_config]}
+    )
+
+    # The automation is valid and set up, only the repair issue flags the dead filter
+    assert hass.states.get("automation.composite_automation").state != STATE_UNAVAILABLE
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    _assert_composite_issue(issues[0])
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_event_trigger_live_device_id_no_issue(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    split_devices: tuple[dr.DeviceEntry, dr.DeviceEntry],
+) -> None:
+    """Test an event trigger filtering on a live device id raises no repair issue."""
+    live_device, _ = split_devices
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "id": "composite_auto",
+                    "alias": "Composite automation",
+                    "triggers": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                        "event_data": {"device_id": live_device.id},
+                    },
+                    "actions": {"action": "test.automation"},
+                }
+            ]
+        },
+    )
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 0
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_event_trigger_composite_device_id_cleared_on_reload(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test reloading to a fixed config clears the composite device repair issue."""
+    config = {
+        automation.DOMAIN: {
+            "id": "composite_auto",
+            "alias": "Composite automation",
+            "triggers": {
+                "platform": "event",
+                "event_type": "test_event",
+                "event_data": {"device_id": COMPOSITE_ID},
+            },
+            "actions": {"action": "test.automation"},
+        }
+    }
+    assert await async_setup_component(hass, automation.DOMAIN, config)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    _assert_composite_issue(issues[0])
+
+    fixed_config = {
+        automation.DOMAIN: {
+            "id": "composite_auto",
+            "alias": "Composite automation",
+            "triggers": {"platform": "event", "event_type": "test_event"},
+            "actions": {"action": "test.automation"},
+        }
+    }
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value=fixed_config,
+    ):
+        await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 0
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_event_trigger_composite_device_id_kept_on_unchanged_reload(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test an unchanged reload keeps the composite device repair issue."""
+    config = {
+        automation.DOMAIN: {
+            "id": "composite_auto",
+            "alias": "Composite automation",
+            "triggers": {
+                "platform": "event",
+                "event_type": "test_event",
+                "event_data": {"device_id": COMPOSITE_ID},
+            },
+            "actions": {"action": "test.automation"},
+        }
+    }
+    assert await async_setup_component(hass, automation.DOMAIN, config)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    _assert_composite_issue(issues[0])
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value=config,
+    ):
+        await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    _assert_composite_issue(issues[0])
+
+
+_MOCK_CONDITION_FINDING = ValidationFinding(
+    finding_type="mock_condition_finding",
+    issue_key="mock_key",
+    placeholders={"detail": "mock"},
+)
+
+
+class _MockReportingCondition(Condition):
+    """Condition whose validator reports a finding via the issue reporter."""
+
+    @classmethod
+    async def async_validate_complete_config(
+        cls,
+        hass: HomeAssistant,
+        complete_config: ConfigType,
+        *,
+        issue_reporter: ValidationIssueReporter | None = None,
+    ) -> ConfigType:
+        """Report a finding when a reporter is supplied, then validate normally."""
+        if issue_reporter is not None:
+            issue_reporter(_MOCK_CONDITION_FINDING)
+        return await super().async_validate_complete_config(hass, complete_config)
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return config
+
+    def _async_check(self, **kwargs: Any) -> bool:
+        """Check the condition."""
+        return True
+
+
+@pytest.mark.parametrize(
+    "ignore_missing_translations",
+    [
+        [
+            "component.homeassistant.issues.mock_condition_finding.title",
+            "component.homeassistant.issues.mock_condition_finding.description",
+        ]
+    ],
+)
+async def test_condition_validation_finding_raises_issue(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """A condition validator's finding surfaces as a repair issue on the automation.
+
+    This proves the automation owner forwards its reporter to condition validation.
+    """
+
+    async def async_get_conditions(
+        hass: HomeAssistant,
+    ) -> dict[str, type[Condition]]:
+        return {"_": _MockReportingCondition}
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(
+        hass, "test.condition", Mock(async_get_conditions=async_get_conditions)
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "id": "mock_cond_auto",
+                "alias": "Mock condition automation",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "test"},
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # The automation is valid and set up; only the repair issue flags the finding.
+    assert (
+        hass.states.get("automation.mock_condition_automation").state
+        != STATE_UNAVAILABLE
+    )
+
+    issues = await get_repairs(hass, hass_ws_client)
+    assert len(issues) == 1
+    issue = issues[0]
+    # Translations live in the homeassistant integration; attributed to automation.
+    assert issue["domain"] == "homeassistant"
+    assert issue["issue_domain"] == "automation"
+    assert issue["issue_id"] == "mock_condition_finding_mock_cond_auto_mock_key"
+    assert issue["translation_key"] == "mock_condition_finding"
+    assert issue["is_fixable"] is False
+    assert issue["severity"] == "error"
+    placeholders = issue["translation_placeholders"]
+    assert placeholders["name"] == "Mock condition automation"
+    assert placeholders["entity_id"] == "automation.mock_condition_automation"
+    assert placeholders["edit"] == "/config/automation/edit/mock_cond_auto"
+    assert placeholders["detail"] == "mock"

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -4860,6 +4860,8 @@ async def test_event_trigger_composite_device_id_idless_no_edit(
 
 _MOCK_CONDITION_FINDING = ValidationFinding(
     finding_type="mock_condition_finding",
+    translation_domain="homeassistant",
+    translation_key="mock_condition_finding",
     issue_key="mock_key",
     placeholders={"detail": "mock"},
 )

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -9,6 +9,7 @@ from homeassistant.components import automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
 from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, script, trigger
+from homeassistant.helpers.automation import ValidationFinding
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_component
@@ -700,6 +701,23 @@ async def test_composite_device_id_logs_warning(
     """Test a composite event_data.device_id filter logs the full warning."""
     with caplog.at_level(logging.WARNING):
         await trigger.async_validate_trigger_config(hass, [_EVENT_TRIGGER])
+    assert caplog.messages == [_expected_composite_warning(*split_devices)]
+
+
+async def test_composite_device_id_reports_and_logs(
+    hass: HomeAssistant,
+    split_devices: tuple[dr.DeviceEntry, dr.DeviceEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a reporter receives the finding and the warning is still logged."""
+    findings: list[ValidationFinding] = []
+    with caplog.at_level(logging.WARNING):
+        await trigger.async_validate_trigger_config(
+            hass, [_EVENT_TRIGGER], issue_reporter=findings.append
+        )
+    assert len(findings) == 1
+    assert findings[0].finding_type == "event_trigger_composite_device_id"
+    assert findings[0].issue_key == COMPOSITE_ID
     assert caplog.messages == [_expected_composite_warning(*split_devices)]
 
 

--- a/tests/helpers/test_automation.py
+++ b/tests/helpers/test_automation.py
@@ -420,7 +420,10 @@ def test_create_and_clear_validation_issue_with_edit(
         entity_id="automation.test",
         edit_url="/config/automation/edit/1234",
     )
-    assert issue_id == f"event_trigger_composite_device_id_1234_{_SAMPLE_DEVICE_ID}"
+    assert (
+        issue_id
+        == f"automation_event_trigger_composite_device_id_1234_{_SAMPLE_DEVICE_ID}"
+    )
 
     # Filed under the homeassistant domain (where the translations live), attributed to
     # the owning integration via issue_domain.

--- a/tests/helpers/test_automation.py
+++ b/tests/helpers/test_automation.py
@@ -1,14 +1,41 @@
 """Test automation helpers."""
 
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import Mock
+
 import pytest
 import voluptuous as vol
 
+from homeassistant.const import CONF_CONDITION, CONF_PLATFORM
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    HomeAssistant,
+)
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.automation import (
+    ValidationFinding,
+    ValidationIssueReporter,
+    async_call_platform_validator,
+    async_clear_validation_issues,
+    async_create_validation_issue,
     get_absolute_description_key,
     get_relative_description_key,
     move_options_fields_to_top_level,
     move_top_level_schema_fields_to_options,
 )
+from homeassistant.helpers.condition import Condition, async_validate_conditions_config
+from homeassistant.helpers.script import async_validate_actions_config
+from homeassistant.helpers.trigger import (
+    Trigger,
+    TriggerActionRunner,
+    TriggerNotTriggeredReporter,
+    async_validate_trigger_config,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from tests.common import MockModule, mock_integration, mock_platform
 
 
 @pytest.mark.parametrize(
@@ -180,3 +207,252 @@ async def test_move_options_fields_to_top_level(config, expected_config) -> None
     original_config = config.copy()
     assert move_options_fields_to_top_level(config, base_schema) == expected_config
     assert config == original_config  # Ensure original config is not modified
+
+
+# Findings reported by the mock validators below. The generic machinery does not
+# interpret their contents, so any finding type/key is fine for these tests.
+_TRIGGER_FINDING = ValidationFinding(
+    finding_type="mock_trigger_finding",
+    issue_key="trigger_key",
+    placeholders={"detail": "trigger"},
+)
+_CONDITION_FINDING = ValidationFinding(
+    finding_type="mock_condition_finding",
+    issue_key="condition_key",
+    placeholders={"detail": "condition"},
+)
+
+
+class _MockReportingTrigger(Trigger):
+    """Trigger whose validator opts in to the reporter and reports a finding."""
+
+    @classmethod
+    async def async_validate_complete_config(
+        cls,
+        hass: HomeAssistant,
+        complete_config: ConfigType,
+        *,
+        issue_reporter: ValidationIssueReporter | None = None,
+    ) -> ConfigType:
+        """Report a finding when a reporter is supplied, then validate normally."""
+        if issue_reporter is not None:
+            issue_reporter(_TRIGGER_FINDING)
+        return await super().async_validate_complete_config(hass, complete_config)
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return config
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger."""
+        return lambda: None
+
+
+class _MockReportingCondition(Condition):
+    """Condition whose validator opts in to the reporter and reports a finding."""
+
+    @classmethod
+    async def async_validate_complete_config(
+        cls,
+        hass: HomeAssistant,
+        complete_config: ConfigType,
+        *,
+        issue_reporter: ValidationIssueReporter | None = None,
+    ) -> ConfigType:
+        """Report a finding when a reporter is supplied, then validate normally."""
+        if issue_reporter is not None:
+            issue_reporter(_CONDITION_FINDING)
+        return await super().async_validate_complete_config(hass, complete_config)
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return config
+
+    def _async_check(self, **kwargs: Any) -> bool:
+        """Check the condition."""
+        return True
+
+
+def _register_mock_trigger_platform(hass: HomeAssistant) -> None:
+    """Register a trigger platform exposing the reporting mock trigger."""
+
+    async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+        return {"_": _MockReportingTrigger}
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+
+
+def _register_mock_condition_platform(hass: HomeAssistant) -> None:
+    """Register a condition platform exposing the reporting mock condition."""
+
+    async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+        return {"_": _MockReportingCondition}
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(
+        hass, "test.condition", Mock(async_get_conditions=async_get_conditions)
+    )
+
+
+async def test_trigger_validator_reports_finding(hass: HomeAssistant) -> None:
+    """A trigger validator reaches the reporter via async_validate_trigger_config."""
+    _register_mock_trigger_platform(hass)
+    findings: list[ValidationFinding] = []
+    validated = await async_validate_trigger_config(
+        hass, [{CONF_PLATFORM: "test"}], issue_reporter=findings.append
+    )
+    assert validated == [{CONF_PLATFORM: "test"}]
+    assert findings == [_TRIGGER_FINDING]
+
+
+async def test_trigger_validator_no_reporter(hass: HomeAssistant) -> None:
+    """Without a reporter the opted-in trigger validator still validates cleanly."""
+    _register_mock_trigger_platform(hass)
+    validated = await async_validate_trigger_config(hass, [{CONF_PLATFORM: "test"}])
+    assert validated == [{CONF_PLATFORM: "test"}]
+
+
+async def _validate_via_conditions(
+    hass: HomeAssistant, reporter: ValidationIssueReporter
+) -> None:
+    """Reach the condition validator through the condition pipeline."""
+    await async_validate_conditions_config(
+        hass, [{CONF_CONDITION: "test"}], issue_reporter=reporter
+    )
+
+
+async def _validate_via_actions(
+    hass: HomeAssistant, reporter: ValidationIssueReporter
+) -> None:
+    """Reach the condition validator through the action pipeline.
+
+    A bare condition is a ``check_condition`` action, so the action pipeline
+    forwards the reporter to the same condition validator.
+    """
+    await async_validate_actions_config(
+        hass, [{CONF_CONDITION: "test"}], issue_reporter=reporter
+    )
+
+
+@pytest.mark.parametrize(
+    "validate",
+    [
+        pytest.param(_validate_via_conditions, id="condition_pipeline"),
+        pytest.param(_validate_via_actions, id="action_pipeline"),
+    ],
+)
+async def test_condition_validator_reports_finding(
+    hass: HomeAssistant,
+    validate: Callable[[HomeAssistant, ValidationIssueReporter], Awaitable[None]],
+) -> None:
+    """A condition validator reaches the reporter through the condition and action paths."""
+    _register_mock_condition_platform(hass)
+    findings: list[ValidationFinding] = []
+    await validate(hass, findings.append)
+    assert findings == [_CONDITION_FINDING]
+
+
+async def test_call_platform_validator_signature_inspection(
+    hass: HomeAssistant,
+) -> None:
+    """The reporter is only forwarded to validators that declare the parameter."""
+    calls: list[str] = []
+
+    async def legacy_validator(hass: HomeAssistant, conf: ConfigType) -> ConfigType:
+        # Two-arg legacy signature - must not receive issue_reporter.
+        return conf
+
+    async def opted_in_validator(
+        hass: HomeAssistant,
+        conf: ConfigType,
+        *,
+        issue_reporter: ValidationIssueReporter | None = None,
+    ) -> ConfigType:
+        if issue_reporter is not None:
+            calls.append("reporter")
+        return conf
+
+    reporter = calls.append
+    # Legacy validator: no TypeError, reporter not delivered.
+    await async_call_platform_validator(legacy_validator, hass, {}, reporter)
+    assert calls == []
+    # Opted-in validator: reporter delivered.
+    await async_call_platform_validator(opted_in_validator, hass, {}, reporter)
+    assert calls == ["reporter"]
+
+
+_SAMPLE_DEVICE_ID = "composite00000000000000000000ab"
+
+
+def _sample_finding() -> ValidationFinding:
+    """Build a representative validation finding."""
+    return ValidationFinding(
+        finding_type="event_trigger_composite_device_id",
+        issue_key=_SAMPLE_DEVICE_ID,
+        placeholders={
+            "device_id": _SAMPLE_DEVICE_ID,
+            "devices": "Split device 1 (abc)",
+        },
+    )
+
+
+def test_create_and_clear_validation_issue_with_edit(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """A finding is filed under homeassistant, attributed to the owner via issue_domain."""
+    issue_id = async_create_validation_issue(
+        hass,
+        _sample_finding(),
+        issue_domain="automation",
+        owner_key="1234",
+        name="Test automation",
+        entity_id="automation.test",
+        edit_url="/config/automation/edit/1234",
+    )
+    assert issue_id == f"event_trigger_composite_device_id_1234_{_SAMPLE_DEVICE_ID}"
+
+    # Filed under the homeassistant domain (where the translations live), attributed to
+    # the owning integration via issue_domain.
+    issue = issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.issue_domain == "automation"
+    assert issue.is_fixable is False
+    assert issue.severity == ir.IssueSeverity.ERROR
+    assert issue.translation_key == "event_trigger_composite_device_id"
+    assert issue.translation_placeholders["edit"] == "/config/automation/edit/1234"
+    assert issue.translation_placeholders["device_id"] == _SAMPLE_DEVICE_ID
+    assert issue.translation_placeholders["name"] == "Test automation"
+
+    async_clear_validation_issues(hass, [issue_id])
+    assert issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id) is None
+
+
+def test_create_validation_issue_without_edit(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """The no-edit translation key is used for owners without a deep link."""
+    issue_id = async_create_validation_issue(
+        hass,
+        _sample_finding(),
+        issue_domain="template",
+        owner_key="my_template",
+        name="My template",
+        entity_id="sensor.my_template",
+        edit_url=None,
+    )
+    issue = issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.issue_domain == "template"
+    assert issue.translation_key == "event_trigger_composite_device_id_no_edit"
+    assert "edit" not in issue.translation_placeholders

--- a/tests/helpers/test_automation.py
+++ b/tests/helpers/test_automation.py
@@ -213,11 +213,15 @@ async def test_move_options_fields_to_top_level(config, expected_config) -> None
 # interpret their contents, so any finding type/key is fine for these tests.
 _TRIGGER_FINDING = ValidationFinding(
     finding_type="mock_trigger_finding",
+    translation_domain="homeassistant",
+    translation_key="mock_trigger_finding",
     issue_key="trigger_key",
     placeholders={"detail": "trigger"},
 )
 _CONDITION_FINDING = ValidationFinding(
     finding_type="mock_condition_finding",
+    translation_domain="homeassistant",
+    translation_key="mock_condition_finding",
     issue_key="condition_key",
     placeholders={"detail": "condition"},
 )
@@ -399,6 +403,8 @@ def _sample_finding() -> ValidationFinding:
     """Build a representative validation finding."""
     return ValidationFinding(
         finding_type="event_trigger_composite_device_id",
+        translation_domain="homeassistant",
+        translation_key="event_trigger_composite_device_id",
         issue_key=_SAMPLE_DEVICE_ID,
         placeholders={
             "device_id": _SAMPLE_DEVICE_ID,
@@ -410,8 +416,8 @@ def _sample_finding() -> ValidationFinding:
 def test_create_and_clear_validation_issue_with_edit(
     hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
-    """A finding is filed under homeassistant, attributed to the owner via issue_domain."""
-    issue_id = async_create_validation_issue(
+    """A finding is filed under its translation_domain, attributed via issue_domain."""
+    translation_domain, issue_id = async_create_validation_issue(
         hass,
         _sample_finding(),
         issue_domain="automation",
@@ -420,13 +426,14 @@ def test_create_and_clear_validation_issue_with_edit(
         entity_id="automation.test",
         edit_url="/config/automation/edit/1234",
     )
+    assert translation_domain == "homeassistant"
     assert (
         issue_id
         == f"automation_event_trigger_composite_device_id_1234_{_SAMPLE_DEVICE_ID}"
     )
 
-    # Filed under the homeassistant domain (where the translations live), attributed to
-    # the owning integration via issue_domain.
+    # Filed under the finding's translation_domain (where the translations live),
+    # attributed to the owning integration via issue_domain.
     issue = issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
     assert issue is not None
     assert issue.issue_domain == "automation"
@@ -437,7 +444,7 @@ def test_create_and_clear_validation_issue_with_edit(
     assert issue.translation_placeholders["device_id"] == _SAMPLE_DEVICE_ID
     assert issue.translation_placeholders["name"] == "Test automation"
 
-    async_clear_validation_issues(hass, [issue_id])
+    async_clear_validation_issues(hass, [(translation_domain, issue_id)])
     assert issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id) is None
 
 
@@ -445,7 +452,7 @@ def test_create_validation_issue_without_edit(
     hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
     """The no-edit translation key is used for owners without a deep link."""
-    issue_id = async_create_validation_issue(
+    _, issue_id = async_create_validation_issue(
         hass,
         _sample_finding(),
         issue_domain="template",

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -6337,15 +6337,20 @@ async def test_validate_trigger_reports_composite_device(hass: HomeAssistant) ->
 
 
 @pytest.mark.usefixtures("split_devices")
-async def test_validate_trigger_no_reporter_no_registry_lookup(
+async def test_validate_trigger_without_reporter(
     hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Without a reporter the validator does not report (and skips the registry)."""
-    # No reporter passed - should validate fine and report nothing.
-    validated = await trigger.async_validate_trigger_config(
-        hass, [_event_trigger(COMPOSITE_ID)]
-    )
+    """Without a reporter the validator still validates and logs a warning."""
+    with caplog.at_level(logging.WARNING):
+        validated = await trigger.async_validate_trigger_config(
+            hass, [_event_trigger(COMPOSITE_ID)]
+        )
     assert validated[0][CONF_EVENT_DATA][CONF_DEVICE_ID] == COMPOSITE_ID
+    assert any(
+        "was split into one device per integration" in message
+        for message in caplog.messages
+    )
 
 
 async def test_validate_trigger_ignores_live_unknown_and_non_event(

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -6323,17 +6323,26 @@ def _event_trigger(device_id: Any) -> dict[str, Any]:
 
 
 @pytest.mark.usefixtures("split_devices")
-async def test_validate_trigger_reports_composite_device(hass: HomeAssistant) -> None:
-    """The event trigger validator reports a composite device id via the reporter."""
+async def test_validate_trigger_reports_composite_device(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The event trigger validator reports a composite device id and also logs it."""
     findings: list[ValidationFinding] = []
-    await trigger.async_validate_trigger_config(
-        hass, [_event_trigger(COMPOSITE_ID)], issue_reporter=findings.append
-    )
+    with caplog.at_level(logging.WARNING):
+        await trigger.async_validate_trigger_config(
+            hass, [_event_trigger(COMPOSITE_ID)], issue_reporter=findings.append
+        )
     assert len(findings) == 1
     assert findings[0].finding_type == "event_trigger_composite_device_id"
     assert findings[0].issue_key == COMPOSITE_ID
     assert findings[0].placeholders["device_id"] == COMPOSITE_ID
     assert "Split device 1" in findings[0].placeholders["devices"]
+    # The warning is logged regardless of whether a reporter is provided.
+    assert any(
+        "was split into one device per integration" in message
+        for message in caplog.messages
+    )
 
 
 @pytest.mark.usefixtures("split_devices")

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
+import attr
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
@@ -24,7 +25,9 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_LABEL_ID,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_DEVICE_ID,
     CONF_ENTITY_ID,
+    CONF_EVENT_DATA,
     CONF_FOR,
     CONF_OPTIONS,
     CONF_PLATFORM,
@@ -54,10 +57,12 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
     label_registry as lr,
+    script,
     trigger,
 )
 from homeassistant.helpers.automation import (
     DomainSpec,
+    ValidationFinding,
     move_top_level_schema_fields_to_options,
 )
 from homeassistant.helpers.event import async_track_state_change_event
@@ -6275,3 +6280,117 @@ def test_entity_state_trigger_schema_behavior_invalid(behavior: str) -> None:
     }
     with pytest.raises(vol.Invalid):
         ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR(config)
+
+
+COMPOSITE_ID = "composite00000000000000000000ab"
+
+
+@pytest.fixture
+def split_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> tuple[dr.DeviceEntry, dr.DeviceEntry]:
+    """Create two devices which are splits of a pre-migration composite device."""
+    entry_1 = MockConfigEntry(domain="itg1")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="itg2")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        identifiers={("itg1", "1")},
+        name="Split device 1",
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id,
+        identifiers={("itg2", "1")},
+        name="Split device 2",
+    )
+    device_registry._devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=COMPOSITE_ID
+    )
+    device_registry._devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=COMPOSITE_ID
+    )
+    return device_registry._devices[device_1.id], device_registry._devices[device_2.id]
+
+
+def _event_trigger(device_id: Any) -> dict[str, Any]:
+    """Build an event trigger config filtering on a device id."""
+    return {
+        CONF_PLATFORM: "event",
+        "event_type": "my_event",
+        CONF_EVENT_DATA: {CONF_DEVICE_ID: device_id},
+    }
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_validate_trigger_reports_composite_device(hass: HomeAssistant) -> None:
+    """The event trigger validator reports a composite device id via the reporter."""
+    findings: list[ValidationFinding] = []
+    await trigger.async_validate_trigger_config(
+        hass, [_event_trigger(COMPOSITE_ID)], issue_reporter=findings.append
+    )
+    assert len(findings) == 1
+    assert findings[0].finding_type == "event_trigger_composite_device_id"
+    assert findings[0].issue_key == COMPOSITE_ID
+    assert findings[0].placeholders["device_id"] == COMPOSITE_ID
+    assert "Split device 1" in findings[0].placeholders["devices"]
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_validate_trigger_no_reporter_no_registry_lookup(
+    hass: HomeAssistant,
+) -> None:
+    """Without a reporter the validator does not report (and skips the registry)."""
+    # No reporter passed - should validate fine and report nothing.
+    validated = await trigger.async_validate_trigger_config(
+        hass, [_event_trigger(COMPOSITE_ID)]
+    )
+    assert validated[0][CONF_EVENT_DATA][CONF_DEVICE_ID] == COMPOSITE_ID
+
+
+async def test_validate_trigger_ignores_live_unknown_and_non_event(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Live, unknown, templated and non-event device ids are not reported."""
+    entry = MockConfigEntry(domain="itg")
+    entry.add_to_hass(hass)
+    live_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={("itg", "1")}
+    )
+    findings: list[ValidationFinding] = []
+    await trigger.async_validate_trigger_config(
+        hass,
+        [
+            _event_trigger(live_device.id),
+            _event_trigger("unknown_device_id"),
+            # A templated device id becomes a Template, not a plain string.
+            _event_trigger("{{ '" + COMPOSITE_ID + "' }}"),
+            # A non-event trigger is not inspected for event_data.device_id.
+            {CONF_PLATFORM: "event", "event_type": "my_event"},
+        ],
+        issue_reporter=findings.append,
+    )
+    assert findings == []
+
+
+@pytest.mark.usefixtures("split_devices")
+async def test_validate_actions_reports_wait_for_trigger_composite(
+    hass: HomeAssistant,
+) -> None:
+    """A composite device id in a wait_for_trigger event trigger is reported."""
+    findings: list[ValidationFinding] = []
+    actions = [
+        {
+            "choose": [
+                {
+                    "conditions": [],
+                    "sequence": [{"wait_for_trigger": [_event_trigger(COMPOSITE_ID)]}],
+                }
+            ]
+        }
+    ]
+    await script.async_validate_actions_config(
+        hass, actions, issue_reporter=findings.append
+    )
+    assert len(findings) == 1
+    assert findings[0].issue_key == COMPOSITE_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow conditions and triggers to raise issues during validation, and make use of that in the event trigger.

Users of conditions, scripts and triggers can opt-in to the new functionality.
In this PR, only the automation integration adds support for the new API. In follow-up PRs, the script and template integration will gain the same support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
