### PR TITLE
Use async_get_device_and_config_entry service helper in home_connect

### DIFF
--- a/homeassistant/components/home_connect/services.py
+++ b/homeassistant/components/home_connect/services.py
@@ -20,7 +20,7 @@ import voluptuous as vol
 from homeassistant.const import ATTR_DEVICE_ID, UnitOfTemperature
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
@@ -167,26 +167,10 @@ SERVICE_START_SELECTED_PROGRAM_SCHEMA = vol.All(
 async def _get_client_and_ha_id(
     hass: HomeAssistant, device_id: str
 ) -> tuple[HomeConnectClient, str]:
-    config_entry: HomeConnectConfigEntry | None
-    device, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        hass, device_id, domain=DOMAIN
+    config_entry: HomeConnectConfigEntry
+    device, config_entry = service.async_get_device_and_config_entry(
+        hass, DOMAIN, device_id
     )
-    if device is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="device_entry_not_found",
-            translation_placeholders={
-                "device_id": device_id,
-            },
-        )
-    if config_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="config_entry_not_found",
-            translation_placeholders={
-                "device_id": device_id,
-            },
-        )
 
     ha_id = next(
         (identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN),

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1602,12 +1602,6 @@
     "auth_error": {
       "message": "Authentication error: {error}. Please, re-authenticate your account"
     },
-    "config_entry_not_found": {
-      "message": "Config entry for device ID {device_id} not found"
-    },
-    "device_entry_not_found": {
-      "message": "Device entry for device ID {device_id} not found"
-    },
     "execute_command": {
       "message": "Error executing command {command}: {error}"
     },

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -650,7 +650,7 @@ async def test_services_appliance_not_found(
 
     service_call["service_data"]["device_id"] = "DOES_NOT_EXISTS"
 
-    with pytest.raises(ServiceValidationError, match=r"Device entry.*not found"):
+    with pytest.raises(ServiceValidationError, match=r"Device with ID.*not found"):
         await hass.services.async_call(**service_call)
 
     unrelated_config_entry = MockConfigEntry(
@@ -663,7 +663,9 @@ async def test_services_appliance_not_found(
     )
     service_call["service_data"]["device_id"] = device_entry.id
 
-    with pytest.raises(ServiceValidationError, match=r"Config entry.*not found"):
+    with pytest.raises(
+        ServiceValidationError, match=rf"does not belong to integration {DOMAIN}"
+    ):
         await hass.services.async_call(**service_call)
 
     device_entry = device_registry.async_get_or_create(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new helper introduced in #180132

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
