### PR TITLE
Avoid a naive datetime.now() in the elmax tests

### DIFF
--- a/tests/components/elmax/conftest.py
+++ b/tests/components/elmax/conftest.py
@@ -1,7 +1,7 @@
 """Configuration for Elmax tests."""
 
 from collections.abc import Generator
-from datetime import datetime, timedelta
+from datetime import timedelta
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -15,6 +15,8 @@ from httpx import Response
 import jwt
 import pytest
 import respx
+
+from homeassistant.util import dt as dt_util
 
 from . import (
     MOCK_DIRECT_HOST,
@@ -81,7 +83,7 @@ def httpx_mock_direct_fixture(base_uri: str) -> Generator[respx.MockRouter]:
             algorithms="HS256",
             options={"verify_signature": False},
         )
-        expiration = datetime.now() + timedelta(hours=1)  # pylint: disable=home-assistant-enforce-naive-now
+        expiration = dt_util.utcnow() + timedelta(hours=1)
         decoded_jwt["payload"]["exp"] = int(expiration.timestamp())
         jws_string = jwt.encode(
             payload=decoded_jwt["payload"], algorithm="HS256", key=TOKEN_SIGNING_KEY


### PR DESCRIPTION
## Proposed change

The fixture builds an expiration only to put `int(expiration.timestamp())` into the `exp` claim of the mocked JWT. An aware value yields the same epoch, so `dt_util.utcnow()` removes the naive call without changing the token.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177796
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
