### PR TITLE
Avoid a naive datetime.now() in the telegram_bot tests

### DIFF
--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -1,7 +1,6 @@
 """Tests for the telegram_bot integration."""
 
 from collections.abc import Generator
-from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -35,6 +34,7 @@ from homeassistant.components.telegram_bot.const import (
 from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import CONF_API_KEY, CONF_PLATFORM, CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -82,7 +82,7 @@ def mock_register_webhook() -> Generator[None]:
             AsyncMock(
                 return_value=WebhookInfo(
                     url="mock url",
-                    last_error_date=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                    last_error_date=dt_util.utcnow(),
                     has_custom_certificate=False,
                     pending_update_count=0,
                 )
@@ -111,7 +111,7 @@ def mock_external_calls() -> Generator[None]:
     test_user = User(123456, "Testbot", True, "mock last name", "mock_bot")
     message = Message(
         message_id=12345,
-        date=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+        date=dt_util.utcnow(),
         chat=Chat(id=123456, type=ChatType.PRIVATE),
     )
 
@@ -130,7 +130,7 @@ def mock_external_calls() -> Generator[None]:
         return [
             Message(
                 message_id=12345 + idx,
-                date=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                date=dt_util.utcnow(),
                 chat=Chat(id=chat_id, type=ChatType.PRIVATE),
             )
             for idx, _ in enumerate(kwargs[ATTR_MEDIA])
@@ -160,7 +160,7 @@ def mock_external_calls() -> Generator[None]:
                     1,
                     Message(
                         1,
-                        datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                        dt_util.utcnow(),
                         Chat(
                             id=123456,
                             type=ChatType.PRIVATE,

--- a/tests/components/telegram_bot/test_notify.py
+++ b/tests/components/telegram_bot/test_notify.py
@@ -1,6 +1,5 @@
 """Test the telegram bot notify platform."""
 
-from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,6 +14,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_capture_events
 
@@ -34,7 +34,7 @@ async def test_send_message(
         AsyncMock(
             return_value=Message(
                 message_id=12345,
-                date=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                date=dt_util.utcnow(),
                 chat=Chat(id=12345678, type=ChatType.PRIVATE),
             )
         ),

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -1,7 +1,6 @@
 """Tests for the telegram_bot component."""
 
 import base64
-from datetime import datetime
 from http import HTTPStatus
 import io
 import os
@@ -102,7 +101,7 @@ from homeassistant.const import (
 from homeassistant.core import Context, Event, HomeAssistant, ServiceResponse
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.issue_registry import IssueRegistry
-from homeassistant.util import json as json_util
+from homeassistant.util import dt as dt_util, json as json_util
 from homeassistant.util.file import write_utf8_file
 
 from tests.common import MockConfigEntry, async_capture_events, async_load_fixture
@@ -287,7 +286,7 @@ async def test_send_message_with_inline_keyboard(
         AsyncMock(
             return_value=Message(
                 message_id=12345,
-                date=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+                date=dt_util.utcnow(),
                 chat=Chat(id=12345678, type=ChatType.PRIVATE),
             )
         ),


### PR DESCRIPTION
## Proposed change

`Message.date` and `WebhookInfo.last_error_date` are built by `python-telegram-bot` through `from_timestamp()`, which is documented to return a timezone aware value and falls back to UTC when the bot carries no `Defaults` — which this integration does not set. So the integration only ever sees aware values for these two fields, while the tests were constructing them naive.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177835
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
