### PR TITLE
Fix Teslemetry tariff calendar crash on hour-24 period boundaries

### DIFF
--- a/homeassistant/components/teslemetry/calendar.py
+++ b/homeassistant/components/teslemetry/calendar.py
@@ -46,6 +46,16 @@ def _is_day_in_range(day_of_week: int, from_day: int, to_day: int) -> bool:
     return day_of_week >= from_day or day_of_week <= to_day
 
 
+def _period_datetime(base_day: datetime, hour: int, minute: int) -> datetime:
+    """Resolve a tariff hour/minute, normalising the hour-24 and minute-60 end-of-boundary encodings."""
+    # Tesla marks an end of day as hour 24 and an end of hour as minute 60, both of
+    # which datetime.replace rejects, so roll the overflow into the hour and day.
+    day_offset, hour = divmod(hour + minute // 60, 24)
+    return base_day.replace(
+        hour=hour, minute=minute % 60, second=0, microsecond=0
+    ) + timedelta(days=day_offset)
+
+
 def _parse_period_times(
     period_def: dict[str, Any],
     base_day: datetime,
@@ -62,18 +72,12 @@ def _parse_period_times(
     if not _is_day_in_range(base_day.weekday(), from_day, to_day):
         return None
 
-    # Hours are from 0-23, so 24 hours is 0-0
-    from_hour = period_def.get("fromHour", 0)
-    to_hour = period_def.get("toHour", 0)
-
-    # Minutes are from 0-59, so 60 minutes is 0-0
-    from_minute = period_def.get("fromMinute", 0)
-    to_minute = period_def.get("toMinute", 0)
-
-    start_time = base_day.replace(
-        hour=from_hour, minute=from_minute, second=0, microsecond=0
+    start_time = _period_datetime(
+        base_day, period_def.get("fromHour", 0), period_def.get("fromMinute", 0)
     )
-    end_time = base_day.replace(hour=to_hour, minute=to_minute, second=0, microsecond=0)
+    end_time = _period_datetime(
+        base_day, period_def.get("toHour", 0), period_def.get("toMinute", 0)
+    )
 
     if end_time <= start_time:
         end_time += timedelta(days=1)

--- a/tests/components/teslemetry/test_calendar.py
+++ b/tests/components/teslemetry/test_calendar.py
@@ -79,6 +79,29 @@ def mock_site_info_invalid_season(mock_site_info) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def mock_site_info_end_of_day(mock_site_info) -> Generator[AsyncMock]:
+    """Mock site_info with a real end-of-day tariff period ending at hour 24."""
+    site_info = deepcopy(SITE_INFO)
+    tariff = site_info["response"]["tariff_content_v2"]
+    # 23:30->24:00 period taken verbatim from a PowerSync Flow Power tariff,
+    # where Tesla encodes the end of the day as hour 24.
+    tariff["energy_charges"]["Summer"]["rates"] = {"PERIOD_23_30": 0.3561}
+    tariff["seasons"]["Summer"]["tou_periods"] = {
+        "PERIOD_23_30": {
+            "periods": [
+                {"toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, "toHour": 24}
+            ]
+        }
+    }
+    tariff["sell_tariff"]["seasons"] = {}
+    with patch(
+        "tesla_fleet_api.tesla.energysite.EnergySite.site_info",
+        side_effect=lambda: deepcopy(site_info),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
 def mock_site_info_invalid_price(mock_site_info) -> Generator[AsyncMock]:
     """Mock site_info with non-numeric price data."""
     site_info = deepcopy(SITE_INFO)
@@ -379,6 +402,44 @@ async def test_calendar_midnight_crossing_local_start(
     assert starts[0].day == 31  # Dec 31 21:00 (previous evening)
     assert starts[1].day == 1  # Jan 1 16:00
     assert starts[2].day == 1  # Jan 1 21:00
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_calendar_end_of_day_period(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_legacy: AsyncMock,
+    mock_site_info_end_of_day: AsyncMock,
+) -> None:
+    """Test a tariff period ending at hour 24 parses instead of crashing."""
+    tz = dt_util.get_default_time_zone()
+    # Sunday 23:45, inside the 23:30->24:00 end-of-day period
+    freezer.move_to(datetime(2024, 1, 7, 23, 45, 0, tzinfo=tz))
+
+    await setup_platform(hass, [Platform.CALENDAR])
+
+    # Before the fix, hour 24 raised ValueError while the state was written
+    state = hass.states.get(ENTITY_BUY)
+    assert state
+    assert state.state == "on"
+
+    result = await hass.services.async_call(
+        CALENDAR_DOMAIN,
+        SERVICE_GET_EVENTS,
+        {
+            ATTR_ENTITY_ID: [ENTITY_BUY],
+            EVENT_START_DATETIME: datetime(2024, 1, 7, 0, 0, 0, tzinfo=tz),
+            EVENT_END_DATETIME: datetime(2024, 1, 8, 0, 0, 0, tzinfo=tz),
+        },
+        blocking=True,
+        return_response=True,
+    )
+    events = result[ENTITY_BUY]["events"]
+    assert len(events) == 1
+    # Hour 24 normalises to the following midnight
+    assert dt_util.parse_datetime(events[0]["end"]) == datetime(
+        2024, 1, 8, 0, 0, 0, tzinfo=tz
+    )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/teslemetry/test_calendar.py
+++ b/tests/components/teslemetry/test_calendar.py
@@ -418,7 +418,6 @@ async def test_calendar_end_of_day_period(
 
     await setup_platform(hass, [Platform.CALENDAR])
 
-    # Before the fix, hour 24 raised ValueError while the state was written
     state = hass.states.get(ENTITY_BUY)
     assert state
     assert state.state == "on"

--- a/tests/components/teslemetry/test_calendar.py
+++ b/tests/components/teslemetry/test_calendar.py
@@ -79,17 +79,19 @@ def mock_site_info_invalid_season(mock_site_info) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_site_info_end_of_day(mock_site_info) -> Generator[AsyncMock]:
-    """Mock site_info with a real end-of-day tariff period ending at hour 24."""
+def mock_site_info_end_of_day(
+    request: pytest.FixtureRequest, mock_site_info
+) -> Generator[AsyncMock]:
+    """Mock site_info with a real end-of-day tariff period ending at the day boundary."""
     site_info = deepcopy(SITE_INFO)
     tariff = site_info["response"]["tariff_content_v2"]
     # 23:30->24:00 period taken verbatim from a PowerSync Flow Power tariff,
-    # where Tesla encodes the end of the day as hour 24.
+    # where Tesla encodes the end of the day as hour 24 or minute 60.
     tariff["energy_charges"]["Summer"]["rates"] = {"PERIOD_23_30": 0.3561}
     tariff["seasons"]["Summer"]["tou_periods"] = {
         "PERIOD_23_30": {
             "periods": [
-                {"toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, "toHour": 24}
+                {"toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, **request.param}
             ]
         }
     }
@@ -405,13 +407,21 @@ async def test_calendar_midnight_crossing_local_start(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    "mock_site_info_end_of_day",
+    [
+        pytest.param({"toHour": 24}, id="hour_24"),
+        pytest.param({"toHour": 23, "toMinute": 60}, id="minute_60"),
+    ],
+    indirect=True,
+)
 async def test_calendar_end_of_day_period(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_legacy: AsyncMock,
     mock_site_info_end_of_day: AsyncMock,
 ) -> None:
-    """Test a tariff period ending at hour 24 parses instead of crashing."""
+    """Test a tariff period ending at the day boundary parses instead of crashing."""
     tz = dt_util.get_default_time_zone()
     # Sunday 23:45, inside the 23:30->24:00 end-of-day period
     freezer.move_to(datetime(2024, 1, 7, 23, 45, 0, tzinfo=tz))
@@ -435,7 +445,7 @@ async def test_calendar_end_of_day_period(
     )
     events = result[ENTITY_BUY]["events"]
     assert len(events) == 1
-    # Hour 24 normalises to the following midnight
+    # The day boundary normalises to the following midnight
     assert dt_util.parse_datetime(events[0]["end"]) == datetime(
         2024, 1, 8, 0, 0, 0, tzinfo=tz
     )


### PR DESCRIPTION
## Proposed change

The Teslemetry Energy Site tariff calendar passes tariff hour/minute values straight into `datetime.replace()`. Tesla encodes the end of a day as `"toHour": 24` and the end of an hour as minute 60, both of which `replace` rejects with `ValueError: hour must be in 0..23`. The exception escapes `_handle_coordinator_update`, so the calendar entity fails to write its state on every coordinator update whenever a tariff contains such a period.

A `_period_datetime` helper now normalises the hour-24 and minute-60 end-of-boundary encodings for both the start and end of a period by rolling the overflow into the hour and day. In-range values keep their existing behaviour, and the pre-existing end-before-start rollover still applies.

`_parse_period_times` landed on 2026-06-19 already carrying comments describing this normalisation ("Hours are from 0-23, so 24 hours is 0-0") but never implementing it, so it has been broken since it was introduced. A regression test covers a real 23:30->24:00 end-of-day period.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
