### PR TITLE
Write the google_sheets created column in the configured time zone

### DIFF
--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -1,6 +1,5 @@
 """Support for Google Sheets."""
 
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from google.auth.exceptions import RefreshError
@@ -21,6 +20,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.selector import ConfigEntrySelector
+from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
 from .const import DOMAIN
@@ -69,7 +69,7 @@ def _append_to_sheet(call: ServiceCall, entry: GoogleSheetsConfigEntry) -> None:
     worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
     columns: list[str] = next(iter(worksheet.get_values("A1:ZZ1")), [])
     add_created_column = call.data[ADD_CREATED_COLUMN]
-    now = str(datetime.now())  # pylint: disable=home-assistant-enforce-naive-now
+    now = str(dt_util.now())
     rows = []
     for d in call.data[DATA]:
         row_data = ({"created": now} | d) if add_created_column else d

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -268,13 +268,13 @@ async def test_setup_oauth_transient_error(
 @pytest.mark.parametrize(
     ("add_created_column_param", "expected_row"),
     [
-        ({ADD_CREATED_COLUMN: True}, ["bar", "2024-01-15 12:30:45.123456"]),
+        ({ADD_CREATED_COLUMN: True}, ["bar", "2024-01-15 04:30:45.123456-08:00"]),
         ({ADD_CREATED_COLUMN: False}, ["bar", ""]),
-        ({}, ["bar", "2024-01-15 12:30:45.123456"]),
+        ({}, ["bar", "2024-01-15 04:30:45.123456-08:00"]),
     ],
     ids=["created_column_true", "created_column_false", "created_column_default"],
 )
-@freeze_time("2024-01-15 12:30:45.123456")
+@freeze_time("2024-01-15 04:30:45.123456-08:00")
 async def test_append_sheet(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
@@ -310,6 +310,42 @@ async def test_append_sheet(
         mock_worksheet.append_rows.assert_called_once()
         rows_data = mock_worksheet.append_rows.call_args[0][0]
         assert rows_data[0] == expected_row
+
+
+@freeze_time("2024-01-15 12:30:45.123456")
+async def test_append_sheet_created_column_uses_configured_time_zone(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test the created column follows the time zone configured in Home Assistant.
+
+    Home Assistant never changes the process time zone, so the machine the
+    installation happens to run on must not decide what is written here.
+    """
+    await hass.config.async_set_time_zone("Australia/Sydney")
+    await setup_integration()
+
+    with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
+        mock_worksheet = (
+            mock_client.return_value.open_by_key.return_value.worksheet.return_value
+        )
+        mock_worksheet.get_values.return_value = [["foo", "created"]]
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_APPEND_SHEET,
+            {
+                DATA_CONFIG_ENTRY: config_entry.entry_id,
+                WORKSHEET: "Sheet1",
+                DATA: {"foo": "bar"},
+                ADD_CREATED_COLUMN: True,
+            },
+            blocking=True,
+        )
+
+        rows_data = mock_worksheet.append_rows.call_args[0][0]
+        assert rows_data[0] == ["bar", "2024-01-15 23:30:45.123456+11:00"]
 
 
 async def test_get_sheet(


### PR DESCRIPTION
## Breaking change

The created column in google_sheets now follows the Home Assistant timezone, rather than the system timezone

## Proposed change

The `created` column was filled from `datetime.now()`, which reads the machine's time zone. Home Assistant never changes the process time zone — `set_default_time_zone()` only sets its own default, there is no `TZ`/`tzset()` anywhere — so on a container started without `TZ` this writes UTC into the user's sheet while the installation is configured for somewhere else, and the string carries nothing to say which zone it is.

`dt_util.now()` uses the configured zone instead, and being aware, `str()` renders the offset.

This does change what lands in the sheet, so it is worth being explicit: for an installation configured as `America/Los_Angeles`, `2024-01-15 12:30:45.123456` becomes `2024-01-15 04:30:45.123456-08:00`. The added test sets a different zone and asserts the value follows it.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177804
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
