### PR TITLE
Complete exception-translations quality scale rule for tplink_omada

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -52,10 +52,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
         client = await create_omada_client(hass, entry.data)
         await client.login()
 
-    except (LoginFailed, UnsupportedControllerVersion) as ex:
+    except LoginFailed as ex:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="auth_failed",
+        ) from ex
+    except UnsupportedControllerVersion as ex:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="unsupported_controller",
         ) from ex
     except ConnectionFailed as ex:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -54,16 +54,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     except (LoginFailed, UnsupportedControllerVersion) as ex:
         raise ConfigEntryAuthFailed(
-            f"Omada controller refused login attempt: {ex}"
+            translation_domain=DOMAIN,
+            translation_key="auth_failed",
+            translation_placeholders={"error": str(ex)},
         ) from ex
     except ConnectionFailed as ex:
         raise ConfigEntryNotReady(
-            f"Omada controller could not be reached: {ex}"
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"error": str(ex)},
         ) from ex
 
     except OmadaClientException as ex:
         raise ConfigEntryNotReady(
-            f"Unexpected error connecting to Omada controller: {ex}"
+            translation_domain=DOMAIN,
+            translation_key="unexpected_error",
+            translation_placeholders={"error": str(ex)},
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -56,20 +56,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="auth_failed",
-            translation_placeholders={"error": str(ex)},
         ) from ex
     except ConnectionFailed as ex:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
-            translation_placeholders={"error": str(ex)},
         ) from ex
 
     except OmadaClientException as ex:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="unexpected_error",
-            translation_placeholders={"error": str(ex)},
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -18,6 +18,8 @@ from tplink_omada_client.exceptions import OmadaClientException
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from . import OmadaConfigEntry
 
@@ -60,7 +62,11 @@ class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
             async with asyncio.timeout(10):
                 return await self.poll_update()
         except OmadaClientException as err:
-            raise UpdateFailed(f"Error communicating with API: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def poll_update(self) -> dict[str, _T]:
         """Poll the current data from the controller."""

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -65,7 +65,6 @@ class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="api_error",
-                translation_placeholders={"error": str(err)},
             ) from err
 
     async def poll_update(self) -> dict[str, _T]:

--- a/homeassistant/components/tplink_omada/quality_scale.yaml
+++ b/homeassistant/components/tplink_omada/quality_scale.yaml
@@ -64,7 +64,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -25,20 +25,27 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
             call.data[ATTR_CONFIG_ENTRY_ID]
         )
         if not entry:
-            raise ServiceValidationError("Specified TP-Link Omada controller not found")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_not_found",
+            )
     else:
         # Assume first loaded entry if none specified
         # (for backward compatibility/99% use case)
         entries = call.hass.config_entries.async_entries(DOMAIN)
         if len(entries) == 0:
-            raise ServiceValidationError("No active TP-Link Omada controllers found")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_controllers",
+            )
         entry = entries[0]
 
     entry = cast(ConfigEntry[OmadaSiteController], entry)
 
     if entry.state is not ConfigEntryState.LOADED:
         raise ServiceValidationError(
-            "The TP-Link Omada integration is not currently available"
+            translation_domain=DOMAIN,
+            translation_key="controller_unavailable",
         )
     return entry.runtime_data
 
@@ -64,7 +71,11 @@ async def _handle_reconnect_client(call: ServiceCall) -> None:
     try:
         await controller.omada_client.reconnect_client(mac)
     except OmadaClientException as ex:
-        raise HomeAssistantError(f"Failed to reconnect client with MAC {mac}") from ex
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="reconnect_failed",
+            translation_placeholders={"mac": mac},
+        ) from ex
 
 
 SERVICES = [

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -132,6 +132,9 @@
     },
     "unexpected_error": {
       "message": "Unexpected error connecting to Omada controller."
+    },
+    "unsupported_controller": {
+      "message": "Omada controller version not supported."
     }
   },
   "services": {

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -117,5 +117,31 @@
       },
       "name": "Reconnect wireless client"
     }
+  },
+  "exceptions": {
+    "api_error": {
+      "message": "Failed to communicate with the Omada controller: {error}"
+    },
+    "auth_failed": {
+      "message": "Omada controller refused login attempt: {error}"
+    },
+    "cannot_connect": {
+      "message": "Omada controller could not be reached: {error}"
+    },
+    "controller_not_found": {
+      "message": "Specified TP-Link Omada controller not found"
+    },
+    "controller_unavailable": {
+      "message": "The TP-Link Omada integration is not currently available"
+    },
+    "no_controllers": {
+      "message": "No active TP-Link Omada controllers found"
+    },
+    "reconnect_failed": {
+      "message": "Failed to reconnect client with MAC {mac}"
+    },
+    "unexpected_error": {
+      "message": "Unexpected error connecting to Omada controller: {error}"
+    }
   }
 }

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -102,22 +102,6 @@
       }
     }
   },
-  "services": {
-    "reconnect_client": {
-      "description": "Tries to get wireless client to reconnect to Omada network.",
-      "fields": {
-        "config_entry_id": {
-          "description": "The instance of the Omada integration to which the client is connected.",
-          "name": "Omada controller"
-        },
-        "mac": {
-          "description": "MAC address of the device.",
-          "name": "MAC address"
-        }
-      },
-      "name": "Reconnect wireless client"
-    }
-  },
   "exceptions": {
     "api_error": {
       "message": "Failed to communicate with the Omada controller: {error}"
@@ -142,6 +126,22 @@
     },
     "unexpected_error": {
       "message": "Unexpected error connecting to Omada controller: {error}"
+    }
+  },
+  "services": {
+    "reconnect_client": {
+      "description": "Tries to get wireless client to reconnect to Omada network.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The instance of the Omada integration to which the client is connected.",
+          "name": "Omada controller"
+        },
+        "mac": {
+          "description": "MAC address of the device.",
+          "name": "MAC address"
+        }
+      },
+      "name": "Reconnect wireless client"
     }
   }
 }

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -130,6 +130,9 @@
     "reconnect_failed": {
       "message": "Failed to reconnect client with MAC {mac}"
     },
+    "switch_action_failed": {
+      "message": "Failed to update the switch."
+    },
     "unexpected_error": {
       "message": "Unexpected error connecting to Omada controller."
     },

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -104,19 +104,25 @@
   },
   "exceptions": {
     "api_error": {
-      "message": "Failed to communicate with the Omada controller: {error}"
+      "message": "Failed to communicate with the Omada controller."
     },
     "auth_failed": {
-      "message": "Omada controller refused login attempt: {error}"
+      "message": "Omada controller refused login attempt."
     },
     "cannot_connect": {
-      "message": "Omada controller could not be reached: {error}"
+      "message": "Omada controller could not be reached."
     },
     "controller_not_found": {
       "message": "Specified TP-Link Omada controller not found"
     },
     "controller_unavailable": {
       "message": "The TP-Link Omada integration is not currently available"
+    },
+    "firmware_update_failed": {
+      "message": "Unable to send firmware update request. Check the controller is online."
+    },
+    "firmware_update_rejected": {
+      "message": "Firmware update request rejected"
     },
     "no_controllers": {
       "message": "No active TP-Link Omada controllers found"
@@ -125,7 +131,7 @@
       "message": "Failed to reconnect client with MAC {mac}"
     },
     "unexpected_error": {
-      "message": "Unexpected error connecting to Omada controller: {error}"
+      "message": "Unexpected error connecting to Omada controller."
     }
   },
   "services": {

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -26,14 +26,17 @@ from tplink_omada_client.devices import (
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
+from tplink_omada_client.exceptions import OmadaClientException
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
+from .const import DOMAIN
 from .controller import OmadaGatewayCoordinator, OmadaSwitchPortCoordinator
 from .coordinator import OmadaCoordinator
 from .entity import OmadaDeviceEntity, get_switch_port_base_name
@@ -293,9 +296,18 @@ class OmadaDevicePortSwitchEntity[
         self._do_update()
 
     async def _async_turn_on_off(self, enable: bool) -> None:
-        updated_details = await self.entity_description.set_func(
-            self.coordinator.omada_client, self._device, self._port_details, enable
-        )
+        try:
+            updated_details = await self.entity_description.set_func(
+                self.coordinator.omada_client,
+                self._device,
+                self._port_details,
+                enable,
+            )
+        except OmadaClientException as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_action_failed",
+            ) from ex
 
         if updated_details:
             self._port_details = updated_details

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
+from .const import DOMAIN
 from .coordinator import OmadaFirmwareUpdateCoordinator
 from .entity import OmadaDeviceEntity
 
@@ -85,11 +86,14 @@ class OmadaDeviceUpdate(
                 self.coordinator.data[self._mac].device
             )
         except RequestFailed as ex:
-            raise HomeAssistantError("Firmware update request rejected") from ex
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="firmware_update_rejected",
+            ) from ex
         except OmadaClientException as ex:
             raise HomeAssistantError(
-                "Unable to send Firmware update request."
-                " Check the controller is online."
+                translation_domain=DOMAIN,
+                translation_key="firmware_update_failed",
             ) from ex
         finally:
             await self.coordinator.async_request_refresh()

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -83,11 +83,14 @@ async def test_coordinator_update_failure_is_translated(
     coordinator = OmadaCoordinator(
         hass, mock_config_entry, mock_omada_site_client, "test"
     )
-    with patch.object(
-        OmadaCoordinator,
-        "poll_update",
-        side_effect=OmadaClientException("boom"),
-    ), pytest.raises(UpdateFailed) as err:
+    with (
+        patch.object(
+            OmadaCoordinator,
+            "poll_update",
+            side_effect=OmadaClientException("boom"),
+        ),
+        pytest.raises(UpdateFailed) as err,
+    ):
         await coordinator._async_update_data()
 
     assert err.value.translation_domain == DOMAIN

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -34,7 +34,7 @@ MOCK_ENTRY_DATA = {
         (
             UnsupportedControllerVersion("4.0.0"),
             ConfigEntryState.SETUP_ERROR,
-            "auth_failed",
+            "unsupported_controller",
         ),
         (
             LoginFailed(401, "invalid credentials"),

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,18 +1,21 @@
 """Tests for TP-Link Omada integration init."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
+    LoginFailed,
     OmadaClientException,
     UnsupportedControllerVersion,
 )
 
 from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.coordinator import OmadaCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from tests.common import MockConfigEntry
 
@@ -26,19 +29,27 @@ MOCK_ENTRY_DATA = {
 
 
 @pytest.mark.parametrize(
-    ("side_effect", "entry_state"),
+    ("side_effect", "entry_state", "translation_key"),
     [
         (
             UnsupportedControllerVersion("4.0.0"),
             ConfigEntryState.SETUP_ERROR,
+            "auth_failed",
+        ),
+        (
+            LoginFailed(401, "invalid credentials"),
+            ConfigEntryState.SETUP_ERROR,
+            "auth_failed",
         ),
         (
             ConnectionFailed(),
             ConfigEntryState.SETUP_RETRY,
+            "cannot_connect",
         ),
         (
             OmadaClientException(),
             ConfigEntryState.SETUP_RETRY,
+            "unexpected_error",
         ),
     ],
 )
@@ -48,6 +59,7 @@ async def test_setup_entry_login_failed_raises_configentryauthfailed(
     mock_config_entry: MockConfigEntry,
     side_effect: OmadaClientException,
     entry_state: ConfigEntryState,
+    translation_key: str,
 ) -> None:
     """Test setup entry with login failed raises ConfigEntryAuthFailed."""
     mock_omada_client.login.side_effect = side_effect
@@ -58,6 +70,28 @@ async def test_setup_entry_login_failed_raises_configentryauthfailed(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is entry_state
+    assert mock_config_entry.error_reason_translation_key == translation_key
+    assert mock_config_entry.error_reason_translation_placeholders is None
+
+
+async def test_coordinator_update_failure_is_translated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_site_client: MagicMock,
+) -> None:
+    """Test coordinator API failures raise a translated UpdateFailed."""
+    coordinator = OmadaCoordinator(
+        hass, mock_config_entry, mock_omada_site_client, "test"
+    )
+    with patch.object(
+        OmadaCoordinator,
+        "poll_update",
+        side_effect=OmadaClientException("boom"),
+    ), pytest.raises(UpdateFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "api_error"
 
 
 async def test_missing_devices_removed_at_startup(

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -21,15 +21,15 @@ async def test_service_reconnect_no_config_entries(
     async_setup_services(hass)
 
     mac = "AA:BB:CC:DD:EE:FF"
-    with pytest.raises(
-        ServiceValidationError, match="No active TP-Link Omada controllers found"
-    ):
+    with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
             "reconnect_client",
             {"mac": mac},
             blocking=True,
         )
+    assert err.value.translation_key == "no_controllers"
+    assert err.value.translation_domain == DOMAIN
 
 
 async def test_service_reconnect_client(
@@ -68,15 +68,15 @@ async def test_service_reconnect_failed_with_invalid_entry(
     await hass.async_block_till_done()
 
     mac = "AA:BB:CC:DD:EE:FF"
-    with pytest.raises(
-        ServiceValidationError, match="Specified TP-Link Omada controller not found"
-    ):
+    with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
             "reconnect_client",
             {"config_entry_id": "invalid_entry_id", "mac": mac},
             blocking=True,
         )
+    assert err.value.translation_key == "controller_not_found"
+    assert err.value.translation_domain == DOMAIN
 
 
 async def test_service_reconnect_without_config_entry_id(
@@ -122,16 +122,15 @@ async def test_service_reconnect_entry_not_loaded(
     unloaded_entry.add_to_hass(hass)
 
     mac = "AA:BB:CC:DD:EE:FF"
-    with pytest.raises(
-        ServiceValidationError,
-        match="The TP-Link Omada integration is not currently available",
-    ):
+    with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
             "reconnect_client",
             {"config_entry_id": unloaded_entry.entry_id, "mac": mac},
             blocking=True,
         )
+    assert err.value.translation_key == "controller_unavailable"
+    assert err.value.translation_domain == DOMAIN
 
 
 async def test_service_reconnect_failed_raises_homeassistanterror(
@@ -149,12 +148,15 @@ async def test_service_reconnect_failed_raises_homeassistanterror(
 
     mac = "AA:BB:CC:DD:EE:FF"
     mock_omada_site_client.reconnect_client.side_effect = OmadaClientException
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
             DOMAIN,
             "reconnect_client",
             {"config_entry_id": mock_config_entry.entry_id, "mac": mac},
             blocking=True,
         )
+    assert err.value.translation_key == "reconnect_failed"
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_placeholders == {"mac": mac}
 
     mock_omada_site_client.reconnect_client.assert_awaited_once_with(mac)

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -217,18 +217,33 @@ async def test_gateway_port_poe_switch(
     assert entity and entity.state == "on"
 
 
+@pytest.mark.parametrize(
+    ("entity_id", "service", "api_method"),
+    [
+        ("switch.test_poe_switch_port_1_poe", "turn_off", "update_switch_port"),
+        (
+            "switch.test_router_port_4_internet_connected",
+            "turn_on",
+            "set_gateway_wan_port_connect_state",
+        ),
+        ("switch.test_router_port_5_poe", "turn_off", "set_gateway_port_settings"),
+    ],
+)
 async def test_switch_action_failure_is_translated(
     hass: HomeAssistant,
     mock_omada_site_client: MagicMock,
     init_integration: MockConfigEntry,
+    entity_id: str,
+    service: str,
+    api_method: str,
 ) -> None:
     """Test switch action failures raise a translated HomeAssistantError."""
-    mock_omada_site_client.update_switch_port.side_effect = OmadaClientException(
+    getattr(mock_omada_site_client, api_method).side_effect = OmadaClientException(
         "mock failure"
     )
 
     with pytest.raises(HomeAssistantError) as err:
-        await call_service(hass, "turn_off", "switch.test_poe_switch_port_1_poe")
+        await call_service(hass, service, entity_id)
 
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == "switch_action_failed"

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -17,13 +17,14 @@ from tplink_omada_client.devices import (
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
-from tplink_omada_client.exceptions import InvalidDevice
+from tplink_omada_client.exceptions import InvalidDevice, OmadaClientException
 
 from homeassistant.components import switch
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_GATEWAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceResponse
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -214,6 +215,23 @@ async def test_gateway_port_poe_switch(
 
     entity = hass.states.get(entity_id)
     assert entity and entity.state == "on"
+
+
+async def test_switch_action_failure_is_translated(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test switch action failures raise a translated HomeAssistantError."""
+    mock_omada_site_client.update_switch_port.side_effect = OmadaClientException(
+        "mock failure"
+    )
+
+    with pytest.raises(HomeAssistantError) as err:
+        await call_service(hass, "turn_off", "switch.test_poe_switch_port_1_poe")
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "switch_action_failed"
 
 
 async def test_gateway_wan_port_has_no_poe_switch(

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -9,6 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
+from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
@@ -131,15 +132,15 @@ async def test_install_firmware_success(
 
 
 @pytest.mark.parametrize(
-    ("exception_type", "error_message"),
+    ("exception_type", "translation_key"),
     [
         (
             RequestFailed(500, "Update rejected"),
-            "Firmware update request rejected",
+            "firmware_update_rejected",
         ),
         (
             OmadaClientException("Connection error"),
-            "Unable to send Firmware update request. Check the controller is online.",
+            "firmware_update_failed",
         ),
     ],
 )
@@ -148,7 +149,7 @@ async def test_install_firmware_exceptions(
     init_integration: MockConfigEntry,
     mock_omada_site_client: MagicMock,
     exception_type: Exception,
-    error_message: str,
+    translation_key: str,
 ) -> None:
     """Test firmware installation exception handling."""
     entity_id = "update.test_poe_switch_firmware"
@@ -159,16 +160,16 @@ async def test_install_firmware_exceptions(
     )
 
     # Call install service and expect error
-    with pytest.raises(
-        HomeAssistantError,
-        match=error_message,
-    ):
+    with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
+
+    assert err.value.translation_key == translation_key
+    assert err.value.translation_domain == DOMAIN
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All exceptions raised by the TP-Link Omada integration now use `translation_domain`/`translation_key`/`translation_placeholders` instead of hardcoded English messages: the coordinator's `UpdateFailed`, `ConfigEntryAuthFailed`/`ConfigEntryNotReady` on entry setup, and the reconnect-client service's `ServiceValidationError`/`HomeAssistantError`. Completes the gold-tier `exception-translations` quality scale rule.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: quality scale `exception-translations` rule (todo to done)
- Link to documentation pull request: N/A - Implements the translation pattern requested for this integration in #180001.
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
