### PR TITLE
Use async_set_updated_data in Hot Spring number entity

### DIFF
--- a/homeassistant/components/hotspring/number.py
+++ b/homeassistant/components/hotspring/number.py
@@ -64,4 +64,4 @@ class HotSpringNumberEntity(HotSpringEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the target temperature."""
         await self.coordinator.hotspring.set_temperature(round(value))
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/tests/components/hotspring/test_number.py
+++ b/tests/components/hotspring/test_number.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from hotspring import HotSpringConnectionError, HotSpringError
+from hotspring import HotSpringConnectionError, HotSpringError, Spa
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -39,8 +39,17 @@ async def test_set_target_temperature(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_hotspring: MagicMock,
+    device_fixture: Spa,
 ) -> None:
     """Test setting target temperature."""
+    assert (state := hass.states.get(ENTITY_ID))
+    assert state.state == "40.0"
+
+    def set_temp_mock(value: int) -> None:
+        device_fixture.heater.set_temperature = float(value)
+
+    mock_hotspring.set_temperature.side_effect = set_temp_mock
+
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
@@ -52,6 +61,9 @@ async def test_set_target_temperature(
     )
 
     mock_hotspring.set_temperature.assert_called_once_with(100)
+    mock_hotspring.update.assert_called_once()
+    assert (state := hass.states.get(ENTITY_ID))
+    assert state.state == "37.8"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Update `HotSpringNumberEntity` to use `self.coordinator.async_set_updated_data(self.coordinator.data)` instead of `self.coordinator.async_request_refresh()` when setting a new target temperature.

Since `python-hotspring` updates its internal state in-place upon receiving the command response, updating the coordinator data directly avoids a redundant network fetch, updates entity listeners immediately, and resets the polling interval.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr