### PR TITLE
Add CI jobs to test recorder against multiple SQLite versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,11 @@ env:
   # 18 is the latest version
   # - 18.6 is the latest (as of 19 Aug 2026)
   POSTGRESQL_VERSIONS: "['postgres:12.22','postgres:15.19', 'postgres:18.6']"
+  # 3.40.1 is the oldest supported version (recorder MIN_VERSION_SQLITE),
+  # shipped in Debian 12 (bookworm)
+  # 3.53.4 is the latest (as of 25 Aug 2026)
+  # The year is part of the sqlite.org amalgamation download URL
+  SQLITE_VERSIONS: '[{"version": "3.40.1", "year": "2022"}, {"version": "3.53.4", "year": "2026"}]'
   UV_CACHE_DIR: /tmp/uv-cache
   APT_CACHE_VERSION: 1
   SQLALCHEMY_WARN_20: 1
@@ -90,6 +95,7 @@ jobs:
       requirements: ${{ steps.core.outputs.requirements }}
       mariadb_groups: ${{ steps.info.outputs.mariadb_groups }}
       postgresql_groups: ${{ steps.info.outputs.postgresql_groups }}
+      sqlite_groups: ${{ steps.info.outputs.sqlite_groups }}
       python_versions: ${{ steps.info.outputs.python_versions }}
       default_python: ${{ steps.info.outputs.default_python }}
       uv_version: ${{ steps.info.outputs.uv_version }}
@@ -156,6 +162,7 @@ jobs:
           integrations_glob=""
           mariadb_groups=${MARIADB_VERSIONS}
           postgresql_groups=${POSTGRESQL_VERSIONS}
+          sqlite_groups=${SQLITE_VERSIONS}
           test_full_suite="true"
           test_groups="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
           test_group_count=10
@@ -196,6 +203,7 @@ jobs:
 
             mariadb_groups="[]"
             postgresql_groups="[]"
+            sqlite_groups="[]"
             test_full_suite="false"
           fi
 
@@ -210,6 +218,7 @@ jobs:
           then
             mariadb_groups=${MARIADB_VERSIONS}
             postgresql_groups=${POSTGRESQL_VERSIONS}
+            sqlite_groups=${SQLITE_VERSIONS}
             test_groups="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
             test_group_count=10
             test_full_suite="true"
@@ -237,6 +246,8 @@ jobs:
           echo "mariadb_groups=${mariadb_groups}" >> $GITHUB_OUTPUT
           echo "postgresql_groups: ${postgresql_groups}"
           echo "postgresql_groups=${postgresql_groups}" >> $GITHUB_OUTPUT
+          echo "sqlite_groups: ${sqlite_groups}"
+          echo "sqlite_groups=${sqlite_groups}" >> $GITHUB_OUTPUT
           echo "python_versions: ${all_python_versions}"
           echo "python_versions=${all_python_versions}" >> $GITHUB_OUTPUT
           echo "default_python: ${default_python}"
@@ -1223,6 +1234,110 @@ jobs:
           name: test-results-postgres-${{ matrix.python-version }}-${{
             steps.pytest-partial.outputs.postgresql }}
           path: junit.xml
+      - name: Check dirty
+        run: |
+          ./script/check_dirty
+
+  pytest-sqlite:
+    name: Run SQLite ${{ matrix.sqlite-group.version }} tests Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs:
+      - info
+      - base
+      - gen-requirements-all
+      - hassfest
+      - prek
+      - mypy
+    if: |
+      needs.info.outputs.lint_only != 'true'
+      && needs.info.outputs.sqlite_groups != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
+        sqlite-group: ${{ fromJson(needs.info.outputs.sqlite_groups) }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install additional OS dependencies
+        timeout-minutes: 10
+        uses: ./.github/actions/cache-apt-packages
+        with:
+          packages: >-
+            bluez
+            ffmpeg
+            libturbojpeg
+            libxml2-utils
+          version: ${{ env.APT_CACHE_VERSION }}
+          execute_install_scripts: true
+      - name: Set up Python ${{ matrix.python-version }} and restore venv
+        id: python
+        uses: ./.github/actions/restore-or-build-venv
+        with:
+          uv-version: ${{ needs.info.outputs.uv_version }}
+          python-version: ${{ matrix.python-version }}
+          python-cache-key: ${{ needs.info.outputs.python_cache_key }}
+          uv-cache-dir: ${{ env.UV_CACHE_DIR }}
+          apt-cache-version: ${{ env.APT_CACHE_VERSION }}
+      - name: Register Python problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/python.json"
+      - name: Build sqlite3 module with SQLite ${{ matrix.sqlite-group.version }}
+        env:
+          SQLITE_VERSION: ${{ matrix.sqlite-group.version }}
+          SQLITE_YEAR: ${{ matrix.sqlite-group.year }}
+        run: |
+          . venv/bin/activate
+          python3 script/vendor_sqlite3.py --version "${SQLITE_VERSION}" --year "${SQLITE_YEAR}"
+      - name: Compile English translations
+        run: |
+          . venv/bin/activate
+          python3 -m script.translations develop --all
+      - name: Run pytest (partially)
+        timeout-minutes: 20
+        id: pytest-partial
+        shell: bash
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+          EXPECTED_SQLITE_VERSION: ${{ matrix.sqlite-group.version }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          . venv/bin/activate
+          python --version
+          set -o pipefail
+
+          # No coverage collection: these tests already run with coverage in
+          # the pytest-full job with the interpreter's own SQLite.
+          python3 -b -X dev -m pytest \
+            -qq \
+            --timeout=20 \
+            --numprocesses auto \
+            --dist=loadfile \
+            --snapshot-details \
+            -o console_output_style=count \
+            --durations=0 \
+            --durations-min=10 \
+            -p no:sugar \
+            -p tests.sqlite3_shim \
+            --exclude-warning-annotations \
+            tests/components/history \
+            tests/components/logbook \
+            tests/components/recorder \
+            tests/components/sensor \
+              2>&1 | tee pytest-${PYTHON_VERSION}-sqlite-${EXPECTED_SQLITE_VERSION}.txt
+      - name: Upload pytest output
+        if: success() || failure() && steps.pytest-partial.conclusion == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name:
+            pytest-${{ github.run_number }}-${{ matrix.python-version }}-sqlite-${{
+            matrix.sqlite-group.version }}
+          path: pytest-*.txt
+          overwrite: true
       - name: Check dirty
         run: |
           ./script/check_dirty

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,11 @@ env:
   # 3.53.4 is the latest (as of 25 Aug 2026)
   # The year is part of the sqlite.org amalgamation download URL
   SQLITE_VERSIONS: '[{"version": "3.40.1", "year": "2022"}, {"version": "3.53.4", "year": "2026"}]'
+  RECORDER_TEST_DIRS: >-
+    tests/components/history
+    tests/components/logbook
+    tests/components/recorder
+    tests/components/sensor
   UV_CACHE_DIR: /tmp/uv-cache
   APT_CACHE_VERSION: 1
   SQLALCHEMY_WARN_20: 1
@@ -1049,10 +1054,7 @@ jobs:
             -p no:sugar \
             --exclude-warning-annotations \
             --dburl=mysql://root:password@127.0.0.1/homeassistant-test \
-            tests/components/history \
-            tests/components/logbook \
-            tests/components/recorder \
-            tests/components/sensor \
+            ${RECORDER_TEST_DIRS} \
               2>&1 | tee pytest-${PYTHON_VERSION}-${mariadb}.txt
       - name: Upload pytest output
         if: success() || failure() && steps.pytest-partial.conclusion == 'failure'
@@ -1200,10 +1202,7 @@ jobs:
             -p no:sugar \
             --exclude-warning-annotations \
             --dburl=postgresql://postgres:password@127.0.0.1/homeassistant-test \
-            tests/components/history \
-            tests/components/logbook \
-            tests/components/recorder \
-            tests/components/sensor \
+            ${RECORDER_TEST_DIRS} \
               2>&1 | tee pytest-${PYTHON_VERSION}-${postgresql}.txt
       - name: Upload pytest output
         if: success() || failure() && steps.pytest-partial.conclusion == 'failure'
@@ -1286,13 +1285,25 @@ jobs:
       - name: Register Python problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"
-      - name: Build sqlite3 module with SQLite ${{ matrix.sqlite-group.version }}
+      - name: Restore vendored sqlite3 wheel cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/sqlite3-vendor-wheel
+          key: >-
+            sqlite3-vendor-wheel-${{ runner.os }}-${{ runner.arch }}-${{
+            steps.python.outputs.python-version }}-${{
+            matrix.sqlite-group.version }}-${{
+            hashFiles('script/vendor_sqlite3.py', 'script/sqlite3_vendor/**') }}
+      - name: Install sqlite3 module with SQLite ${{ matrix.sqlite-group.version }}
         env:
           SQLITE_VERSION: ${{ matrix.sqlite-group.version }}
           SQLITE_YEAR: ${{ matrix.sqlite-group.year }}
         run: |
           . venv/bin/activate
-          python3 script/vendor_sqlite3.py --version "${SQLITE_VERSION}" --year "${SQLITE_YEAR}"
+          python3 -m script.vendor_sqlite3 \
+            --version "${SQLITE_VERSION}" \
+            --year "${SQLITE_YEAR}" \
+            --wheel-dir ~/sqlite3-vendor-wheel
       - name: Compile English translations
         run: |
           . venv/bin/activate
@@ -1324,10 +1335,7 @@ jobs:
             -p no:sugar \
             -p tests.sqlite3_shim \
             --exclude-warning-annotations \
-            tests/components/history \
-            tests/components/logbook \
-            tests/components/recorder \
-            tests/components/sensor \
+            ${RECORDER_TEST_DIRS} \
               2>&1 | tee pytest-${PYTHON_VERSION}-sqlite-${EXPECTED_SQLITE_VERSION}.txt
       - name: Upload pytest output
         if: success() || failure() && steps.pytest-partial.conclusion == 'failure'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,9 @@ env:
   POSTGRESQL_VERSIONS: "['postgres:12.22','postgres:15.19', 'postgres:18.6']"
   # 3.40.1 is the oldest supported version (recorder MIN_VERSION_SQLITE),
   # shipped in Debian 12 (bookworm)
-  # 3.53.4 is the latest (as of 25 Aug 2026)
+  # 3.53.4 is the latest (as of 25 Aug 2026) and the version shipped with
+  # HA OS and the official container images (Alpine 3.24); when bumping the
+  # latest, keep an entry for the version the container images ship
   # The year is part of the sqlite.org amalgamation download URL
   SQLITE_VERSIONS: '[{"version": "3.40.1", "year": "2022"}, {"version": "3.53.4", "year": "2026"}]'
   RECORDER_TEST_DIRS: >-

--- a/script/sqlite3_vendor/ha_sqlite3_vendor/__init__.py
+++ b/script/sqlite3_vendor/ha_sqlite3_vendor/__init__.py
@@ -1,0 +1,1 @@
+"""CPython sqlite3 C module built against a custom SQLite."""

--- a/script/sqlite3_vendor/pyproject.toml
+++ b/script/sqlite3_vendor/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"

--- a/script/sqlite3_vendor/pyproject.toml
+++ b/script/sqlite3_vendor/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=69"]
+requires = ["setuptools==78.1.1"]
 build-backend = "setuptools.build_meta"

--- a/script/sqlite3_vendor/ruff.toml
+++ b/script/sqlite3_vendor/ruff.toml
@@ -1,0 +1,6 @@
+extend = "../ruff.toml"
+
+[lint]
+extend-ignore = [
+    "INP001", # File is part of an implicit namespace package. Add an `__init__.py`.
+]

--- a/script/sqlite3_vendor/setup.py
+++ b/script/sqlite3_vendor/setup.py
@@ -1,22 +1,27 @@
 """Build CPython's own Modules/_sqlite against a bundled SQLite amalgamation."""
 
-# ruff: noqa: INP001
-
+import os
 from pathlib import Path
 import sysconfig
 
 from setuptools import Extension, setup
 
+# Staged by script/vendor_sqlite3.py next to this file
+sources = sorted(str(p) for p in Path("src").glob("*.c"))
+if not sources or not Path("sqlite3.c").exists():
+    raise FileNotFoundError("Build via script/vendor_sqlite3.py to stage the sources")
+
 setup(
     name="ha-sqlite3-vendor",
-    version="0.1.0",
+    # Version the wheel by the SQLite it bundles
+    version=os.environ["SQLITE_VERSION"],
     packages=["ha_sqlite3_vendor"],
     ext_modules=[
         Extension(
             # The extension must be named _sqlite3 to match the sources'
             # PyInit__sqlite3, hence the wrapping package
             "ha_sqlite3_vendor._sqlite3",
-            sources=[*sorted(str(p) for p in Path("src").glob("*.c")), "sqlite3.c"],
+            sources=[*sources, "sqlite3.c"],
             include_dirs=[
                 "src",
                 ".",
@@ -29,6 +34,9 @@ setup(
                 ("SQLITE_ENABLE_RTREE", "1"),
                 ("SQLITE_ENABLE_MATH_FUNCTIONS", "1"),
             ],
+            # Override the interpreter's -O3 -g, which make compiling the
+            # amalgamation much slower for no runtime gain
+            extra_compile_args=["-O2", "-g0"],
         )
     ],
 )

--- a/script/sqlite3_vendor/setup.py
+++ b/script/sqlite3_vendor/setup.py
@@ -1,0 +1,34 @@
+"""Build CPython's own Modules/_sqlite against a bundled SQLite amalgamation."""
+
+# ruff: noqa: INP001
+
+from pathlib import Path
+import sysconfig
+
+from setuptools import Extension, setup
+
+setup(
+    name="ha-sqlite3-vendor",
+    version="0.1.0",
+    packages=["ha_sqlite3_vendor"],
+    ext_modules=[
+        Extension(
+            # The extension must be named _sqlite3 to match the sources'
+            # PyInit__sqlite3, hence the wrapping package
+            "ha_sqlite3_vendor._sqlite3",
+            sources=[*sorted(str(p) for p in Path("src").glob("*.c")), "sqlite3.c"],
+            include_dirs=[
+                "src",
+                ".",
+                str(Path(sysconfig.get_paths()["include"]) / "internal"),
+            ],
+            define_macros=[
+                ("Py_BUILD_CORE_MODULE", "1"),
+                # Feature flags matching common distro builds
+                ("SQLITE_ENABLE_FTS5", "1"),
+                ("SQLITE_ENABLE_RTREE", "1"),
+                ("SQLITE_ENABLE_MATH_FUNCTIONS", "1"),
+            ],
+        )
+    ],
+)

--- a/script/vendor_sqlite3.py
+++ b/script/vendor_sqlite3.py
@@ -20,6 +20,7 @@ import argparse
 import io
 from pathlib import Path
 import platform
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -29,48 +30,7 @@ import urllib.request
 import zipfile
 
 DOWNLOAD_ATTEMPTS = 3
-
-SETUP_PY = '''\
-"""Build CPython's own Modules/_sqlite against a bundled SQLite amalgamation."""
-
-from pathlib import Path
-import sysconfig
-
-from setuptools import Extension, setup
-
-setup(
-    name="ha-sqlite3-vendor",
-    version="0.1.0",
-    packages=["ha_sqlite3_vendor"],
-    ext_modules=[
-        Extension(
-            # The extension must be named _sqlite3 to match the sources'
-            # PyInit__sqlite3, hence the wrapping package
-            "ha_sqlite3_vendor._sqlite3",
-            sources=sorted(str(p) for p in Path("src").glob("*.c"))
-            + ["sqlite3.c"],
-            include_dirs=[
-                "src",
-                ".",
-                str(Path(sysconfig.get_paths()["include"]) / "internal"),
-            ],
-            define_macros=[
-                ("Py_BUILD_CORE_MODULE", "1"),
-                # Feature flags matching common distro builds
-                ("SQLITE_ENABLE_FTS5", "1"),
-                ("SQLITE_ENABLE_RTREE", "1"),
-                ("SQLITE_ENABLE_MATH_FUNCTIONS", "1"),
-            ],
-        )
-    ],
-)
-'''
-
-PYPROJECT_TOML = """\
-[build-system]
-requires = ["setuptools>=69"]
-build-backend = "setuptools.build_meta"
-"""
+FIXTURE_DIR = Path(__file__).parent / "sqlite3_vendor"
 
 
 def open_url(url: str) -> io.BufferedIOBase:
@@ -132,18 +92,20 @@ def main() -> None:
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        workdir = Path(tmpdir)
+        workdir = Path(tmpdir) / "build"
+        shutil.copytree(FIXTURE_DIR, workdir)
         fetch_module_sources(workdir)
         fetch_amalgamation(workdir, args.version, args.year)
-        (workdir / "setup.py").write_text(SETUP_PY)
-        (workdir / "pyproject.toml").write_text(PYPROJECT_TOML)
-        package = workdir / "ha_sqlite3_vendor"
-        package.mkdir()
-        (package / "__init__.py").write_text(
-            '"""CPython sqlite3 C module built against a custom SQLite."""\n'
-        )
         subprocess.run(
-            ["uv", "pip", "install", "--python", sys.executable, "--reinstall", tmpdir],
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+                "--reinstall",
+                str(workdir),
+            ],
             check=True,
         )
 

--- a/script/vendor_sqlite3.py
+++ b/script/vendor_sqlite3.py
@@ -9,15 +9,11 @@ suite run against any SQLite version, independent of the one bundled with the
 interpreter. Rebuilding the module is required because uv managed interpreters
 statically link SQLite with hidden symbols, so it cannot be replaced with
 LD_PRELOAD.
-
-Usage: python3 script/vendor_sqlite3.py --version 3.40.1 --year 2022
-
-The year is part of the sqlite.org amalgamation download URL and can be found
-at https://www.sqlite.org/chronology.html.
 """
 
 import argparse
 import io
+import os
 from pathlib import Path
 import platform
 import shutil
@@ -59,14 +55,16 @@ def fetch_module_sources(workdir: Path) -> None:
         open_url(url) as response,
         tarfile.open(fileobj=response, mode="r|gz") as tar,
     ):
+        seen = False
         for member in tar:
-            if not member.isfile() or not member.name.startswith(prefix):
-                continue
-            target = src / member.name.removeprefix(prefix)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            extracted = tar.extractfile(member)
-            assert extracted is not None
-            target.write_bytes(extracted.read())
+            if member.name.startswith(prefix):
+                seen = True
+                if member.isfile():
+                    member.name = member.name.removeprefix(prefix)
+                    tar.extract(member, src, filter="data")
+            elif seen:
+                # Tar entries are sorted, so everything wanted has been seen
+                break
 
 
 def fetch_amalgamation(workdir: Path, version: str, year: str) -> None:
@@ -74,12 +72,27 @@ def fetch_amalgamation(workdir: Path, version: str, year: str) -> None:
     major, minor, patch = (int(part) for part in version.split("."))
     release = f"{major}{minor:02d}{patch:02d}00"
     url = f"https://www.sqlite.org/{year}/sqlite-amalgamation-{release}.zip"
-    with open_url(url) as response:
-        archive_bytes = response.read()
-    with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+    with (
+        open_url(url) as response,
+        zipfile.ZipFile(io.BytesIO(response.read())) as archive,
+    ):
         for filename in ("sqlite3.c", "sqlite3.h"):
             data = archive.read(f"sqlite-amalgamation-{release}/{filename}")
             (workdir / filename).write_bytes(data)
+
+
+def build_wheel(wheel_dir: Path, version: str, year: str) -> None:
+    """Build a ha_sqlite3_vendor wheel for the given SQLite version."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir) / "build"
+        shutil.copytree(FIXTURE_DIR, workdir)
+        fetch_module_sources(workdir)
+        fetch_amalgamation(workdir, version, year)
+        subprocess.run(
+            ["uv", "build", "--wheel", str(workdir), "--out-dir", str(wheel_dir)],
+            check=True,
+            env={**os.environ, "SQLITE_VERSION": version},
+        )
 
 
 def main() -> None:
@@ -87,15 +100,26 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", required=True, help="SQLite version, e.g. 3.40.1")
     parser.add_argument(
-        "--year", required=True, help="Release year in the sqlite.org download URL"
+        "--year",
+        required=True,
+        help="Release year in the sqlite.org download URL, "
+        "see https://www.sqlite.org/chronology.html",
+    )
+    parser.add_argument(
+        "--wheel-dir",
+        type=Path,
+        help="Keep the built wheel here and reuse it if one already exists",
     )
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        workdir = Path(tmpdir) / "build"
-        shutil.copytree(FIXTURE_DIR, workdir)
-        fetch_module_sources(workdir)
-        fetch_amalgamation(workdir, args.version, args.year)
+        wheel_dir = args.wheel_dir or Path(tmpdir)
+        pattern = f"ha_sqlite3_vendor-{args.version}-*.whl"
+        if wheels := sorted(wheel_dir.glob(pattern)):
+            print(f"Using cached wheel {wheels[0]}")
+        else:
+            build_wheel(wheel_dir, args.version, args.year)
+            wheels = sorted(wheel_dir.glob(pattern))
         subprocess.run(
             [
                 "uv",
@@ -104,7 +128,7 @@ def main() -> None:
                 "--python",
                 sys.executable,
                 "--reinstall",
-                str(workdir),
+                str(wheels[0]),
             ],
             check=True,
         )

--- a/script/vendor_sqlite3.py
+++ b/script/vendor_sqlite3.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Build the running interpreter's sqlite3 C module against a chosen SQLite.
+
+Downloads the Modules/_sqlite sources for the exact CPython version that is
+running plus the requested SQLite amalgamation from sqlite.org, compiles them
+into the ha_sqlite3_vendor package, and installs it into the current
+environment. Combined with `pytest -p tests.sqlite3_shim` this lets the test
+suite run against any SQLite version, independent of the one bundled with the
+interpreter. Rebuilding the module is required because uv managed interpreters
+statically link SQLite with hidden symbols, so it cannot be replaced with
+LD_PRELOAD.
+
+Usage: python3 script/vendor_sqlite3.py --version 3.40.1 --year 2022
+
+The year is part of the sqlite.org amalgamation download URL and can be found
+at https://www.sqlite.org/chronology.html.
+"""
+
+import argparse
+import io
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.request
+import zipfile
+
+DOWNLOAD_ATTEMPTS = 3
+
+SETUP_PY = '''\
+"""Build CPython's own Modules/_sqlite against a bundled SQLite amalgamation."""
+
+from pathlib import Path
+import sysconfig
+
+from setuptools import Extension, setup
+
+setup(
+    name="ha-sqlite3-vendor",
+    version="0.1.0",
+    packages=["ha_sqlite3_vendor"],
+    ext_modules=[
+        Extension(
+            # The extension must be named _sqlite3 to match the sources'
+            # PyInit__sqlite3, hence the wrapping package
+            "ha_sqlite3_vendor._sqlite3",
+            sources=sorted(str(p) for p in Path("src").glob("*.c"))
+            + ["sqlite3.c"],
+            include_dirs=[
+                "src",
+                ".",
+                str(Path(sysconfig.get_paths()["include"]) / "internal"),
+            ],
+            define_macros=[
+                ("Py_BUILD_CORE_MODULE", "1"),
+                # Feature flags matching common distro builds
+                ("SQLITE_ENABLE_FTS5", "1"),
+                ("SQLITE_ENABLE_RTREE", "1"),
+                ("SQLITE_ENABLE_MATH_FUNCTIONS", "1"),
+            ],
+        )
+    ],
+)
+'''
+
+PYPROJECT_TOML = """\
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+"""
+
+
+def open_url(url: str) -> io.BufferedIOBase:
+    """Open a URL for reading, retrying transient failures."""
+    print(f"Downloading {url}")
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        try:
+            return urllib.request.urlopen(url, timeout=60)
+        except OSError as err:
+            if attempt == DOWNLOAD_ATTEMPTS:
+                raise
+            print(f"Download failed ({err}), retrying")
+            time.sleep(5 * attempt)
+    raise AssertionError("unreachable")
+
+
+def fetch_module_sources(workdir: Path) -> None:
+    """Extract Modules/_sqlite for the running CPython version into workdir/src."""
+    python_version = platform.python_version()
+    url = (
+        f"https://github.com/python/cpython/archive/refs/tags/v{python_version}.tar.gz"
+    )
+    prefix = f"cpython-{python_version}/Modules/_sqlite/"
+    src = workdir / "src"
+    with (
+        open_url(url) as response,
+        tarfile.open(fileobj=response, mode="r|gz") as tar,
+    ):
+        for member in tar:
+            if not member.isfile() or not member.name.startswith(prefix):
+                continue
+            target = src / member.name.removeprefix(prefix)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            extracted = tar.extractfile(member)
+            assert extracted is not None
+            target.write_bytes(extracted.read())
+
+
+def fetch_amalgamation(workdir: Path, version: str, year: str) -> None:
+    """Extract the SQLite amalgamation for the given version into workdir."""
+    major, minor, patch = (int(part) for part in version.split("."))
+    release = f"{major}{minor:02d}{patch:02d}00"
+    url = f"https://www.sqlite.org/{year}/sqlite-amalgamation-{release}.zip"
+    with open_url(url) as response:
+        archive_bytes = response.read()
+    with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+        for filename in ("sqlite3.c", "sqlite3.h"):
+            data = archive.read(f"sqlite-amalgamation-{release}/{filename}")
+            (workdir / filename).write_bytes(data)
+
+
+def main() -> None:
+    """Build and install ha_sqlite3_vendor."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="SQLite version, e.g. 3.40.1")
+    parser.add_argument(
+        "--year", required=True, help="Release year in the sqlite.org download URL"
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir)
+        fetch_module_sources(workdir)
+        fetch_amalgamation(workdir, args.version, args.year)
+        (workdir / "setup.py").write_text(SETUP_PY)
+        (workdir / "pyproject.toml").write_text(PYPROJECT_TOML)
+        package = workdir / "ha_sqlite3_vendor"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            '"""CPython sqlite3 C module built against a custom SQLite."""\n'
+        )
+        subprocess.run(
+            ["uv", "pip", "install", "--python", sys.executable, "--reinstall", tmpdir],
+            check=True,
+        )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from ha_sqlite3_vendor import _sqlite3;"
+            f"assert _sqlite3.sqlite_version == '{args.version}', _sqlite3.sqlite_version;"
+            "print('ha_sqlite3_vendor provides SQLite', _sqlite3.sqlite_version)",
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,12 @@ asyncio.set_event_loop_policy = lambda policy: None
 # Capture the real socket functions before any test patches them
 _real_getaddrinfo = socket.getaddrinfo
 
+# Guard for CI jobs that pin the SQLite version via tests.sqlite3_shim
+if expected_sqlite := os.environ.get("EXPECTED_SQLITE_VERSION"):
+    assert sqlite3.sqlite_version == expected_sqlite, (
+        f"Expected SQLite {expected_sqlite}, got {sqlite3.sqlite_version}"
+    )
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom pytest options."""

--- a/tests/sqlite3_shim.py
+++ b/tests/sqlite3_shim.py
@@ -12,10 +12,9 @@ import sys
 
 from ha_sqlite3_vendor import _sqlite3
 
-sys.modules.pop("sqlite3", None)
-sys.modules.pop("sqlite3.dbapi2", None)
+if "sqlite3" in sys.modules:
+    raise RuntimeError(
+        "sqlite3 was already imported, load this module earlier with "
+        "pytest -p tests.sqlite3_shim"
+    )
 sys.modules["_sqlite3"] = _sqlite3
-
-import sqlite3  # noqa: E402
-
-assert sqlite3.sqlite_version == _sqlite3.sqlite_version

--- a/tests/sqlite3_shim.py
+++ b/tests/sqlite3_shim.py
@@ -1,0 +1,21 @@
+"""Run tests against a custom-built SQLite instead of the interpreter's own.
+
+script/vendor_sqlite3.py builds CPython's own Modules/_sqlite sources against
+a chosen SQLite amalgamation as the ha_sqlite3_vendor package. Loading this
+module with `pytest -p tests.sqlite3_shim` rebinds the stdlib sqlite3 package
+to that build. It must be loaded with `-p` instead of being imported from
+conftest.py because plugins load before conftest.py, which already imports
+sqlite3 at the top of the file.
+"""
+
+import sys
+
+from ha_sqlite3_vendor import _sqlite3
+
+sys.modules.pop("sqlite3", None)
+sys.modules.pop("sqlite3.dbapi2", None)
+sys.modules["_sqlite3"] = _sqlite3
+
+import sqlite3  # noqa: E402
+
+assert sqlite3.sqlite_version == _sqlite3.sqlite_version


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

CI only ever tests recorder against the SQLite bundled with the uv managed Python, currently 3.50.4, so we never exercise the minimum version we claim to support. This adds a pytest-sqlite job matrix that builds CPython's own sqlite3 module from the matching CPython tag against a chosen SQLite amalgamation and rebinds the stdlib sqlite3 package to it for the test run. The matrix currently covers 3.40.1, the recorder minimum, and 3.53.4, the latest release.

LD_PRELOAD cannot be used here because the uv managed interpreters statically link SQLite with hidden symbols; rebuilding Modules/_sqlite gives us the exact stdlib code with only the SQLite version changed. A guard in conftest asserts the expected version is actually in use, so a misconfigured job cannot silently test the bundled SQLite instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
