### PR TITLE
Avoid a naive datetime.now() in the hassio tests

### DIFF
--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -1,7 +1,6 @@
 """Test supervisor jobs manager."""
 
 from collections.abc import Generator
-from datetime import datetime
 import os
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -52,7 +51,7 @@ async def test_job_manager_setup(hass: HomeAssistant, jobs_info: AsyncMock) -> N
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 extra=None,
                 child_jobs=[
                     Job(
@@ -63,7 +62,7 @@ async def test_job_manager_setup(hass: HomeAssistant, jobs_info: AsyncMock) -> N
                         stage=None,
                         done=False,
                         errors=[],
-                        created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                        created=dt_util.utcnow(),
                         extra=None,
                         child_jobs=[],
                     )
@@ -142,7 +141,7 @@ async def test_job_manager_ws_updates(
                     "stage": None,
                     "done": False,
                     "errors": [],
-                    "created": (created := datetime.now().isoformat()),  # pylint: disable=home-assistant-enforce-naive-now
+                    "created": (created := dt_util.utcnow().isoformat()),
                     "extra": None,
                 },
             },
@@ -306,7 +305,7 @@ async def test_job_manager_reload_on_supervisor_restart(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 extra=None,
                 child_jobs=[],
             )
@@ -384,7 +383,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 extra=None,
                 child_jobs=[],
             )
@@ -428,7 +427,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
                     "stage": None,
                     "done": False,
                     "errors": [],
-                    "created": datetime.now().isoformat(),  # pylint: disable=home-assistant-enforce-naive-now
+                    "created": dt_util.utcnow().isoformat(),
                     "extra": None,
                 },
             },
@@ -457,7 +456,7 @@ async def test_job_manager_periodic_refresh(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 extra=None,
                 child_jobs=[],
             )

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -1,7 +1,7 @@
 """The tests for the hassio update entities."""
 
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import timedelta
 import os
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -276,7 +276,7 @@ async def test_addon_update_progress_startup(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 child_jobs=[],
                 extra={"total": 1234567890},
             )
@@ -853,7 +853,7 @@ async def test_core_update_progress_startup(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                created=dt_util.utcnow(),
                 child_jobs=[],
                 extra={"total": 1234567890},
             )


### PR DESCRIPTION
## Proposed change

The supervisor always sends `created` with an explicit offset — every fixture in `tests/components/hassio/fixtures/` carries values like `"created": "2025-05-14T08:56:22.801143+00:00"` — so `Job.created` is aware in production. These tests build that same field naive, which diverges from what the code under test actually receives and is what the suppression comment was covering.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177806
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
