### PR TITLE
Fix intent service result attribution

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1129,6 +1129,13 @@ class DynamicServiceIntentHandler(IntentHandler):
         failed_results: list[IntentResponseTarget] = []
         service_results = await asyncio.gather(*service_coros, return_exceptions=True)
         for state, service_result in zip(states, service_results, strict=True):
+            if isinstance(service_result, BaseException) and not isinstance(
+                service_result, Exception
+            ):
+                # Cancellation and other non-Exception base exceptions
+                # propagate, matching the previous behavior.
+                raise service_result
+
             target = IntentResponseTarget(
                 type=IntentResponseTargetType.ENTITY,
                 name=state.name,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1123,22 +1123,27 @@ class DynamicServiceIntentHandler(IntentHandler):
             )
 
         # Handle service calls in parallel, noting failures as they occur.
+        # asyncio.as_completed cannot be used here: it yields results in
+        # completion order, which would misattribute them when zipped with
+        # the submission-ordered states list.
         failed_results: list[IntentResponseTarget] = []
-        for state, service_coro in zip(
-            states, asyncio.as_completed(service_coros), strict=False
-        ):
+        service_results = await asyncio.gather(*service_coros, return_exceptions=True)
+        for state, service_result in zip(states, service_results, strict=True):
             target = IntentResponseTarget(
                 type=IntentResponseTargetType.ENTITY,
                 name=state.name,
                 id=state.entity_id,
             )
 
-            try:
-                await service_coro
-                success_results.append(target)
-            except Exception:
+            if isinstance(service_result, Exception):
                 failed_results.append(target)
-                _LOGGER.exception("Service call failed for %s", state.entity_id)
+                _LOGGER.error(
+                    "Service call failed for %s",
+                    state.entity_id,
+                    exc_info=service_result,
+                )
+            else:
+                success_results.append(target)
 
         if not success_results:
             # If no entities succeeded, raise an error.

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1101,3 +1101,42 @@ async def test_intent_response_dict() -> None:
 
     # The original dict should not be affected by the mutations
     assert response_dict1 == response_dict2
+
+
+async def test_service_result_attribution(hass: HomeAssistant) -> None:
+    """Test that failures are attributed to the entities whose calls failed.
+
+    A service call that fails instantly must not steal the failed label from
+    an entity whose call succeeds more slowly: results arrive in completion
+    order, not submission order.
+    """
+    hass.states.async_set("light.a_slow_ok", "off", {ATTR_FRIENDLY_NAME: "Slow"})
+    hass.states.async_set("light.b_fast_fail", "off", {ATTR_FRIENDLY_NAME: "Fast"})
+
+    async def mock_service(call: ServiceCall) -> None:
+        """Fail instantly for one entity, succeed slowly for the other."""
+        if call.data["entity_id"] == "light.b_fast_fail":
+            raise HomeAssistantError("boom")
+        await asyncio.sleep(0.05)
+
+    hass.services.async_register("light", "turn_on", mock_service)
+
+    handler = intent.ServiceIntentHandler("TestType", "light", "turn_on")
+    intent.async_register(hass, handler)
+
+    result = await intent.async_handle(
+        hass,
+        "test",
+        "TestType",
+        slots={"domain": {"value": "light"}},
+    )
+
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
+    success_ids = {
+        target.id
+        for target in result.success_results
+        if target.type is intent.IntentResponseTargetType.ENTITY
+    }
+    failed_ids = {target.id for target in result.failed_results}
+    assert success_ids == {"light.a_slow_ok"}
+    assert failed_ids == {"light.b_fast_fail"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

`DynamicServiceIntentHandler.async_handle_states` paired submission-ordered `states` with completion-ordered `asyncio.as_completed(service_coros)` results:

```python
for state, service_coro in zip(
    states, asyncio.as_completed(service_coros), strict=False
):
```

Whenever completion order differs from submission order — e.g. some calls raise instantly (domain without a `turn_on` service, unavailable entity) while others succeed after a real device round-trip — success and failure are attributed to the wrong entities. The intent response then reports entities as `failed` that were actually actuated (and vice versa), and the `Service call failed for %s` log line names the wrong entity. Observed in the wild via Assist/LLM consumers: an area-wide `HassTurnOn` turned on all lights in the room, yet the response listed every light as failed (and the actually-failing sensor entities as success), so the voice assistant told the user their lights had not turned on.

This change collects results with `asyncio.gather(return_exceptions=True)`, keeping each result paired with the entity whose call produced it. Non-`Exception` base exceptions (e.g. `asyncio.CancelledError`) are re-raised, matching the previous loop's propagation behavior. Failure logging keeps the traceback via `exc_info`.

The included regression test (`test_service_result_attribution`) fails on the current code — the fast-failing entity is reported as success and the slow-succeeding entity as failed — and passes with this change.



## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #180219
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
