### PR TITLE
Add Fronius Modbus setpoint numbers

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -406,8 +406,9 @@ class FroniusSolarNet:
     ) -> bool:
         """Do the first refresh of a Modbus coordinator, reporting success.
 
-        Modbus data is optional, so a device that doesn't answer never fails
-        the whole entry.
+        Not `async_config_entry_first_refresh`: Modbus data is optional, so a
+        device that doesn't answer must leave the rest of the entry alone
+        instead of raising `ConfigEntryNotReady`.
         """
         await coordinator.async_refresh()
         if not coordinator.last_update_success:

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -409,18 +409,13 @@ class FroniusSolarNet:
         Modbus data is optional, so a device that doesn't answer never fails
         the whole entry.
         """
-        if self.config_entry.state is ConfigEntryState.LOADED:
-            await coordinator.async_refresh()
-            if not coordinator.last_update_success:
-                return False
-            # Only for re-scans. Initial setup adds entities through the
-            # platforms' async_setup_entry.
-            async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, coordinator)
-            return True
-        try:
-            await coordinator.async_config_entry_first_refresh()
-        except ConfigEntryNotReady:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
             return False
+        # Only for re-scans. Initial setup adds entities through the
+        # platforms' async_setup_entry.
+        if self.config_entry.state is ConfigEntryState.LOADED:
+            async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, coordinator)
         return True
 
     async def _modbus_control_allowed(

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -42,13 +42,14 @@ from .coordinator import (
     FroniusLoggerUpdateCoordinator,
     FroniusMeterUpdateCoordinator,
     FroniusModbusInverterUpdateCoordinator,
+    FroniusModbusSettingsUpdateCoordinator,
     FroniusOhmpilotUpdateCoordinator,
     FroniusPowerFlowUpdateCoordinator,
     FroniusStorageUpdateCoordinator,
 )
 
 _LOGGER: Final = logging.getLogger(__name__)
-PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 
 type FroniusConfigEntry = ConfigEntry[FroniusSolarNet]
 
@@ -123,6 +124,9 @@ class FroniusSolarNet:
 
         self.modbus_inverter_coordinators: list[
             FroniusModbusInverterUpdateCoordinator
+        ] = []
+        self.modbus_settings_coordinators: list[
+            FroniusModbusSettingsUpdateCoordinator
         ] = []
         # one hold on the shared connection per inverter, kept across re-scans
         self.modbus_inverters: dict[SolarNetId, FroniusModbusInverter] = {}
@@ -358,37 +362,37 @@ class FroniusSolarNet:
                 err,
             )
             return
-        if modbus_inverter.mppt is None:
+        if modbus_inverter.mppt is not None:
+            readings = FroniusModbusInverterUpdateCoordinator(
+                hass=self.hass,
+                solar_net=self,
+                logger=_LOGGER,
+                name=f"{DOMAIN}_modbus_inverter_{inverter_info.solar_net_id}_{self.host}",
+                inverter_info=inverter_info,
+                modbus_inverter=modbus_inverter,
+                config_entry=self.config_entry,
+            )
+            if await self._start_modbus_coordinator(readings):
+                self.modbus_inverter_coordinators.append(readings)
+        else:
             _LOGGER.debug(
                 "No MPPT model exposed by inverter %s at Modbus unit %s",
                 inverter_info.solar_net_id,
                 unit_id,
             )
-            return
 
-        coordinator = FroniusModbusInverterUpdateCoordinator(
-            hass=self.hass,
-            solar_net=self,
-            logger=_LOGGER,
-            name=f"{DOMAIN}_modbus_inverter_{inverter_info.solar_net_id}_{self.host}",
-            inverter_info=inverter_info,
-            modbus_inverter=modbus_inverter,
-            config_entry=self.config_entry,
-        )
-        if self.config_entry.state is ConfigEntryState.LOADED:
-            await coordinator.async_refresh()
-        else:
-            try:
-                await coordinator.async_config_entry_first_refresh()
-            except ConfigEntryNotReady:
-                # never fail the whole entry for optional Modbus data
-                return
-        self.modbus_inverter_coordinators.append(coordinator)
-
-        # Only for re-scans. Initial setup adds entities
-        # through sensor.async_setup_entry
-        if self.config_entry.state is ConfigEntryState.LOADED:
-            async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, coordinator)
+        if await self._modbus_control_allowed(modbus_inverter, unit_id):
+            settings = FroniusModbusSettingsUpdateCoordinator(
+                hass=self.hass,
+                solar_net=self,
+                logger=_LOGGER,
+                name=f"{DOMAIN}_modbus_settings_{inverter_info.solar_net_id}_{self.host}",
+                inverter_info=inverter_info,
+                modbus_inverter=modbus_inverter,
+                config_entry=self.config_entry,
+            )
+            if await self._start_modbus_coordinator(settings):
+                self.modbus_settings_coordinators.append(settings)
 
         _LOGGER.debug(
             "Modbus enabled for inverter %s (UID: %s, unit ID: %s)",
@@ -396,6 +400,50 @@ class FroniusSolarNet:
             inverter_info.unique_id,
             unit_id,
         )
+
+    async def _start_modbus_coordinator(
+        self, coordinator: FroniusCoordinatorBase
+    ) -> bool:
+        """Do the first refresh of a Modbus coordinator, reporting success.
+
+        Modbus data is optional, so a device that doesn't answer never fails
+        the whole entry.
+        """
+        if self.config_entry.state is ConfigEntryState.LOADED:
+            await coordinator.async_refresh()
+            if not coordinator.last_update_success:
+                return False
+            # Only for re-scans. Initial setup adds entities through the
+            # platforms' async_setup_entry.
+            async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, coordinator)
+            return True
+        try:
+            await coordinator.async_config_entry_first_refresh()
+        except ConfigEntryNotReady:
+            return False
+        return True
+
+    async def _modbus_control_allowed(
+        self, modbus_inverter: FroniusModbusInverter, unit_id: int
+    ) -> bool:
+        """Check whether the device accepts the writes the controls need.
+
+        "Inverter control via Modbus" has to be enabled on the device web
+        interface, and no register reports it - the only way to find out is
+        to write. `probe_write_access` writes a register's own value back.
+        """
+        if (controls := modbus_inverter.controls) is None:
+            return False
+        try:
+            allowed = await controls.probe_write_access()
+        except (ModbusError, SunSpecError) as err:
+            _LOGGER.debug("Modbus write probe failed for unit %s: %s", unit_id, err)
+            return False
+        if not allowed:
+            _LOGGER.debug(
+                "Inverter control via Modbus is not enabled on unit %s", unit_id
+            )
+        return allowed
 
     def _modbus_unit_id(self, solar_net_id: str) -> int | None:
         """Return the Modbus unit ID for an inverter."""

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -342,8 +342,8 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         if (controls := inverter.controls) is not None:
             values["power_limit"] = controls.power_limit
         if (storage := inverter.storage) is not None:
-            values["battery_charge_limit"] = storage.charge_limit
-            values["battery_discharge_limit"] = storage.discharge_limit
+            values["battery_charge_power_limit"] = storage.charge_limit
+            values["battery_discharge_power_limit"] = storage.discharge_limit
             values["battery_minimum_reserve"] = storage.minimum_reserve
 
         return self._as_device_data(values)

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from fronius_modbus import (
     FroniusModbusInverter,
@@ -16,6 +16,7 @@ from pyfronius import BadStatusError, FroniusError
 
 from homeassistant.const import Platform
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -28,6 +29,7 @@ from .const import (
     SolarNetId,
 )
 from .entity import FroniusEntity, FroniusEntityDescription
+from .number import MODBUS_NUMBER_ENTITY_DESCRIPTIONS
 from .sensor import (
     INVERTER_ENTITY_DESCRIPTIONS,
     LOGGER_ENTITY_DESCRIPTIONS,
@@ -185,12 +187,10 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
         return {self.inverter_info.solar_net_id: data}
 
 
-class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
-    """Query SunSpec data from an inverters Modbus interface."""
+class FroniusModbusCoordinatorBase(FroniusCoordinatorBase):
+    """Shared behaviour of the coordinators reading an inverter over Modbus."""
 
-    default_interval = timedelta(minutes=1)
     error_interval = timedelta(minutes=10)
-    valid_descriptions = {Platform.SENSOR: MODBUS_INVERTER_ENTITY_DESCRIPTIONS}
     update_exceptions = (ModbusError, SunSpecError)
 
     def __init__(
@@ -200,7 +200,7 @@ class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
         modbus_inverter: FroniusModbusInverter,
         **kwargs: Any,
     ) -> None:
-        """Set up a Fronius Modbus inverter device scope coordinator."""
+        """Set up a Fronius Modbus device scope coordinator."""
         super().__init__(*args, **kwargs)
         self.inverter_info = inverter_info
         self.modbus_inverter = modbus_inverter
@@ -215,11 +215,51 @@ class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
         """
         return await self._do_update()
 
+    @abstractmethod
+    async def _refresh_components(self) -> None:
+        """Refresh the components this coordinator reads."""
+
+    async def _refresh(self) -> None:
+        """Refresh the components, re-discovering once on a register map shift."""
+        try:
+            await self._refresh_components()
+        except SunSpecMapShiftError:
+            # The register map shifts when the data type setting is changed on
+            # the device. Re-discover once at the new addresses and retry.
+            await self.modbus_inverter.discover()
+            await self._refresh_components()
+
+    def _as_device_data(
+        self, values: Mapping[str, float | bool | None]
+    ) -> dict[SolarNetId, Any]:
+        """Wrap values in the SolarAPI's {"value": ...} shape entities read."""
+        return {
+            self.inverter_info.solar_net_id: {
+                key: {"value": value} for key, value in values.items()
+            }
+        }
+
+
+class FroniusModbusInverterUpdateCoordinator(FroniusModbusCoordinatorBase):
+    """Query SunSpec MPPT data from an inverters Modbus interface."""
+
+    default_interval = timedelta(minutes=1)
+    valid_descriptions = {Platform.SENSOR: MODBUS_INVERTER_ENTITY_DESCRIPTIONS}
+
+    @override
+    async def _refresh_components(self) -> None:
+        """Refresh the Multiple MPPT model."""
+        if (mppt := self.modbus_inverter.mppt) is None:
+            raise SunSpecError("Multiple MPPT model not available")
+        await mppt.async_update()
+
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from the Modbus interface."""
-        mppt = await self._update_mppt()
-        values: dict[str, float | None] = {
+        await self._refresh()
+        # re-discovery on a map shift replaces the component
+        mppt = cast("Mppt", self.modbus_inverter.mppt)
+        values: dict[str, float | bool | None] = {
             "energy_total_pv": mppt.pv_energy_total,
             "storage_energy_charged_total": mppt.storage_charge_energy_total,
             "storage_energy_discharged_total": mppt.storage_discharge_energy_total,
@@ -229,27 +269,84 @@ class FroniusModbusInverterUpdateCoordinator(FroniusCoordinatorBase):
             values[f"mppt_{number}_voltage_dc"] = module.voltage
             values[f"mppt_{number}_power_dc"] = module.power
             values[f"mppt_{number}_energy_dc"] = module.energy
-        # entities read the SolarAPI's {"value": ...} shape, so match it here
-        return {
-            self.inverter_info.solar_net_id: {
-                key: {"value": value} for key, value in values.items()
-            }
-        }
+        return self._as_device_data(values)
 
-    async def _update_mppt(self) -> Mppt:
-        """Refresh the MPPT model, re-discovering once on a register map shift."""
-        if (mppt := self.modbus_inverter.mppt) is None:
-            raise SunSpecError("Multiple MPPT model not available")
+
+class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
+    """Query the writable settings of an inverters Modbus interface.
+
+    Settings only change when something writes them, so they are polled on
+    their own interval rather than with the live MPPT readings.
+    """
+
+    default_interval = timedelta(minutes=5)
+    valid_descriptions = {Platform.NUMBER: MODBUS_NUMBER_ENTITY_DESCRIPTIONS}
+
+    @override
+    async def _refresh_components(self) -> None:
+        """Refresh the models carrying the writable settings."""
+        for component in (
+            self.modbus_inverter.controls,
+            self.modbus_inverter.storage,
+        ):
+            if component is not None:
+                await component.async_update()
+
+    async def async_write(
+        self,
+        component_name: str,
+        field: str,
+        value: float | bool,
+        *,
+        enable_field: str | None = None,
+    ) -> None:
+        """Write a setpoint to the device and refresh what it reports back.
+
+        The model is refreshed first so its header check catches a shifted
+        register map before anything is written - the register addresses
+        move when the data type setting is changed on the device.
+
+        A setpoint on its own has no effect: the device applies it only while
+        the mode it belongs to is enabled, and per the Fronius documentation a
+        change to an already active mode is picked up by enabling it again.
+        ``enable_field`` is written after the setpoint for both reasons.
+        """
+        component = getattr(self.modbus_inverter, component_name)
+        if component is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="modbus_model_unavailable",
+            )
         try:
-            await mppt.async_update()
-        except SunSpecMapShiftError:
-            # The register map shifts when the data type setting is changed on
-            # the device. Re-discover once at the new addresses and retry.
-            await self.modbus_inverter.discover()
-            if (mppt := self.modbus_inverter.mppt) is None:
-                raise
-            await mppt.async_update()
-        return mppt
+            await component.async_update()
+            await component.write(field, value)
+            if enable_field is not None:
+                await component.write(enable_field, True)
+        except (ModbusError, SunSpecError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="modbus_write_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        # not debounced: the entity should settle on what the device reports
+        # back, and writes are rare and user initiated
+        await self.async_refresh()
+
+    @override
+    async def _update_method(self) -> dict[SolarNetId, Any]:
+        """Return the settings per solar net id from the Modbus interface."""
+        await self._refresh()
+        inverter = self.modbus_inverter
+        values: dict[str, float | bool | None] = {}
+
+        if (controls := inverter.controls) is not None:
+            values["power_limit"] = controls.power_limit
+        if (storage := inverter.storage) is not None:
+            values["battery_charge_limit"] = storage.charge_limit
+            values["battery_discharge_limit"] = storage.discharge_limit
+            values["battery_minimum_reserve"] = storage.minimum_reserve
+
+        return self._as_device_data(values)
 
 
 class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -9,10 +9,10 @@
       }
     },
     "number": {
-      "battery_charge_limit": {
+      "battery_charge_power_limit": {
         "default": "mdi:battery-arrow-up"
       },
-      "battery_discharge_limit": {
+      "battery_discharge_power_limit": {
         "default": "mdi:battery-arrow-down"
       },
       "battery_minimum_reserve": {

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -8,6 +8,20 @@
         "default": "mdi:power-standby"
       }
     },
+    "number": {
+      "battery_charge_limit": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "battery_discharge_limit": {
+        "default": "mdi:battery-arrow-down"
+      },
+      "battery_minimum_reserve": {
+        "default": "mdi:battery-lock"
+      },
+      "power_limit": {
+        "default": "mdi:speedometer-slow"
+      }
+    },
     "sensor": {
       "cash_factor": {
         "default": "mdi:cash-plus"

--- a/homeassistant/components/fronius/number.py
+++ b/homeassistant/components/fronius/number.py
@@ -1,0 +1,126 @@
+"""Number entities for the Fronius Modbus setpoints."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, override
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.const import PERCENTAGE, EntityCategory, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import FroniusEntity, FroniusEntityDescription
+
+if TYPE_CHECKING:
+    from . import FroniusConfigEntry
+    from .coordinator import FroniusModbusSettingsUpdateCoordinator
+
+# writes go to one device at a time
+PARALLEL_UPDATES: Final = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class FroniusNumberEntityDescription(FroniusEntityDescription, NumberEntityDescription):
+    """Describes a Fronius Modbus number entity.
+
+    ``field`` is the writable field of the model the setpoint lives in, and
+    ``enable_field`` the one that puts it into effect, where there is one.
+    """
+
+    component: str
+    field: str
+    enable_field: str | None = None
+
+
+MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
+    FroniusNumberEntityDescription(
+        key="power_limit",
+        component="controls",
+        field="power_limit",
+        enable_field="enabled",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusNumberEntityDescription(
+        key="battery_charge_limit",
+        component="storage",
+        field="charge_limit",
+        enable_field="charge_limit_enabled",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusNumberEntityDescription(
+        key="battery_discharge_limit",
+        component="storage",
+        field="discharge_limit",
+        enable_field="discharge_limit_enabled",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusNumberEntityDescription(
+        key="battery_minimum_reserve",
+        component="storage",
+        field="minimum_reserve",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FroniusConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Fronius number entities based on a config entry."""
+    for coordinator in config_entry.runtime_data.modbus_settings_coordinators:
+        coordinator.add_entities_for_seen_keys(
+            async_add_entities, Platform.NUMBER, ModbusSetpointNumber
+        )
+
+
+class ModbusSetpointNumber(FroniusEntity, NumberEntity):
+    """A writable setpoint of an inverters Modbus interface."""
+
+    entity_description: FroniusNumberEntityDescription
+    coordinator: FroniusModbusSettingsUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: FroniusModbusSettingsUpdateCoordinator,
+        description: FroniusNumberEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius Modbus setpoint."""
+        super().__init__(coordinator, description, solar_net_id)
+        self._attr_device_info = coordinator.inverter_info.device_info
+        self._attr_unique_id = (
+            f"{coordinator.inverter_info.unique_id}-modbus-{description.key}"
+        )
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the setpoint as the device reports it."""
+        return self._device_data()[self.response_key]["value"]  # type: ignore[no-any-return]
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Write the setpoint to the device."""
+        await self.coordinator.async_write(
+            self.entity_description.component,
+            self.entity_description.field,
+            value,
+            enable_field=self.entity_description.enable_field,
+        )

--- a/homeassistant/components/fronius/number.py
+++ b/homeassistant/components/fronius/number.py
@@ -44,7 +44,7 @@ MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
         entity_category=EntityCategory.CONFIG,
     ),
     FroniusNumberEntityDescription(
-        key="battery_charge_limit",
+        key="battery_charge_power_limit",
         component="storage",
         field="charge_limit",
         enable_field="charge_limit_enabled",
@@ -55,7 +55,7 @@ MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
         entity_category=EntityCategory.CONFIG,
     ),
     FroniusNumberEntityDescription(
-        key="battery_discharge_limit",
+        key="battery_discharge_power_limit",
         component="storage",
         field="discharge_limit",
         enable_field="discharge_limit_enabled",

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -49,11 +49,11 @@
       }
     },
     "number": {
-      "battery_charge_limit": {
-        "name": "Battery charge limit"
+      "battery_charge_power_limit": {
+        "name": "Battery charge power limit"
       },
-      "battery_discharge_limit": {
-        "name": "Battery discharge limit"
+      "battery_discharge_power_limit": {
+        "name": "Battery discharge power limit"
       },
       "battery_minimum_reserve": {
         "name": "Battery minimum reserve"

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -48,6 +48,20 @@
         "name": "Battery standby"
       }
     },
+    "number": {
+      "battery_charge_limit": {
+        "name": "Battery charge limit"
+      },
+      "battery_discharge_limit": {
+        "name": "Battery discharge limit"
+      },
+      "battery_minimum_reserve": {
+        "name": "Battery minimum reserve"
+      },
+      "power_limit": {
+        "name": "Power limit"
+      }
+    },
     "sensor": {
       "capacity_designed": {
         "name": "Designed capacity"
@@ -59,7 +73,7 @@
         "name": "Grid export tariff"
       },
       "co2_factor": {
-        "name": "CO₂ factor"
+        "name": "CO\u2082 factor"
       },
       "current_ac": {
         "name": "AC current"
@@ -162,8 +176,8 @@
           "hardware_id_problem": "Hardware ID problem",
           "hid_range_error": "HID range error",
           "initialisation_error_file_system_error_on_usb": "Initialization error in file system on USB flash drive",
-          "initialisation_error_usb_flash_drive_not_supported": "Initialization error – USB flash drive is not supported",
-          "initialisation_error_usb_stick_over_current": "Initialization error – Overcurrent on USB stick",
+          "initialisation_error_usb_flash_drive_not_supported": "Initialization error \u2013 USB flash drive is not supported",
+          "initialisation_error_usb_stick_over_current": "Initialization error \u2013 Overcurrent on USB stick",
           "insulation_error_on_solar_panels": "Insulation error on the solar panels",
           "insulation_fault": "Insulation fault",
           "insulation_measurement_triggered": "Insulation measurement triggered",
@@ -420,6 +434,12 @@
   "exceptions": {
     "entry_cannot_connect": {
       "message": "Failed to connect to Fronius device at {host}: {fronius_error}"
+    },
+    "modbus_model_unavailable": {
+      "message": "The inverter no longer exposes the model this setting lives in"
+    },
+    "modbus_write_failed": {
+      "message": "Could not write the setting to the inverter: {error}"
     },
     "update_failed": {
       "message": "An error occurred while attempting to fetch data: {fronius_error}"

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -1,7 +1,7 @@
 """Tests for the Fronius Modbus TCP (SunSpec) support."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
@@ -251,7 +251,11 @@ async def test_no_mppt_model(
     mock_fronius_modbus: MockModbusConnection,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test a SunSpec device without MPPT model creates no Modbus entities."""
+    """Test a SunSpec device without MPPT model still gets its controls.
+
+    The power limit and battery setpoints live in their own models, so they
+    do not depend on the MPPT data being there.
+    """
     mock_fronius_modbus.for_unit(1).holding.update(
         build_sunspec_map([], include_mppt_model=False)
     )
@@ -262,13 +266,16 @@ async def test_no_mppt_model(
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert config_entry.runtime_data.modbus_inverter_coordinators == []
-    assert not [
+    modbus_entities = [
         entry
         for entry in er.async_entries_for_config_entry(
             entity_registry, config_entry.entry_id
         )
         if "-modbus-" in entry.unique_id
     ]
+    # no MPPT sensors, but the controls and their derived values are there
+    assert not [entry for entry in modbus_entities if "mppt" in entry.unique_id]
+    assert "number" in {entry.domain for entry in modbus_entities}
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -411,3 +418,36 @@ async def test_modbus_retried_after_setup(
     assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
     # the hold on the shared connection is taken once, not once per re-scan
     assert mock_modbus_unavailable.call_count == 1
+
+
+async def test_control_refused_creates_no_control_entities(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a device that rejects writes gets readings but no controls.
+
+    "Inverter control via Modbus" has to be enabled on the device web
+    interface; without it every write is refused, so offering the controls
+    would only produce entities that error when used.
+    """
+    mock_fronius_modbus.for_unit(1).holding.update(
+        build_sunspec_map(GEN24_HYBRID_MODULES, storage_wcha_max=5000)
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch(
+        "fronius_modbus.Controls.probe_write_access", AsyncMock(return_value=False)
+    ):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+
+    assert config_entry.runtime_data.modbus_settings_coordinators == []
+    assert not [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        if entry.domain == "number"
+    ]

--- a/tests/components/fronius/test_number.py
+++ b/tests/components/fronius/test_number.py
@@ -1,0 +1,125 @@
+"""Tests for the Fronius Modbus setpoint numbers."""
+
+from unittest.mock import patch
+
+from fronius_modbus.testing import build_sunspec_map
+from modbus_connection import IllegalDataValueError
+from modbus_connection.mock import MockModbusConnection
+import pytest
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import mock_responses, setup_fronius_integration
+from .test_modbus import GEN24_HYBRID_MODULES, assert_state
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+POWER_LIMIT = "number.gen24_storage_power_limit"
+CHARGE_LIMIT = "number.gen24_storage_battery_charge_limit"
+
+
+async def _setup(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    connection: MockModbusConnection,
+) -> MockConfigEntry:
+    connection.for_unit(1).holding.update(
+        build_sunspec_map(
+            GEN24_HYBRID_MODULES, storage_wcha_max=12800, storage_min_reserve=20.0
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.NUMBER]):
+        return await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+
+
+async def test_setpoints_read_from_the_device(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test the setpoints show what the inverter reports."""
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+
+    assert_state(hass, POWER_LIMIT, 100.0)
+    assert_state(hass, CHARGE_LIMIT, 0.0)
+    assert_state(hass, "number.gen24_storage_battery_discharge_limit", 0.0)
+    assert_state(hass, "number.gen24_storage_battery_minimum_reserve", 20.0)
+
+
+async def test_setting_a_value_writes_the_register(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a new setpoint reaches the device and is put into effect.
+
+    A setpoint on its own is stored but not applied - the device acts on it
+    only while the mode it belongs to is enabled.
+    """
+    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    inverter = config_entry.runtime_data.modbus_settings_coordinators[0].modbus_inverter
+    assert inverter.controls.enabled is False
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_LIMIT, ATTR_VALUE: 60},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, POWER_LIMIT, 60.0)
+    assert inverter.controls.enabled is True
+
+
+async def test_a_refused_write_raises(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a device rejecting the write surfaces as an error to the user."""
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    mock_fronius_modbus.for_unit(1).fail_requests(IllegalDataValueError())
+
+    with pytest.raises(HomeAssistantError, match="Could not write"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: CHARGE_LIMIT, ATTR_VALUE: 50},
+            blocking=True,
+        )
+
+
+async def test_battery_setpoint_enables_its_own_limit(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a battery setpoint activates only its own half of StorCtl_Mod."""
+    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    storage = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.storage
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: CHARGE_LIMIT, ATTR_VALUE: 50},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, CHARGE_LIMIT, 50.0)
+    assert storage.charge_limit_enabled is True
+    assert storage.discharge_limit_enabled is False

--- a/tests/components/fronius/test_number.py
+++ b/tests/components/fronius/test_number.py
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 POWER_LIMIT = "number.gen24_storage_power_limit"
-CHARGE_LIMIT = "number.gen24_storage_battery_charge_limit"
+CHARGE_LIMIT = "number.gen24_storage_battery_charge_power_limit"
 
 
 async def _setup(
@@ -53,7 +53,7 @@ async def test_setpoints_read_from_the_device(
 
     assert_state(hass, POWER_LIMIT, 100.0)
     assert_state(hass, CHARGE_LIMIT, 0.0)
-    assert_state(hass, "number.gen24_storage_battery_discharge_limit", 0.0)
+    assert_state(hass, "number.gen24_storage_battery_discharge_power_limit", 0.0)
     assert_state(hass, "number.gen24_storage_battery_minimum_reserve", 20.0)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Builds on the Modbus TCP reading added in #179995 by exposing the inverter's writable setpoints as `number` entities:

| entity | register | model |
|---|---|---|
| Power limit | `WMaxLimPct` | Immediate Controls (123) |
| Battery charge limit | `InWRte` | Basic Storage Control (124) |
| Battery discharge limit | `OutWRte` | Basic Storage Control (124) |
| Battery minimum reserve | `MinRsvPct` | Basic Storage Control (124) |

All four are percentages — of `WMax` for the power limit, of `WChaMax` for the battery. Fronius exposes no absolute-watt setpoint.

### A setpoint alone has no effect

The device applies a setpoint only while the mode it belongs to is enabled, and the Fronius Modbus documentation is explicit that changing an already active mode needs the mode enabled again:

> **WMaxLim_Ena (10)** Zum Starten und Beenden dieser Betriebsart […]
> **HINWEIS!** Um bei einer aktiven Betriebsart Werte zu verändern […] neuen Wert in das entsprechende Register schreiben → die Betriebsart über Register `WMaxLim_Ena` erneut starten

So each setpoint writes its enable register after the value. `100 %` is what "no limit" means to the device. `MinRsvPct` has no enable register and is written on its own. Explicit on/off switches are a follow-up.

### Only offered where the device accepts writes

"Inverter control via Modbus" has to be enabled on the device's web interface, and no register reports whether it is. The only way to find out is to write, so setup writes a harmless register's own value back to itself (`probe_write_access()`); if the device refuses, no control entities are created rather than entities that error when used. Control priority (IO control, dynamic power reduction) can also cause a device to refuse, and surfaces the same way.

### Settings are polled apart from readings

Settings only change when something writes them, so they get their own coordinator on a 5 minute interval rather than riding the 1 minute MPPT poll, as the library [recommends](https://home-assistant-libs.github.io/modbus-connection/home-assistant/integration/). Both Modbus coordinators now share a base that carries the re-discovery retry for a shifted register map.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47615
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

