### PR TITLE
Teach async_get_device_and_config_entry service helper about child devices

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -63,6 +63,9 @@
     "service_config_entry_wrong_domain": {
       "message": "Config entry {entry_title} does not belong to integration {domain}."
     },
+    "service_device_is_child_device": {
+      "message": "Device {device_name} is a sub-device and can't be targeted directly. Target its main device instead."
+    },
     "service_device_not_found": {
       "message": "Device with ID {device_id} was not found."
     },

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1422,13 +1422,33 @@ def async_get_device_and_config_entry(
 ) -> tuple[device_registry.DeviceEntry, ConfigEntry]:
     """Get and validate the device and the loaded config entry of the domain owning it.
 
-    Raises ServiceValidationError if the device is unknown, is not owned by a
-    config entry of the domain, or if that config entry is not loaded.
+    Raises ServiceValidationError if the device is unknown, is a child device, is
+    not owned by a config entry of the domain, or if that config entry is not
+    loaded. Child devices are rejected because the returned DeviceEntry would not
+    carry the attributes callers read from it; target the main device instead.
     """
     device, config_entry = device_registry.async_get_device_and_config_entry_for_domain(
         hass, device_id, domain=domain
     )
     if device is None:
+        # A child device id resolves to no device above. Report that specifically,
+        # so the caller is not sent looking for a missing device.
+        if (
+            child_device := device_registry.async_get(hass).async_get(
+                device_id,
+                include_main_devices=False,
+                include_composite_devices=False,
+            )
+        ) is not None:
+            raise ServiceValidationError(
+                translation_domain=HOMEASSISTANT_DOMAIN,
+                translation_key="service_device_is_child_device",
+                translation_placeholders={
+                    "device_name": child_device.name_by_user
+                    or child_device.name
+                    or device_id,
+                },
+            )
         raise ServiceValidationError(
             translation_domain=HOMEASSISTANT_DOMAIN,
             translation_key="service_device_not_found",

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3460,3 +3460,35 @@ async def test_get_service_device_and_config_entry(
     with pytest.raises(exceptions.ServiceValidationError) as err:
         service.async_get_device_and_config_entry(hass, domain, device.id)
     assert err.value.translation_key == "service_config_entry_not_loaded"
+
+
+async def test_get_service_device_and_config_entry_child_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that a child device is reported as such, not as a missing device."""
+    domain = "mock_integration"
+    entry = MockConfigEntry(domain=domain)
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    parent = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(domain, "parent")},
+        name="Parent device",
+    )
+    child = device_registry.async_get_or_create_child(
+        config_entry_id=entry.entry_id,
+        parent_device_id=parent.id,
+        identifiers={(domain, "child")},
+        name="Child device",
+    )
+
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.async_get_device_and_config_entry(hass, domain, child.id)
+    assert err.value.translation_key == "service_device_is_child_device"
+    assert err.value.translation_placeholders == {"device_name": "Child device"}
+
+    # The parent device still resolves normally
+    assert service.async_get_device_and_config_entry(hass, domain, parent.id) == (
+        parent,
+        entry,
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`service.async_get_device_and_config_entry` rejects a child device id with `service_device_not_found` — "Device with ID … was not found." That message is wrong: the device exists, it is simply a child. Someone hitting it goes looking for a missing or renamed device instead of retargeting the parent.

This is because the helper delegates to `device_registry.async_get_device_and_config_entry_for_domain`, which returns `(None, None)` for a child device by design. That design is right: the helper is typed `-> tuple[DeviceEntry, ConfigEntry]`, and a `ChildDeviceEntry` deliberately omits `DeviceEntry`-only attributes (`connections`, `manufacturer`, `serial_number`, `via_device_id`). Returning one would be unsound — `alexa_devices` and `teslemetry` both read `device.serial_number` straight off the returned device.

So this keeps the rejection and fixes only the diagnosis: when no device resolves, check whether the id belongs to a child device and, if so, raise the new `service_device_is_child_device` — "Device {device_name} is a sub-device and can't be targeted directly. Target its main device instead." The docstring now records the rejection and why.

No behaviour change for any currently reachable input: only `kitchen_sink` creates child devices today (`DeviceInfo(parent_device_id=...`) is the sole route into `async_get_or_create_child`), so no integration using this helper can hit the new branch yet. It is reachable in principle — these services read a raw `device_id` from call data, so a child id can arrive via YAML, the API, or an automation — and it becomes reachable in practice as soon as an integration adopts child devices.

Note that what targeting a child device should mean is left open. Two alternatives were considered and not taken, as both need a maintainer's call rather than an implementer's: resolving the child to its parent's entry (type-safe, but silently redirects the action, which is wrong when a child is a distinct actionable unit), and widening the return to `AnyDeviceEntry` (honest, but breaks the two `serial_number` callers and pushes child handling onto every consumer). A child carries `config_entry_id` directly, so either would be straightforward to add later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
