### PR TITLE
Add light platform to Hot Spring integration

### DIFF
--- a/homeassistant/components/hotspring/__init__.py
+++ b/homeassistant/components/hotspring/__init__.py
@@ -7,6 +7,7 @@ from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.LIGHT,
     Platform.NUMBER,
     Platform.SENSOR,
 ]

--- a/homeassistant/components/hotspring/light.py
+++ b/homeassistant/components/hotspring/light.py
@@ -99,7 +99,7 @@ class HotSpringLightEntity(HotSpringEntity, LightEntity):
             await self.coordinator.hotspring.set_light_rgb(self._zone_id, *rgb_color)
 
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
-            intensity = round(brightness_to_value((1, 5), brightness))
+            intensity = max(1, round(brightness_to_value((1, 5), brightness)))
             await self.coordinator.hotspring.set_light_brightness(
                 self._zone_id, intensity
             )

--- a/homeassistant/components/hotspring/light.py
+++ b/homeassistant/components/hotspring/light.py
@@ -80,8 +80,6 @@ class HotSpringLightEntity(HotSpringEntity, LightEntity):
     @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 1..255."""
-        if not self._zone.is_on:
-            return None
         return value_to_brightness((1, 5), self._zone.intensity)
 
     @property
@@ -89,11 +87,7 @@ class HotSpringLightEntity(HotSpringEntity, LightEntity):
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value."""
         zone = self._zone
-        if zone.rgb_state == "active" and (zone.c_red, zone.c_green, zone.c_blue) != (
-            0,
-            0,
-            0,
-        ):
+        if zone.rgb_state == "active":
             return (zone.c_red, zone.c_green, zone.c_blue)
         return LIGHT_COLOR_TO_RGB.get(zone.color)
 

--- a/homeassistant/components/hotspring/light.py
+++ b/homeassistant/components/hotspring/light.py
@@ -1,8 +1,8 @@
 """Support for Hot Spring light entities."""
 
-from typing import Any, override
+from typing import Any, cast, override
 
-from hotspring import LightColor, LightZone
+from hotspring import LightColor, LightZone, Spa
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -74,13 +74,13 @@ class HotSpringLightEntity(HotSpringEntity, LightEntity):
     @override
     def is_on(self) -> bool:
         """Return true if the light is on."""
-        return self._zone.intensity > 0
+        return self._zone.is_on
 
     @property
     @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 1..255."""
-        if self._zone.intensity <= 0:
+        if not self._zone.is_on:
             return None
         return value_to_brightness((1, 5), self._zone.intensity)
 
@@ -88,53 +88,39 @@ class HotSpringLightEntity(HotSpringEntity, LightEntity):
     @override
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value."""
-        return LIGHT_COLOR_TO_RGB.get(self._zone.color)
+        zone = self._zone
+        if zone.rgb_state == "active" and (zone.c_red, zone.c_green, zone.c_blue) != (
+            0,
+            0,
+            0,
+        ):
+            return (zone.c_red, zone.c_green, zone.c_blue)
+        return LIGHT_COLOR_TO_RGB.get(zone.color)
 
     @hotspring_exception_handler
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        zone = self._zone
+        if (rgb_color := kwargs.get(ATTR_RGB_COLOR)) is not None:
+            await self.coordinator.hotspring.set_light_rgb(self._zone_id, *rgb_color)
 
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
             intensity = round(brightness_to_value((1, 5), brightness))
-        elif zone.intensity > 0:
-            intensity = zone.intensity
-        else:
-            intensity = 5
+            await self.coordinator.hotspring.set_light_brightness(
+                self._zone_id, intensity
+            )
+        elif not self.is_on:
+            await self.coordinator.hotspring.set_light_brightness(self._zone_id, 5)
 
-        if (rgb_color := kwargs.get(ATTR_RGB_COLOR)) is not None:
-            r, g, b = rgb_color
-            await self.coordinator.hotspring.set_light_rgb(self._zone_id, r, g, b)
-            if zone.intensity <= 0 or ATTR_BRIGHTNESS in kwargs:
-                color = (
-                    zone.color.value
-                    if zone.color in LIGHT_COLOR_TO_RGB
-                    else LightColor.WHITE.value
-                )
-                await self.coordinator.hotspring.set_light_color(
-                    self._zone_id,
-                    color=color,
-                    intensity=intensity,
-                )
-            await self.coordinator.async_request_refresh()
-            return
-
-        if zone.color in LIGHT_COLOR_TO_RGB:
-            color = zone.color.value
-        else:
-            color = LightColor.WHITE.value
-
-        await self.coordinator.hotspring.set_light_color(
-            self._zone_id,
-            color=color,
-            intensity=intensity,
+        self.coordinator.async_set_updated_data(
+            cast(Spa, self.coordinator.hotspring.spa)
         )
-        await self.coordinator.async_request_refresh()
 
     @hotspring_exception_handler
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self.coordinator.hotspring.turn_off_light(self._zone_id)
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(
+            cast(Spa, self.coordinator.hotspring.spa)
+        )

--- a/homeassistant/components/hotspring/light.py
+++ b/homeassistant/components/hotspring/light.py
@@ -1,0 +1,140 @@
+"""Support for Hot Spring light entities."""
+
+from typing import Any, override
+
+from hotspring import LightColor, LightZone
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.color import brightness_to_value, value_to_brightness
+
+from .coordinator import HotSpringConfigEntry, HotSpringDataUpdateCoordinator
+from .entity import HotSpringEntity
+from .helpers import hotspring_exception_handler
+
+PARALLEL_UPDATES = 1
+
+LIGHT_COLOR_TO_RGB: dict[LightColor, tuple[int, int, int]] = {
+    LightColor.RED: (255, 0, 0),
+    LightColor.GREEN: (0, 255, 0),
+    LightColor.BLUE: (0, 0, 255),
+    LightColor.YELLOW: (255, 255, 0),
+    LightColor.WHITE: (255, 255, 255),
+    LightColor.AQUA: (0, 255, 255),
+    LightColor.MAGENTA: (255, 0, 255),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HotSpringConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Hot Spring light entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        HotSpringLightEntity(coordinator, zone.zone_id)
+        for zone in coordinator.data.light_zones
+        if zone.is_enabled
+    )
+
+
+class HotSpringLightEntity(HotSpringEntity, LightEntity):
+    """Defines a Hot Spring light entity."""
+
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_translation_key = "light_zone"
+
+    def __init__(
+        self,
+        coordinator: HotSpringDataUpdateCoordinator,
+        zone_id: int,
+    ) -> None:
+        """Initialize the light entity."""
+        super().__init__(coordinator, f"light_zone_{zone_id}")
+        self._zone_id = zone_id
+        self._attr_translation_placeholders = {"zone": str(zone_id)}
+
+    @property
+    def _zone(self) -> LightZone:
+        """Return the light zone data."""
+        for zone in self.coordinator.data.light_zones:
+            if zone.zone_id == self._zone_id:
+                return zone
+        raise AssertionError("Light zone must exist in coordinator data")
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return true if the light is on."""
+        return self._zone.intensity > 0
+
+    @property
+    @override
+    def brightness(self) -> int | None:
+        """Return the brightness of this light between 1..255."""
+        if self._zone.intensity <= 0:
+            return None
+        return value_to_brightness((1, 5), self._zone.intensity)
+
+    @property
+    @override
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the rgb color value."""
+        return LIGHT_COLOR_TO_RGB.get(self._zone.color)
+
+    @hotspring_exception_handler
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        zone = self._zone
+
+        if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
+            intensity = round(brightness_to_value((1, 5), brightness))
+        elif zone.intensity > 0:
+            intensity = zone.intensity
+        else:
+            intensity = 5
+
+        if (rgb_color := kwargs.get(ATTR_RGB_COLOR)) is not None:
+            r, g, b = rgb_color
+            await self.coordinator.hotspring.set_light_rgb(self._zone_id, r, g, b)
+            if zone.intensity <= 0 or ATTR_BRIGHTNESS in kwargs:
+                color = (
+                    zone.color.value
+                    if zone.color in LIGHT_COLOR_TO_RGB
+                    else LightColor.WHITE.value
+                )
+                await self.coordinator.hotspring.set_light_color(
+                    self._zone_id,
+                    color=color,
+                    intensity=intensity,
+                )
+            await self.coordinator.async_request_refresh()
+            return
+
+        if zone.color in LIGHT_COLOR_TO_RGB:
+            color = zone.color.value
+        else:
+            color = LightColor.WHITE.value
+
+        await self.coordinator.hotspring.set_light_color(
+            self._zone_id,
+            color=color,
+            intensity=intensity,
+        )
+        await self.coordinator.async_request_refresh()
+
+    @hotspring_exception_handler
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self.coordinator.hotspring.turn_off_light(self._zone_id)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hotspring/strings.json
+++ b/homeassistant/components/hotspring/strings.json
@@ -34,6 +34,11 @@
         "name": "Spa connected"
       }
     },
+    "light": {
+      "light_zone": {
+        "name": "Light zone {zone}"
+      }
+    },
     "number": {
       "target_temperature": {
         "name": "Target temperature"

--- a/tests/components/hotspring/conftest.py
+++ b/tests/components/hotspring/conftest.py
@@ -178,6 +178,7 @@ def mock_hotspring(device_fixture: Spa) -> Generator[MagicMock]:
     ):
         client = hotspring_mock.return_value
         client.update.return_value = device_fixture
+        client.spa = device_fixture
         yield client
 
 

--- a/tests/components/hotspring/snapshots/test_light.ambr
+++ b/tests/components/hotspring/snapshots/test_light.ambr
@@ -1,0 +1,64 @@
+# serializer version: 1
+# name: test_light_state[light.connectedspa_ddeeff_light_zone_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.RGB: 'rgb'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.connectedspa_ddeeff_light_zone_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Light zone 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light zone 1',
+    'platform': 'hotspring',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_zone',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_light_zone_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_state[light.connectedspa_ddeeff_light_zone_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.BRIGHTNESS: 'brightness'>: None,
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'ConnectedSpa_DDEEFF Light zone 1',
+      <LightEntityStateAttribute.HS_COLOR: 'hs_color'>: None,
+      <LightEntityStateAttribute.RGB_COLOR: 'rgb_color'>: None,
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.RGB: 'rgb'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+      <LightEntityStateAttribute.XY_COLOR: 'xy_color'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.connectedspa_ddeeff_light_zone_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/hotspring/test_light.py
+++ b/tests/components/hotspring/test_light.py
@@ -1,0 +1,317 @@
+"""Tests for the Hot Spring light platform."""
+
+from unittest.mock import MagicMock
+
+from hotspring import (
+    HotSpringConnectionError,
+    HotSpringError,
+    LightColor,
+    LightWheelMode,
+    LightZone,
+    Spa,
+)
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.hotspring.light import HotSpringLightEntity
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    DOMAIN as LIGHT_DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_with_selected_platforms
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "light.connectedspa_ddeeff_light_zone_1"
+
+
+async def test_light_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the light entity state."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_turn_on_default(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test turning on light with default settings."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_color.assert_called_once_with(
+        1,
+        color="WHITE",
+        intensity=5,
+    )
+
+
+async def test_turn_on_with_brightness(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test turning on light with brightness."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_BRIGHTNESS: 153,
+        },
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_color.assert_called_once_with(
+        1,
+        color="WHITE",
+        intensity=3,
+    )
+
+
+async def test_turn_on_with_rgb_color_when_off(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test turning on light with rgb color when light is off."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_RGB_COLOR: (120, 200, 50),
+        },
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
+    mock_hotspring.set_light_color.assert_called_once_with(
+        1,
+        color="WHITE",
+        intensity=5,
+    )
+
+
+async def test_turn_on_with_rgb_color_when_on(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    device_fixture: Spa,
+) -> None:
+    """Test setting rgb color when light is already on."""
+    device_fixture.light_zones = [
+        LightZone(
+            zone_id=1,
+            is_enabled=True,
+            is_on=True,
+            color=LightColor.BLUE,
+            light_wheel=LightWheelMode.OFF,
+            intensity=3,
+            loop_speed=0,
+        ),
+    ]
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_RGB_COLOR: (120, 200, 50),
+        },
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
+    mock_hotspring.set_light_color.assert_not_called()
+
+
+async def test_turn_on_with_rgb_color_and_brightness(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test turning on light with rgb color and brightness."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_RGB_COLOR: (120, 200, 50),
+            ATTR_BRIGHTNESS: 102,
+        },
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
+    mock_hotspring.set_light_color.assert_called_once_with(
+        1,
+        color="WHITE",
+        intensity=2,
+    )
+
+
+async def test_turn_on_preserves_existing_color_and_intensity(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    device_fixture: Spa,
+) -> None:
+    """Test turning on light preserves existing color and intensity."""
+    device_fixture.light_zones = [
+        LightZone(
+            zone_id=1,
+            is_enabled=True,
+            is_on=True,
+            color=LightColor.BLUE,
+            light_wheel=LightWheelMode.OFF,
+            intensity=3,
+            loop_speed=0,
+        ),
+    ]
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_hotspring.set_light_color.assert_called_once_with(
+        1,
+        color="BLUE",
+        intensity=3,
+    )
+
+
+async def test_turn_off(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+) -> None:
+    """Test turning off light."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_hotspring.turn_off_light.assert_called_once_with(1)
+
+
+@pytest.mark.parametrize(
+    ("exception", "match"),
+    [
+        (
+            HotSpringConnectionError,
+            "An error occurred while communicating with the Hot Spring API",
+        ),
+        (HotSpringError, "Invalid response received from the Hot Spring API"),
+    ],
+)
+async def test_turn_on_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    exception: type[Exception],
+    match: str,
+) -> None:
+    """Test exception handling when turning on light."""
+    mock_hotspring.set_light_color.side_effect = exception
+
+    with pytest.raises(HomeAssistantError, match=match):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("exception", "match"),
+    [
+        (
+            HotSpringConnectionError,
+            "An error occurred while communicating with the Hot Spring API",
+        ),
+        (HotSpringError, "Invalid response received from the Hot Spring API"),
+    ],
+)
+async def test_turn_off_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    exception: type[Exception],
+    match: str,
+) -> None:
+    """Test exception handling when turning off light."""
+    mock_hotspring.turn_off_light.side_effect = exception
+
+    with pytest.raises(HomeAssistantError, match=match):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+
+async def test_disabled_zone_not_added(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    device_fixture: Spa,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test disabled light zones are not added to entity registry."""
+    device_fixture.light_zones = [
+        LightZone(
+            zone_id=1,
+            is_enabled=False,
+            is_on=False,
+            color=LightColor.OFF,
+            light_wheel=LightWheelMode.OFF,
+            intensity=0,
+            loop_speed=0,
+        ),
+    ]
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+
+    assert not entity_registry.async_is_registered(ENTITY_ID)
+
+
+async def test_brightness_property_when_off(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test brightness property returns None when light intensity is 0."""
+    coordinator = init_integration.runtime_data
+    entity = HotSpringLightEntity(coordinator, 1)
+    assert entity.brightness is None
+    assert not entity.is_on

--- a/tests/components/hotspring/test_light.py
+++ b/tests/components/hotspring/test_light.py
@@ -13,7 +13,6 @@ from hotspring import (
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.hotspring.light import HotSpringLightEntity
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_RGB_COLOR,
@@ -52,8 +51,20 @@ async def test_turn_on_default(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_hotspring: MagicMock,
+    device_fixture: Spa,
 ) -> None:
     """Test turning on light with default settings."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "off"
+    assert state.attributes.get(ATTR_BRIGHTNESS) is None
+
+    def _set_light_brightness(zone: int, brightness: int) -> None:
+        device_fixture.light_zones[0].intensity = brightness
+        device_fixture.light_zones[0].is_on = brightness > 0
+
+    mock_hotspring.set_light_brightness.side_effect = _set_light_brightness
+
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -62,14 +73,26 @@ async def test_turn_on_default(
     )
 
     mock_hotspring.set_light_brightness.assert_called_once_with(1, 5)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 255
 
 
 async def test_turn_on_with_brightness(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_hotspring: MagicMock,
+    device_fixture: Spa,
 ) -> None:
     """Test turning on light with brightness."""
+
+    def _set_light_brightness(zone: int, brightness: int) -> None:
+        device_fixture.light_zones[0].intensity = brightness
+        device_fixture.light_zones[0].is_on = brightness > 0
+
+    mock_hotspring.set_light_brightness.side_effect = _set_light_brightness
+
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -81,6 +104,10 @@ async def test_turn_on_with_brightness(
     )
 
     mock_hotspring.set_light_brightness.assert_called_once_with(1, 3)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 153
 
 
 async def test_turn_on_with_rgb_color_when_off(
@@ -187,12 +214,65 @@ async def test_rgb_color_active_custom(
     assert state.attributes.get("rgb_color") == (120, 200, 50)
 
 
+async def test_rgb_color_all_zero(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hotspring: MagicMock,
+    device_fixture: Spa,
+) -> None:
+    """Test rgb_color property returns (0, 0, 0) when rgb_state is active."""
+    device_fixture.light_zones = [
+        LightZone(
+            zone_id=1,
+            is_enabled=True,
+            is_on=True,
+            color=LightColor.CUSTOM,
+            light_wheel=LightWheelMode.OFF,
+            intensity=3,
+            loop_speed=0,
+            c_red=0,
+            c_green=0,
+            c_blue=0,
+            rgb_state="active",
+        ),
+    ]
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("rgb_color") == (0, 0, 0)
+
+
 async def test_turn_off(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
     mock_hotspring: MagicMock,
+    device_fixture: Spa,
 ) -> None:
     """Test turning off light."""
+    device_fixture.light_zones = [
+        LightZone(
+            zone_id=1,
+            is_enabled=True,
+            is_on=True,
+            color=LightColor.BLUE,
+            light_wheel=LightWheelMode.OFF,
+            intensity=5,
+            loop_speed=0,
+        ),
+    ]
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
+
+    def _turn_off_light(zone: int) -> None:
+        device_fixture.light_zones[0].intensity = 0
+        device_fixture.light_zones[0].is_on = False
+
+    mock_hotspring.turn_off_light.side_effect = _turn_off_light
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
+
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
@@ -201,6 +281,9 @@ async def test_turn_off(
     )
 
     mock_hotspring.turn_off_light.assert_called_once_with(1)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "off"
 
 
 @pytest.mark.parametrize(
@@ -283,14 +366,3 @@ async def test_disabled_zone_not_added(
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
 
     assert not entity_registry.async_is_registered(ENTITY_ID)
-
-
-async def test_brightness_property_when_off(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-) -> None:
-    """Test brightness property returns None when light intensity is 0."""
-    coordinator = init_integration.runtime_data
-    entity = HotSpringLightEntity(coordinator, 1)
-    assert entity.brightness is None
-    assert not entity.is_on

--- a/tests/components/hotspring/test_light.py
+++ b/tests/components/hotspring/test_light.py
@@ -61,11 +61,7 @@ async def test_turn_on_default(
         blocking=True,
     )
 
-    mock_hotspring.set_light_color.assert_called_once_with(
-        1,
-        color="WHITE",
-        intensity=5,
-    )
+    mock_hotspring.set_light_brightness.assert_called_once_with(1, 5)
 
 
 async def test_turn_on_with_brightness(
@@ -84,11 +80,7 @@ async def test_turn_on_with_brightness(
         blocking=True,
     )
 
-    mock_hotspring.set_light_color.assert_called_once_with(
-        1,
-        color="WHITE",
-        intensity=3,
-    )
+    mock_hotspring.set_light_brightness.assert_called_once_with(1, 3)
 
 
 async def test_turn_on_with_rgb_color_when_off(
@@ -108,11 +100,7 @@ async def test_turn_on_with_rgb_color_when_off(
     )
 
     mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
-    mock_hotspring.set_light_color.assert_called_once_with(
-        1,
-        color="WHITE",
-        intensity=5,
-    )
+    mock_hotspring.set_light_brightness.assert_called_once_with(1, 5)
 
 
 async def test_turn_on_with_rgb_color_when_on(
@@ -146,7 +134,7 @@ async def test_turn_on_with_rgb_color_when_on(
     )
 
     mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
-    mock_hotspring.set_light_color.assert_not_called()
+    mock_hotspring.set_light_brightness.assert_not_called()
 
 
 async def test_turn_on_with_rgb_color_and_brightness(
@@ -167,45 +155,36 @@ async def test_turn_on_with_rgb_color_and_brightness(
     )
 
     mock_hotspring.set_light_rgb.assert_called_once_with(1, 120, 200, 50)
-    mock_hotspring.set_light_color.assert_called_once_with(
-        1,
-        color="WHITE",
-        intensity=2,
-    )
+    mock_hotspring.set_light_brightness.assert_called_once_with(1, 2)
 
 
-async def test_turn_on_preserves_existing_color_and_intensity(
+async def test_rgb_color_active_custom(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hotspring: MagicMock,
     device_fixture: Spa,
 ) -> None:
-    """Test turning on light preserves existing color and intensity."""
+    """Test rgb_color property returns custom RGB values when active."""
     device_fixture.light_zones = [
         LightZone(
             zone_id=1,
             is_enabled=True,
             is_on=True,
-            color=LightColor.BLUE,
+            color=LightColor.CUSTOM,
             light_wheel=LightWheelMode.OFF,
             intensity=3,
             loop_speed=0,
+            c_red=120,
+            c_green=200,
+            c_blue=50,
+            rgb_state="active",
         ),
     ]
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.LIGHT])
 
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_ID},
-        blocking=True,
-    )
-
-    mock_hotspring.set_light_color.assert_called_once_with(
-        1,
-        color="BLUE",
-        intensity=3,
-    )
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("rgb_color") == (120, 200, 50)
 
 
 async def test_turn_off(
@@ -242,7 +221,7 @@ async def test_turn_on_error(
     match: str,
 ) -> None:
     """Test exception handling when turning on light."""
-    mock_hotspring.set_light_color.side_effect = exception
+    mock_hotspring.set_light_brightness.side_effect = exception
 
     with pytest.raises(HomeAssistantError, match=match):
         await hass.services.async_call(
@@ -295,7 +274,7 @@ async def test_disabled_zone_not_added(
             zone_id=1,
             is_enabled=False,
             is_on=False,
-            color=LightColor.OFF,
+            color=LightColor.UNKNOWN,
             light_wheel=LightWheelMode.OFF,
             intensity=0,
             loop_speed=0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the `light` platform to the Hot Spring integration for spas equipped with the Connected Spa Kit 2 module.

Key features:
- Adds `HotSpringLightEntity` for each enabled light zone on the spa.
- Supports turning lights on/off, discrete brightness scaling (1..5 <-> 1..255), and exact 0..255 RGB color selection.
- Reflects active custom RGB colors via `(c_red, c_green, c_blue)` properties from `python-hotspring==2.0.1`.
- Uses `async_set_updated_data` to immediately reflect spa state from command responses without additional GET polling requests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47611
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr