### PR TITLE
Add Auto shut-off threshold numbers to Watergate Sonic device

### DIFF
--- a/homeassistant/components/watergate/__init__.py
+++ b/homeassistant/components/watergate/__init__.py
@@ -33,6 +33,7 @@ WEBHOOK_AUTO_SHUT_OFF = "auto-shut-off-report"
 
 PLATFORMS: list[Platform] = [
     Platform.EVENT,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VALVE,

--- a/homeassistant/components/watergate/number.py
+++ b/homeassistant/components/watergate/number.py
@@ -1,0 +1,106 @@
+"""Support for Watergate numbers."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import override
+
+from watergate_local_api import WatergateApiException, WatergateLocalApiClient
+from watergate_local_api.models import AutoShutOffState
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import EntityCategory, UnitOfTime, UnitOfVolume
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import WatergateConfigEntry, WatergateDataCoordinator
+from .entity import WatergateEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(kw_only=True, frozen=True)
+class WatergateNumberEntityDescription(NumberEntityDescription):
+    """Description for Watergate number entities."""
+
+    value_fn: Callable[[AutoShutOffState], int]
+    set_fn: Callable[[WatergateLocalApiClient, int], Awaitable[bool]]
+
+
+DESCRIPTIONS: tuple[WatergateNumberEntityDescription, ...] = (
+    WatergateNumberEntityDescription(
+        key="auto_shut_off_volume_threshold",
+        translation_key="auto_shut_off_volume_threshold",
+        device_class=NumberDeviceClass.WATER,
+        native_unit_of_measurement=UnitOfVolume.LITERS,
+        native_min_value=1,
+        native_max_value=10000,
+        native_step=1,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda auto_shut_off: auto_shut_off.volume_threshold,
+        set_fn=lambda client, value: client.async_update_auto_shut_off(volume=value),
+    ),
+    WatergateNumberEntityDescription(
+        key="auto_shut_off_duration_threshold",
+        translation_key="auto_shut_off_duration_threshold",
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_min_value=1,
+        native_max_value=1440,
+        native_step=1,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda auto_shut_off: auto_shut_off.duration_threshold,
+        set_fn=lambda client, value: client.async_update_auto_shut_off(duration=value),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WatergateConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Watergate number entities."""
+    coordinator = config_entry.runtime_data
+
+    async_add_entities(
+        SonicAutoShutOffThreshold(coordinator, description)
+        for description in DESCRIPTIONS
+    )
+
+
+class SonicAutoShutOffThreshold(WatergateEntity, NumberEntity):
+    """Number to configure an auto-shut-off threshold."""
+
+    entity_description: WatergateNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: WatergateDataCoordinator,
+        entity_description: WatergateNumberEntityDescription,
+    ) -> None:
+        """Initialize the number."""
+        super().__init__(coordinator, entity_description.key)
+        self.entity_description = entity_description
+
+    @property
+    @override
+    def native_value(self) -> int:
+        """Return the configured threshold."""
+        return self.entity_description.value_fn(self.coordinator.data.auto_shut_off)
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new threshold."""
+        try:
+            await self.entity_description.set_fn(self._api_client, round(value))
+        except WatergateApiException as exc:
+            raise HomeAssistantError("Failed to update auto shut-off") from exc
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/watergate/strings.json
+++ b/homeassistant/components/watergate/strings.json
@@ -55,6 +55,14 @@
         }
       }
     },
+    "number": {
+      "auto_shut_off_duration_threshold": {
+        "name": "Auto shut-off duration threshold"
+      },
+      "auto_shut_off_volume_threshold": {
+        "name": "Auto shut-off volume threshold"
+      }
+    },
     "sensor": {
       "mqtt_up_since": {
         "name": "MQTT up since"

--- a/tests/components/watergate/snapshots/test_number.ambr
+++ b/tests/components/watergate/snapshots/test_number.ambr
@@ -1,0 +1,123 @@
+# serializer version: 1
+# name: test_all_entities[number.sonic_auto_shut_off_duration_threshold-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 1440,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.sonic_auto_shut_off_duration_threshold',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Auto shut-off duration threshold',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Auto shut-off duration threshold',
+    'platform': 'watergate',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_shut_off_duration_threshold',
+    'unique_id': 'a63182948ce2896a.auto_shut_off_duration_threshold',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.sonic_auto_shut_off_duration_threshold-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Sonic Auto shut-off duration threshold',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 1440,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.sonic_auto_shut_off_duration_threshold',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_all_entities[number.sonic_auto_shut_off_volume_threshold-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 10000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.sonic_auto_shut_off_volume_threshold',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Auto shut-off volume threshold',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Auto shut-off volume threshold',
+    'platform': 'watergate',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_shut_off_volume_threshold',
+    'unique_id': 'a63182948ce2896a.auto_shut_off_volume_threshold',
+    'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+  })
+# ---
+# name: test_all_entities[number.sonic_auto_shut_off_volume_threshold-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'water',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Sonic Auto shut-off volume threshold',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 10000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.sonic_auto_shut_off_volume_threshold',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---

--- a/tests/components/watergate/test_number.py
+++ b/tests/components/watergate/test_number.py
@@ -1,0 +1,157 @@
+"""Tests for the Watergate number platform."""
+
+from collections.abc import Generator
+from datetime import timedelta
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from watergate_local_api import WatergateApiException
+from watergate_local_api.models import AutoShutOffState
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import (
+    AsyncMock,
+    MockConfigEntry,
+    async_fire_time_changed,
+    patch,
+    snapshot_platform,
+)
+
+VOLUME_ENTITY_ID = "number.sonic_auto_shut_off_volume_threshold"
+DURATION_ENTITY_ID = "number.sonic_auto_shut_off_duration_threshold"
+
+
+@pytest.mark.usefixtures("mock_watergate_client")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_entry: MockConfigEntry,
+) -> None:
+    """Snapshot the number entities and their registry entries."""
+    with patch("homeassistant.components.watergate.PLATFORMS", [Platform.NUMBER]):
+        await init_integration(hass, mock_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected_kwargs"),
+    [
+        pytest.param(VOLUME_ENTITY_ID, {"volume": 250}, id="volume"),
+        pytest.param(DURATION_ENTITY_ID, {"duration": 250}, id="duration"),
+    ],
+)
+async def test_setting_threshold_calls_client(
+    hass: HomeAssistant,
+    mock_watergate_client: Generator[AsyncMock],
+    mock_entry: MockConfigEntry,
+    entity_id: str,
+    expected_kwargs: dict[str, int],
+) -> None:
+    """Setting a threshold calls the client with the requested value."""
+    await init_integration(hass, mock_entry)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 250},
+        blocking=True,
+    )
+
+    update_mock = mock_watergate_client.async_update_auto_shut_off
+    update_mock.assert_called_once_with(**expected_kwargs)
+    # Home Assistant coerces the service value to a float, the device expects an integer.
+    assert all(
+        isinstance(value, int) for value in update_mock.call_args.kwargs.values()
+    )
+
+
+async def test_setting_fractional_threshold_rounds_to_integer(
+    hass: HomeAssistant,
+    mock_watergate_client: Generator[AsyncMock],
+    mock_entry: MockConfigEntry,
+) -> None:
+    """A fractional threshold is rounded, the device only accepts whole liters."""
+    await init_integration(hass, mock_entry)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: VOLUME_ENTITY_ID, ATTR_VALUE: 250.6},
+        blocking=True,
+    )
+
+    mock_watergate_client.async_update_auto_shut_off.assert_called_once_with(volume=251)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "initial_state", "polled_state"),
+    [
+        pytest.param(VOLUME_ENTITY_ID, "1000", "500", id="volume"),
+        pytest.param(DURATION_ENTITY_ID, "60", "15", id="duration"),
+    ],
+)
+async def test_number_reflects_polled_state(
+    hass: HomeAssistant,
+    mock_watergate_client: Generator[AsyncMock],
+    mock_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    entity_id: str,
+    initial_state: str,
+    polled_state: str,
+) -> None:
+    """The thresholds reflect an auto-shut-off change picked up by polling."""
+    await init_integration(hass, mock_entry)
+
+    assert hass.states.get(entity_id).state == initial_state
+
+    mock_watergate_client.async_get_auto_shut_off.return_value = AutoShutOffState(
+        True, 500, 15
+    )
+    freezer.tick(timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == polled_state
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        pytest.param(VOLUME_ENTITY_ID, id="volume"),
+        pytest.param(DURATION_ENTITY_ID, id="duration"),
+    ],
+)
+async def test_number_raises_on_client_failure(
+    hass: HomeAssistant,
+    mock_watergate_client: Generator[AsyncMock],
+    mock_entry: MockConfigEntry,
+    entity_id: str,
+) -> None:
+    """Client failure while setting a threshold surfaces as a HomeAssistantError."""
+    await init_integration(hass, mock_entry)
+
+    mock_watergate_client.async_update_auto_shut_off.side_effect = (
+        WatergateApiException("boom")
+    )
+
+    with pytest.raises(HomeAssistantError, match="Failed to update auto shut-off"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 250},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expose the auto shut-off volume and duration thresholds as number entities, completing the auto shut-off configuration alongside the enable switch.

The Sonic Local API documents no bounds for either threshold, so the ranges are the integration's own: 1-10000 L and 1-1440 min. A number's min/max are enforced on input but never on the reported state, so a too-narrow range would leave a firmware-accepted value visible but uneditable, while a too-wide one surfaces as an error from the device. Step is 1 because both fields are integers on the device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47621
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
