### PR TITLE
Use async_get_config_entry service helper in screenlogic

### DIFF
--- a/homeassistant/components/screenlogic/services.py
+++ b/homeassistant/components/screenlogic/services.py
@@ -7,10 +7,9 @@ from screenlogicpy import ScreenLogicError
 from screenlogicpy.device_const.system import EQUIPMENT_FLAG
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import selector
+from homeassistant.helpers import selector, service
 
 from .const import (
     ATTR_COLOR_MODE,
@@ -54,52 +53,35 @@ TURN_ON_SUPER_CHLOR_SCHEMA = BASE_SERVICE_SCHEMA.extend(
 )
 
 
-async def _get_coordinators(
+@callback
+def _get_coordinator(
     service_call: ServiceCall,
-) -> list[ScreenlogicDataUpdateCoordinator]:
-    entry_ids = {service_call.data[ATTR_CONFIG_ENTRY]}
-    coordinators: list[ScreenlogicDataUpdateCoordinator] = []
-    for entry_id in entry_ids:
-        config_entry = cast(
-            ScreenLogicConfigEntry | None,
-            service_call.hass.config_entries.async_get_entry(entry_id),
-        )
-        if not config_entry:
-            raise ServiceValidationError(
-                f"Failed to call service '{service_call.service}'. Config entry "
-                f"'{entry_id}' not found"
-            )
-        if not config_entry.domain == DOMAIN:
-            raise ServiceValidationError(
-                f"Failed to call service '{service_call.service}'. Config entry "
-                f"'{entry_id}' is not a {DOMAIN} config"
-            )
-        if config_entry.state is not ConfigEntryState.LOADED:
-            raise ServiceValidationError(
-                f"Failed to call service '{service_call.service}'. Config entry "
-                f"'{entry_id}' not loaded"
-            )
-        coordinators.append(config_entry.runtime_data)
-
-    return coordinators
+) -> ScreenlogicDataUpdateCoordinator:
+    """Get the coordinator for the config entry targeted by a service call."""
+    config_entry = cast(
+        ScreenLogicConfigEntry,
+        service.async_get_config_entry(
+            service_call.hass, DOMAIN, service_call.data[ATTR_CONFIG_ENTRY]
+        ),
+    )
+    return config_entry.runtime_data
 
 
 async def _async_set_color_mode(service_call: ServiceCall) -> None:
     color_num = SUPPORTED_COLOR_MODES[service_call.data[ATTR_COLOR_MODE]]
-    coordinator: ScreenlogicDataUpdateCoordinator
-    for coordinator in await _get_coordinators(service_call):
-        _LOGGER.debug(
-            "Service %s called on %s with mode %s",
-            SERVICE_SET_COLOR_MODE,
-            coordinator.gateway.name,
-            color_num,
-        )
-        try:
-            await coordinator.gateway.async_set_color_lights(color_num)
-            # Debounced refresh to catch any secondary changes in the device
-            await coordinator.async_request_refresh()
-        except ScreenLogicError as error:
-            raise HomeAssistantError(error) from error
+    coordinator = _get_coordinator(service_call)
+    _LOGGER.debug(
+        "Service %s called on %s with mode %s",
+        SERVICE_SET_COLOR_MODE,
+        coordinator.gateway.name,
+        color_num,
+    )
+    try:
+        await coordinator.gateway.async_set_color_lights(color_num)
+        # Debounced refresh to catch any secondary changes in the device
+        await coordinator.async_request_refresh()
+    except ScreenLogicError as error:
+        raise HomeAssistantError(error) from error
 
 
 async def _async_set_super_chlor(
@@ -107,28 +89,27 @@ async def _async_set_super_chlor(
     is_on: bool,
     runtime: int | None = None,
 ) -> None:
-    coordinator: ScreenlogicDataUpdateCoordinator
-    for coordinator in await _get_coordinators(service_call):
-        if EQUIPMENT_FLAG.CHLORINATOR not in coordinator.gateway.equipment_flags:
-            raise ServiceValidationError(
-                f"Equipment configuration for {coordinator.gateway.name} does not"
-                f" support {service_call.service}"
-            )
-        rt_log = f" with runtime {runtime}" if runtime else ""
-        _LOGGER.debug(
-            "Service %s called on %s%s",
-            service_call.service,
-            coordinator.gateway.name,
-            rt_log,
+    coordinator = _get_coordinator(service_call)
+    if EQUIPMENT_FLAG.CHLORINATOR not in coordinator.gateway.equipment_flags:
+        raise ServiceValidationError(
+            f"Equipment configuration for {coordinator.gateway.name} does not"
+            f" support {service_call.service}"
         )
-        try:
-            await coordinator.gateway.async_set_scg_config(
-                super_chlor_timer=runtime, super_chlorinate=is_on
-            )
-            # Debounced refresh to catch any secondary changes in the device
-            await coordinator.async_request_refresh()
-        except ScreenLogicError as error:
-            raise HomeAssistantError(error) from error
+    rt_log = f" with runtime {runtime}" if runtime else ""
+    _LOGGER.debug(
+        "Service %s called on %s%s",
+        service_call.service,
+        coordinator.gateway.name,
+        rt_log,
+    )
+    try:
+        await coordinator.gateway.async_set_scg_config(
+            super_chlor_timer=runtime, super_chlorinate=is_on
+        )
+        # Debounced refresh to catch any secondary changes in the device
+        await coordinator.async_request_refresh()
+    except ScreenLogicError as error:
+        raise HomeAssistantError(error) from error
 
 
 async def _async_start_super_chlor(service_call: ServiceCall) -> None:

--- a/tests/components/screenlogic/test_services.py
+++ b/tests/components/screenlogic/test_services.py
@@ -139,8 +139,8 @@ async def test_service_set_color_mode(
                 ATTR_CONFIG_ENTRY: "invalidconfigentry",
             },
             None,
-            f"Failed to call service '{SERVICE_SET_COLOR_MODE}'. Config entry "
-            "'invalidconfigentry' not found",
+            f"Integration {DOMAIN} config entry with ID invalidconfigentry "
+            "was not found",
         ),
         (
             {
@@ -148,8 +148,7 @@ async def test_service_set_color_mode(
                 ATTR_CONFIG_ENTRY: NON_SL_CONFIG_ENTRY_ID,
             },
             None,
-            f"Failed to call service '{SERVICE_SET_COLOR_MODE}'. Config entry "
-            "'test' is not a screenlogic config",
+            f"Config entry Mock Title does not belong to integration {DOMAIN}",
         ),
     ],
 )
@@ -233,8 +232,8 @@ async def test_service_start_super_chlorination(
                 ATTR_RUNTIME: 24,
             },
             None,
-            f"Failed to call service '{SERVICE_START_SUPER_CHLORINATION}'. "
-            "Config entry 'invalidconfigentry' not found",
+            f"Integration {DOMAIN} config entry with ID invalidconfigentry "
+            "was not found",
         ),
         (
             {
@@ -322,8 +321,8 @@ async def test_service_stop_super_chlorination(
                 ATTR_CONFIG_ENTRY: "invalidconfigentry",
             },
             None,
-            f"Failed to call service '{SERVICE_STOP_SUPER_CHLORINATION}'. "
-            "Config entry 'invalidconfigentry' not found",
+            f"Integration {DOMAIN} config entry with ID invalidconfigentry "
+            "was not found",
         ),
         (
             {
@@ -408,8 +407,8 @@ async def test_service_config_entry_not_loaded(
 
         with pytest.raises(
             ServiceValidationError,
-            match=f"Failed to call service '{SERVICE_SET_COLOR_MODE}'. "
-            f"Config entry '{MOCK_CONFIG_ENTRY_ID}' not loaded",
+            match=f"Config entry {MOCK_ADAPTER_NAME} for integration {DOMAIN} "
+            "is not loaded",
         ):
             await hass.services.async_call(
                 DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Also removes loop leftover from #123432

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
