### PR TITLE
Bump ZHA to 2.2.0

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==2.1.0", "zha-quirks==2.2.0"],
+  "requirements": ["zha==2.2.0", "zha-quirks==2.2.0"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3507,7 +3507,7 @@ zeversolar==0.3.2
 zha-quirks==2.2.0
 
 # homeassistant.components.zha
-zha==2.1.0
+zha==2.2.0
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.19

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -192,7 +192,7 @@ async def test_number_quirks_v2_metadata(
     await gateway.async_device_initialized(zigpy_device)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    entity_id = "number.test_manf_test_number_model"
+    entity_id = "number.test_manf_test_number_model_temperature"
     hass_state = hass.states.get(entity_id)
     assert hass_state is not None
 


### PR DESCRIPTION
## Proposed change

This updates ZHA to [2.2.0](https://github.com/zigpy/zha/releases/tag/2.2.0). Full diff: https://github.com/zigpy/zha/compare/2.1.0...2.2.0
These dependency upgrades are bundled with it: 

- `bellows` [1.0.1](https://github.com/zigpy/bellows/releases/tag/1.0.1)
full diff: https://github.com/zigpy/bellows/compare/1.0.0...1.0.1

Relevant changes in these releases:
- An issue was fixed where an incorrect status could be shown in the frontend when sending Zigbee commands via UI
- An issue was fixed where EZSP status messages could be incorrectly interpreted, some as error codes
- An issue was fixed where an entity could stay "primary" (i.e. use device name) after a re-interview
- An issue was fixed where a single entity on an mock/test device, without a `Basic` cluster, would always be "primary"
  - This is why the one test here was adjusted. It's correct as quirks v2 entities should not become primary by default and the test now mirrors reality, as real devices always had the primary entity election tied with RSSI and LQI diagnostics sensors, which all have weight 0. See the commit message and relevant ZHA PRs for more details.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
