### PR TITLE
Do not create template entities when action validation fails during setup

### DIFF
--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -133,10 +133,10 @@ async def validate_template_scripts(
     hass: HomeAssistant,
     config: ConfigType,
     script_options: tuple[str, ...] | None = None,
-) -> None:
+) -> bool:
     """Validate template scripts."""
     if not script_options:
-        return
+        return True
 
     def _humanize(err: Exception, data: Any) -> str:
         """Humanize vol.Invalid, stringify other exceptions."""
@@ -160,6 +160,9 @@ async def validate_template_scripts(
                     breadcrumb,
                     _humanize(err, script_config),
                 )
+                return False
+
+    return True
 
 
 def async_create_platform_template_not_supported_issue(
@@ -199,15 +202,12 @@ async def async_setup_template_platform(
     # Trigger Configuration
     if "coordinator" in discovery_info:
         if trigger_entity_cls:
-            entities = []
-            for entity_config in discovery_info["entities"]:
-                await validate_template_scripts(hass, entity_config, script_options)
-                entities.append(
-                    trigger_entity_cls(
-                        hass, discovery_info["coordinator"], entity_config
-                    )
-                )
-            async_add_entities(entities)
+            if trigger_entities := [
+                trigger_entity_cls(hass, discovery_info["coordinator"], entity_config)
+                for entity_config in discovery_info["entities"]
+                if await validate_template_scripts(hass, entity_config, script_options)
+            ]:
+                async_add_entities(trigger_entities)
         else:
             raise PlatformNotReady(
                 f"The template {domain} platform doesn't support trigger entities"
@@ -215,16 +215,18 @@ async def async_setup_template_platform(
         return
 
     # Modern Configuration
-    for entity_config in discovery_info["entities"]:
-        await validate_template_scripts(hass, entity_config, script_options)
-
-    async_create_template_tracking_entities(
-        state_entity_cls,
-        async_add_entities,
-        hass,
-        discovery_info["entities"],
-        discovery_info["unique_id"],
-    )
+    if state_entities := [
+        entity_config
+        for entity_config in discovery_info["entities"]
+        if await validate_template_scripts(hass, entity_config, script_options)
+    ]:
+        async_create_template_tracking_entities(
+            state_entity_cls,
+            async_add_entities,
+            hass,
+            state_entities,
+            discovery_info["unique_id"],
+        )
 
 
 async def async_setup_template_entry(
@@ -247,11 +249,10 @@ async def async_setup_template_entry(
         options[CONF_STATE] = options.pop(CONF_VALUE_TEMPLATE)
 
     validated_config = config_schema(options)
-    await validate_template_scripts(hass, validated_config, script_options)
-
-    async_add_entities(
-        [state_entity_cls(hass, validated_config, config_entry.entry_id)]
-    )
+    if await validate_template_scripts(hass, validated_config, script_options):
+        async_add_entities(
+            [state_entity_cls(hass, validated_config, config_entry.entry_id)]
+        )
 
 
 def async_setup_template_preview[T: TemplateEntity](

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
+    MockConfigEntry,
     assert_setup_component,
     async_mock_service,
     mock_restore_cache,
@@ -290,6 +291,74 @@ async def start_ha(
 async def caplog_setup_text(caplog: pytest.LogCaptureFixture) -> str:
     """Return setup log of integration."""
     return caplog.text
+
+
+def _create_bad_action_config(action: str, config: ConfigType) -> ConfigType:
+    """Create a bad device action."""
+    return {
+        action: {
+            "type": "turn_off",
+            "device_id": "70c5f67ec2f82f9ba128fe6e99eb7dfa",
+            "entity_id": "c7e6f3753cb18937f2147bbbdccdd949",
+            "domain": "light",
+        },
+        **config,
+    }
+
+
+async def assert_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    platform_setup: TemplatePlatformSetup,
+    style: ConfigurationStyle,
+    config: ConfigType,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Assert invalid yaml actions on entity services do not create entities."""
+
+    await setup_entity(
+        hass,
+        platform_setup,
+        style,
+        1,
+        {
+            "default_entity_id": platform_setup.entity_id,
+            **_create_bad_action_config(action, config),
+        },
+    )
+    assert len(hass.states.async_all(platform_setup.domain)) == 0
+
+    error = f"The '{action}' actions for {platform_setup.object_id} failed to setup: Unknown device '70c5f67ec2f82f9ba128fe6e99eb7dfa'"
+    assert error in caplog.text
+
+
+async def assert_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    platform_setup: TemplatePlatformSetup,
+    config: ConfigType,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Assert invalid config entry actions on entity services do not create entities."""
+
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=template.DOMAIN,
+        options={
+            "name": platform_setup.object_id,
+            "template_type": platform_setup.domain,
+            **_create_bad_action_config(action, config),
+        },
+        title="My template",
+    )
+    template_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all(platform_setup.domain)) == 0
+
+    error = f"The '{action}' actions for {platform_setup.object_id} failed to setup: Unknown device '70c5f67ec2f82f9ba128fe6e99eb7dfa'"
+    assert error in caplog.text
 
 
 async def async_get_flow_preview_state(

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -11,7 +11,10 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityStateAttribute,
     AlarmControlPanelState,
 )
-from homeassistant.components.template.alarm_control_panel import DEFAULT_NAME
+from homeassistant.components.template.alarm_control_panel import (
+    DEFAULT_NAME,
+    SCRIPT_FIELDS,
+)
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -24,6 +27,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -795,6 +800,34 @@ async def test_invalid_availability_template_keeps_component_available(
     assert hass.states.get(TEST_PANEL.entity_id).state != STATE_UNAVAILABLE
     error = "UndefinedError: 'x' is undefined"
     assert error in caplog_setup_text or error in caplog.text
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_PANEL, style, {}, action, caplog
+    )
+
+
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_PANEL, {}, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -8,7 +8,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.template import DOMAIN
-from homeassistant.components.template.button import DEFAULT_NAME
+from homeassistant.components.template.button import DEFAULT_NAME, SCRIPT_FIELDS
 from homeassistant.components.template.const import CONF_PICTURE
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
@@ -31,6 +31,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     async_trigger,
     make_test_action,
     setup_and_test_nested_unique_id,
@@ -383,6 +385,34 @@ async def test_invalid_availability_template_keeps_component_available(
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get(TEST_BUTTON.entity_id).state != STATE_UNAVAILABLE
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_BUTTON, style, {}, action, caplog
+    )
+
+
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_BUTTON, {}, action, caplog
+    )
 
 
 async def test_extra_template_attributes(hass: HomeAssistant) -> None:

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -38,6 +38,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -1289,6 +1291,54 @@ async def test_restore_state(
     assert state.state == final_state
     assert state.attributes["current_position"] == 75
     assert state.attributes["current_tilt_position"] == 75
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("open_cover", {"close_cover": []}),
+        ("close_cover", {"open_cover": []}),
+        ("set_cover_position", COVER_ACTIONS),
+        ("stop_cover", COVER_ACTIONS),
+        ("set_cover_tilt_position", COVER_ACTIONS),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_COVER, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("open_cover", {"close_cover": []}),
+        ("close_cover", {"open_cover": []}),
+        ("set_cover_position", COVER_ACTIONS),
+        ("stop_cover", COVER_ACTIONS),
+        ("set_cover_tilt_position", COVER_ACTIONS),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_COVER, config, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -31,6 +31,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -1616,6 +1618,56 @@ async def test_restore_state(
     assert state.attributes["preset_mode"] == "low"
     assert state.attributes["oscillating"] is True
     assert state.attributes["direction"] == DIRECTION_REVERSE
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+        ("set_direction", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_oscillating", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_percentage", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_preset_mode", OPTIMISTIC_ON_OFF_ACTIONS),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_FAN, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+        ("set_direction", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_oscillating", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_percentage", OPTIMISTIC_ON_OFF_ACTIONS),
+        ("set_preset_mode", OPTIMISTIC_ON_OFF_ACTIONS),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_FAN, config, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -43,6 +43,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -2236,6 +2238,78 @@ async def test_saving_state(
         "supported_color_modes": ["brightness"],
         "xy_color": None,
     }
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+        (
+            "set_effect",
+            {
+                "effect_list": "{{ ['Disco', 'Police'] }}",
+                "effect": "{{ None }}",
+                **ON_OFF_ACTIONS,
+            },
+        ),
+        ("set_hs", ON_OFF_ACTIONS),
+        ("set_level", ON_OFF_ACTIONS),
+        ("set_rgb", ON_OFF_ACTIONS),
+        ("set_rgbw", ON_OFF_ACTIONS),
+        ("set_rgbww", ON_OFF_ACTIONS),
+        ("set_temperature", ON_OFF_ACTIONS),
+        ("set_xy", ON_OFF_ACTIONS),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_LIGHT, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+        (
+            "set_effect",
+            {
+                "effect_list": "{{ ['Disco', 'Police'] }}",
+                "effect": "{{ None }}",
+                **ON_OFF_ACTIONS,
+            },
+        ),
+        ("set_hs", ON_OFF_ACTIONS),
+        ("set_level", ON_OFF_ACTIONS),
+        ("set_rgb", ON_OFF_ACTIONS),
+        ("set_rgbw", ON_OFF_ACTIONS),
+        ("set_rgbww", ON_OFF_ACTIONS),
+        ("set_temperature", ON_OFF_ACTIONS),
+        ("set_xy", ON_OFF_ACTIONS),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_LIGHT, config, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -30,6 +30,8 @@ from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -1160,6 +1162,50 @@ async def test_restore_state(
     # The first trigger should replace the restored code_format attribute
     assert_state_and_attributes(
         hass, TEST_LOCK, LockState.UNLOCKED, {"code_format": "\\\\d+"}
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("lock", UNLOCK_ACTION),
+        ("unlock", LOCK_ACTION),
+        ("open", {**LOCK_ACTION, **UNLOCK_ACTION}),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_LOCK, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("lock", UNLOCK_ACTION),
+        ("unlock", LOCK_ACTION),
+        ("open", {**LOCK_ACTION, **UNLOCK_ACTION}),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_LOCK, config, action, caplog
     )
 
 

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -37,6 +37,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -749,6 +751,45 @@ async def test_restore_state(
         TEST_NUMBER,
         "30.0",
         {"step": 3, "min": 3, "max": 60},
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass,
+        TEST_NUMBER,
+        style,
+        {
+            "state": "0",
+            "step": "1",
+        },
+        "set_value",
+        caplog,
+    )
+
+
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass,
+        TEST_NUMBER,
+        {
+            "state": "0",
+            "step": 1,
+        },
+        "set_value",
+        caplog,
     )
 
 

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -35,6 +35,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -687,6 +689,39 @@ async def test_restore_state(
         {
             "options": ["something", "anything", "something_new"],
         },
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass,
+        TEST_SELECT,
+        style,
+        {"options": "{{ ['test', 'yes', 'no'] }}"},
+        "select_option",
+        caplog,
+    )
+
+
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass,
+        TEST_SELECT,
+        {"options": "{{ ['test', 'yes', 'no'] }}"},
+        "select_option",
+        caplog,
     )
 
 

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -27,6 +27,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -828,6 +830,48 @@ async def test_not_optimistic(hass: HomeAssistant, expected: str) -> None:
 
     state = hass.states.get(TEST_SWITCH.entity_id)
     assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_SWITCH, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        ("turn_on", {"turn_off": []}),
+        ("turn_off", {"turn_on": []}),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_SWITCH, config, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_update.py
+++ b/tests/components/template/test_update.py
@@ -6,7 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import template, update
-from homeassistant.components.template.update import DEFAULT_NAME
+from homeassistant.components.template.update import DEFAULT_NAME, SCRIPT_FIELDS
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_ICON,
@@ -26,6 +26,8 @@ from .conftest import (
     TemplatePlatformSetup,
     assert_action,
     assert_extra_template_attributes,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     async_get_flow_preview_state,
     make_test_action,
     make_test_trigger,
@@ -982,6 +984,34 @@ async def test_flow_preview(
     assert state["state"] == STATE_ON
     assert state["attributes"]["installed_version"] == "1.0"
     assert state["attributes"]["latest_version"] == "2.0"
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_UPDATE, style, TEST_UPDATE_CONFIG, action, caplog
+    )
+
+
+@pytest.mark.parametrize("action", SCRIPT_FIELDS)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_UPDATE, TEST_UPDATE_CONFIG, action, caplog
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -32,6 +32,8 @@ from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_invalid_config_entry_actions_do_not_create_entities,
+    assert_invalid_yaml_actions_do_not_create_entities,
     assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
@@ -1471,3 +1473,70 @@ async def test_saving_state(
         "activity": "docked",
         "fan_speed": "high",
     }
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        (
+            "clean_segments",
+            {
+                "segments": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
+                **START_ACTION,
+                "unique_id": "5adfasdffsfsdafad",
+            },
+        ),
+        ("clean_spot", START_ACTION),
+        ("locate", START_ACTION),
+        ("pause", START_ACTION),
+        ("return_to_base", START_ACTION),
+        ("set_fan_speed", START_ACTION),
+        ("start", {}),
+        ("stop", START_ACTION),
+    ],
+)
+async def test_invalid_yaml_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid yaml actions do not create entities."""
+    await assert_invalid_yaml_actions_do_not_create_entities(
+        hass, TEST_VACUUM, style, config, action, caplog
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "config"),
+    [
+        (
+            "clean_segments",
+            {
+                "segments": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
+                **START_ACTION,
+            },
+        ),
+        ("clean_spot", START_ACTION),
+        ("locate", START_ACTION),
+        ("pause", START_ACTION),
+        ("return_to_base", START_ACTION),
+        ("set_fan_speed", START_ACTION),
+        ("start", {}),
+        ("stop", START_ACTION),
+    ],
+)
+async def test_invalid_config_entry_actions_do_not_create_entities(
+    hass: HomeAssistant,
+    action: str,
+    config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid config entry actions do not create entities."""
+    await assert_invalid_config_entry_actions_do_not_create_entities(
+        hass, TEST_VACUUM, config, action, caplog
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When script validation fails, template integration will silently remove the action and still create the entity.  This changes the behavior, now an error is logged and the entity is not created.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
