### PR TITLE
Avoid a naive datetime.now() in the suez_water tests

### DIFF
--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -89,8 +89,7 @@ async def test_statistics_no_price(
     suez_client.get_price.side_effect = PySuezError("will fail")
     suez_client.fetch_all_daily_data.return_value = [
         TelemetryMeasure(
-            # pylint: disable-next=home-assistant-enforce-naive-now
-            (datetime.now().date()).strftime("%Y-%m-%d %H:%M:%S"),
+            dt_util.utcnow().date().strftime("%Y-%m-%d %H:%M:%S"),
             0.5,
             0.5,
         )
@@ -106,7 +105,7 @@ async def test_statistics_no_price(
     stats = await hass.async_add_executor_job(
         statistics_during_period,
         hass,
-        datetime.now() - timedelta(days=1),  # pylint: disable=home-assistant-enforce-naive-now
+        dt_util.utcnow() - timedelta(days=1),
         None,
         [statistic_id],
         "hour",
@@ -203,7 +202,7 @@ async def test_statistics(
     # New daily data retrieved
     suez_client.fetch_all_daily_data.return_value = [
         TelemetryMeasure(
-            date=(datetime.now().date()).strftime("%Y-%m-%d %H:%M:%S"),  # pylint: disable=home-assistant-enforce-naive-now
+            date=dt_util.utcnow().date().strftime("%Y-%m-%d %H:%M:%S"),
             volume=0.5,
             index=0.5 * (121 + 1),
         )


### PR DESCRIPTION
## Proposed change

Two different things here.

`statistics_during_period` is documented to take a UTC period, and it was being handed a naive local value, so that one becomes `dt_util.utcnow()`.

The two measure dates become `dt_util.utcnow().date()`. In `test_statistics` the clock is frozen with `freezer.move_to()`, so `datetime.now()` already resolved to UTC there and the value does not change — the snapshots are untouched. `test_statistics_no_price` has no freezer, so that one was reading the machine's zone; the assertion is `is None` either way, but the date no longer depends on where the test runs.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177831
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
