### PR TITLE
Add Fronius Modbus control switches

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -49,7 +49,12 @@ from .coordinator import (
 )
 
 _LOGGER: Final = logging.getLogger(__name__)
-PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
+PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 type FroniusConfigEntry = ConfigEntry[FroniusSolarNet]
 

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -28,7 +28,7 @@ from .const import (
     FroniusDeviceInfo,
     SolarNetId,
 )
-from .entity import FroniusEntity, FroniusEntityDescription
+from .entity import FroniusEntity, FroniusEntityDescription, ModbusComponentFn
 from .number import MODBUS_NUMBER_ENTITY_DESCRIPTIONS
 from .sensor import (
     INVERTER_ENTITY_DESCRIPTIONS,
@@ -298,7 +298,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
 
     async def async_write(
         self,
-        component_name: str,
+        component_fn: ModbusComponentFn,
         field: str,
         value: float | bool,
         *,
@@ -317,7 +317,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         turning a limit off hands control to the next priority source, and a
         setpoint change should not quietly take it back.
         """
-        component = getattr(self.modbus_inverter, component_name)
+        component = component_fn(self.modbus_inverter)
         if component is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -39,6 +39,7 @@ from .sensor import (
     POWER_FLOW_ENTITY_DESCRIPTIONS,
     STORAGE_ENTITY_DESCRIPTIONS,
 )
+from .switch import MODBUS_SWITCH_ENTITY_DESCRIPTIONS
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry, FroniusSolarNet
@@ -280,7 +281,10 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
     """
 
     default_interval = timedelta(minutes=5)
-    valid_descriptions = {Platform.NUMBER: MODBUS_NUMBER_ENTITY_DESCRIPTIONS}
+    valid_descriptions = {
+        Platform.NUMBER: MODBUS_NUMBER_ENTITY_DESCRIPTIONS,
+        Platform.SWITCH: MODBUS_SWITCH_ENTITY_DESCRIPTIONS,
+    }
 
     @override
     async def _refresh_components(self) -> None:
@@ -306,10 +310,12 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         register map before anything is written - the register addresses
         move when the data type setting is changed on the device.
 
-        A setpoint on its own has no effect: the device applies it only while
-        the mode it belongs to is enabled, and per the Fronius documentation a
-        change to an already active mode is picked up by enabling it again.
-        ``enable_field`` is written after the setpoint for both reasons.
+        ``enable_field`` names the register that puts a setpoint into effect.
+        It is written again after a change, because the device only picks up a
+        change to an active mode when the mode is enabled again - but only
+        when the mode is already on. Turning it on is the switch's job:
+        turning a limit off hands control to the next priority source, and a
+        setpoint change should not quietly take it back.
         """
         component = getattr(self.modbus_inverter, component_name)
         if component is None:
@@ -320,7 +326,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         try:
             await component.async_update()
             await component.write(field, value)
-            if enable_field is not None:
+            if enable_field is not None and getattr(component, enable_field):
                 await component.write(enable_field, True)
         except (ModbusError, SunSpecError) as err:
             raise HomeAssistantError(
@@ -341,10 +347,16 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
 
         if (controls := inverter.controls) is not None:
             values["power_limit"] = controls.power_limit
+            values["power_limit_enabled"] = controls.enabled
         if (storage := inverter.storage) is not None:
             values["battery_charge_power_limit"] = storage.charge_limit
+            values["battery_charge_power_limit_enabled"] = storage.charge_limit_enabled
             values["battery_discharge_power_limit"] = storage.discharge_limit
+            values["battery_discharge_power_limit_enabled"] = (
+                storage.discharge_limit_enabled
+            )
             values["battery_minimum_reserve"] = storage.minimum_reserve
+            values["battery_grid_charging"] = storage.grid_charging
 
         return self._as_device_data(values)
 

--- a/homeassistant/components/fronius/entity.py
+++ b/homeassistant/components/fronius/entity.py
@@ -1,13 +1,20 @@
 """Base entity for the Fronius integration."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from fronius_modbus import Controls, FroniusModbusInverter, Storage
 
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
     from .coordinator import FroniusCoordinatorBase
+
+# the model a writable setting lives in, picked off a discovered inverter
+type ModbusComponent = Controls | Storage
+type ModbusComponentFn = Callable[[FroniusModbusInverter], ModbusComponent | None]
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -74,6 +74,20 @@
       "voltage_dc_mppt_no": {
         "default": "mdi:current-dc"
       }
+    },
+    "switch": {
+      "battery_charge_power_limit_enabled": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "battery_discharge_power_limit_enabled": {
+        "default": "mdi:battery-arrow-down"
+      },
+      "battery_grid_charging": {
+        "default": "mdi:transmission-tower-import"
+      },
+      "power_limit_enabled": {
+        "default": "mdi:speedometer-slow"
+      }
     }
   }
 }

--- a/homeassistant/components/fronius/number.py
+++ b/homeassistant/components/fronius/number.py
@@ -8,7 +8,7 @@ from homeassistant.const import PERCENTAGE, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .entity import FroniusEntity, FroniusEntityDescription
+from .entity import FroniusEntity, FroniusEntityDescription, ModbusComponentFn
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry
@@ -26,7 +26,7 @@ class FroniusNumberEntityDescription(FroniusEntityDescription, NumberEntityDescr
     ``enable_field`` the one that puts it into effect, where there is one.
     """
 
-    component: str
+    component_fn: ModbusComponentFn
     field: str
     enable_field: str | None = None
 
@@ -34,7 +34,7 @@ class FroniusNumberEntityDescription(FroniusEntityDescription, NumberEntityDescr
 MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
     FroniusNumberEntityDescription(
         key="power_limit",
-        component="controls",
+        component_fn=lambda inverter: inverter.controls,
         field="power_limit",
         enable_field="enabled",
         native_unit_of_measurement=PERCENTAGE,
@@ -45,7 +45,7 @@ MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
     ),
     FroniusNumberEntityDescription(
         key="battery_charge_power_limit",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="charge_limit",
         enable_field="charge_limit_enabled",
         native_unit_of_measurement=PERCENTAGE,
@@ -56,7 +56,7 @@ MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
     ),
     FroniusNumberEntityDescription(
         key="battery_discharge_power_limit",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="discharge_limit",
         enable_field="discharge_limit_enabled",
         native_unit_of_measurement=PERCENTAGE,
@@ -67,7 +67,7 @@ MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
     ),
     FroniusNumberEntityDescription(
         key="battery_minimum_reserve",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="minimum_reserve",
         native_unit_of_measurement=PERCENTAGE,
         native_min_value=0,
@@ -119,7 +119,7 @@ class ModbusSetpointNumber(FroniusEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Write the setpoint to the device."""
         await self.coordinator.async_write(
-            self.entity_description.component,
+            self.entity_description.component_fn,
             self.entity_description.field,
             value,
             enable_field=self.entity_description.enable_field,

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -429,6 +429,20 @@
       "voltage_dc_mppt_no": {
         "name": "DC voltage {mppt_no}"
       }
+    },
+    "switch": {
+      "battery_charge_power_limit_enabled": {
+        "name": "Battery charge power limiting"
+      },
+      "battery_discharge_power_limit_enabled": {
+        "name": "Battery discharge power limiting"
+      },
+      "battery_grid_charging": {
+        "name": "Battery grid charging"
+      },
+      "power_limit_enabled": {
+        "name": "Power limiting"
+      }
     }
   },
   "exceptions": {

--- a/homeassistant/components/fronius/switch.py
+++ b/homeassistant/components/fronius/switch.py
@@ -8,7 +8,7 @@ from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .entity import FroniusEntity, FroniusEntityDescription
+from .entity import FroniusEntity, FroniusEntityDescription, ModbusComponentFn
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry
@@ -25,32 +25,32 @@ class FroniusSwitchEntityDescription(FroniusEntityDescription, SwitchEntityDescr
     ``field`` is the writable field of the model the control lives in.
     """
 
-    component: str
+    component_fn: ModbusComponentFn
     field: str
 
 
 MODBUS_SWITCH_ENTITY_DESCRIPTIONS: list[FroniusSwitchEntityDescription] = [
     FroniusSwitchEntityDescription(
         key="power_limit_enabled",
-        component="controls",
+        component_fn=lambda inverter: inverter.controls,
         field="enabled",
         entity_category=EntityCategory.CONFIG,
     ),
     FroniusSwitchEntityDescription(
         key="battery_charge_power_limit_enabled",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="charge_limit_enabled",
         entity_category=EntityCategory.CONFIG,
     ),
     FroniusSwitchEntityDescription(
         key="battery_discharge_power_limit_enabled",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="discharge_limit_enabled",
         entity_category=EntityCategory.CONFIG,
     ),
     FroniusSwitchEntityDescription(
         key="battery_grid_charging",
-        component="storage",
+        component_fn=lambda inverter: inverter.storage,
         field="grid_charging",
         entity_category=EntityCategory.CONFIG,
     ),
@@ -111,5 +111,5 @@ class ModbusControlSwitch(FroniusEntity, SwitchEntity):
 
     async def _async_write(self, value: bool) -> None:
         await self.coordinator.async_write(
-            self.entity_description.component, self.entity_description.field, value
+            self.entity_description.component_fn, self.entity_description.field, value
         )

--- a/homeassistant/components/fronius/switch.py
+++ b/homeassistant/components/fronius/switch.py
@@ -1,0 +1,115 @@
+"""Switch entities for the Fronius Modbus controls."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, override
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import FroniusEntity, FroniusEntityDescription
+
+if TYPE_CHECKING:
+    from . import FroniusConfigEntry
+    from .coordinator import FroniusModbusSettingsUpdateCoordinator
+
+# writes go to one device at a time
+PARALLEL_UPDATES: Final = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class FroniusSwitchEntityDescription(FroniusEntityDescription, SwitchEntityDescription):
+    """Describes a Fronius Modbus switch entity.
+
+    ``field`` is the writable field of the model the control lives in.
+    """
+
+    component: str
+    field: str
+
+
+MODBUS_SWITCH_ENTITY_DESCRIPTIONS: list[FroniusSwitchEntityDescription] = [
+    FroniusSwitchEntityDescription(
+        key="power_limit_enabled",
+        component="controls",
+        field="enabled",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusSwitchEntityDescription(
+        key="battery_charge_power_limit_enabled",
+        component="storage",
+        field="charge_limit_enabled",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusSwitchEntityDescription(
+        key="battery_discharge_power_limit_enabled",
+        component="storage",
+        field="discharge_limit_enabled",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    FroniusSwitchEntityDescription(
+        key="battery_grid_charging",
+        component="storage",
+        field="grid_charging",
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FroniusConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Fronius switch entities based on a config entry."""
+    for coordinator in config_entry.runtime_data.modbus_settings_coordinators:
+        coordinator.add_entities_for_seen_keys(
+            async_add_entities, Platform.SWITCH, ModbusControlSwitch
+        )
+
+
+class ModbusControlSwitch(FroniusEntity, SwitchEntity):
+    """A control of an inverters Modbus interface that is on or off.
+
+    Turning a limit off doesn't lift it - it hands control back to the next
+    priority source, which may impose a limit of its own. To override such a
+    source, leave the limit on and set its setpoint to 100%.
+    """
+
+    entity_description: FroniusSwitchEntityDescription
+    coordinator: FroniusModbusSettingsUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: FroniusModbusSettingsUpdateCoordinator,
+        description: FroniusSwitchEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius Modbus control switch."""
+        super().__init__(coordinator, description, solar_net_id)
+        self._attr_device_info = coordinator.inverter_info.device_info
+        self._attr_unique_id = (
+            f"{coordinator.inverter_info.unique_id}-modbus-{description.key}"
+        )
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return whether the control is active as the device reports it."""
+        return self._device_data()[self.response_key]["value"]  # type: ignore[no-any-return]
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate the control."""
+        await self._async_write(True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Deactivate the control."""
+        await self._async_write(False)
+
+    async def _async_write(self, value: bool) -> None:
+        await self.coordinator.async_write(
+            self.entity_description.component, self.entity_description.field, value
+        )

--- a/tests/components/fronius/test_number.py
+++ b/tests/components/fronius/test_number.py
@@ -97,7 +97,7 @@ async def test_setting_a_value_re_enables_an_active_limit(
     config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
     coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
     controls = coordinator.modbus_inverter.controls
-    await coordinator.async_write("controls", "enabled", True)
+    await coordinator.async_write(lambda inverter: inverter.controls, "enabled", True)
     assert controls.enabled is True
 
     writes: list[WriteEvent] = []

--- a/tests/components/fronius/test_number.py
+++ b/tests/components/fronius/test_number.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from fronius_modbus.testing import build_sunspec_map
 from modbus_connection import IllegalDataValueError
-from modbus_connection.mock import MockModbusConnection
+from modbus_connection.mock import MockModbusConnection, WriteEvent
 import pytest
 
 from homeassistant.components.number import (
@@ -57,19 +57,21 @@ async def test_setpoints_read_from_the_device(
     assert_state(hass, "number.gen24_storage_battery_minimum_reserve", 20.0)
 
 
-async def test_setting_a_value_writes_the_register(
+async def test_setting_a_value_leaves_a_released_limit_released(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_fronius_modbus: MockModbusConnection,
 ) -> None:
-    """Test a new setpoint reaches the device and is put into effect.
+    """Test a setpoint change doesn't take control back from the inverter.
 
-    A setpoint on its own is stored but not applied - the device acts on it
-    only while the mode it belongs to is enabled.
+    Turning a limit off hands control to the next priority source, so a
+    change to the setpoint must not quietly re-assert it.
     """
     config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
-    inverter = config_entry.runtime_data.modbus_settings_coordinators[0].modbus_inverter
-    assert inverter.controls.enabled is False
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    assert controls.enabled is False
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
@@ -80,7 +82,63 @@ async def test_setting_a_value_writes_the_register(
     await hass.async_block_till_done()
 
     assert_state(hass, POWER_LIMIT, 60.0)
-    assert inverter.controls.enabled is True
+    assert controls.enabled is False
+
+
+async def test_setting_a_value_re_enables_an_active_limit(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a change to an active limit is put into effect.
+
+    The device picks up a new setpoint only when the mode is enabled again.
+    """
+    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
+    controls = coordinator.modbus_inverter.controls
+    await coordinator.async_write("controls", "enabled", True)
+    assert controls.enabled is True
+
+    writes: list[WriteEvent] = []
+    mock_fronius_modbus.for_unit(1).on_write(writes.append)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_LIMIT, ATTR_VALUE: 60},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, POWER_LIMIT, 60.0)
+    assert controls.enabled is True
+    # the setpoint, then the enable register that puts it into effect
+    assert len(writes) == 2
+
+
+async def test_battery_setpoint_leaves_the_mode_bits_alone(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a battery setpoint doesn't activate a limit that was off."""
+    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    storage = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.storage
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: CHARGE_LIMIT, ATTR_VALUE: 50},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, CHARGE_LIMIT, 50.0)
+    assert storage.charge_limit_enabled is False
+    assert storage.discharge_limit_enabled is False
 
 
 async def test_a_refused_write_raises(
@@ -99,27 +157,3 @@ async def test_a_refused_write_raises(
             {ATTR_ENTITY_ID: CHARGE_LIMIT, ATTR_VALUE: 50},
             blocking=True,
         )
-
-
-async def test_battery_setpoint_enables_its_own_limit(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    mock_fronius_modbus: MockModbusConnection,
-) -> None:
-    """Test a battery setpoint activates only its own half of StorCtl_Mod."""
-    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
-    storage = config_entry.runtime_data.modbus_settings_coordinators[
-        0
-    ].modbus_inverter.storage
-
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: CHARGE_LIMIT, ATTR_VALUE: 50},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    assert_state(hass, CHARGE_LIMIT, 50.0)
-    assert storage.charge_limit_enabled is True
-    assert storage.discharge_limit_enabled is False

--- a/tests/components/fronius/test_switch.py
+++ b/tests/components/fronius/test_switch.py
@@ -1,0 +1,151 @@
+"""Tests for the Fronius Modbus control switches."""
+
+from unittest.mock import patch
+
+from fronius_modbus.testing import build_sunspec_map
+from modbus_connection import IllegalDataValueError
+from modbus_connection.mock import MockModbusConnection
+import pytest
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import mock_responses, setup_fronius_integration
+from .test_modbus import GEN24_HYBRID_MODULES, assert_state
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+POWER_LIMITING = "switch.gen24_storage_power_limiting"
+CHARGE_LIMITING = "switch.gen24_storage_battery_charge_power_limiting"
+DISCHARGE_LIMITING = "switch.gen24_storage_battery_discharge_power_limiting"
+GRID_CHARGING = "switch.gen24_storage_battery_grid_charging"
+
+
+async def _setup(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    connection: MockModbusConnection,
+) -> MockConfigEntry:
+    connection.for_unit(1).holding.update(
+        build_sunspec_map(
+            GEN24_HYBRID_MODULES, storage_wcha_max=12800, storage_min_reserve=20.0
+        )
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SWITCH]):
+        return await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
+
+
+async def test_switches_read_from_the_device(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test the switches show what the inverter reports."""
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+
+    for entity_id in (
+        POWER_LIMITING,
+        CHARGE_LIMITING,
+        DISCHARGE_LIMITING,
+        GRID_CHARGING,
+    ):
+        assert_state(hass, entity_id, STATE_OFF)
+
+
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [(SERVICE_TURN_ON, STATE_ON), (SERVICE_TURN_OFF, STATE_OFF)],
+)
+async def test_toggling_writes_the_register(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    service: str,
+    expected: str,
+) -> None:
+    """Test toggling a control reaches the device and is read back."""
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, service, {ATTR_ENTITY_ID: GRID_CHARGING}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, GRID_CHARGING, expected)
+
+
+async def test_limit_switches_keep_each_others_mode_bit(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test the two limit switches share a register without clobbering it.
+
+    Both live in StorCtl_Mod, so writing one has to merge rather than replace.
+    """
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+
+    for entity_id in (CHARGE_LIMITING, DISCHARGE_LIMITING):
+        await hass.services.async_call(
+            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+        await hass.async_block_till_done()
+
+    assert_state(hass, CHARGE_LIMITING, STATE_ON)
+    assert_state(hass, DISCHARGE_LIMITING, STATE_ON)
+
+
+async def test_turning_a_limit_on_asserts_its_setpoint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a limit at 100% is an active limit, not a released one.
+
+    Releasing a limit hands control to the next priority source, which may
+    impose one of its own. Holding it at 100% is how that gets overridden.
+    """
+    config_entry = await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    assert controls.power_limit == 100.0
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: POWER_LIMITING}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert_state(hass, POWER_LIMITING, STATE_ON)
+    assert controls.power_limit == 100.0
+
+
+async def test_a_refused_write_raises(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a device rejecting the write surfaces as an error to the user."""
+    await _setup(hass, aioclient_mock, mock_fronius_modbus)
+    mock_fronius_modbus.for_unit(1).fail_requests(IllegalDataValueError())
+
+    with pytest.raises(HomeAssistantError, match="Could not write"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: POWER_LIMITING},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follows #180241, which added the Modbus setpoints as `number` entities, with the switches that turn them on and off:

| entity | register |
|---|---|
| Power limiting | `WMaxLim_Ena` (model 123) |
| Battery charge power limiting | `StorCtl_Mod` bit 0 (model 124) |
| Battery discharge power limiting | `StorCtl_Mod` bit 1 |
| Battery grid charging | `ChaGriSet` |

### Off and 100 % are different things

This is the reason the switches are needed at all. Turning a limit **off** does not lift it — the inverter hands control back to the next priority source, which may impose a limit of its own. The Fronius Modbus documentation is explicit:

> Betriebsart wird […] beendet und **auf die nächste Priorität zurückgestellt** (z.B.: Dynamische Leistungsreduzierung)

So holding a limit **on at 100 %** is how a lower-priority source gets overridden, and releasing control is a separate action. Both have to be reachable, and a `number` alone cannot express both.

### A setpoint no longer activates a released limit

In #180241 each setpoint wrote its enable register, because without a switch it would otherwise have done nothing. That is now wrong: someone who deliberately released a limit — to let dynamic power reduction take over — would silently take control back by nudging a number.

A setpoint now writes the enable register **only when the limit is already on**, which the device requires for a change to an active mode to be picked up:

> Um bei einer aktiven Betriebsart Werte zu verändern […] neuen Wert in das entsprechende Register schreiben → die Betriebsart über Register `WMaxLim_Ena` erneut starten

Writing a setpoint while the limit is off still stores it on the device; the switch then applies the stored value, which is the order the documentation prescribes.

### Tests

Both behaviours are covered and were checked to fail without the code that implements them: that a setpoint leaves a released limit released, that it re-enables an active one, and that the two `StorCtl_Mod` switches don't clobber each other's bit.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47619
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
