### PR TITLE
Persist PlayStation Network refresh tokens

### DIFF
--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from .const import CONF_NPSSO, DOMAIN
+from .const import CONF_NPSSO, CONF_TOKEN_RESPONSE, DOMAIN
 from .coordinator import (
     PlaystationNetworkConfigEntry,
     PlaystationNetworkFriendDataCoordinator,
@@ -33,7 +33,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up Playstation Network from a config entry."""
 
-    psn = PlaystationNetwork(hass, entry.data[CONF_NPSSO])
+    psn = PlaystationNetwork(
+        hass,
+        entry.data[CONF_NPSSO],
+        entry.data.get(CONF_TOKEN_RESPONSE),
+    )
 
     coordinator = PlaystationNetworkUserDataCoordinator(hass, psn, entry)
     await coordinator.async_config_entry_first_refresh()
@@ -81,6 +85,8 @@ async def _async_update_listener(
     hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
 ) -> None:
     """Handle update."""
+    if entry.data[CONF_NPSSO] == entry.runtime_data.user_data.psn.npsso:
+        return
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -89,6 +89,7 @@ async def _async_update_listener(
     if (
         entry.data[CONF_NPSSO] == psn.npsso
         and entry.data.get(CONF_TOKEN_RESPONSE) == psn.token_response
+        and entry.subentries.keys() == entry.runtime_data.friends.keys()
     ):
         return
     await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -85,7 +85,11 @@ async def _async_update_listener(
     hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
 ) -> None:
     """Handle update."""
-    if entry.data[CONF_NPSSO] == entry.runtime_data.user_data.psn.npsso:
+    psn = entry.runtime_data.user_data.psn
+    if (
+        entry.data[CONF_NPSSO] == psn.npsso
+        and entry.data.get(CONF_TOKEN_RESPONSE) == psn.token_response
+    ):
         return
     await hass.config_entries.async_reload(entry.entry_id)
 

--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -30,7 +30,14 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
 )
 
-from .const import CONF_ACCOUNT_ID, CONF_NPSSO, DOMAIN, NPSSO_LINK, PSN_LINK
+from .const import (
+    CONF_ACCOUNT_ID,
+    CONF_NPSSO,
+    CONF_TOKEN_RESPONSE,
+    DOMAIN,
+    NPSSO_LINK,
+    PSN_LINK,
+)
 from .coordinator import PlaystationNetworkConfigEntry
 from .helpers import PlaystationNetwork
 
@@ -90,7 +97,10 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
 
                     return self.async_create_entry(
                         title=user.online_id,
-                        data={CONF_NPSSO: npsso},
+                        data={
+                            CONF_NPSSO: npsso,
+                            CONF_TOKEN_RESPONSE: psn.token_response,
+                        },
                     )
 
         return self.async_show_form(
@@ -152,7 +162,10 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 return self.async_update_and_abort(
                     entry,
-                    data_updates={CONF_NPSSO: npsso},
+                    data_updates={
+                        CONF_NPSSO: npsso,
+                        CONF_TOKEN_RESPONSE: psn.token_response,
+                    },
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -6,6 +6,7 @@ from psnawp_api.models.trophies import PlatformType
 
 DOMAIN = "playstation_network"
 CONF_NPSSO: Final = "npsso"
+CONF_TOKEN_RESPONSE: Final = "token_response"
 CONF_ACCOUNT_ID: Final = "account_id"
 
 SUPPORTED_PLATFORMS = {

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -29,7 +29,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_TOKEN_RESPONSE, DOMAIN
+from .const import CONF_NPSSO, CONF_TOKEN_RESPONSE, DOMAIN
 from .helpers import PlaystationNetwork, PlaystationNetworkData
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,9 +92,9 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
             ) from error
 
         if (
-            token_response := self.psn.token_response
-        ) is not None and token_response != self.config_entry.data.get(
-            CONF_TOKEN_RESPONSE
+            self.config_entry.data[CONF_NPSSO] == self.psn.npsso
+            and (token_response := self.psn.token_response) is not None
+            and token_response != self.config_entry.data.get(CONF_TOKEN_RESPONSE)
         ):
             self.hass.config_entries.async_update_entry(
                 self.config_entry,

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -130,6 +130,7 @@ class PlaystationNetworkUserDataCoordinator(
     @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
+        persisted_token_response = self.psn.persisted_token_response
 
         try:
             await self.psn.async_setup()
@@ -139,10 +140,13 @@ class PlaystationNetworkUserDataCoordinator(
                 translation_key="not_ready",
             ) from error
         except (PSNAWPServerError, PSNAWPClientError) as error:
+            self._persist_token_response(persisted_token_response)
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
             ) from error
+
+        self._persist_token_response(persisted_token_response)
 
     @override
     async def update_data(self) -> PlaystationNetworkData:

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -78,6 +78,9 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     @override
     async def _async_update_data(self) -> _DataT:
         """Get the latest data from the PSN."""
+        persisted_npsso = self.config_entry.data[CONF_NPSSO]
+        persisted_token_response = self.config_entry.data.get(CONF_TOKEN_RESPONSE)
+
         try:
             data = await self.update_data()
         except PSNAWPAuthenticationError as error:
@@ -92,9 +95,11 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
             ) from error
 
         if (
-            self.config_entry.data[CONF_NPSSO] == self.psn.npsso
+            self.config_entry.data[CONF_NPSSO] == persisted_npsso == self.psn.npsso
+            and self.config_entry.data.get(CONF_TOKEN_RESPONSE)
+            == persisted_token_response
             and (token_response := self.psn.token_response) is not None
-            and token_response != self.config_entry.data.get(CONF_TOKEN_RESPONSE)
+            and token_response != persisted_token_response
         ):
             self.hass.config_entries.async_update_entry(
                 self.config_entry,

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -78,8 +78,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     @override
     async def _async_update_data(self) -> _DataT:
         """Get the latest data from the PSN."""
-        persisted_npsso = self.config_entry.data[CONF_NPSSO]
-        persisted_token_response = self.config_entry.data.get(CONF_TOKEN_RESPONSE)
+        persisted_token_response = self.psn.persisted_token_response
 
         try:
             data = await self.update_data()
@@ -95,7 +94,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
             ) from error
 
         if (
-            self.config_entry.data[CONF_NPSSO] == persisted_npsso == self.psn.npsso
+            self.config_entry.data[CONF_NPSSO] == self.psn.npsso
             and self.config_entry.data.get(CONF_TOKEN_RESPONSE)
             == persisted_token_response
             and (token_response := self.psn.token_response) is not None
@@ -108,6 +107,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
                     CONF_TOKEN_RESPONSE: token_response,
                 },
             )
+            self.psn.set_persisted_token_response(token_response)
 
         return data
 

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any, override
 
+from psnawp_api.core.authenticator import TokenResponse
 from psnawp_api.core.psnawp_exceptions import (
     PSNAWPAuthenticationError,
     PSNAWPClientError,
@@ -75,24 +76,10 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def update_data(self) -> _DataT:
         """Update coordinator data."""
 
-    @override
-    async def _async_update_data(self) -> _DataT:
-        """Get the latest data from the PSN."""
-        persisted_token_response = self.psn.persisted_token_response
-
-        try:
-            data = await self.update_data()
-        except PSNAWPAuthenticationError as error:
-            raise ConfigEntryAuthFailed(
-                translation_domain=DOMAIN,
-                translation_key="not_ready",
-            ) from error
-        except (PSNAWPServerError, PSNAWPClientError) as error:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed",
-            ) from error
-
+    def _persist_token_response(
+        self, persisted_token_response: TokenResponse | None
+    ) -> None:
+        """Persist a token response refreshed by this runtime client."""
         if (
             self.config_entry.data[CONF_NPSSO] == self.psn.npsso
             and self.config_entry.data.get(CONF_TOKEN_RESPONSE)
@@ -108,6 +95,27 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
                 },
             )
             self.psn.set_persisted_token_response(token_response)
+
+    @override
+    async def _async_update_data(self) -> _DataT:
+        """Get the latest data from the PSN."""
+        persisted_token_response = self.psn.persisted_token_response
+
+        try:
+            data = await self.update_data()
+        except PSNAWPAuthenticationError as error:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="not_ready",
+            ) from error
+        except (PSNAWPServerError, PSNAWPClientError) as error:
+            self._persist_token_response(persisted_token_response)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+            ) from error
+
+        self._persist_token_response(persisted_token_response)
 
         return data
 

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -29,7 +29,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import CONF_TOKEN_RESPONSE, DOMAIN
 from .helpers import PlaystationNetwork, PlaystationNetworkData
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def _async_update_data(self) -> _DataT:
         """Get the latest data from the PSN."""
         try:
-            return await self.update_data()
+            data = await self.update_data()
         except PSNAWPAuthenticationError as error:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
@@ -90,6 +90,21 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
             ) from error
+
+        if (
+            token_response := self.psn.token_response
+        ) is not None and token_response != self.config_entry.data.get(
+            CONF_TOKEN_RESPONSE
+        ):
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={
+                    **self.config_entry.data,
+                    CONF_TOKEN_RESPONSE: token_response,
+                },
+            )
+
+        return data
 
 
 class PlaystationNetworkUserDataCoordinator(

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -58,6 +58,9 @@ class PlaystationNetwork:
         """Initialize the class with the npsso token."""
         rate = Rate(300, Duration.MINUTE * 15)
         self.psn = PSNAWP(npsso, rate_limit=rate)
+        self._persisted_token_response = (
+            token_response.copy() if token_response is not None else None
+        )
         if token_response is not None:
             self.psn.authenticator.token_response = token_response.copy()
         self.client: Client
@@ -75,6 +78,17 @@ class PlaystationNetwork:
         if (token_response := self.psn.authenticator.token_response) is None:
             return None
         return token_response.copy()
+
+    @property
+    def persisted_token_response(self) -> TokenResponse | None:
+        """Return the token response generation owned by this runtime client."""
+        if self._persisted_token_response is None:
+            return None
+        return self._persisted_token_response.copy()
+
+    def set_persisted_token_response(self, token_response: TokenResponse) -> None:
+        """Record the token response generation persisted by this runtime client."""
+        self._persisted_token_response = token_response.copy()
 
     def _setup(self) -> None:
         """Setup PSN."""

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Any
 
 from psnawp_api import PSNAWP
+from psnawp_api.core.authenticator import TokenResponse
 from psnawp_api.models.client import Client
 from psnawp_api.models.trophies import PlatformType, TrophySummary, TrophyTitle
 from psnawp_api.models.user import User
@@ -48,17 +49,32 @@ class PlaystationNetwork:
 
     shareable_profile_link: dict[str, str]
 
-    def __init__(self, hass: HomeAssistant, npsso: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        npsso: str,
+        token_response: TokenResponse | None = None,
+    ) -> None:
         """Initialize the class with the npsso token."""
         rate = Rate(300, Duration.MINUTE * 15)
         self.psn = PSNAWP(npsso, rate_limit=rate)
+        if token_response is not None:
+            self.psn.authenticator.token_response = token_response.copy()
         self.client: Client
         self.hass = hass
+        self.npsso = npsso
         self.user: User
         self.legacy_profile: dict[str, Any] | None = None
         self.trophy_titles: list[TrophyTitle] = []
         self._title_icon_urls: dict[str, str] = {}
         self.friends_list: dict[str, User] = {}
+
+    @property
+    def token_response(self) -> TokenResponse | None:
+        """Return a copy of the current authentication token response."""
+        if (token_response := self.psn.authenticator.token_response) is None:
+            return None
+        return token_response.copy()
 
     def _setup(self) -> None:
         """Setup PSN."""

--- a/tests/components/playstation_network/conftest.py
+++ b/tests/components/playstation_network/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from psnawp_api.core.authenticator import TokenResponse
 from psnawp_api.models import User
 from psnawp_api.models.group.group import Group
 from psnawp_api.models.trophies import (
@@ -22,6 +23,17 @@ from tests.common import MockConfigEntry
 NPSSO_TOKEN: str = "npsso-token"
 NPSSO_TOKEN_INVALID_JSON: str = "{'npsso': 'npsso-token'"
 PSN_ID: str = "my-psn-id"
+TOKEN_RESPONSE: TokenResponse = {
+    "access_token": "access-token",
+    "access_token_expires_at": 4102444800.0,
+    "expires_in": 3600,
+    "id_token": "id-token",
+    "refresh_token": "refresh-token",
+    "refresh_token_expires_at": 4107628800.0,
+    "refresh_token_expires_in": 5184000,
+    "scope": "psn:mobile.v2.core psn:clientapp",
+    "token_type": "bearer",
+}
 
 
 @pytest.fixture(name="config_entry")
@@ -98,6 +110,8 @@ def mock_psnawpapi(mock_user: MagicMock) -> Generator[MagicMock]:
         autospec=True,
     ) as mock_client:
         client = mock_client.return_value
+        client.authenticator = MagicMock()
+        client.authenticator.token_response = TOKEN_RESPONSE.copy()
 
         client.user.return_value = mock_user
         client.me.return_value.get_account_devices.return_value = [

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.playstation_network.config_flow import (
 from homeassistant.components.playstation_network.const import (
     CONF_ACCOUNT_ID,
     CONF_NPSSO,
+    CONF_TOKEN_RESPONSE,
     DOMAIN,
 )
 from homeassistant.config_entries import (
@@ -25,7 +26,7 @@ from homeassistant.config_entries import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import NPSSO_TOKEN, NPSSO_TOKEN_INVALID_JSON, PSN_ID
+from .conftest import NPSSO_TOKEN, NPSSO_TOKEN_INVALID_JSON, PSN_ID, TOKEN_RESPONSE
 
 from tests.common import MockConfigEntry
 
@@ -49,6 +50,7 @@ async def test_manual_config(hass: HomeAssistant, mock_psnawpapi: MagicMock) -> 
     assert result["result"].unique_id == PSN_ID
     assert result["data"] == {
         CONF_NPSSO: "TEST_NPSSO_TOKEN",
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
     }
 
 
@@ -160,6 +162,7 @@ async def test_form_failures(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_NPSSO: NPSSO_TOKEN,
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
     }
 
 
@@ -193,6 +196,7 @@ async def test_parse_npsso_token_failures(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_NPSSO: NPSSO_TOKEN,
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
     }
 
 
@@ -220,7 +224,10 @@ async def test_flow_reauth(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
-    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+    assert config_entry.data == {
+        CONF_NPSSO: "NEW_NPSSO_TOKEN",
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
+    }
 
     assert len(hass.config_entries.async_entries()) == 1
 
@@ -275,7 +282,10 @@ async def test_flow_reauth_errors(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
-    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+    assert config_entry.data == {
+        CONF_NPSSO: "NEW_NPSSO_TOKEN",
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
+    }
 
     assert len(hass.config_entries.async_entries()) == 1
 
@@ -320,7 +330,10 @@ async def test_flow_reauth_token_error(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
-    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+    assert config_entry.data == {
+        CONF_NPSSO: "NEW_NPSSO_TOKEN",
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
+    }
 
     assert len(hass.config_entries.async_entries()) == 1
 
@@ -378,7 +391,10 @@ async def test_flow_reconfigure(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
-    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+    assert config_entry.data == {
+        CONF_NPSSO: "NEW_NPSSO_TOKEN",
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
+    }
 
     assert len(hass.config_entries.async_entries()) == 1
 

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -191,6 +191,44 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
     }
 
 
+async def test_does_not_persist_tokens_when_reauth_precedes_refresh(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test an old client cannot overwrite a completed same-NPSSO reauth."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    stale_token_response = TOKEN_RESPONSE | {
+        "access_token": "stale-access-token",
+        "refresh_token": "stale-refresh-token",
+    }
+    reauthenticated_token_response = TOKEN_RESPONSE | {
+        "access_token": "reauthenticated-access-token",
+        "refresh_token": "reauthenticated-refresh-token",
+    }
+    mock_psnawpapi.authenticator.token_response = stale_token_response
+
+    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={
+                CONF_NPSSO: NPSSO_TOKEN,
+                CONF_TOKEN_RESPONSE: reauthenticated_token_response,
+            },
+        )
+        await config_entry.runtime_data.user_data.async_request_refresh()
+        await hass.async_block_till_done()
+
+    assert config_entry.data == {
+        CONF_NPSSO: NPSSO_TOKEN,
+        CONF_TOKEN_RESPONSE: reauthenticated_token_response,
+    }
+
+
 @pytest.mark.parametrize(
     "exception", [PSNAWPNotFoundError, PSNAWPServerError, PSNAWPClientError]
 )

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -84,6 +84,37 @@ async def test_restores_and_persists_token_response(
     async_reload.assert_not_awaited()
 
 
+async def test_reloads_after_reauth_with_unchanged_npsso(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test reauthentication reloads when only the token response changes."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    reauthenticated_token_response = TOKEN_RESPONSE | {
+        "access_token": "reauthenticated-access-token",
+        "refresh_token": "reauthenticated-refresh-token",
+    }
+
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as async_reload:
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={
+                CONF_NPSSO: NPSSO_TOKEN,
+                CONF_TOKEN_RESPONSE: reauthenticated_token_response,
+            },
+        )
+        await hass.async_block_till_done()
+
+    async_reload.assert_awaited_once_with(config_entry.entry_id)
+
+
 @pytest.mark.parametrize(
     "exception", [PSNAWPNotFoundError, PSNAWPServerError, PSNAWPClientError]
 )

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -176,6 +176,7 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
             side_effect=delayed_get_data,
         ),
     ):
+        # Trigger the scheduled refresh while the data fetch is held in flight.
         freezer.tick(timedelta(seconds=30))
         async_fire_time_changed(hass)
         await update_started.wait()

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -1,7 +1,7 @@
 """Tests for PlayStation Network."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from psnawp_api.core import (
@@ -13,14 +13,75 @@ from psnawp_api.core import (
 )
 import pytest
 
-from homeassistant.components.playstation_network.const import DOMAIN
+from homeassistant.components.playstation_network.const import (
+    CONF_NPSSO,
+    CONF_TOKEN_RESPONSE,
+    DOMAIN,
+)
 from homeassistant.components.playstation_network.coordinator import (
     PlaystationNetworkRuntimeData,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from .conftest import NPSSO_TOKEN, PSN_ID, TOKEN_RESPONSE
+
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_persists_token_response_for_existing_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test a token response is persisted for an existing config entry."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.data == {
+        CONF_NPSSO: NPSSO_TOKEN,
+        CONF_TOKEN_RESPONSE: TOKEN_RESPONSE,
+    }
+
+
+async def test_restores_and_persists_token_response(
+    hass: HomeAssistant,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test stored tokens are restored and refreshed tokens are persisted."""
+    stored_token_response = TOKEN_RESPONSE | {"access_token": "stored-access-token"}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+            CONF_TOKEN_RESPONSE: stored_token_response,
+        },
+        unique_id=PSN_ID,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_psnawpapi.authenticator.token_response == stored_token_response
+
+    refreshed_token_response = TOKEN_RESPONSE | {
+        "access_token": "refreshed-access-token",
+        "refresh_token": "refreshed-refresh-token",
+    }
+    mock_psnawpapi.authenticator.token_response = refreshed_token_response
+
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as async_reload:
+        await config_entry.runtime_data.user_data.async_request_refresh()
+        await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_TOKEN_RESPONSE] == refreshed_token_response
+    async_reload.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -135,6 +135,44 @@ async def test_reloads_after_friend_subentry_change(
     async_reload.assert_awaited_once_with(config_entry.entry_id)
 
 
+async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test an old runtime client cannot overwrite reauthenticated tokens."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    stale_token_response = TOKEN_RESPONSE | {
+        "access_token": "stale-access-token",
+        "refresh_token": "stale-refresh-token",
+    }
+    reauthenticated_token_response = TOKEN_RESPONSE | {
+        "access_token": "reauthenticated-access-token",
+        "refresh_token": "reauthenticated-refresh-token",
+    }
+    mock_psnawpapi.authenticator.token_response = stale_token_response
+
+    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={
+                CONF_NPSSO: "reauthenticated-npsso",
+                CONF_TOKEN_RESPONSE: reauthenticated_token_response,
+            },
+        )
+        await config_entry.runtime_data.user_data.async_request_refresh()
+        await hass.async_block_till_done()
+
+    assert config_entry.data == {
+        CONF_NPSSO: "reauthenticated-npsso",
+        CONF_TOKEN_RESPONSE: reauthenticated_token_response,
+    }
+
+
 @pytest.mark.parametrize(
     "exception", [PSNAWPNotFoundError, PSNAWPServerError, PSNAWPClientError]
 )

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -51,6 +51,7 @@ async def test_persists_token_response_for_existing_entry(
 async def test_restores_and_persists_token_response(
     hass: HomeAssistant,
     mock_psnawpapi: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test stored tokens are restored and refreshed tokens are persisted."""
     stored_token_response = TOKEN_RESPONSE | {"access_token": "stored-access-token"}
@@ -79,7 +80,8 @@ async def test_restores_and_persists_token_response(
     with patch.object(
         hass.config_entries, "async_reload", new=AsyncMock()
     ) as async_reload:
-        await config_entry.runtime_data.user_data.async_request_refresh()
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
     assert config_entry.data[CONF_TOKEN_RESPONSE] == refreshed_token_response
@@ -141,6 +143,7 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_psnawpapi: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test an old runtime client cannot overwrite reauthenticated tokens."""
     config_entry.add_to_hass(hass)
@@ -157,22 +160,24 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
         "refresh_token": "reauthenticated-refresh-token",
     }
     mock_psnawpapi.authenticator.token_response = stale_token_response
-    coordinator = config_entry.runtime_data.user_data
     update_started = asyncio.Event()
     continue_update = asyncio.Event()
 
-    async def delayed_update_data() -> PlaystationNetworkData:
+    async def delayed_get_data() -> PlaystationNetworkData:
         update_started.set()
         await continue_update.wait()
-        return coordinator.data
+        return PlaystationNetworkData()
 
     with (
         patch.object(hass.config_entries, "async_reload", new=AsyncMock()),
-        patch.object(coordinator, "update_data", side_effect=delayed_update_data),
+        patch(
+            "homeassistant.components.playstation_network.helpers."
+            "PlaystationNetwork.get_data",
+            side_effect=delayed_get_data,
+        ),
     ):
-        refresh_task = hass.async_create_task(
-            coordinator.async_request_refresh(), "test in-flight PSN refresh"
-        )
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
         await update_started.wait()
         hass.config_entries.async_update_entry(
             config_entry,
@@ -182,7 +187,6 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
             },
         )
         continue_update.set()
-        await refresh_task
         await hass.async_block_till_done()
 
     assert config_entry.data == {
@@ -195,6 +199,7 @@ async def test_does_not_persist_tokens_when_reauth_precedes_refresh(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_psnawpapi: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test an old client cannot overwrite a completed same-NPSSO reauth."""
     config_entry.add_to_hass(hass)
@@ -220,7 +225,8 @@ async def test_does_not_persist_tokens_when_reauth_precedes_refresh(
                 CONF_TOKEN_RESPONSE: reauthenticated_token_response,
             },
         )
-        await config_entry.runtime_data.user_data.async_request_refresh()
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
     assert config_entry.data == {

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -329,6 +329,41 @@ async def test_persists_refreshed_token_when_coordinator_update_fails(
     assert config_entry.data[CONF_TOKEN_RESPONSE] == refreshed_token_response
 
 
+async def test_persists_refreshed_token_when_setup_fails(
+    hass: HomeAssistant,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test a refreshed token is persisted when setup fails."""
+    stored_token_response = TOKEN_RESPONSE | {"access_token": "stored-access-token"}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+            CONF_TOKEN_RESPONSE: stored_token_response,
+        },
+        unique_id=PSN_ID,
+    )
+    refreshed_token_response = TOKEN_RESPONSE | {
+        "access_token": "refreshed-access-token",
+        "refresh_token": "refreshed-refresh-token",
+    }
+
+    def refresh_token_then_fail() -> None:
+        mock_psnawpapi.authenticator.token_response = refreshed_token_response
+        raise PSNAWPServerError("error msg")
+
+    mock_psnawpapi.me.return_value.get_shareable_profile_link.side_effect = (
+        refresh_token_then_fail
+    )
+    config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_TOKEN_RESPONSE] == refreshed_token_response
+
+
 async def test_coordinator_update_auth_failed(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -1,5 +1,6 @@
 """Tests for PlayStation Network."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +22,7 @@ from homeassistant.components.playstation_network.const import (
 from homeassistant.components.playstation_network.coordinator import (
     PlaystationNetworkRuntimeData,
 )
+from homeassistant.components.playstation_network.helpers import PlaystationNetworkData
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -155,20 +157,36 @@ async def test_does_not_persist_tokens_from_client_replaced_by_reauth(
         "refresh_token": "reauthenticated-refresh-token",
     }
     mock_psnawpapi.authenticator.token_response = stale_token_response
+    coordinator = config_entry.runtime_data.user_data
+    update_started = asyncio.Event()
+    continue_update = asyncio.Event()
 
-    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+    async def delayed_update_data() -> PlaystationNetworkData:
+        update_started.set()
+        await continue_update.wait()
+        return coordinator.data
+
+    with (
+        patch.object(hass.config_entries, "async_reload", new=AsyncMock()),
+        patch.object(coordinator, "update_data", side_effect=delayed_update_data),
+    ):
+        refresh_task = hass.async_create_task(
+            coordinator.async_request_refresh(), "test in-flight PSN refresh"
+        )
+        await update_started.wait()
         hass.config_entries.async_update_entry(
             config_entry,
             data={
-                CONF_NPSSO: "reauthenticated-npsso",
+                CONF_NPSSO: NPSSO_TOKEN,
                 CONF_TOKEN_RESPONSE: reauthenticated_token_response,
             },
         )
-        await config_entry.runtime_data.user_data.async_request_refresh()
+        continue_update.set()
+        await refresh_task
         await hass.async_block_till_done()
 
     assert config_entry.data == {
-        CONF_NPSSO: "reauthenticated-npsso",
+        CONF_NPSSO: NPSSO_TOKEN,
         CONF_TOKEN_RESPONSE: reauthenticated_token_response,
     }
 

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -300,6 +300,35 @@ async def test_coordinator_update_data_failed(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_persists_refreshed_token_when_coordinator_update_fails(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a refreshed token is persisted when the data update fails."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    refreshed_token_response = TOKEN_RESPONSE | {
+        "access_token": "refreshed-access-token",
+        "refresh_token": "refreshed-refresh-token",
+    }
+
+    def refresh_token_then_fail() -> None:
+        mock_psnawpapi.authenticator.token_response = refreshed_token_response
+        raise PSNAWPServerError("error msg")
+
+    mock_psnawpapi.user.return_value.get_presence.side_effect = refresh_token_then_fail
+
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert config_entry.data[CONF_TOKEN_RESPONSE] == refreshed_token_response
+
+
 async def test_coordinator_update_auth_failed(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -115,6 +115,26 @@ async def test_reloads_after_reauth_with_unchanged_npsso(
     async_reload.assert_awaited_once_with(config_entry.entry_id)
 
 
+async def test_reloads_after_friend_subentry_change(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test changing friend subentries reloads the integration."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as async_reload:
+        hass.config_entries.async_remove_subentry(config_entry, "ABCDEF")
+        await hass.async_block_till_done()
+
+    async_reload.assert_awaited_once_with(config_entry.entry_id)
+
+
 @pytest.mark.parametrize(
     "exception", [PSNAWPNotFoundError, PSNAWPServerError, PSNAWPClientError]
 )


### PR DESCRIPTION
## Proposed change

Persist the PlayStation Network token response in the config entry so PSNAWP can restore and refresh the session across Home Assistant restarts.

This addresses a different failure mode from the browser logout behavior that closed #151442. Logging out intentionally invalidates the NPSSO and cannot be fixed by Home Assistant. However, the current integration also discards PSNAWP's valid OAuth token response on every reload or restart.

PSNAWP uses the NPSSO only to bootstrap an OAuth access/refresh token pair. It refreshes and rotates those tokens in memory, but Home Assistant currently persists only the NPSSO. After a restart, PSNAWP therefore cannot continue the still-valid refresh session and must bootstrap again from the older NPSSO. If that NPSSO is no longer usable while the refreshed session was still valid, the integration unnecessarily enters reauthentication.

This change:

- stores the initial token response during setup and reauthentication;
- restores the stored token response when setting up the integration;
- persists a refreshed token response after successful coordinator updates;
- avoids reloading the integration for token-only config entry updates;
- migrates existing entries after their next successful update;
- adds tests for storage, restoration, refresh persistence, migration, and reload behavior.

Relevant PlayStation Network tests: 71 passed, 65 snapshots passed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #151442
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
