### PR TITLE
Fix ZHA entity registry cleanup on device removal

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1034,9 +1034,23 @@ class ZHAGatewayProxy(EventBase):
                 await asyncio.wait(remove_tasks)
 
         device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+
         reg_device = device_registry.async_get(device.device_id)
         if reg_device is not None:
+            entities_to_cleanup = [
+                entry.entity_id
+                for entry in er.async_entries_for_device(
+                    entity_registry, reg_device.id, include_disabled_entities=True
+                )
+                if entry.platform == DOMAIN
+            ]
+
             device_registry.async_remove_device(reg_device.id)
+
+            for entity_id in entities_to_cleanup:
+                if entity_registry.async_get(entity_id) is not None:
+                    entity_registry.async_remove(entity_id)
 
 
 @callback

--- a/tests/components/zha/test_rename_persistence.py
+++ b/tests/components/zha/test_rename_persistence.py
@@ -1,0 +1,173 @@
+"""Test that renamed ZHA entity IDs persist after a restart."""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from unittest.mock import patch
+
+import pytest
+from zigpy.device import Device
+from zigpy.profiles import zha
+from zigpy.zcl.clusters import general
+
+from homeassistant.components.zha import DOMAIN
+from homeassistant.components.zha.helpers import get_zha_gateway, get_zha_gateway_proxy
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def required_platforms_only():
+    """Only set up required platforms and base platforms."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.BINARY_SENSOR,
+            Platform.BUTTON,
+            Platform.DEVICE_TRACKER,
+            Platform.LIGHT,
+            Platform.NUMBER,
+            Platform.SELECT,
+            Platform.SENSOR,
+            Platform.SWITCH,
+            Platform.SIREN,
+        ),
+    ):
+        yield
+
+
+async def test_entity_id_rename_persists_after_restart(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a renamed entity keeps its new ID after config entry reload."""
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    general.OnOff.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        }
+    )
+
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    switch_entities = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "switch" and entry.platform == DOMAIN
+    ]
+    assert len(switch_entities) == 1, (
+        f"Expected 1 switch entity, got {len(switch_entities)}"
+    )
+
+    switch_entity = switch_entities[0]
+    old_entity_id = switch_entity.entity_id
+    unique_id = switch_entity.unique_id
+
+    new_entity_id = "switch.my_custom_renamed_switch"
+    entity_registry.async_update_entity(old_entity_id, new_entity_id=new_entity_id)
+    await hass.async_block_till_done()
+
+    updated_entity = entity_registry.async_get(new_entity_id)
+    assert updated_entity is not None, "Entity not found with new ID"
+    assert updated_entity.unique_id == unique_id, "Unique ID changed after rename"
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id_after_restart = entity_registry.async_get_entity_id(
+        "switch", DOMAIN, unique_id
+    )
+
+    assert entity_id_after_restart == new_entity_id, (
+        f"BUG: Entity ID reverted to '{entity_id_after_restart}' "
+        f"instead of remaining '{new_entity_id}'"
+    )
+
+
+async def test_device_removal_cleans_up_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that removing a device cleans up its entity registry entries."""
+    await setup_zha()
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    gateway = gateway_proxy.gateway
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    general.OnOff.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        }
+    )
+
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    switch_entities = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "switch" and entry.platform == DOMAIN
+    ]
+    assert len(switch_entities) == 1
+    switch_entity = switch_entities[0]
+    unique_id = switch_entity.unique_id
+    device_id = switch_entity.device_id
+
+    new_entity_id = "switch.my_custom_name"
+    entity_registry.async_update_entity(
+        switch_entity.entity_id, new_entity_id=new_entity_id
+    )
+    await hass.async_block_till_done()
+
+    gateway.device_removed(zigpy_device)
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    await asyncio.sleep(0.2)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_after_removal = entity_registry.async_get_entity_id(
+        "switch", DOMAIN, unique_id
+    )
+    device_after_removal = device_registry.async_get(device_id)
+
+    assert entity_after_removal is None, (
+        f"Entity {entity_after_removal} still exists after device removal"
+    )
+    assert device_after_removal is None, "Device still exists after removal"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix ZHA device removal not cleaning up entity registry entries.

When a ZHA device is removed, its entities were not being explicitly
removed from the entity registry. This caused old entity IDs to be
restored when the device was re-paired, as the registry would match
the same unique IDs to the old entity entries.

The fix snapshots ZHA entities for the device before removal, then
explicitly removes orphaned entity registry entries after the device
is removed from the device registry.

A regression test has been added to verify that device removal properly
cleans up entity registry entries, including renamed entity IDs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180209 
- This PR is related to issue: #180209 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
