### PR TITLE
Use async_get_device_and_config_entry service helper in switchbot_cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/service.py
+++ b/homeassistant/components/switchbot_cloud/service.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, service
 
 from .const import AI_ART_FRAME_UPLOAD_IMAGE_SERVICE, DOMAIN
 
@@ -31,28 +31,22 @@ async def handle_upload_image(call: ServiceCall) -> None:
     device_ids = call.data.get("device_id", [])
 
     for ha_device_id in device_ids:
-        device, config_entry = dr.async_get_device_and_config_entry_for_domain(
-            hass, ha_device_id, domain=DOMAIN
+        device, config_entry = service.async_get_device_and_config_entry(
+            hass, DOMAIN, ha_device_id
         )
-        if device is None:
-            raise ServiceValidationError(f"Device {ha_device_id} not found")
 
         device_mac = next(
             (iid[1] for iid in device.identifiers if iid[0] == DOMAIN), None
         )
-        if device_mac:
-            if config_entry is None:
-                raise ServiceValidationError(
-                    f"Device {ha_device_id} is not a SwitchBot Cloud device"
-                )
-            await config_entry.runtime_data.api.send_command(
-                device_id=device_mac,
-                command=ArtFrameCommands.UPLOAD.value,
-                command_type="command",
-                parameters={"imageUrl": image_url},
-            )
-        else:
+        if device_mac is None:
             raise ServiceValidationError("No valid MAC address obtained.")
+
+        await config_entry.runtime_data.api.send_command(
+            device_id=device_mac,
+            command=ArtFrameCommands.UPLOAD.value,
+            command_type="command",
+            parameters={"imageUrl": image_url},
+        )
 
 
 def async_register_services(hass: HomeAssistant) -> None:

--- a/tests/components/switchbot_cloud/test_services.py
+++ b/tests/components/switchbot_cloud/test_services.py
@@ -96,7 +96,8 @@ async def test_device_not_in_registry_raises(
             entry.runtime_data.api, "send_command", new_callable=AsyncMock
         ) as mock_send,
         pytest.raises(
-            ServiceValidationError, match="Device nonexistent-device-id not found"
+            ServiceValidationError,
+            match="Device with ID nonexistent-device-id was not found",
         ),
     ):
         await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new helper introduced in #180132

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
