### PR TITLE
Migrate DeviceInfo and ChildDeviceInfo to be dataclasses

### DIFF
--- a/homeassistant/components/aprilaire/coordinator.py
+++ b/homeassistant/components/aprilaire/coordinator.py
@@ -106,7 +106,7 @@ class AprilaireCoordinator(BaseDataUpdateCoordinatorProtocol):
 
                 device_registry.async_update_device(
                     device_id=device.id,
-                    **new_device_info,  # type: ignore[misc]
+                    **new_device_info,
                 )
 
     async def start_listen(self):

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -77,7 +77,7 @@ class PassiveBluetoothProcessorData:
 class RestoredPassiveBluetoothDataUpdate(TypedDict):
     """Restored PassiveBluetoothDataUpdate."""
 
-    devices: dict[str, DeviceInfo]
+    devices: dict[str, dict[str, Any]]
     entity_descriptions: dict[str, dict[str, Any]]
     entity_names: dict[str, str | None]
     entity_data: dict[str, Any]
@@ -173,7 +173,9 @@ class PassiveBluetoothDataUpdate[_T]:
         """Serialize restore data to storage."""
         return {
             "devices": {
-                key or "": device_info for key, device_info in self.devices.items()
+                # A device info is stored as the mapping of the fields it sets
+                key or "": dict(device_info)
+                for key, device_info in self.devices.items()
             },
             "entity_descriptions": {
                 key.to_string(): serialize_entity_description(description)
@@ -196,7 +198,7 @@ class PassiveBluetoothDataUpdate[_T]:
         """Set the restored data from storage."""
         self.devices.update(
             {
-                key or None: device_info
+                key or None: DeviceInfo(device_info)
                 for key, device_info in restore_data["devices"].items()
             }
         )

--- a/homeassistant/components/flux_led/entity.py
+++ b/homeassistant/components/flux_led/entity.py
@@ -37,7 +37,7 @@ def _async_device_info(
         sw_version_str = f"{sw_version:0.2f}"
     else:
         sw_version_str = str(device.version_num)
-    device_info: DeviceInfo = {
+    device_info: DeviceInfo = {  # type: ignore[assignment]
         ATTR_IDENTIFIERS: {(DOMAIN, entry.entry_id)},
         ATTR_MANUFACTURER: "Zengge",
         ATTR_MODEL: device.model,

--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -1782,9 +1782,9 @@ def update_device(
     if config_entry_id is not None and device_info is not None:
         if via_device_id := _resolve_via_device_id(hass, specifications, config_entry):
             device_info["via_device_id"] = via_device_id
-        update_device_info = cast(dict[str, Any], device_info)
-        update_device_info["config_entry_id"] = config_entry_id
-        device = device_registry.async_get_or_create(**update_device_info)
+        device = device_registry.async_get_or_create(
+            config_entry_id=config_entry_id, **device_info
+        )
 
     return device.id if device else None
 

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -106,7 +106,7 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         if TYPE_CHECKING:
             assert self._attr_device_info is not None
         self._attr_device_info |= {
-            ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
+            ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},
             ATTR_NAME: zone.get_name(),
             "via_device_id": dr.async_get_device_id_by_identifier(
                 self.coordinator.hass,

--- a/homeassistant/components/onewire/diagnostics.py
+++ b/homeassistant/components/onewire/diagnostics.py
@@ -8,9 +8,16 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
+from .model import OWDeviceDescription
 from .onewirehub import OneWireConfigEntry
 
 TO_REDACT = {CONF_HOST}
+
+
+def _device_diagnostics(device_details: OWDeviceDescription) -> dict[str, Any]:
+    """Return diagnostics for a device description."""
+    # asdict recurses into the device info, which holds a field per key it can set
+    return asdict(device_details) | {"device_info": dict(device_details.device_info)}
 
 
 async def async_get_config_entry_diagnostics(
@@ -25,7 +32,10 @@ async def async_get_config_entry_diagnostics(
             "data": async_redact_data(entry.data, TO_REDACT),
             "options": {**entry.options},
         },
-        "devices": [asdict(device_details) for device_details in onewire_hub.devices],
+        "devices": [
+            _device_diagnostics(device_details)
+            for device_details in onewire_hub.devices
+        ],
     }
 
 
@@ -42,7 +52,7 @@ async def async_get_device_diagnostics(
             "data": async_redact_data(entry.data, TO_REDACT),
             "options": {**entry.options},
         },
-        "device": asdict(
+        "device": _device_diagnostics(
             next(
                 device_details
                 for device_details in onewire_hub.devices

--- a/homeassistant/components/openrgb/select.py
+++ b/homeassistant/components/openrgb/select.py
@@ -39,7 +39,7 @@ class OpenRGBProfileSelect(CoordinatorEntity[OpenRGBCoordinator], SelectEntity):
         """Initialize the select entity."""
         super().__init__(coordinator)
         self._attr_unique_id = UID_SEPARATOR.join([entry.entry_id, "profile"])
-        self._attr_device_info = {
+        self._attr_device_info = {  # type: ignore[assignment]
             "identifiers": {(DOMAIN, entry.entry_id)},
         }
         self._update_attrs()

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -299,16 +299,17 @@ class DeviceInfo(_DeviceInfoMapping):
     translation_placeholders: Mapping[str, str] | UndefinedType | None = UNDEFINED
     via_device_id: str | UndefinedType = UNDEFINED
 
-    # Deprecated fields, accepted until the versions listed in
-    # _DEPRECATED_DEVICE_INFO_PARAMETERS. They are hidden from type checkers, as
-    # they were dropped from the typed device info when they were deprecated,
-    # but integrations still set them and async_get_or_create still reports them.
-    created_at: str | UndefinedType = UNDEFINED
-    default_manufacturer: str | UndefinedType = UNDEFINED
-    default_model: str | UndefinedType = UNDEFINED
-    default_name: str | UndefinedType = UNDEFINED
-    modified_at: str | UndefinedType = UNDEFINED
-    via_device: tuple[str, str] | UndefinedType = UNDEFINED
+    if not TYPE_CHECKING:
+        # Deprecated fields, accepted until the versions listed in
+        # _DEPRECATED_DEVICE_INFO_PARAMETERS. They are hidden from type checkers, as
+        # they were dropped from the typed device info when they were deprecated,
+        # but integrations still set them and async_get_or_create still reports them.
+        created_at: str | UndefinedType = UNDEFINED
+        default_manufacturer: str | UndefinedType = UNDEFINED
+        default_model: str | UndefinedType = UNDEFINED
+        default_name: str | UndefinedType = UNDEFINED
+        modified_at: str | UndefinedType = UNDEFINED
+        via_device: tuple[str, str] | UndefinedType = UNDEFINED
 
 
 @_device_info_fields

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2983,6 +2983,44 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         return updated_child_device
 
     @callback
+    def async_get_or_create_from_device_info(
+        self,
+        *,
+        config_entry_id: str,
+        config_subentry_id: str | UndefinedType | None = UNDEFINED,
+        device_info: DeviceInfo | ChildDeviceInfo | Mapping[str, Any],
+    ) -> AnyDeviceEntry:
+        """Get or create the device a device info describes.
+
+        A ChildDeviceInfo, or a device info carrying a parent_device_id, gets or
+        creates a child device, any other a main device.
+        """
+        if isinstance(device_info, _DeviceInfoMapping):
+            # Read the fields, rather than the mapping interface integrations use
+            device_info_fields = {
+                name: value
+                for name in device_info._field_names  # noqa: SLF001
+                if (value := getattr(device_info, name)) is not UNDEFINED
+            }
+        else:
+            device_info_fields = dict(device_info)
+        # An explicit parent_device_id of None, as a dynamically built device info
+        # may carry, means a main device
+        parent_device_id = device_info_fields.pop("parent_device_id", None)
+        if parent_device_id is not None:
+            return self.async_get_or_create_child(
+                config_entry_id=config_entry_id,
+                config_subentry_id=config_subentry_id,
+                parent_device_id=parent_device_id,
+                **device_info_fields,
+            )
+        return self.async_get_or_create(
+            config_entry_id=config_entry_id,
+            config_subentry_id=config_subentry_id,
+            **device_info_fields,
+        )
+
+    @callback
     def _async_validate_device_to_child_conversion(
         self,
         device: DeviceEntry,

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -153,12 +153,14 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
 
     def __post_init__(self, initial: Mapping[str, Any] | None) -> None:
         """Apply the fields of a mapping passed to the constructor."""
+        # Integrations build a device info from a mapping: `DeviceInfo({...})`
         if initial is not None:
             self.update(initial)
 
     @override
     def __getitem__(self, key: str) -> Any:
         """Return the value of a set field."""
+        # Also backs `.get()`, `in` and `**device_info` unpacking
         if key in self._field_names:
             value = getattr(self, key)
             if value is not UNDEFINED:
@@ -168,6 +170,8 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
     @override
     def __setitem__(self, key: str, value: Any) -> None:
         """Set the value of a field."""
+        # Integrations fill a device info in after building it, and `.update()`
+        # merges another mapping in field by field
         if key not in self._field_names:
             raise KeyError(f"'{key}' is not a valid {type(self).__name__} field")
         setattr(self, key, value)
@@ -175,6 +179,7 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
     @override
     def __delitem__(self, key: str) -> None:
         """Unset a field."""
+        # Integrations drop fields before passing a device info on, with `.pop()`
         if key not in self._field_names or getattr(self, key) is UNDEFINED:
             raise KeyError(key)
         setattr(self, key, UNDEFINED)
@@ -192,17 +197,21 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
     @override
     def __repr__(self) -> str:
         """Return the representation, listing the set fields only."""
+        # The generated repr would spell out UNDEFINED for every unset field
         set_fields = ", ".join(f"{key}={value!r}" for key, value in self.items())
         return f"{type(self).__name__}({set_fields})"
 
     def __or__(self, other: Mapping[str, Any]) -> Self:
         """Return a copy updated with the fields of another mapping."""
+        # Integrations layer a device info on top of a shared one:
+        # `base_device_info | DeviceInfo(...)`
         new = copy.copy(self)
         new.update(other)
         return new
 
     def __ior__(self, other: Mapping[str, Any]) -> Self:
         """Update with the fields of another mapping."""
+        # Integrations merge extra fields in: `self._attr_device_info |= {...}`
         self.update(other)
         return self
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,9 +2,16 @@
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Collection, Iterable, Iterator, Mapping, Set as AbstractSet
+from collections.abc import (
+    Collection,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Set as AbstractSet,
+)
 import copy
-from dataclasses import dataclass
+from dataclasses import KW_ONLY, Field, InitVar, dataclass, fields as dataclass_fields
 from datetime import datetime
 from enum import StrEnum
 from functools import lru_cache
@@ -15,9 +22,10 @@ import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Literal,
     NamedTuple,
-    Required,
+    Self,
     TypedDict,
     Unpack,
     overload,
@@ -125,27 +133,115 @@ class DeviceEntryDisabler(StrEnum):
     USER = "user"
 
 
-class DeviceInfo(TypedDict, total=False):
+class _DeviceInfoMapping(MutableMapping[str, Any]):
+    """Mapping interface for the device info dataclasses.
+
+    Device info used to be a TypedDict and is widely consumed as a mapping, for
+    example by passing it to the device registry with `**device_info`. A field
+    left at UNDEFINED is not part of the mapping, which preserves the TypedDict
+    semantics of an unset key.
+    """
+
+    __slots__ = ()
+
+    # The mapping keys, in field declaration order
+    _field_names: ClassVar[tuple[str, ...]]
+
+    if TYPE_CHECKING:
+        # Set by the @dataclass decorator, declared for _device_info_fields
+        __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
+
+    def __post_init__(self, initial: Mapping[str, Any] | None) -> None:
+        """Apply the fields of a mapping passed to the constructor."""
+        if initial is not None:
+            self.update(initial)
+
+    @override
+    def __getitem__(self, key: str) -> Any:
+        """Return the value of a set field."""
+        if key in self._field_names:
+            value = getattr(self, key)
+            if value is not UNDEFINED:
+                return value
+        raise KeyError(key)
+
+    @override
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Set the value of a field."""
+        if key not in self._field_names:
+            raise KeyError(f"'{key}' is not a valid {type(self).__name__} field")
+        setattr(self, key, value)
+
+    @override
+    def __delitem__(self, key: str) -> None:
+        """Unset a field."""
+        if key not in self._field_names or getattr(self, key) is UNDEFINED:
+            raise KeyError(key)
+        setattr(self, key, UNDEFINED)
+
+    @override
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the set fields."""
+        return (key for key in self._field_names if getattr(self, key) is not UNDEFINED)
+
+    @override
+    def __len__(self) -> int:
+        """Return the number of set fields."""
+        return sum(getattr(self, key) is not UNDEFINED for key in self._field_names)
+
+    @override
+    def __repr__(self) -> str:
+        """Return the representation, listing the set fields only."""
+        set_fields = ", ".join(f"{key}={value!r}" for key, value in self.items())
+        return f"{type(self).__name__}({set_fields})"
+
+    def __or__(self, other: Mapping[str, Any]) -> Self:
+        """Return a copy updated with the fields of another mapping."""
+        new = copy.copy(self)
+        new.update(other)
+        return new
+
+    def __ior__(self, other: Mapping[str, Any]) -> Self:
+        """Update with the fields of another mapping."""
+        self.update(other)
+        return self
+
+
+def _device_info_fields[_DeviceInfoT: _DeviceInfoMapping](
+    cls: type[_DeviceInfoT],
+) -> type[_DeviceInfoT]:
+    """Cache the field names a device info dataclass exposes as mapping keys."""
+    cls._field_names = tuple(field.name for field in dataclass_fields(cls))
+    return cls
+
+
+@_device_info_fields
+@dataclass(eq=False, repr=False, slots=True)
+class DeviceInfo(_DeviceInfoMapping):
     """Entity device information for device registry."""
 
-    configuration_url: str | URL | None
-    connections: set[tuple[str, str]]
-    entry_type: DeviceEntryType | None
-    identifiers: set[tuple[str, str]]
-    manufacturer: str | None
-    model: str | None
-    model_id: str | None
-    name: str | None
-    serial_number: str | None
-    suggested_area: str | None
-    sw_version: str | None
-    hw_version: str | None
-    translation_key: str | None
-    translation_placeholders: Mapping[str, str] | None
-    via_device_id: str
+    initial: InitVar[Mapping[str, Any] | None] = None
+    _: KW_ONLY
+    configuration_url: str | URL | UndefinedType | None = UNDEFINED
+    connections: set[tuple[str, str]] | UndefinedType = UNDEFINED
+    entry_type: DeviceEntryType | UndefinedType | None = UNDEFINED
+    identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED
+    manufacturer: str | UndefinedType | None = UNDEFINED
+    model: str | UndefinedType | None = UNDEFINED
+    model_id: str | UndefinedType | None = UNDEFINED
+    name: str | UndefinedType | None = UNDEFINED
+    serial_number: str | UndefinedType | None = UNDEFINED
+    suggested_area: str | UndefinedType | None = UNDEFINED
+    sw_version: str | UndefinedType | None = UNDEFINED
+    hw_version: str | UndefinedType | None = UNDEFINED
+    translation_key: str | UndefinedType | None = UNDEFINED
+    translation_placeholders: Mapping[str, str] | UndefinedType | None = UNDEFINED
+    via_device_id: str | UndefinedType = UNDEFINED
 
 
-class ChildDeviceInfo(TypedDict, total=False):
+@_device_info_fields
+@dataclass(eq=False, repr=False, slots=True)
+class ChildDeviceInfo(_DeviceInfoMapping):
     """Entity device information for a child device in the device registry.
 
     A child device is a lightweight logical part of a parent device. The parent
@@ -153,12 +249,14 @@ class ChildDeviceInfo(TypedDict, total=False):
     entry, and must belong to the same config subentry.
     """
 
-    identifiers: Required[set[tuple[str, str]]]
-    name: str | None
-    parent_device_id: Required[str]
-    suggested_area: str | None
-    translation_key: str | None
-    translation_placeholders: Mapping[str, str] | None
+    initial: InitVar[Mapping[str, Any] | None] = None
+    _: KW_ONLY
+    identifiers: set[tuple[str, str]]
+    name: str | UndefinedType | None = UNDEFINED
+    parent_device_id: str
+    suggested_area: str | UndefinedType | None = UNDEFINED
+    translation_key: str | UndefinedType | None = UNDEFINED
+    translation_placeholders: Mapping[str, str] | UndefinedType | None = UNDEFINED
 
 
 class _EventDeviceRegistryUpdatedData_Create(TypedDict):
@@ -200,7 +298,9 @@ class DeviceEntryType(StrEnum):
 class DeviceInfoError(HomeAssistantError):
     """Raised when device info is invalid."""
 
-    def __init__(self, domain: str, device_info: DeviceInfo, message: str) -> None:
+    def __init__(
+        self, domain: str, device_info: Mapping[str, Any], message: str
+    ) -> None:
         """Initialize error."""
         super().__init__(
             f"Invalid device info {device_info} for '{domain}' config entry: {message}",
@@ -240,7 +340,7 @@ class DeviceConnectionCollisionError(DeviceCollisionError):
 
 def _validate_device_info(
     config_entry: ConfigEntry,
-    device_info: DeviceInfo,
+    device_info: Mapping[str, Any],
 ) -> None:
     """Validate that a device info has enough information to match up a device."""
     if not device_info.get("connections") and not device_info.get("identifiers"):
@@ -2321,10 +2421,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 config_entry, translation_key, translation_placeholders
             )
 
-        # Reconstruct a DeviceInfo dict from the arguments.
-        # When we upgrade to Python 3.12, we can change this method to instead
-        # accept kwargs typed as a DeviceInfo dict (PEP 692)
-        device_info: DeviceInfo = {  # type: ignore[assignment]
+        # Reconstruct a device info dict from the arguments, used for error
+        # reporting. It can hold deprecated keys, so it's not a DeviceInfo.
+        device_info: dict[str, Any] = {
             key: val
             for key, val in (
                 ("connections", connections),
@@ -2636,9 +2735,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 config_entry, translation_key, translation_placeholders
             )
 
-        # Reconstruct a ChildDeviceInfo dict from the arguments, used for error reporting
-        # and conversion of an existing device to a child device.
-        device_info: DeviceInfo = {  # type: ignore[assignment]
+        # Reconstruct a child device info dict from the arguments, used for error
+        # reporting and conversion of an existing device to a child device.
+        device_info: dict[str, Any] = {
             key: val
             for key, val in (
                 ("identifiers", identifiers),
@@ -2823,7 +2922,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         device: DeviceEntry,
         parent: DeviceEntry,
         config_entry: ConfigEntry,
-        device_info: DeviceInfo,
+        device_info: Mapping[str, Any],
     ) -> None:
         """Validate converting a device to a child device.
 
@@ -3832,7 +3931,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         self,
         matched_device: DeviceEntry | None,
         config_entry: ConfigEntry,
-        device_info: DeviceInfo,
+        device_info: Mapping[str, Any],
         identifiers: set[tuple[str, str]],
         connections: set[tuple[str, str]],
     ) -> None:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -213,10 +213,17 @@ class _DeviceInfoMapping:
         return tuple((key, getattr(self, key)) for key in self)
 
     def as_dict(self) -> dict[str, Any]:
-        """Return the set fields."""
-        # The JSON encoders serialize an object with an as_dict; a dataclass would
-        # otherwise be serialized field by field, unset fields included
-        return dict(self)
+        """Return the set fields.
+
+        Reads the fields, so a caller does not need the mapping interface the
+        integrations use. The JSON encoders serialize an object with an as_dict; a
+        dataclass would otherwise be serialized field by field, unset ones included.
+        """
+        return {
+            name: value
+            for name in self._field_names
+            if (value := getattr(self, name)) is not UNDEFINED
+        }
 
     def get(self, key: str, default: Any = None) -> Any:
         """Return the value of a field, or default if the field is not set."""
@@ -2988,44 +2995,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             updated_child_device.id
         )
         return updated_child_device
-
-    @callback
-    def async_get_or_create_from_device_info(
-        self,
-        *,
-        config_entry_id: str,
-        config_subentry_id: str | UndefinedType | None = UNDEFINED,
-        device_info: DeviceInfo | ChildDeviceInfo | Mapping[str, Any],
-    ) -> AnyDeviceEntry:
-        """Get or create the device a device info describes.
-
-        A ChildDeviceInfo, or a device info carrying a parent_device_id, gets or
-        creates a child device, any other a main device.
-        """
-        if isinstance(device_info, _DeviceInfoMapping):
-            # Read the fields, rather than the mapping interface integrations use
-            device_info_fields = {
-                name: value
-                for name in device_info._field_names  # noqa: SLF001
-                if (value := getattr(device_info, name)) is not UNDEFINED
-            }
-        else:
-            device_info_fields = dict(device_info)
-        # An explicit parent_device_id of None, as a dynamically built device info
-        # may carry, means a main device
-        parent_device_id = device_info_fields.pop("parent_device_id", None)
-        if parent_device_id is not None:
-            return self.async_get_or_create_child(
-                config_entry_id=config_entry_id,
-                config_subentry_id=config_subentry_id,
-                parent_device_id=parent_device_id,
-                **device_info_fields,
-            )
-        return self.async_get_or_create(
-            config_entry_id=config_entry_id,
-            config_subentry_id=config_subentry_id,
-            **device_info_fields,
-        )
 
     @callback
     def _async_validate_device_to_child_conversion(

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -270,6 +270,17 @@ class DeviceInfo(_DeviceInfoMapping):
     translation_placeholders: Mapping[str, str] | UndefinedType | None = UNDEFINED
     via_device_id: str | UndefinedType = UNDEFINED
 
+    # Deprecated fields, accepted until the versions listed in
+    # _DEPRECATED_DEVICE_INFO_PARAMETERS. They are hidden from type checkers, as
+    # they were dropped from the typed device info when they were deprecated,
+    # but integrations still set them and async_get_or_create still reports them.
+    created_at: str | UndefinedType = UNDEFINED
+    default_manufacturer: str | UndefinedType = UNDEFINED
+    default_model: str | UndefinedType = UNDEFINED
+    default_name: str | UndefinedType = UNDEFINED
+    modified_at: str | UndefinedType = UNDEFINED
+    via_device: tuple[str, str] | UndefinedType = UNDEFINED
+
 
 @_device_info_fields
 @dataclass(repr=False, slots=True)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -184,6 +184,19 @@ class _DeviceInfoMapping:
         return sum(getattr(self, key) is not UNDEFINED for key in self._field_names)
 
     @override
+    def __eq__(self, other: object) -> bool:
+        """Return if the set fields match those of another device info or mapping."""
+        # Integrations compare a device info to a plain mapping, so this can't be
+        # left to the dataclass
+        if isinstance(other, _DeviceInfoMapping):
+            return type(other) is type(self) and all(
+                getattr(self, key) == getattr(other, key) for key in self._field_names
+            )
+        if isinstance(other, Mapping):
+            return dict(self) == other
+        return NotImplemented
+
+    @override
     def __repr__(self) -> str:
         """Return the representation, listing the set fields only."""
         # The generated repr would spell out UNDEFINED for every unset field
@@ -232,6 +245,16 @@ class _DeviceInfoMapping:
         new.update(other)
         return new
 
+    def __ror__(self, other: _DeviceInfoLike) -> Self:
+        """Return a copy holding the fields of another mapping it does not set."""
+        # An integration can hold a device info as a plain dict, and layer on top
+        # of it: `base_device_info | DeviceInfo(...)`
+        new = copy.copy(self)
+        for key, value in other.items():
+            if key not in self:
+                new[key] = value
+        return new
+
     def __ior__(self, other: _DeviceInfoLike) -> Self:
         """Update with the fields of another mapping."""
         # Integrations merge extra fields in: `self._attr_device_info |= {...}`
@@ -248,7 +271,7 @@ def _device_info_fields[_DeviceInfoT: _DeviceInfoMapping](
 
 
 @_device_info_fields
-@dataclass(repr=False, slots=True)
+@dataclass(eq=False, repr=False, slots=True)
 class DeviceInfo(_DeviceInfoMapping):
     """Entity device information for device registry."""
 
@@ -283,7 +306,7 @@ class DeviceInfo(_DeviceInfoMapping):
 
 
 @_device_info_fields
-@dataclass(repr=False, slots=True)
+@dataclass(eq=False, repr=False, slots=True)
 class ChildDeviceInfo(_DeviceInfoMapping):
     """Entity device information for a child device in the device registry.
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,14 +2,7 @@
 
 import asyncio
 from collections import defaultdict
-from collections.abc import (
-    Collection,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    Set as AbstractSet,
-)
+from collections.abc import Collection, Iterable, Iterator, Mapping, Set as AbstractSet
 import copy
 from dataclasses import KW_ONLY, Field, InitVar, dataclass, fields as dataclass_fields
 from datetime import datetime
@@ -133,13 +126,20 @@ class DeviceEntryDisabler(StrEnum):
     USER = "user"
 
 
-class _DeviceInfoMapping(MutableMapping[str, Any]):
-    """Mapping interface for the device info dataclasses.
+type _DeviceInfoLike = _DeviceInfoMapping | Mapping[str, Any]
 
-    Device info used to be a TypedDict and is widely consumed as a mapping, for
-    example by passing it to the device registry with `**device_info`. A field
-    left at UNDEFINED is not part of the mapping, which preserves the TypedDict
-    semantics of an unset key.
+
+class _DeviceInfoMapping:
+    """Dict-style access for the device info dataclasses.
+
+    Device info used to be a TypedDict, and integrations still build and read it as
+    a mapping, for example by passing it to the device registry with
+    `**device_info`. A field left at UNDEFINED is not part of the mapping, which
+    preserves the TypedDict semantics of an unset key.
+
+    Every method here exists for a usage found in an integration; the set is
+    deliberately closed, as this compatibility layer is meant to be deprecated
+    once integrations read and write the fields directly.
     """
 
     __slots__ = ()
@@ -151,47 +151,36 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
         # Set by the @dataclass decorator, declared for _device_info_fields
         __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
 
-    def __post_init__(self, initial: Mapping[str, Any] | None) -> None:
+    def __post_init__(self, initial: _DeviceInfoLike | None) -> None:
         """Apply the fields of a mapping passed to the constructor."""
         # Integrations build a device info from a mapping: `DeviceInfo({...})`
         if initial is not None:
             self.update(initial)
 
-    @override
     def __getitem__(self, key: str) -> Any:
         """Return the value of a set field."""
-        # Also backs `.get()`, `in` and `**device_info` unpacking
+        # Also backs `.get()`, `dict()` and `**device_info` unpacking
         if key in self._field_names:
             value = getattr(self, key)
             if value is not UNDEFINED:
                 return value
         raise KeyError(key)
 
-    @override
     def __setitem__(self, key: str, value: Any) -> None:
         """Set the value of a field."""
-        # Integrations fill a device info in after building it, and `.update()`
-        # merges another mapping in field by field
+        # Integrations fill a device info in after building it
         if key not in self._field_names:
             raise KeyError(f"'{key}' is not a valid {type(self).__name__} field")
         setattr(self, key, value)
 
-    @override
-    def __delitem__(self, key: str) -> None:
-        """Unset a field."""
-        # Integrations drop fields before passing a device info on, with `.pop()`
-        if key not in self._field_names or getattr(self, key) is UNDEFINED:
-            raise KeyError(key)
-        setattr(self, key, UNDEFINED)
-
-    @override
     def __iter__(self) -> Iterator[str]:
         """Iterate over the set fields."""
+        # Also backs `in`, there being no __contains__ to fall back on
         return (key for key in self._field_names if getattr(self, key) is not UNDEFINED)
 
-    @override
     def __len__(self) -> int:
         """Return the number of set fields."""
+        # A device info without any field must be falsy, as an empty dict was
         return sum(getattr(self, key) is not UNDEFINED for key in self._field_names)
 
     @override
@@ -201,7 +190,41 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
         set_fields = ", ".join(f"{key}={value!r}" for key, value in self.items())
         return f"{type(self).__name__}({set_fields})"
 
-    def __or__(self, other: Mapping[str, Any]) -> Self:
+    def keys(self) -> tuple[str, ...]:
+        """Return the names of the set fields."""
+        # Required, together with __getitem__, for `**device_info` unpacking
+        return tuple(self)
+
+    def items(self) -> tuple[tuple[str, Any], ...]:
+        """Return the set fields as key-value pairs."""
+        return tuple((key, getattr(self, key)) for key in self)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the value of a field, or default if the field is not set."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def update(self, other: _DeviceInfoLike) -> None:
+        """Set the fields another device info or mapping has set."""
+        # Integrations merge fields in with `device_info.update(...)`
+        for key, value in other.items():
+            self[key] = value
+
+    def pop(self, key: str, default: Any = UNDEFINED) -> Any:
+        """Unset a field and return its value, or default if it is not set."""
+        # Integrations drop fields before passing a device info on
+        try:
+            value = self[key]
+        except KeyError:
+            if default is UNDEFINED:
+                raise
+            return default
+        setattr(self, key, UNDEFINED)
+        return value
+
+    def __or__(self, other: _DeviceInfoLike) -> Self:
         """Return a copy updated with the fields of another mapping."""
         # Integrations layer a device info on top of a shared one:
         # `base_device_info | DeviceInfo(...)`
@@ -209,7 +232,7 @@ class _DeviceInfoMapping(MutableMapping[str, Any]):
         new.update(other)
         return new
 
-    def __ior__(self, other: Mapping[str, Any]) -> Self:
+    def __ior__(self, other: _DeviceInfoLike) -> Self:
         """Update with the fields of another mapping."""
         # Integrations merge extra fields in: `self._attr_device_info |= {...}`
         self.update(other)
@@ -225,11 +248,11 @@ def _device_info_fields[_DeviceInfoT: _DeviceInfoMapping](
 
 
 @_device_info_fields
-@dataclass(eq=False, repr=False, slots=True)
+@dataclass(repr=False, slots=True)
 class DeviceInfo(_DeviceInfoMapping):
     """Entity device information for device registry."""
 
-    initial: InitVar[Mapping[str, Any] | None] = None
+    initial: InitVar[_DeviceInfoLike | None] = None
     _: KW_ONLY
     configuration_url: str | URL | UndefinedType | None = UNDEFINED
     connections: set[tuple[str, str]] | UndefinedType = UNDEFINED
@@ -249,7 +272,7 @@ class DeviceInfo(_DeviceInfoMapping):
 
 
 @_device_info_fields
-@dataclass(eq=False, repr=False, slots=True)
+@dataclass(repr=False, slots=True)
 class ChildDeviceInfo(_DeviceInfoMapping):
     """Entity device information for a child device in the device registry.
 
@@ -258,7 +281,7 @@ class ChildDeviceInfo(_DeviceInfoMapping):
     entry, and must belong to the same config subentry.
     """
 
-    initial: InitVar[Mapping[str, Any] | None] = None
+    initial: InitVar[_DeviceInfoLike | None] = None
     _: KW_ONLY
     identifiers: set[tuple[str, str]]
     name: str | UndefinedType | None = UNDEFINED

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -212,6 +212,12 @@ class _DeviceInfoMapping:
         """Return the set fields as key-value pairs."""
         return tuple((key, getattr(self, key)) for key in self)
 
+    def as_dict(self) -> dict[str, Any]:
+        """Return the set fields."""
+        # The JSON encoders serialize an object with an as_dict; a dataclass would
+        # otherwise be serialized field by field, unset fields included
+        return dict(self)
+
     def get(self, key: str, default: Any = None) -> Any:
         """Return the value of a field, or default if the field is not set."""
         try:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextvars import ContextVar
 from datetime import timedelta
 from logging import Logger, getLogger
-from typing import TYPE_CHECKING, Any, Protocol, cast, overload, override
+from typing import TYPE_CHECKING, Any, Protocol, overload, override
 
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -953,33 +953,15 @@ class EntityPlatform:
 
             device: dr.AnyDeviceEntry | None
             if self.config_entry:
+                # A device info without any field means no device
                 if device_info := entity.device_info:
                     dev_reg = dr.async_get(self.hass)
                     try:
-                        # A device info carrying a parent_device_id registers a child
-                        # device. An explicit None (as a dynamically built device info
-                        # may carry) means a main device, so check `is not None`.
-                        if device_info.get("parent_device_id") is not None:
-                            device = dev_reg.async_get_or_create_child(
-                                config_entry_id=self.config_entry.entry_id,
-                                config_subentry_id=config_subentry_id,
-                                **cast("dr.ChildDeviceInfo", device_info),
-                            )
-                        else:
-                            # An explicit parent_device_id=None means a main device;
-                            # drop the key as async_get_or_create is main-only.
-                            device = dev_reg.async_get_or_create(
-                                config_entry_id=self.config_entry.entry_id,
-                                config_subentry_id=config_subentry_id,
-                                **cast(
-                                    "dr.DeviceInfo",
-                                    {
-                                        key: value
-                                        for key, value in device_info.items()
-                                        if key != "parent_device_id"
-                                    },
-                                ),
-                            )
+                        device = dev_reg.async_get_or_create_from_device_info(
+                            config_entry_id=self.config_entry.entry_id,
+                            config_subentry_id=config_subentry_id,
+                            device_info=device_info,
+                        )
                     except dr.DeviceInfoError as exc:
                         self.logger.error(
                             "%s: Not adding entity with invalid device info: %s",

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -956,12 +956,29 @@ class EntityPlatform:
                 # A device info without any field means no device
                 if device_info := entity.device_info:
                     dev_reg = dr.async_get(self.hass)
+                    if isinstance(device_info, dr.DeviceInfo | dr.ChildDeviceInfo):
+                        device_info_fields = device_info.as_dict()
+                    else:
+                        # An integration can still describe its device with a plain
+                        # mapping, which its type does not allow. To be deprecated.
+                        device_info_fields = dict(device_info)  # type: ignore[unreachable]
+                    # An explicit parent_device_id of None, as a dynamically built
+                    # device info may carry, means a main device
+                    parent_device_id = device_info_fields.pop("parent_device_id", None)
                     try:
-                        device = dev_reg.async_get_or_create_from_device_info(
-                            config_entry_id=self.config_entry.entry_id,
-                            config_subentry_id=config_subentry_id,
-                            device_info=device_info,
-                        )
+                        if parent_device_id is not None:
+                            device = dev_reg.async_get_or_create_child(
+                                config_entry_id=self.config_entry.entry_id,
+                                config_subentry_id=config_subentry_id,
+                                parent_device_id=parent_device_id,
+                                **device_info_fields,
+                            )
+                        else:
+                            device = dev_reg.async_get_or_create(
+                                config_entry_id=self.config_entry.entry_id,
+                                config_subentry_id=config_subentry_id,
+                                **device_info_fields,
+                            )
                     except dr.DeviceInfoError as exc:
                         self.logger.error(
                             "%s: Not adding entity with invalid device info: %s",

--- a/tests/components/airq/test_coordinator.py
+++ b/tests/components/airq/test_coordinator.py
@@ -81,7 +81,14 @@ async def test_logging_in_coordinator_subsequent_update_data(
     """
     caplog.set_level(logging.DEBUG)
     coordinator = AirQCoordinator(hass, MOCKED_ENTRY)
-    coordinator.device_info.update(DeviceInfo(**TEST_DEVICE_INFO))
+    coordinator.device_info.update(
+        DeviceInfo(
+            name=TEST_DEVICE_INFO["name"],
+            model=TEST_DEVICE_INFO["model"],
+            sw_version=TEST_DEVICE_INFO["sw_version"],
+            hw_version=TEST_DEVICE_INFO["hw_version"],
+        )
+    )
 
     await coordinator._async_update_data()
     # check that the name _is not_ missing

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4631,48 +4631,18 @@ async def test_async_get_or_create_deprecated_parameters(
         ("via_device", ("some_domain", "via_id")),
     ],
 )
-@pytest.mark.parametrize(
-    "integration_frame_path", ["custom_components/test_integration"]
-)
-@pytest.mark.usefixtures("mock_integration_frame")
-async def test_device_info_deprecated_parameters(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    caplog: pytest.LogCaptureFixture,
-    parameter: str,
-    value: Any,
-) -> None:
+def test_device_info_deprecated_parameters(parameter: str, value: Any) -> None:
     """Test a device info can carry deprecated parameters.
 
     They were dropped from the typed device info when they were deprecated, but an
-    integration can still set them until they are removed.
+    integration can still set them until they are removed. Passing them on to
+    async_get_or_create is covered by its own deprecation tests.
     """
-    config_entry = MockConfigEntry()
-    config_entry.add_to_hass(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
-    )
+    assert dict(dr.DeviceInfo(**{parameter: value})) == {parameter: value}
 
-    assert dr.DeviceInfo(**{parameter: value})[parameter] == value
-
-    device_info = dr.DeviceInfo(identifiers={("some_domain", "some_id")})
+    device_info = dr.DeviceInfo()
     device_info[parameter] = value
-    assert dict(device_info) == {
-        "identifiers": {("some_domain", "some_id")},
-        parameter: value,
-    }
-
-    what = (
-        "calls `device_registry.async_get_or_create` with a deprecated "
-        f"`{parameter}` parameter"
-    )
-    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
-        device = device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id, **device_info
-        )
-
-    assert device.identifiers == {("some_domain", "some_id")}
-    assert caplog.text.count(what) == 1
+    assert dict(device_info) == {parameter: value}
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4631,6 +4631,61 @@ async def test_async_get_or_create_deprecated_parameters(
         ("via_device", ("some_domain", "via_id")),
     ],
 )
+@pytest.mark.parametrize(
+    "integration_frame_path", ["custom_components/test_integration"]
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_device_info_deprecated_parameters(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    parameter: str,
+    value: Any,
+) -> None:
+    """Test a device info can carry deprecated parameters.
+
+    They were dropped from the typed device info when they were deprecated, but an
+    integration can still set them until they are removed.
+    """
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
+    )
+
+    assert dr.DeviceInfo(**{parameter: value})[parameter] == value
+
+    device_info = dr.DeviceInfo(identifiers={("some_domain", "some_id")})
+    device_info[parameter] = value
+    assert dict(device_info) == {
+        "identifiers": {("some_domain", "some_id")},
+        parameter: value,
+    }
+
+    what = (
+        "calls `device_registry.async_get_or_create` with a deprecated "
+        f"`{parameter}` parameter"
+    )
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+        device = device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id, **device_info
+        )
+
+    assert device.identifiers == {("some_domain", "some_id")}
+    assert caplog.text.count(what) == 1
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("created_at", "2024-01-01T00:00:00+00:00"),
+        ("default_manufacturer", "manufacturer"),
+        ("default_model", "model"),
+        ("default_name", "name"),
+        ("modified_at", "2024-01-01T00:00:00+00:00"),
+        ("via_device", ("some_domain", "via_id")),
+    ],
+)
 @pytest.mark.usefixtures("mock_integration_frame")
 async def test_async_get_or_create_deprecated_parameter_reported_before_mutation(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate `DeviceInfo` and `ChildDeviceInfo` to be dataclasses

### Background and problem description

`DeviceInfo` and `ChildDeviceInfo` are two of the most widely used types in the codebase, yet as `TypedDicts` they give up most of the guarantees a type carries. A `TypedDict` has no runtime identity - it is a plain dict - so it collapses back to an untyped `dict[str, Any]` at the slightest friction, and the type checker stops helping exactly where mistakes are easiest to make:
 - It can't be handed off without escape hatches. Spreading it needs `**device_info  # type: ignore[misc]` (`aprilaire`), and handing it on often means an explicit `cast(dict[str, Any], device_info)` (`mqtt`) - at which point every field type is lost.
- It can't be identified at runtime. There is no `isinstance(x, DeviceInfo)`, so code that receives "device info" can't tell a real one from an arbitrary mapping and has to trust the caller.
 - It can't carry behavior. No defaults, no validation, no `as_dict()` / serialization contract, no distinction between "field unset" and "field set to None" beyond `total=False + Required[...]`.

### Solution

This PR migrates both classes to `@dataclass(slots=True)`. That restores a real nominal type: attribute access that the checker follows across **-unpacking boundaries, `isinstance` dispatch (used now in `entity_platform` to route child vs. main devices), an explicit `UNDEFINED` sentinel that separates "unset" from `None`, and a single place to hang serialization and validation. The concrete payoff is visible in the diff - several `cast(...)` and `type: ignore` markers disappear because the value no longer has to be laundered through an untyped dict.

Today, integrations build and read device info as a mapping (`DeviceInfo({...})`, `device_info["identifiers"]`, `**device_info`, `|=`). The `_DeviceInfoMapping` base preserves that surface exactly. The target state, however, is for integrations to construct and read the dataclass fields directly; core integrations can be migrated in-tree, while the mapping layer exists primarily to give custom integrations a deprecation runway.

As part of a suggestion from @emontnemery in #172558

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
