### PR TITLE
Avoid a naive datetime.now() in the ssdp tests

### DIFF
--- a/tests/components/ssdp/__init__.py
+++ b/tests/components/ssdp/__init__.py
@@ -1,7 +1,5 @@
 """Tests for the SSDP integration."""
 
-from datetime import datetime
-
 from async_upnp_client.ssdp import udn_from_headers
 from async_upnp_client.ssdp_listener import SsdpListener
 from async_upnp_client.utils import CaseInsensitiveDict
@@ -9,6 +7,7 @@ from async_upnp_client.utils import CaseInsensitiveDict
 from homeassistant.components import ssdp
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 
 async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
@@ -20,6 +19,6 @@ async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
 
 def _ssdp_headers(headers) -> CaseInsensitiveDict:
     """Create a CaseInsensitiveDict with headers and a timestamp."""
-    ssdp_headers = CaseInsensitiveDict(headers, _timestamp=datetime.now())  # pylint: disable=home-assistant-enforce-naive-now
+    ssdp_headers = CaseInsensitiveDict(headers, _timestamp=dt_util.naive_now())
     ssdp_headers["_udn"] = udn_from_headers(ssdp_headers)
     return ssdp_headers


### PR DESCRIPTION
## Proposed change

Unlike most of these, this one has to stay naive: `async_upnp_client` stamps `_timestamp` itself with `datetime.now()` when it parses a datagram, and the listener only ever compares that value against others derived from it (`extract_valid_to`, `purge_devices`). Making the test aware would make it disagree with the library, so this uses `dt_util.naive_now()`, which produces the same value without the suppression.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177828
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
