### PR TITLE
Avoid a naive datetime.now() in the flume tests

### DIFF
--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -1,8 +1,8 @@
 """Flume test fixtures."""
 
 from collections.abc import Generator
-import datetime
 from http import HTTPStatus
+import time
 from unittest.mock import patch
 
 import jwt
@@ -102,10 +102,9 @@ TOKEN_SIGNING_KEY = "flume-test-token-signing-key-0123"
 
 def encode_access_token() -> str:
     """Encode the payload of the access token."""
-    expiration_time = datetime.datetime.now() + datetime.timedelta(hours=12)  # pylint: disable=home-assistant-enforce-naive-now
     payload = {
         "user_id": USER_ID,
-        "exp": int(expiration_time.timestamp()),
+        "exp": int(time.time() + 12 * 3600),
     }
     return jwt.encode(payload, key=TOKEN_SIGNING_KEY)
 


### PR DESCRIPTION
## Proposed change

The `expiration_time` datetime existed only to be turned straight back into `int(...timestamp())` for the JWT `exp` claim, which is a plain count of seconds since the epoch. Going through the wall clock to produce it is a detour, so this uses `time.time()` directly, as the epic suggests for values that are only ever seconds.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177798
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
