### PR TITLE
Migrate ChildDeviceInfo to a dataclass

### DIFF
--- a/homeassistant/components/bang_olufsen/entity.py
+++ b/homeassistant/components/bang_olufsen/entity.py
@@ -52,6 +52,7 @@ class BeoBase:
 class BeoEntity(Entity, BeoBase):
     """Base Entity for Bang & Olufsen entities."""
 
+    _attr_device_info: DeviceInfo
     _attr_has_entity_name = True
     _attr_should_poll = False
 

--- a/homeassistant/components/bang_olufsen/media_player.py
+++ b/homeassistant/components/bang_olufsen/media_player.py
@@ -244,8 +244,7 @@ class BeoMediaPlayer(BeoEntity, MediaPlayerEntity):
         # Use a fallback list of sources
         except ValueError:
             # Try to get software version from device
-            if self.device_info:
-                sw_version = self.device_info.get("sw_version")
+            sw_version = self._attr_device_info.get("sw_version")
             if not sw_version:
                 sw_version = self._software_status.software_version
 

--- a/homeassistant/components/devolo_home_control/entity.py
+++ b/homeassistant/components/devolo_home_control/entity.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 class DevoloDeviceEntity(Entity):
     """Abstract representation of a device within devolo Home Control."""
 
+    _attr_device_info: dr.DeviceInfo
     _attr_has_entity_name = True
 
     def __init__(
@@ -53,10 +54,9 @@ class DevoloDeviceEntity(Entity):
     @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
-        assert self.device_info
-        assert self.device_info["name"]  # The name was set on entity creation
+        assert self._attr_device_info["name"]  # The name was set on entity creation
         self.subscriber = Subscriber(
-            self.device_info["name"], callback=self.sync_callback
+            self._attr_device_info["name"], callback=self.sync_callback
         )
         self._homecontrol.publisher.register(
             self._device_instance.uid, self.subscriber, self.sync_callback

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -855,6 +855,8 @@ async def async_setup_entry(
 class SMAsensor(CoordinatorEntity[SMADataUpdateCoordinator], SensorEntity):
     """Representation of a SMA sensor."""
 
+    _attr_device_info: DeviceInfo
+
     def __init__(
         self,
         coordinator: SMADataUpdateCoordinator,
@@ -897,9 +899,7 @@ class SMAsensor(CoordinatorEntity[SMADataUpdateCoordinator], SensorEntity):
     @override
     def name(self) -> str:
         """Return the name of the sensor prefixed with the device name."""
-        if self._attr_device_info is None or not (
-            name_prefix := self._attr_device_info.get("name")
-        ):
+        if not (name_prefix := self._attr_device_info.get("name")):
             name_prefix = "SMA"
 
         return f"{name_prefix} {super().name}"

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -17,7 +17,6 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
-    Required,
     TypedDict,
     Unpack,
     overload,
@@ -145,7 +144,8 @@ class DeviceInfo(TypedDict, total=False):
     via_device_id: str
 
 
-class ChildDeviceInfo(TypedDict, total=False):
+@dataclass(kw_only=True, slots=True)
+class ChildDeviceInfo:
     """Entity device information for a child device in the device registry.
 
     A child device is a lightweight logical part of a parent device. The parent
@@ -153,12 +153,12 @@ class ChildDeviceInfo(TypedDict, total=False):
     entry, and must belong to the same config subentry.
     """
 
-    identifiers: Required[set[tuple[str, str]]]
-    name: str | None
-    parent_device_id: Required[str]
-    suggested_area: str | None
-    translation_key: str | None
-    translation_placeholders: Mapping[str, str] | None
+    identifiers: set[tuple[str, str]]
+    name: str | UndefinedType | None = UNDEFINED
+    parent_device_id: str
+    suggested_area: str | UndefinedType | None = UNDEFINED
+    translation_key: str | None = None
+    translation_placeholders: Mapping[str, str] | None = None
 
 
 class _EventDeviceRegistryUpdatedData_Create(TypedDict):

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextvars import ContextVar
 from datetime import timedelta
 from logging import Logger, getLogger
-from typing import TYPE_CHECKING, Any, Protocol, cast, overload, override
+from typing import TYPE_CHECKING, Any, Protocol, overload, override
 
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -956,29 +956,24 @@ class EntityPlatform:
                 if device_info := entity.device_info:
                     dev_reg = dr.async_get(self.hass)
                     try:
-                        # A device info carrying a parent_device_id registers a child
-                        # device. An explicit None (as a dynamically built device info
-                        # may carry) means a main device, so check `is not None`.
-                        if device_info.get("parent_device_id") is not None:
+                        if isinstance(device_info, dr.ChildDeviceInfo):
                             device = dev_reg.async_get_or_create_child(
                                 config_entry_id=self.config_entry.entry_id,
                                 config_subentry_id=config_subentry_id,
-                                **cast("dr.ChildDeviceInfo", device_info),
+                                identifiers=device_info.identifiers,
+                                name=device_info.name,
+                                parent_device_id=device_info.parent_device_id,
+                                suggested_area=device_info.suggested_area,
+                                translation_key=device_info.translation_key,
+                                translation_placeholders=(
+                                    device_info.translation_placeholders
+                                ),
                             )
                         else:
-                            # An explicit parent_device_id=None means a main device;
-                            # drop the key as async_get_or_create is main-only.
                             device = dev_reg.async_get_or_create(
                                 config_entry_id=self.config_entry.entry_id,
                                 config_subentry_id=config_subentry_id,
-                                **cast(
-                                    "dr.DeviceInfo",
-                                    {
-                                        key: value
-                                        for key, value in device_info.items()
-                                        if key != "parent_device_id"
-                                    },
-                                ),
+                                **device_info,
                             )
                     except dr.DeviceInfoError as exc:
                         self.logger.error(

--- a/tests/common.py
+++ b/tests/common.py
@@ -1434,7 +1434,7 @@ class MockEntity(entity.Entity):
         return self._handle("device_class")
 
     @property
-    def device_info(self) -> dr.DeviceInfo | None:
+    def device_info(self) -> dr.DeviceInfo | dr.ChildDeviceInfo | None:
         """Info how it links to a device."""
         return self._handle("device_info")
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -2970,11 +2970,11 @@ async def test_device_info_child_device(
                     unique_id="power",
                     has_entity_name=True,
                     name="Power",
-                    device_info={
-                        "identifiers": {(config_entry.domain, "strip_outlet_1")},
-                        "name": "Outlet 1",
-                        "parent_device_id": parent.id,
-                    },
+                    device_info=dr.ChildDeviceInfo(
+                        identifiers={(config_entry.domain, "strip_outlet_1")},
+                        name="Outlet 1",
+                        parent_device_id=parent.id,
+                    ),
                 ),
             ]
         )
@@ -3028,11 +3028,11 @@ async def test_device_info_child_device_invalid(
             [
                 MockEntity(
                     unique_id="power",
-                    device_info={
-                        "identifiers": {(config_entry.domain, "strip_outlet_1")},
-                        "name": "Outlet 1",
-                        "parent_device_id": "nonexistent-device-id",
-                    },
+                    device_info=dr.ChildDeviceInfo(
+                        identifiers={(config_entry.domain, "strip_outlet_1")},
+                        name="Outlet 1",
+                        parent_device_id="nonexistent-device-id",
+                    ),
                 ),
             ]
         )
@@ -3050,15 +3050,14 @@ async def test_device_info_child_device_invalid(
     assert "Not adding entity with invalid device info" in caplog.text
 
 
-async def test_device_info_parent_device_id_routing(
+async def test_device_info_type_routing(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test parent_device_id in device info routes to a child or a main device.
+    """Test the device info type routes to a child or a main device.
 
-    A device info carrying a parent_device_id creates a child device, while one
-    without a parent_device_id creates a main device.
+    A ChildDeviceInfo creates a child device, a DeviceInfo a main device.
     """
     config_entry = MockConfigEntry(entry_id="super-mock-id")
     config_entry.add_to_hass(hass)
@@ -3078,26 +3077,18 @@ async def test_device_info_parent_device_id_routing(
             [
                 MockEntity(
                     unique_id="child",
-                    device_info={
-                        "identifiers": {(config_entry.domain, "child")},
-                        "name": "Child",
-                        "parent_device_id": parent.id,
-                    },
+                    device_info=dr.ChildDeviceInfo(
+                        identifiers={(config_entry.domain, "child")},
+                        name="Child",
+                        parent_device_id=parent.id,
+                    ),
                 ),
                 MockEntity(
                     unique_id="main",
-                    device_info={
-                        "identifiers": {(config_entry.domain, "main")},
-                        "name": "Main",
-                    },
-                ),
-                MockEntity(
-                    unique_id="main_explicit_none",
-                    device_info={
-                        "identifiers": {(config_entry.domain, "main_none")},
-                        "name": "Main explicit none",
-                        "parent_device_id": None,
-                    },
+                    device_info=dr.DeviceInfo(
+                        identifiers={(config_entry.domain, "main")},
+                        name="Main",
+                    ),
                 ),
             ]
         )
@@ -3110,7 +3101,7 @@ async def test_device_info_parent_device_id_routing(
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
 
-    # A parent_device_id routes to a child device, not a main device
+    # A ChildDeviceInfo routes to a child device, not a main device
     child_device = device_registry.async_get_child_device_by_identifier(
         (config_entry.domain, "child"), config_entry.entry_id
     )
@@ -3123,7 +3114,7 @@ async def test_device_info_parent_device_id_routing(
         is None
     )
 
-    # A device info without a parent_device_id routes to a main device, not a child
+    # A DeviceInfo routes to a main device, not a child device
     main_device = device_registry.async_get_device_by_identifier(
         (config_entry.domain, "main"), config_entry.entry_id
     )
@@ -3131,18 +3122,6 @@ async def test_device_info_parent_device_id_routing(
     assert (
         device_registry.async_get_child_device_by_identifier(
             (config_entry.domain, "main"), config_entry.entry_id
-        )
-        is None
-    )
-
-    # An explicit parent_device_id=None routes to a main device, not a child
-    main_none_device = device_registry.async_get_device_by_identifier(
-        (config_entry.domain, "main_none"), config_entry.entry_id
-    )
-    assert isinstance(main_none_device, dr.DeviceEntry)
-    assert (
-        device_registry.async_get_child_device_by_identifier(
-            (config_entry.domain, "main_none"), config_entry.entry_id
         )
         is None
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None - it was introduced in https://github.com/home-assistant/core/pull/178666 (unreleased)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use a dataclass instead of a typed dict.
As part of a suggestion from @emontnemery in #172558

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
