### PR TITLE
Show a dedicated ESPHome config flow error when provisioning closed

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -10,7 +10,9 @@ from aioesphomeapi import (
     APIClient,
     APIConnectionError,
     BluetoothProxyFeature,
+    ConnectionClosedEvent,
     DeviceInfo,
+    DisconnectReason,
     InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
     RequiresEncryptionAPIError,
@@ -69,6 +71,7 @@ from .encryption_key_storage import async_get_encryption_key_storage
 from .entry_data import ESPHomeConfigEntry
 from .manager import async_replace_device
 
+ERROR_PROVISIONING_CLOSED = "provisioning_closed"
 ERROR_REQUIRES_ENCRYPTION_KEY = "requires_encryption_key"
 ERROR_INVALID_ENCRYPTION_KEY = "invalid_psk"
 ERROR_INVALID_PASSWORD_AUTH = "invalid_auth"
@@ -831,6 +834,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             zeroconf_instance=zeroconf_instance,
             noise_psk=noise_psk,
         )
+        provisioning_closed = False
+
+        def _on_connection_closed(event: ConnectionClosedEvent) -> None:
+            nonlocal provisioning_closed
+            if event.reason is DisconnectReason.PROVISIONING_CLOSED:
+                provisioning_closed = True
+
+        cli.add_connection_closed_callback(_on_connection_closed)
         try:
             await cli.connect()
             self._device_info = await cli.device_info()
@@ -851,6 +862,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         except ResolveAPIError:
             return "resolve_error"
         except APIConnectionError:
+            if provisioning_closed:
+                return ERROR_PROVISIONING_CLOSED
             return "connection_error"
         finally:
             await cli.disconnect(force=True)

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -23,6 +23,7 @@
       "connection_error": "Unable to connect to the ESPHome device. Make sure the device’s YAML configuration includes an `api` section.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device’s YAML configuration under `api -> encryption -> key`.",
+      "provisioning_closed": "The ESPHome device closed its setup window and no longer accepts new connections. Power the device off and on again, then retry.",
       "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device’s YAML configuration under `api -> encryption -> key`.",
       "resolve_error": "Unable to resolve the address of the ESPHome device. If this issue continues, consider setting a static IP address."
     },

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -9,7 +9,9 @@ from aioesphomeapi import (
     APIClient,
     APIConnectionError,
     BluetoothProxyFeature,
+    ConnectionClosedEvent,
     DeviceInfo,
+    DisconnectReason,
     InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
     RequiresEncryptionAPIError,
@@ -410,6 +412,45 @@ async def test_user_causes_zeroconf_to_abort(hass: HomeAssistant) -> None:
     }
 
     assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")
+async def test_user_provisioning_closed(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+) -> None:
+    """Test user step when the device closed its provisioning window."""
+
+    def _provisioning_closed() -> None:
+        mock_client.add_connection_closed_callback.call_args[0][0](
+            ConnectionClosedEvent(
+                expected_disconnect=True,
+                reason=DisconnectReason.PROVISIONING_CLOSED,
+            )
+        )
+        raise APIConnectionError
+
+    mock_client.device_info.side_effect = _provisioning_closed
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "provisioning_closed"}
+
+    # Power cycling the device reopens the provisioning window
+    mock_client.device_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An ESPHome device whose provisioning window has closed answers the hello and then requests a disconnect with `DISCONNECT_REASON_PROVISIONING_CLOSED`, without completing authentication ([`api_connection.cpp`](https://github.com/esphome/esphome/blob/dev/esphome/components/api/api_connection.cpp)). The config flow reported this as the generic `connection_error`, which told the user to check for an `api` section in the YAML. That is the wrong advice and gives the user no way to recover.

The flow now registers a connection closed callback before it probes the device, and returns a dedicated error when the device reported that reason:

> The ESPHome device closed its setup window and no longer accepts new connections. Power the device off and on again, then retry.

The check sits in `_fetch_device_info`, so every flow that probes the device is covered: user, discovery, reauth and reconfigure.

Notes on the client behaviour, verified against `aioesphomeapi==46.2.0` with a device that sends the hello response followed by the disconnect request:

- `APIClient.connect()` succeeds; the failure surfaces on `device_info()` as `ConnectionNotEstablishedAPIError`, which is an `APIConnectionError`. That is why the new branch sits in the existing `except APIConnectionError` handler.
- The reason arrives as `ConnectionClosedEvent(expected_disconnect=True, reason=DisconnectReason.PROVISIONING_CLOSED)`. This holds whether the two frames arrive in one TCP segment or two.
- `APIConnection.disconnect_reason` is not usable directly, because `APIClient._connection` is cleared before the exception reaches the flow. The callback is the only public route.

No dependency bump is needed. `aioesphomeapi==46.2.0` already ships `DisconnectReason`, `ConnectionClosedEvent` and `add_connection_closed_callback`.

`try_login` is left alone. It only runs for password devices, and provisioning is an encryption-only feature.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr