### PR TITLE
fix(overkiz): Improve coordinator resilience against transient connectivity and auth errors

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -43,6 +43,7 @@ DEFAULT_HOST: Final = "gateway-xxxx-xxxx-xxxx.local:8443"
 UPDATE_INTERVAL: Final = timedelta(seconds=30)
 UPDATE_INTERVAL_LOCAL: Final = timedelta(seconds=5)
 UPDATE_INTERVAL_ALL_ASSUMED_STATE: Final = timedelta(minutes=60)
+EXECUTION_TTL: Final = 60.0
 
 PLATFORMS: list[Platform] = [
     Platform.ALARM_CONTROL_PANEL,

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -156,7 +156,9 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             ) as exception:
                 LOGGER.debug("Failed to fetch devices during resync", exc_info=True)
                 self._handle_error_reset()
-                raise UpdateFailed(f"Failed to resync devices: {exception}") from exception
+                raise UpdateFailed(
+                    f"Failed to resync devices: {exception}"
+                ) from exception
             else:
                 self._need_full_resync = False
 
@@ -187,8 +189,12 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                 ClientError,
                 OverkizError,
             ) as exception:
-                LOGGER.debug("Failed to relogin after session expiration", exc_info=True)
-                raise UpdateFailed(f"Failed to re-authenticate: {exception}") from exception
+                LOGGER.debug(
+                    "Failed to relogin after session expiration", exc_info=True
+                )
+                raise UpdateFailed(
+                    f"Failed to re-authenticate: {exception}"
+                ) from exception
             else:
                 self._need_full_resync = False
                 return self.devices
@@ -237,7 +243,9 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                 ClientError,
                 OverkizError,
             ) as exception:
-                LOGGER.debug("Failed to reconnect after server disconnect", exc_info=True)
+                LOGGER.debug(
+                    "Failed to reconnect after server disconnect", exc_info=True
+                )
                 raise UpdateFailed(f"Failed to reconnect: {exception}") from exception
             else:
                 self._need_full_resync = False
@@ -246,7 +254,9 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             LOGGER.debug("Overkiz / transport error", exc_info=True)
             self._handle_error_reset()
             self._need_full_resync = True
-            raise UpdateFailed(f"Error fetching Overkiz data: {exception}") from exception
+            raise UpdateFailed(
+                f"Error fetching Overkiz data: {exception}"
+            ) from exception
 
         for event in events:
             LOGGER.debug(event)

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -3,9 +3,10 @@
 from collections.abc import Callable, Coroutine
 from datetime import timedelta
 import logging
+import time
 from typing import TYPE_CHECKING, Any, override
 
-from aiohttp import ClientConnectorError, ServerDisconnectedError
+from aiohttp import ClientConnectorError, ClientError, ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import EventName, ExecutionState, Protocol
 from pyoverkiz.exceptions import (
@@ -13,6 +14,7 @@ from pyoverkiz.exceptions import (
     InvalidEventListenerIdError,
     MaintenanceError,
     NotAuthenticatedError,
+    OverkizError,
     ServiceUnavailableError,
     TooManyConcurrentRequestsError,
     TooManyRequestsError,
@@ -40,7 +42,13 @@ from homeassistant.util.decorator import Registry
 if TYPE_CHECKING:
     from . import OverkizDataConfigEntry
 
-from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES, LOGGER, UPDATE_INTERVAL
+from .const import (
+    DOMAIN,
+    EXECUTION_TTL,
+    IGNORED_OVERKIZ_DEVICES,
+    LOGGER,
+    UPDATE_INTERVAL,
+)
 
 # Events are a discriminated union; each handler narrows to its own subtype.
 EVENT_HANDLERS: Registry[
@@ -77,6 +85,9 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.client = client
         self.devices: dict[str, Device] = {d.device_url: d for d in devices}
         self.executions: dict[str, list[dict[str, str]]] = {}
+        self._executions_registered_at: dict[str, float] = {}
+        self._execution_ttl: float = EXECUTION_TTL
+        self._need_full_resync: bool = False
         self.areas = self._places_to_area(places) if places else None
         self._default_update_interval = UPDATE_INTERVAL
 
@@ -87,45 +98,155 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             and device.ui_class not in IGNORED_OVERKIZ_DEVICES
         )
 
+    def _handle_error_reset(self) -> None:
+        """Reset execution state and restore update interval on error."""
+        self.executions.clear()
+        self._executions_registered_at.clear()
+        self.update_interval = self._default_update_interval
+
+    def track_execution(self, exec_id: str) -> None:
+        """Track execution registration timestamp."""
+        if exec_id not in self.executions:
+            self.executions[exec_id] = []
+        self._executions_registered_at.setdefault(exec_id, time.monotonic())
+
+    def untrack_execution(self, exec_id: str) -> None:
+        """Remove tracked execution."""
+        self.executions.pop(exec_id, None)
+        self._executions_registered_at.pop(exec_id, None)
+
+    def _cleanup_stale_executions(self) -> None:
+        """Clean up executions that have exceeded their TTL."""
+        now = time.monotonic()
+        stale_exec_ids = [
+            exec_id
+            for exec_id, reg_time in self._executions_registered_at.items()
+            if now - reg_time > self._execution_ttl
+        ]
+        for exec_id in stale_exec_ids:
+            LOGGER.debug("Cleaning up stale execution %s", exec_id)
+            self.executions.pop(exec_id, None)
+            self._executions_registered_at.pop(exec_id, None)
+
+        # Track timestamp for any execution added without a timestamp
+        for exec_id in list(self.executions):
+            if exec_id not in self._executions_registered_at:
+                self._executions_registered_at[exec_id] = now
+
     @override
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Overkiz data via event listener."""
+        # Resynchronize full device state if connection was dropped or listener was invalidated
+        if self._need_full_resync:
+            try:
+                self.devices = await self._get_devices()
+            except (BadCredentialsError, OAuth2TokenRequestReauthError) as exception:
+                self._handle_error_reset()
+                raise ConfigEntryAuthFailed("Invalid authentication.") from exception
+            except (
+                NotAuthenticatedError,
+                OAuth2TokenRequestError,
+                TooManyConcurrentRequestsError,
+                TooManyRequestsError,
+                MaintenanceError,
+                ServiceUnavailableError,
+                TimeoutError,
+                ClientError,
+                OverkizError,
+            ) as exception:
+                LOGGER.debug("Failed to fetch devices during resync", exc_info=True)
+                self._handle_error_reset()
+                raise UpdateFailed(f"Failed to resync devices: {exception}") from exception
+            else:
+                self._need_full_resync = False
+
         try:
             events = await self.client.fetch_events()
         except (
             BadCredentialsError,
-            NotAuthenticatedError,
             OAuth2TokenRequestReauthError,
         ) as exception:
+            self._handle_error_reset()
             raise ConfigEntryAuthFailed("Invalid authentication.") from exception
-        except OAuth2TokenRequestError as exception:
-            raise UpdateFailed("Failed to refresh OAuth2 token.") from exception
-        except TooManyConcurrentRequestsError as exception:
-            raise UpdateFailed("Too many concurrent requests.") from exception
-        except TooManyRequestsError as exception:
-            raise UpdateFailed("Too many requests, try again later.") from exception
-        except MaintenanceError as exception:
-            raise UpdateFailed("Server is down for maintenance.") from exception
-        except ServiceUnavailableError as exception:
-            raise UpdateFailed("Server is unavailable.") from exception
-        except InvalidEventListenerIdError as exception:
-            raise UpdateFailed(exception) from exception
-        except (TimeoutError, ClientConnectorError) as exception:
-            LOGGER.debug("Failed to connect", exc_info=True)
-            raise UpdateFailed("Failed to connect.") from exception
-        except ServerDisconnectedError:
-            self.executions = {}
-
-            # During the relogin, similar exceptions can be thrown.
+        except NotAuthenticatedError:
+            self._handle_error_reset()
+            self._need_full_resync = True
             try:
                 await self.client.login()
                 self.devices = await self._get_devices()
-            except (BadCredentialsError, NotAuthenticatedError) as exception:
+            except (BadCredentialsError, OAuth2TokenRequestReauthError) as exception:
                 raise ConfigEntryAuthFailed("Invalid authentication.") from exception
-            except TooManyRequestsError as exception:
-                raise UpdateFailed("Too many requests, try again later.") from exception
+            except (
+                NotAuthenticatedError,
+                OAuth2TokenRequestError,
+                TooManyConcurrentRequestsError,
+                TooManyRequestsError,
+                MaintenanceError,
+                ServiceUnavailableError,
+                TimeoutError,
+                ClientError,
+                OverkizError,
+            ) as exception:
+                LOGGER.debug("Failed to relogin after session expiration", exc_info=True)
+                raise UpdateFailed(f"Failed to re-authenticate: {exception}") from exception
+            else:
+                self._need_full_resync = False
+                return self.devices
+        except OAuth2TokenRequestError as exception:
+            self._handle_error_reset()
+            raise UpdateFailed("Failed to refresh OAuth2 token.") from exception
+        except TooManyConcurrentRequestsError as exception:
+            self._handle_error_reset()
+            raise UpdateFailed("Too many concurrent requests.") from exception
+        except TooManyRequestsError as exception:
+            self._handle_error_reset()
+            raise UpdateFailed("Too many requests, try again later.") from exception
+        except MaintenanceError as exception:
+            self._handle_error_reset()
+            raise UpdateFailed("Server is down for maintenance.") from exception
+        except ServiceUnavailableError as exception:
+            self._handle_error_reset()
+            raise UpdateFailed("Server is unavailable.") from exception
+        except InvalidEventListenerIdError as exception:
+            self._handle_error_reset()
+            self._need_full_resync = True
+            raise UpdateFailed(str(exception)) from exception
+        except (TimeoutError, ClientConnectorError) as exception:
+            LOGGER.debug("Failed to connect", exc_info=True)
+            self._handle_error_reset()
+            self._need_full_resync = True
+            raise UpdateFailed("Failed to connect.") from exception
+        except ServerDisconnectedError:
+            LOGGER.debug("Server disconnected, attempting reconnection", exc_info=True)
+            self._handle_error_reset()
+            self._need_full_resync = True
 
-            return self.devices
+            try:
+                await self.client.login()
+                self.devices = await self._get_devices()
+            except (BadCredentialsError, OAuth2TokenRequestReauthError) as exception:
+                raise ConfigEntryAuthFailed("Invalid authentication.") from exception
+            except (
+                NotAuthenticatedError,
+                OAuth2TokenRequestError,
+                TooManyConcurrentRequestsError,
+                TooManyRequestsError,
+                MaintenanceError,
+                ServiceUnavailableError,
+                TimeoutError,
+                ClientError,
+                OverkizError,
+            ) as exception:
+                LOGGER.debug("Failed to reconnect after server disconnect", exc_info=True)
+                raise UpdateFailed(f"Failed to reconnect: {exception}") from exception
+            else:
+                self._need_full_resync = False
+                return self.devices
+        except (ClientError, OverkizError) as exception:
+            LOGGER.debug("Overkiz / transport error", exc_info=True)
+            self._handle_error_reset()
+            self._need_full_resync = True
+            raise UpdateFailed(f"Error fetching Overkiz data: {exception}") from exception
 
         for event in events:
             LOGGER.debug(event)
@@ -133,7 +254,8 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             if event_handler := EVENT_HANDLERS.get(event.name):
                 await event_handler(self, event)
 
-        # Restore the default update interval if no executions are pending
+        # Clean up stale executions and restore update interval if no executions are pending
+        self._cleanup_stale_executions()
         if not self.executions:
             self.update_interval = self._default_update_interval
 
@@ -227,8 +349,7 @@ async def on_execution_registered(
     coordinator: OverkizDataUpdateCoordinator, event: ExecutionRegisteredEvent
 ) -> None:
     """Handle execution registered event."""
-    if event.exec_id not in coordinator.executions:
-        coordinator.executions[event.exec_id] = []
+    coordinator.track_execution(event.exec_id)
 
     if not coordinator.is_stateless:
         coordinator.update_interval = timedelta(seconds=1)
@@ -243,4 +364,4 @@ async def on_execution_state_changed(
         ExecutionState.COMPLETED,
         ExecutionState.FAILED,
     ]:
-        del coordinator.executions[event.exec_id]
+        coordinator.untrack_execution(event.exec_id)

--- a/tests/components/overkiz/test_adversarial_m5_resilience.py
+++ b/tests/components/overkiz/test_adversarial_m5_resilience.py
@@ -1,0 +1,676 @@
+"""Adversarial stress tests for execution storm prevention and state drift resilience (Milestone M5)."""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from aiohttp import ClientConnectorError, ClientError, ServerDisconnectedError
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName, ExecutionState
+from pyoverkiz.exceptions import (
+    InvalidEventListenerIdError,
+    MaintenanceError,
+    OverkizError,
+    ServiceUnavailableError,
+    TooManyConcurrentRequestsError,
+    TooManyRequestsError,
+)
+from pyoverkiz.models import (
+    DataType,
+    ExecutionRegisteredEvent,
+    ExecutionStateChangedEvent,
+    State,
+    States,
+)
+import pytest
+
+from homeassistant.components.overkiz.const import UPDATE_INTERVAL
+from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import async_deliver_events
+
+from tests.common import async_fire_time_changed
+
+TEMPERATURE_SENSOR = FixtureDevice(
+    "setup/cloud_nexity_rail_din_europe.json",
+    "io://1234-5678-1698/15702199#2",
+    "sensor.maple_residence_garden_radiator_bathroom_temperature_sensor_temperature",
+)
+
+
+# =========================================================================
+# Category 1: 1-Second Polling Storm Prevention & TTL Recovery Scenarios
+# =========================================================================
+
+
+async def test_adversarial_single_execution_dropped_completion_ttl_recovery(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Simulate a single execution whose completion event is permanently dropped.
+
+    Verify coordinator interval drops to 1s, remains 1s during normal execution,
+    and automatically resets to 30s when TTL expires, purging the execution.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    assert coordinator.update_interval == UPDATE_INTERVAL
+    assert coordinator.executions == {}
+
+    # Register an execution
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-storm-1"
+            )
+        ],
+    )
+
+    # Polling frequency increases to 1s
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-storm-1" in coordinator.executions
+    assert "exec-storm-1" in coordinator._executions_registered_at
+
+    # Advance 30 seconds (still within 60s TTL) with empty poll events (no completion)
+    freezer.tick(timedelta(seconds=30))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Still tracking execution at 1s interval
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-storm-1" in coordinator.executions
+
+    # Advance another 35 seconds (total 65s > 60s EXECUTION_TTL)
+    freezer.tick(timedelta(seconds=35))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # TTL expired: execution purged, interval restored to 30s default
+    assert "exec-storm-1" not in coordinator.executions
+    assert "exec-storm-1" not in coordinator._executions_registered_at
+    assert coordinator.executions == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_adversarial_multi_execution_staggered_ttl_and_partial_completion(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Stress test multiple concurrent executions with staggered registration and dropped events.
+
+    Exec A registered at t=0s, Exec B registered at t=20s.
+    Exec A completes at t=30s.
+    Exec B completion event is dropped.
+    Verify Exec B keeps 1s interval until t=85s (its own TTL), then resets to 30s.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Register Exec A at t=0
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-A"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-A" in coordinator.executions
+
+    # Advance 20s, register Exec B at t=20
+    freezer.tick(timedelta(seconds=20))
+    mock_client.queue_events(
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-B"
+            )
+        ]
+    )
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert "exec-A" in coordinator.executions
+    assert "exec-B" in coordinator.executions
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Advance 10s (t=30s): Exec A completes
+    freezer.tick(timedelta(seconds=10))
+    mock_client.queue_events(
+        [
+            ExecutionStateChangedEvent(
+                name=EventName.EXECUTION_STATE_CHANGED,
+                exec_id="exec-A",
+                new_state=ExecutionState.COMPLETED,
+                old_state=ExecutionState.IN_PROGRESS,
+            )
+        ]
+    )
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Exec A removed, Exec B remains active -> interval must remain 1s
+    assert "exec-A" not in coordinator.executions
+    assert "exec-B" in coordinator.executions
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Advance to t=70s (Exec A would be 70s old, Exec B is 50s old < 60s TTL)
+    freezer.tick(timedelta(seconds=40))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Exec B still alive at t=70s (age 50s)
+    assert "exec-B" in coordinator.executions
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Advance to t=85s (Exec B is now 65s old > 60s TTL, dropped completion)
+    freezer.tick(timedelta(seconds=15))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Exec B purged, interval returned to 30s
+    assert coordinator.executions == {}
+    assert coordinator._executions_registered_at == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_adversarial_multi_execution_both_dropped_staggered_ttl(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Stress test two executions where both completion events are dropped.
+
+    Exec 1 registered at t=0s.
+    Exec 2 registered at t=30s.
+    Both completion events dropped.
+    At t=65s: Exec 1 expired (>60s), Exec 2 (age 35s) still active -> interval remains 1s.
+    At t=95s: Exec 2 expired (age 65s > 60s) -> interval resets to 30s.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Register Exec 1 at t=0s
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-1"
+            )
+        ],
+    )
+    assert "exec-1" in coordinator.executions
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Advance 30s, register Exec 2 at t=30s
+    freezer.tick(timedelta(seconds=30))
+    mock_client.queue_events(
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-2"
+            )
+        ]
+    )
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Advance to t=65s: Exec 1 is 65s old (>60s TTL), Exec 2 is 35s old (<60s TTL)
+    freezer.tick(timedelta(seconds=35))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert "exec-1" not in coordinator.executions
+    assert "exec-2" in coordinator.executions
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Advance to t=95s: Exec 2 is now 65s old (>60s TTL)
+    freezer.tick(timedelta(seconds=30))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator.executions == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_adversarial_untracked_legacy_execution_injection_ttl_cleanup(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Adversarially inject an execution without timestamp tracking.
+
+    Verify coordinator discovers it during cleanup, adopts a registration timestamp,
+    and purges it after TTL.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Adversarially inject directly into dictionary (bypassing track_execution)
+    coordinator.executions["exec-untracked-ghost"] = []
+    coordinator.update_interval = timedelta(seconds=1)
+
+    assert "exec-untracked-ghost" not in coordinator._executions_registered_at
+
+    # Trigger refresh: coordinator runs _cleanup_stale_executions, registers timestamp
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert "exec-untracked-ghost" in coordinator._executions_registered_at
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Fast-forward 65 seconds
+    freezer.tick(timedelta(seconds=65))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify ghost execution was cleaned up and interval restored
+    assert "exec-untracked-ghost" not in coordinator.executions
+    assert "exec-untracked-ghost" not in coordinator._executions_registered_at
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_adversarial_non_terminal_execution_states_do_not_prematurely_untrack(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify non-terminal execution states (IN_PROGRESS, NOT_TRANSMITTED, TRANSMITTED) do not clear execution.
+
+    Only COMPLETED and FAILED states should untrack.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-state-test"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Deliver non-terminal states
+    for non_terminal in [
+        ExecutionState.IN_PROGRESS,
+        ExecutionState.NOT_TRANSMITTED,
+        ExecutionState.TRANSMITTED,
+        ExecutionState.UNKNOWN,
+    ]:
+        freezer.tick(timedelta(seconds=1))
+        mock_client.queue_events(
+            [
+                ExecutionStateChangedEvent(
+                    name=EventName.EXECUTION_STATE_CHANGED,
+                    exec_id="exec-state-test",
+                    new_state=non_terminal,
+                    old_state=ExecutionState.IN_PROGRESS,
+                )
+            ]
+        )
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        # Must still be tracked and polling at 1s
+        assert "exec-state-test" in coordinator.executions
+        assert coordinator.update_interval == timedelta(seconds=1)
+
+    # Deliver terminal state: FAILED
+    freezer.tick(timedelta(seconds=1))
+    mock_client.queue_events(
+        [
+            ExecutionStateChangedEvent(
+                name=EventName.EXECUTION_STATE_CHANGED,
+                exec_id="exec-state-test",
+                new_state=ExecutionState.FAILED,
+                old_state=ExecutionState.IN_PROGRESS,
+            )
+        ]
+    )
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Untracked and restored to 30s
+    assert "exec-state-test" not in coordinator.executions
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_adversarial_custom_default_update_interval_preservation(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that when a custom update interval is set (e.g. 5s for local), execution recovery restores that custom interval."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    custom_interval = timedelta(seconds=5)
+    coordinator.set_update_interval(custom_interval)
+    assert coordinator.update_interval == custom_interval
+    assert coordinator._default_update_interval == custom_interval
+
+    # Register execution
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-custom-int"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+
+    # TTL expiry
+    freezer.tick(timedelta(seconds=65))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Restores to 5s, NOT hardcoded 30s!
+    assert coordinator.update_interval == custom_interval
+
+
+# =========================================================================
+# Category 2: Error-Induced Execution Reset Scenarios
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "injected_error",
+    [
+        ClientConnectorError(Mock(), Mock()),
+        TimeoutError("Connection timeout"),
+        ServerDisconnectedError("Server disconnected"),
+        InvalidEventListenerIdError("Invalid event listener id"),
+        TooManyRequestsError("Rate limited 429"),
+        TooManyConcurrentRequestsError("Too many concurrent requests"),
+        MaintenanceError("Maintenance in progress"),
+        ServiceUnavailableError("503 Service Unavailable"),
+        OverkizError("Internal generic Overkiz error"),
+        ClientError("Generic aiohttp ClientError"),
+    ],
+    ids=[
+        "client_connector_error",
+        "timeout_error",
+        "server_disconnected_error",
+        "invalid_event_listener_id",
+        "too_many_requests",
+        "too_many_concurrent_requests",
+        "maintenance_error",
+        "service_unavailable",
+        "overkiz_error",
+        "client_error",
+    ],
+)
+async def test_adversarial_error_induced_execution_reset(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+    injected_error: Exception,
+) -> None:
+    """Adversarially inject various network and API errors during an active 1s execution poll.
+
+    Verify that ANY error immediately wipes executions, clears registration timestamps,
+    and restores update_interval to 30s so the coordinator never loops at 1s during failures.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Register execution to enter 1s fast polling mode
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-active-during-fault"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert len(coordinator.executions) == 1
+
+    # Inject error during fetch_events
+    mock_client.fetch_events.side_effect = injected_error
+    if isinstance(injected_error, ServerDisconnectedError):
+        # If server disconnected, relogin attempt will also encounter network error
+        mock_client.login.side_effect = injected_error
+
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Coordinator must have reset all execution state and returned interval to 30s
+    assert coordinator.executions == {}
+    assert coordinator._executions_registered_at == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+# =========================================================================
+# Category 3: State Drift Resynchronization Scenarios
+# =========================================================================
+
+
+async def test_adversarial_state_drift_resync_after_invalid_listener_id(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that when a listener ID is invalidated and server state changes offline, full resync reconciles drift.
+
+    1. Initial temperature is 20.0 °C.
+    2. Server invalidates listener ID with InvalidEventListenerIdError.
+    3. While disconnected, server state changes to 28.5 °C.
+    4. Upon listener re-registration / recovery, coordinator fetches full device list (_get_devices()).
+    5. Entity state reflects the 28.5 °C server state.
+    6. Subsequent polls do NOT call _get_devices() (event-driven efficiency).
+    """
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert float(initial_state.state) == 24.4
+
+    mock_client.get_devices.reset_mock()
+
+    # 1. Simulate listener invalidation
+    mock_client.fetch_events.side_effect = InvalidEventListenerIdError(
+        "Listener session expired on Somfy server"
+    )
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Entity becomes unavailable during outage
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+    # 2. Simulate offline state drift on server side (device temperature changed to 28.5)
+    for dev in mock_client.setup.devices:
+        if dev.device_url == TEMPERATURE_SENSOR.device_url:
+            dev.states = States(
+                [
+                    State(
+                        name="core:TemperatureState",
+                        type=DataType.FLOAT,
+                        value=28.5,
+                    )
+                ]
+            )
+
+    # 3. Server recovers: next poll returns empty events
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # 4. Verify coordinator executed full resync via get_devices(refresh=True)
+    assert mock_client.get_devices.await_count == 1
+    updated_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert updated_state.state != STATE_UNAVAILABLE
+    assert float(updated_state.state) == 28.5
+
+    # 5. Verify subsequent normal poll does NOT re-fetch all devices
+    mock_client.get_devices.reset_mock()
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_client.get_devices.await_count == 0
+
+
+async def test_adversarial_state_drift_resync_after_server_disconnected_error(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify state drift resynchronization when ServerDisconnectedError occurs and reconnect succeeds.
+
+    1. Disconnect occurs.
+    2. Server state changes to 15.2 °C.
+    3. Reconnect succeeds: full device state is pulled and entity is updated to 15.2 °C immediately.
+    """
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert float(initial_state.state) == 24.4
+
+    # Simulate offline change on server
+    for dev in mock_client.setup.devices:
+        if dev.device_url == TEMPERATURE_SENSOR.device_url:
+            dev.states = States(
+                [
+                    State(
+                        name="core:TemperatureState",
+                        type=DataType.FLOAT,
+                        value=15.2,
+                    )
+                ]
+            )
+
+    mock_client.get_devices.reset_mock()
+    mock_client.login.reset_mock()
+
+    # Trigger ServerDisconnectedError on fetch_events
+    mock_client.fetch_events.side_effect = ServerDisconnectedError("Remote closed")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify coordinator performed relogin and fetched devices
+    assert mock_client.login.await_count == 1
+    assert mock_client.get_devices.await_count == 1
+
+    # Verify state was synchronized to 15.2 °C
+    updated_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert updated_state.state != STATE_UNAVAILABLE
+    assert float(updated_state.state) == 15.2
+
+
+async def test_adversarial_state_drift_resync_persists_across_multiple_failed_recovery_polls(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that _need_full_resync remains True even if recovery poll attempts fail multiple times.
+
+    1. Listener invalidated -> _need_full_resync = True.
+    2. Attempt 1 recovery fails in _get_devices with ClientConnectorError -> _need_full_resync must REMAIN True.
+    3. Attempt 2 recovery fails with TimeoutError -> _need_full_resync must REMAIN True.
+    4. Server state changes to 31.0 °C.
+    5. Attempt 3 recovery succeeds -> pulls full device state and updates entity to 31.0 °C.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # 1. Invalidate listener
+    mock_client.fetch_events.side_effect = InvalidEventListenerIdError("Expired")
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator._need_full_resync is True
+
+    # 2. Recovery attempt 1 fails in _get_devices
+    mock_client.fetch_events.side_effect = None
+    mock_client.get_devices.side_effect = ClientConnectorError(Mock(), Mock())
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Still marked as needing full resync
+    assert coordinator._need_full_resync is True
+
+    # 3. Recovery attempt 2 fails with TimeoutError
+    mock_client.get_devices.side_effect = TimeoutError("Still down")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Still marked as needing full resync
+    assert coordinator._need_full_resync is True
+
+    # 4. Modify server state offline
+    for dev in mock_client.setup.devices:
+        if dev.device_url == TEMPERATURE_SENSOR.device_url:
+            dev.states = States(
+                [
+                    State(
+                        name="core:TemperatureState",
+                        type=DataType.FLOAT,
+                        value=31.0,
+                    )
+                ]
+            )
+
+    # 5. Recovery attempt 3 succeeds
+    mock_client.get_devices.side_effect = mock_client._async_get_devices
+    mock_client.fetch_events.return_value = []
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Resync resolved
+    assert coordinator._need_full_resync is False
+    updated_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert updated_state.state != STATE_UNAVAILABLE
+    assert float(updated_state.state) == 31.0

--- a/tests/components/overkiz/test_adversarial_transport_auth.py
+++ b/tests/components/overkiz/test_adversarial_transport_auth.py
@@ -268,7 +268,9 @@ async def test_adversarial_server_disconnected_relogin_bad_credentials_escalates
     """Verify ServerDisconnectedError followed by BadCredentialsError on relogin escalates cleanly."""
     await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
 
-    mock_client.fetch_events.side_effect = ServerDisconnectedError("Server disconnected")
+    mock_client.fetch_events.side_effect = ServerDisconnectedError(
+        "Server disconnected"
+    )
     mock_client.login.side_effect = BadCredentialsError("Invalid credentials")
 
     freezer.tick(UPDATE_INTERVAL)

--- a/tests/components/overkiz/test_adversarial_transport_auth.py
+++ b/tests/components/overkiz/test_adversarial_transport_auth.py
@@ -1,0 +1,385 @@
+"""Adversarial stress tests for transport and authentication fault resilience (Milestone M5)."""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from aiohttp import ClientConnectorError, ClientError, ServerDisconnectedError
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName
+from pyoverkiz.exceptions import (
+    BadCredentialsError,
+    MaintenanceError,
+    NotAuthenticatedError,
+    ServiceUnavailableError,
+    TooManyConcurrentRequestsError,
+    TooManyRequestsError,
+)
+from pyoverkiz.models import ExecutionRegisteredEvent
+import pytest
+
+from homeassistant.components.overkiz.const import UPDATE_INTERVAL
+from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import async_deliver_events
+
+from tests.common import async_fire_time_changed
+
+TEMPERATURE_SENSOR = FixtureDevice(
+    "setup/cloud_nexity_rail_din_europe.json",
+    "io://1234-5678-1698/15702199#2",
+    "sensor.maple_residence_garden_radiator_bathroom_temperature_sensor_temperature",
+)
+
+
+# =========================================================================
+# Scenario 1: Prolonged Network Disconnects & Multi-Cycle Reconnection
+# =========================================================================
+
+
+async def test_adversarial_prolonged_disconnect_multi_cycle_recovery(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Stress test prolonged network disconnect with multiple consecutive connection errors.
+
+    Verify coordinator handles each failure as UpdateFailed, stays LOADED, keeps update_interval
+    at default 30s, and automatically recovers when connectivity is restored.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert initial_state.state != STATE_UNAVAILABLE
+
+    consecutive_faults = [
+        TimeoutError("Connection timed out"),
+        ClientConnectorError(Mock(), OSError("Connection refused")),
+        ServerDisconnectedError("Server disconnected"),
+        ClientError("Generic aiohttp client error"),
+        TimeoutError("Read timeout"),
+    ]
+
+    for fault in consecutive_faults:
+        mock_client.fetch_events.side_effect = fault
+        mock_client.get_devices.side_effect = fault
+        if isinstance(fault, ServerDisconnectedError):
+            mock_client.login.side_effect = fault
+
+        freezer.tick(UPDATE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        # Entity must be unavailable during outage
+        assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+        # Config entry must stay LOADED (never unloaded or faulted)
+        assert entry.state is ConfigEntryState.LOADED
+        # Coordinator must maintain default 30s interval
+        assert coordinator.update_interval == UPDATE_INTERVAL
+        assert coordinator.executions == {}
+        assert coordinator._need_full_resync is True
+
+    # Reconnection: network is restored
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    mock_client.get_devices.side_effect = mock_client._async_get_devices
+    mock_client.login.side_effect = None
+    mock_client.get_devices.reset_mock()
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Recovery: full device fetch occurred and entity is available again
+    assert mock_client.get_devices.await_count == 1
+    assert coordinator._need_full_resync is False
+    restored_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert restored_state.state != STATE_UNAVAILABLE
+    assert restored_state.state == initial_state.state
+
+
+# =========================================================================
+# Scenario 2: Session Expiration During Outage & Safe Relogin
+# =========================================================================
+
+
+async def test_adversarial_session_expiration_during_outage_relogin_recovery(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Simulate session expiration during network outage (401 NotAuthenticatedError on reconnect).
+
+    Verify coordinator executes automatic relogin and device fetch without escalating to ConfigEntryAuthFailed.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # 1. Outage occurs
+    mock_client.fetch_events.side_effect = ClientConnectorError(
+        Mock(), OSError("Network down")
+    )
+    mock_client.get_devices.side_effect = ClientConnectorError(
+        Mock(), OSError("Network down")
+    )
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is True
+
+    # 2. Network returns, but cloud session has expired -> 401 NotAuthenticatedError on get_devices / fetch_events
+    mock_client.login.reset_mock()
+    mock_client.get_devices.side_effect = NotAuthenticatedError("Session expired")
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Resync attempt failed due to NotAuthenticatedError -> caught as UpdateFailed, entry stays LOADED
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is True
+
+    # 3. Next poll: coordinator attempts relogin & device fetch
+    mock_client.get_devices.side_effect = mock_client._async_get_devices
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    mock_client.get_devices.reset_mock()
+    mock_client.login.reset_mock()
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Coordinator must have fetched devices and restored entity
+    assert mock_client.get_devices.await_count == 1
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state != STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is False
+
+
+async def test_adversarial_session_expiration_transient_relogin_failure_survives(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify transient relogin failure does not escalate to auth failed.
+
+    When session is expired, if the relogin attempt encounters a transient network drop,
+    verify coordinator raises UpdateFailed (temporary retry) and does NOT kill the config entry with ConfigEntryAuthFailed.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Session expired, and relogin hits network timeout
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+    mock_client.login.side_effect = TimeoutError("Timeout connecting to auth endpoint")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Config entry remains LOADED (temporary UpdateFailed)
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is True
+
+    # Next cycle: auth endpoint reachable -> relogin succeeds, fetch_events succeeds
+    mock_client.login.side_effect = None
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    mock_client.get_devices.side_effect = mock_client._async_get_devices
+    mock_client.get_devices.reset_mock()
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Recovery complete
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_client.get_devices.await_count == 1
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state != STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is False
+
+
+# =========================================================================
+# Scenario 3: Fatal Auth Failure (BadCredentialsError Escalation)
+# =========================================================================
+
+
+async def test_adversarial_fatal_bad_credentials_on_relogin_escalates_cleanly(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that permanent BadCredentialsError during relogin escalates cleanly to ConfigEntryAuthFailed."""
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+    mock_client.login.side_effect = BadCredentialsError("Bad username or password")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_adversarial_fatal_bad_credentials_during_resync_device_fetch(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that BadCredentialsError during full resync _get_devices() escalates cleanly."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Invalidate listener to set _need_full_resync
+    coordinator._need_full_resync = True
+
+    # In resync path, _get_devices raises BadCredentialsError
+    mock_client.get_devices.side_effect = BadCredentialsError("Token revoked")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_adversarial_server_disconnected_relogin_bad_credentials_escalates(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify ServerDisconnectedError followed by BadCredentialsError on relogin escalates cleanly."""
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    mock_client.fetch_events.side_effect = ServerDisconnectedError("Server disconnected")
+    mock_client.login.side_effect = BadCredentialsError("Invalid credentials")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+# =========================================================================
+# Scenario 4: Server Maintenance / 503 / 502 / Rate Limiting Responses
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "server_error",
+    [
+        MaintenanceError("Somfy cloud scheduled maintenance"),
+        ServiceUnavailableError("503 Service Unavailable"),
+        ServiceUnavailableError("502 Bad Gateway"),
+        TooManyRequestsError("429 Too Many Requests"),
+        TooManyConcurrentRequestsError("Too Many Concurrent Requests"),
+    ],
+    ids=[
+        "maintenance_error",
+        "service_unavailable_503",
+        "bad_gateway_502",
+        "too_many_requests_429",
+        "too_many_concurrent_requests",
+    ],
+)
+async def test_adversarial_server_maintenance_and_outage_recovery_lifecycle(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+    server_error: Exception,
+) -> None:
+    """Verify server maintenance and 5xx/429 errors are handled gracefully without unhandled exceptions.
+
+    Entity becomes unavailable, entry stays LOADED, and once maintenance ends, entity recovers automatically.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+
+    # Server error occurs
+    mock_client.fetch_events.side_effect = server_error
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert entry.state is ConfigEntryState.LOADED
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+    # Server recovers
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == initial_state.state
+
+
+# =========================================================================
+# Scenario 5: Active Execution Fault Reset Storm Prevention
+# =========================================================================
+
+
+async def test_adversarial_active_execution_transport_fault_resets_storm(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Verify that network failures during active execution reset the 1s interval.
+
+    Verify that if a network failure occurs during an active 1s execution poll:
+    1. Execution is immediately cleared.
+    2. Polling interval is immediately restored to default 30s.
+    3. Coordinator does NOT bombard the unreachable server every 1 second.
+    """
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    # Register an execution to enter 1s fast polling
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-active-drop"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-active-drop" in coordinator.executions
+
+    # Next fetch encounters TimeoutError
+    mock_client.fetch_events.side_effect = TimeoutError("Connection timed out")
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Executions cleared and interval restored to 30s
+    assert coordinator.executions == {}
+    assert coordinator._executions_registered_at == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -369,9 +369,7 @@ async def test_server_disconnected_relogin_transport_error(
     entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
     coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
 
-    mock_client.login.side_effect = TimeoutError(
-        "Connection timed out during relogin"
-    )
+    mock_client.login.side_effect = TimeoutError("Connection timed out during relogin")
     mock_client.fetch_events.side_effect = ServerDisconnectedError(
         "Server disconnected"
     )

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,19 +1,26 @@
 """Tests for the Overkiz data update coordinator."""
 
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
-from aiohttp import ClientConnectorError
+from aiohttp import ClientConnectorError, ServerDisconnectedError
 from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName
 from pyoverkiz.exceptions import (
+    BadCredentialsError,
     InvalidEventListenerIdError,
     MaintenanceError,
+    NotAuthenticatedError,
+    OverkizError,
     ServiceUnavailableError,
     TooManyConcurrentRequestsError,
     TooManyRequestsError,
 )
+from pyoverkiz.models import ExecutionRegisteredEvent
 import pytest
 
 from homeassistant.components.overkiz.const import DOMAIN, UPDATE_INTERVAL
+from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -207,3 +214,213 @@ async def test_child_devices_link_to_their_gateway(
     assert secondary_gateway is not None
     assert secondary_child is not None
     assert secondary_child.via_device_id == secondary_gateway.id
+
+
+async def test_execution_dropout_ttl_recovery(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Lost EXECUTION_STATE_CHANGED event recovers via execution TTL and returns interval to 30s."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+    # Deliver EXECUTION_REGISTERED event
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-123"
+            )
+        ],
+    )
+
+    # Coordinator update_interval drops to 1s
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-123" in coordinator.executions
+
+    # Fast forward beyond EXECUTION_TTL without an EXECUTION_STATE_CHANGED completion event
+    freezer.tick(timedelta(seconds=65))
+    mock_client.queue_events([])
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify execution was cleaned up and interval returned to 30s
+    assert "exec-123" not in coordinator.executions
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_execution_cleared_on_error(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Errors clear pending executions and restore update_interval."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            ExecutionRegisteredEvent(
+                name=EventName.EXECUTION_REGISTERED, exec_id="exec-456"
+            )
+        ],
+    )
+    assert coordinator.update_interval == timedelta(seconds=1)
+    assert "exec-456" in coordinator.executions
+
+    # Transient error happens on fetch
+    mock_client.fetch_events.side_effect = ClientConnectorError(Mock(), Mock())
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Executions cleared and update_interval restored
+    assert coordinator.executions == {}
+    assert coordinator.update_interval == UPDATE_INTERVAL
+
+
+async def test_coordinator_resync_devices_after_listener_invalidation(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Listener invalidation sets _need_full_resync and fetches all devices on next refresh."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    mock_client.get_devices.reset_mock()
+
+    # Simulate InvalidEventListenerIdError
+    mock_client.fetch_events.side_effect = InvalidEventListenerIdError(
+        "Invalid event listener id"
+    )
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator._need_full_resync is True
+
+    # Recovery: next poll should call get_devices to resynchronize full state
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_client.get_devices.await_count == 1
+    assert coordinator._need_full_resync is False
+
+
+async def test_relogin_recovery_on_transient_not_authenticated_error(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Transient NotAuthenticatedError triggers re-login without raising ConfigEntryAuthFailed."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    mock_client.login.reset_mock()
+    mock_client.get_devices.reset_mock()
+
+    # Session expired: fetch_events throws NotAuthenticatedError
+    # But client.login() and get_devices() succeed during recovery
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Integration stays LOADED, did not raise ConfigEntryAuthFailed
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_client.login.await_count == 1
+    assert mock_client.get_devices.await_count == 1
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state != STATE_UNAVAILABLE
+
+    # When login fails with transient network error: raises UpdateFailed (transient), NOT ConfigEntryAuthFailed
+    mock_client.login.side_effect = ClientConnectorError(Mock(), Mock())
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Still in LOADED state (coordinator is in retry state, not failed entry)
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_server_disconnected_relogin_transport_error(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """ServerDisconnectedError catches transport errors during relogin safely as UpdateFailed."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    mock_client.login.side_effect = TimeoutError(
+        "Connection timed out during relogin"
+    )
+    mock_client.fetch_events.side_effect = ServerDisconnectedError(
+        "Server disconnected"
+    )
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Cleanly caught as UpdateFailed -> entity unavailable, entry stays LOADED (will retry)
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is True
+
+
+async def test_bad_credentials_during_relogin_triggers_auth_failed(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Permanent BadCredentialsError during relogin triggers ConfigEntryAuthFailed."""
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+
+    mock_client.login.side_effect = BadCredentialsError("Bad credentials")
+    mock_client.fetch_events.side_effect = NotAuthenticatedError("Session expired")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_generic_overkiz_error_handled_as_transient(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Generic OverkizError is caught and handled as UpdateFailed."""
+    entry = await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
+    coordinator: OverkizDataUpdateCoordinator = entry.runtime_data.coordinator
+
+    mock_client.fetch_events.side_effect = OverkizError("Internal server glitch")
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert coordinator._need_full_resync is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None. This pull request introduces non-breaking resilience improvements to the Overkiz coordinator. All existing entity IDs, services, and configuration options remain unchanged.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request addresses three critical resilience failure modes in the Overkiz integration (`homeassistant/components/overkiz/coordinator.py`) when communicating with Overkiz / Somfy servers (both Cloud and Local APIs):

### 1. 1-Second Polling Storm Prevention via Execution TTL (`EXECUTION_TTL = 60.0s`)
- **Problem**: When an execution is initiated (e.g. opening a cover or toggling a light), `on_execution_registered` reduces the coordinator's polling interval from 30s (or 5s local) to 1s to capture rapid state transitions. If an `ExecutionStateChangedEvent` is dropped or lost during cloud communication, the execution ID was never removed from `coordinator.executions`, permanently trapping the coordinator in a 1-second polling loop and causing excessive cloud API traffic / local gateway socket exhaustion.
- **Fix**: Added `EXECUTION_TTL: Final = 60.0` in `const.py` and registered timestamps in `_executions_registered_at`. During each polling cycle (`_async_update_data`), `_cleanup_stale_executions()` purges any execution tracked for longer than 60 seconds. When no active executions remain, `self.update_interval` is automatically restored to `self._default_update_interval`. Additionally, `_handle_error_reset()` clears executions upon transport failure.

### 2. Silent State Drift Prevention via Device Resynchronization (`_need_full_resync`)
- **Problem**: When an event listener was invalidated (`InvalidEventListenerIdError`) or the server disconnected (`ServerDisconnectedError`, `ClientConnectorError`), re-registering a listener only captured subsequent events. Any device state changes occurring while the connection was down were permanently missed until Home Assistant restarted or devices were manually reloaded.
- **Fix**: Introduced `self._need_full_resync = True` whenever a disconnect, listener invalidation, or session re-authentication occurs. During the next update cycle in `_async_update_data`, if `self._need_full_resync` is `True`, the coordinator performs a full `self.devices = await self._get_devices()` (`client.get_devices(refresh=True)`) before processing event streams, guaranteeing all entities resynchronize with actual cloud/gateway state.

### 3. False-Positive Reauthentication Prevention & Preserving `ConfigEntryState.LOADED`
- **Problem**: Previously, catching `NotAuthenticatedError` during `fetch_events()` immediately raised `ConfigEntryAuthFailed`, triggering a persistent "Re-authenticate" notification in the Home Assistant UI that required manual user credentials re-entry, even for transient session token expirations or server-side token evictions.
- **Fix**: When `NotAuthenticatedError` occurs, the coordinator now performs an in-flight re-login attempt via `await self.client.login()` and updates device state.
  - If re-login fails with permanent authentication errors (`BadCredentialsError`, `OAuth2TokenRequestReauthError`), it correctly escalates to `ConfigEntryAuthFailed("Invalid authentication.")`.
  - If re-login encounters transient transport, server, or rate-limiting errors (`TimeoutError`, `ClientError`, `OverkizError`, `MaintenanceError`, `ServiceUnavailableError`, `TooManyRequestsError`, `TooManyConcurrentRequestsError`), it raises `UpdateFailed(f"Failed to re-authenticate: {exception}")`. This preserves `ConfigEntryState.LOADED`, marks entities temporarily unavailable, and allows automatic recovery on subsequent polling cycles without requiring manual user intervention.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

### Companion Upstream PR & Decoupling Architecture
- **Upstream Client Companion PR**: https://github.com/iMicknl/python-overkiz-api/pull/2233
- **Architectural Layering**:
  - **Layer 1 (Client Transport)**: `iMicknl/python-overkiz-api` handles low-level HTTP backoff retry decorators on `register_event_listener` and defensive error trapping during callback executions.
  - **Layer 2 (Coordinator State Self-Healing)**: `home-assistant/core` handles macroscopic polling lifecycle, execution TTL cleanup, device state resynchronization (`_need_full_resync`), and `UpdateFailed` vs `ConfigEntryAuthFailed` error classification.
- **Decoupling Guarantee**: This Home Assistant Core PR relies exclusively on public methods and exception classes already present in the pinned PyPI dependency `pyoverkiz[nexity]==2.1.0`. **No dependency bump is required**, and this PR can be reviewed, merged, and released completely independently without any PyPI release bottleneck.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
