### PR TITLE
Use async_get_device_and_config_entry service helper in fully_kiosk

### DIFF
--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -2,11 +2,9 @@
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, service
 
 from .const import (
     ATTR_APPLICATION,
@@ -25,27 +23,12 @@ async def _collect_coordinators(
     call: ServiceCall,
 ) -> list[FullyKioskDataUpdateCoordinator]:
     device_ids: list[str] = call.data[ATTR_DEVICE_ID]
-    config_entries = list[ConfigEntry]()
-    registry = dr.async_get(call.hass)
-    for target in device_ids:
-        device = registry.async_get(target)
-        if device:
-            device_entries = list[ConfigEntry]()
-            for entry_id in device.config_entries:
-                entry = call.hass.config_entries.async_get_entry(entry_id)
-                if entry and entry.domain == DOMAIN:
-                    device_entries.append(entry)
-            if not device_entries:
-                raise HomeAssistantError(f"Device '{target}' is not a {DOMAIN} device")
-            config_entries.extend(device_entries)
-        else:
-            raise HomeAssistantError(f"Device '{target}' not found in device registry")
-    coordinators = list[FullyKioskDataUpdateCoordinator]()
-    for config_entry in config_entries:
-        if config_entry.state is not ConfigEntryState.LOADED:
-            raise HomeAssistantError(f"{config_entry.title} is not loaded")
-        coordinators.append(config_entry.runtime_data)
-    return coordinators
+    return [
+        service.async_get_device_and_config_entry(call.hass, DOMAIN, device_id)[
+            1
+        ].runtime_data
+        for device_id in device_ids
+    ]
 
 
 async def _async_load_url(call: ServiceCall) -> None:

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -15,7 +15,7 @@ from homeassistant.components.fully_kiosk.const import (
     SERVICE_START_APPLICATION,
 )
 from homeassistant.const import ATTR_DEVICE_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
@@ -140,7 +140,8 @@ async def test_service_unloaded_entry(
             {ATTR_DEVICE_ID: [device_entry.id], ATTR_URL: "https://nabucasa.com"},
             blocking=True,
         )
-    assert "Test device is not loaded" in str(excinfo)
+    assert excinfo.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert excinfo.value.translation_key == "service_config_entry_not_loaded"
     mock_fully_kiosk.loadUrl.assert_not_called()
 
     with pytest.raises(HomeAssistantError) as excinfo:
@@ -150,7 +151,8 @@ async def test_service_unloaded_entry(
             {ATTR_DEVICE_ID: [device_entry.id], ATTR_APPLICATION: "de.ozerov.fully"},
             blocking=True,
         )
-    assert "Test device is not loaded" in str(excinfo)
+    assert excinfo.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert excinfo.value.translation_key == "service_config_entry_not_loaded"
     mock_fully_kiosk.startApplication.assert_not_called()
 
 
@@ -168,7 +170,9 @@ async def test_service_bad_device_id(
             blocking=True,
         )
 
-    assert "Device 'bad-device_id' not found in device registry" in str(excinfo)
+    assert excinfo.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert excinfo.value.translation_key == "service_device_not_found"
+    assert excinfo.value.translation_placeholders == {"device_id": "bad-device_id"}
 
 
 async def test_service_called_with_non_fkb_target_devices(
@@ -203,4 +207,9 @@ async def test_service_called_with_non_fkb_target_devices(
             blocking=True,
         )
 
-    assert f"Device '{device_entry.id}' is not a fully_kiosk device" in str(excinfo)
+    assert excinfo.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert excinfo.value.translation_key == "service_device_wrong_domain"
+    assert excinfo.value.translation_placeholders == {
+        "device_name": device_entry.name,
+        "domain": DOMAIN,
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new helper introduced in #180132

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
