### PR TITLE
Reolink test coverage to 100%

### DIFF
--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -373,48 +373,40 @@ async def test_remove_config_entry_device_rejects_child_device(
     assert device_registry.async_get(child_device.id)
 
 
+@pytest.mark.parametrize(
+    (
+        "support_uid",
+        "id_prefix",
+        "cam_id",
+    ),
+    [
+        (
+            True,
+            TEST_UID,
+            TEST_UID_CAM,
+        ),
+        (
+            False,
+            TEST_MAC,
+            "ch0",
+        ),
+    ],
+)
 async def test_via_device_id_chain(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    reolink_chime: MagicMock,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test the host -> camera -> chime devices are linked via via_device_id."""
-    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-    assert config_entry.state is ConfigEntryState.LOADED
-
-    host_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, TEST_UID), config_entry.entry_id
-    )
-    assert host_device is not None
-
-    camera_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_UID}_{TEST_UID_CAM}"), config_entry.entry_id
-    )
-    assert camera_device is not None
-    assert camera_device.via_device_id == host_device.id
-
-    chime_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_UID}_chime{reolink_chime.dev_id}"), config_entry.entry_id
-    )
-    assert chime_device is not None
-    assert chime_device.via_device_id == camera_device.id
-
-
-async def test_via_device_id_chain_no_uid(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_host: MagicMock,
     reolink_chime: MagicMock,
     device_registry: dr.DeviceRegistry,
+    support_uid: bool,
+    id_prefix: str,
+    cam_id: str,
 ) -> None:
-    """Test the host -> camera -> chime devices are linked via via_device_id when UID not supported."""
+    """Test the host -> camera -> chime devices are linked via via_device_id."""
 
     def mock_supported(ch, capability):
         if capability == "UID":
-            return False
+            return support_uid
         return True
 
     reolink_host.supported = mock_supported
@@ -425,18 +417,18 @@ async def test_via_device_id_chain_no_uid(
     assert config_entry.state is ConfigEntryState.LOADED
 
     host_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, TEST_MAC), config_entry.entry_id
+        (DOMAIN, id_prefix), config_entry.entry_id
     )
     assert host_device is not None
 
     camera_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_MAC}_ch0"), config_entry.entry_id
+        (DOMAIN, f"{id_prefix}_{cam_id}"), config_entry.entry_id
     )
     assert camera_device is not None
     assert camera_device.via_device_id == host_device.id
 
     chime_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_MAC}_chime{reolink_chime.dev_id}"), config_entry.entry_id
+        (DOMAIN, f"{id_prefix}_chime{reolink_chime.dev_id}"), config_entry.entry_id
     )
     assert chime_device is not None
     assert chime_device.via_device_id == camera_device.id

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -403,6 +403,45 @@ async def test_via_device_id_chain(
     assert chime_device.via_device_id == camera_device.id
 
 
+async def test_via_device_id_chain_no_uid(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    reolink_chime: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the host -> camera -> chime devices are linked via via_device_id when UID not supported."""
+
+    def mock_supported(ch, capability):
+        if capability == "UID":
+            return False
+        return True
+
+    reolink_host.supported = mock_supported
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    host_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_MAC), config_entry.entry_id
+    )
+    assert host_device is not None
+
+    camera_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_MAC}_ch0"), config_entry.entry_id
+    )
+    assert camera_device is not None
+    assert camera_device.via_device_id == host_device.id
+
+    chime_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_MAC}_chime{reolink_chime.dev_id}"), config_entry.entry_id
+    )
+    assert chime_device is not None
+    assert chime_device.via_device_id == camera_device.id
+
+
 @pytest.mark.parametrize(
     (
         "original_id",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bring Reolink test coverage back to 100%

The missing line was introduced in PR https://github.com/home-assistant/core/pull/177752

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
