### PR TITLE
Bump yalexs to 9.2.13

### DIFF
--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -30,5 +30,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==9.2.10", "yalexs-ble==4.0.1"]
+  "requirements": ["yalexs==9.2.13", "yalexs-ble==4.0.1"]
 }

--- a/homeassistant/components/yale/manifest.json
+++ b/homeassistant/components/yale/manifest.json
@@ -14,5 +14,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["socketio", "engineio", "yalexs"],
-  "requirements": ["yalexs==9.2.10", "yalexs-ble==4.0.1"]
+  "requirements": ["yalexs==9.2.13", "yalexs-ble==4.0.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3455,7 +3455,7 @@ yalexs-ble==4.0.1
 
 # homeassistant.components.august
 # homeassistant.components.yale
-yalexs==9.2.10
+yalexs==9.2.13
 
 # homeassistant.components.yeelight
 yeelight==0.7.16


### PR DESCRIPTION
## Proposed change

Bumps `yalexs` from 9.2.10 to 9.2.13. Both the `august` and `yale` integrations depend on `yalexs` and share a single pinned version, so both manifests are bumped together.

The motivating fix is [Yale-Libs/yalexs#433](https://github.com/Yale-Libs/yalexs/pull/433): the websocket `lockAction` value `secure` was missing from `LOCKED_STATUS`, so a lock reporting `secure` over the websocket was never resolved to a locked state and kept showing as not locked in Home Assistant until the next poll corrected it. The fix appends `secure` and `securemode` to the existing tuple.

Version diff 9.2.10 → 9.2.13:

- Yale-Libs/yalexs#433 — treat websocket lockAction `secure` as locked (9.2.13)
- Yale-Libs/yalexs#412 — make doorbell `image_url`/`content_token` setters visible to type-checkers (9.2.12)
- Yale-Libs/yalexs#404 — correct `AlarmDevice.status` annotation to `dict[str, Any]` (9.2.11)
- Yale-Libs/yalexs#401 — test-only, guard action→state map completeness (9.2.11)

No public API is removed or renamed in this range, so neither `august` nor `yale` needs code or test changes:

- `lock.py` is additive only, and HA core does not reference `LOCKED_STATUS` directly.
- `alarm.py` is an annotation-only correction; the value was already a `dict` at runtime (the constructor already called `self._status.get("lowBattery")`). HA core does not import `yalexs.alarm`.
- `doorbell.py` moves the `content_token` property next to its setter, with no behavioral change.

Release notes: https://github.com/Yale-Libs/yalexs/releases/tag/v9.2.13
Diff: https://github.com/Yale-Libs/yalexs/compare/v9.2.10...v9.2.13

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
