### PR TITLE
Only export in_zones attribute in TrackerEntity when populated

### DIFF
--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -419,9 +419,9 @@ class TrackerEntity(
     @override
     def state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
-        attr: dict[str, Any] = {
-            DeviceTrackerEntityStateAttribute.IN_ZONES: self.__in_zones or []
-        }
+        attr: dict[str, Any] = {}
+        if self.__in_zones is not None:
+            attr[DeviceTrackerEntityStateAttribute.IN_ZONES] = self.__in_zones
         attr.update(super().state_attributes)
 
         if self.latitude is not None and self.longitude is not None:

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -570,7 +570,6 @@ def test_tracking_type_capability_attribute() -> None:
             "zen_zone",
             {
                 ATTR_SOURCE_TYPE: SourceType.GPS,
-                ATTR_IN_ZONES: [],
             },
             id="location_name",
         ),
@@ -583,7 +582,6 @@ def test_tracking_type_capability_attribute() -> None:
             STATE_UNKNOWN,
             {
                 ATTR_SOURCE_TYPE: SourceType.GPS,
-                ATTR_IN_ZONES: [],
             },
             id="no_location",
         ),
@@ -597,7 +595,6 @@ def test_tracking_type_capability_attribute() -> None:
             {
                 ATTR_BATTERY_LEVEL: 100,
                 ATTR_SOURCE_TYPE: SourceType.GPS,
-                ATTR_IN_ZONES: [],
             },
             id="battery_only",
         ),

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -804,7 +804,6 @@ async def test_modern_platform_setup(hass: HomeAssistant) -> None:
     assert state
     assert state.state == STATE_UNKNOWN
     assert state.attributes == {
-        "in_zones": [],
         "source_type": SourceType.ROUTER,
         "tracking_type": TrackingType.POSITION,
     }
@@ -825,7 +824,6 @@ async def test_modern_platform_setup(hass: HomeAssistant) -> None:
     assert state
     assert state.state == STATE_NOT_HOME
     assert state.attributes == {
-        "in_zones": [],
         "source_type": SourceType.ROUTER,
         "tracking_type": TrackingType.POSITION,
     }

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -103,10 +103,10 @@ async def setup_zone(hass: HomeAssistant) -> None:
             "School",
         ),
         # Send location_name only
-        ({"location_name": "home"}, {"in_zones": []}, "home"),
-        ({"location_name": "office"}, {"in_zones": []}, "Office"),
-        ({"location_name": "school"}, {"in_zones": []}, "School"),
-        ({"location_name": "no_such_zone"}, {"in_zones": []}, "no_such_zone"),
+        ({"location_name": "home"}, {}, "home"),
+        ({"location_name": "office"}, {}, "Office"),
+        ({"location_name": "school"}, {}, "School"),
+        ({"location_name": "no_such_zone"}, {}, "no_such_zone"),
         # Send coordinates only - location is determined by coordinates
         (
             {"gps": [10, 20]},
@@ -375,7 +375,6 @@ async def test_restoring_location(
                 "course": 60,
                 "speed": 70,
                 "vertical_accuracy": 80,
-                "in_zones": [],
                 "tracking_type": "position",
             },
             {
@@ -529,7 +528,6 @@ async def test_saving_state(
                 "course": 60,
                 "speed": 70,
                 "vertical_accuracy": 80,
-                "in_zones": [],
                 "tracking_type": "position",
             },
         ),
@@ -677,7 +675,6 @@ async def test_restoring_state(
                 "course": 60,
                 "speed": 70,
                 "vertical_accuracy": 80,
-                "in_zones": [],
                 "tracking_type": "position",
             },
         ),
@@ -774,6 +771,5 @@ async def test_restoring_state_invalid_extra_data(
     assert state.attributes == {
         "friendly_name": "Test 1",
         "source_type": "gps",
-        "in_zones": [],
         "tracking_type": "position",
     }

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -683,6 +683,25 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     assert state.state == STATE_HOME
 
 
+async def test_mqtt_device_tracker_without_in_zones(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test MQTT device tracker without coordinates does not report empty in_zones."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{"name": "test", "state_topic": "test-topic"}',
+    )
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "test-topic", "home")
+    state = hass.states.get("device_tracker.test")
+    assert state is not None
+    assert state.state == STATE_HOME
+    assert "in_zones" not in state.attributes
+
+
 async def test_setting_blocked_attribute_via_mqtt_json_message(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -741,6 +741,18 @@ async def test_scanner_associated_with_other_zone(
             {ATTR_SOURCE: DEVICE_TRACKER},
             id="office",
         ),
+        # A device tracker reporting "home" without in_zones or coordinates gets placed in zone.home
+        pytest.param(
+            ("home", {ATTR_SOURCE_TYPE: SourceType.GPS}),
+            "home",
+            {
+                ATTR_IN_ZONES: ["zone.home"],
+                ATTR_LATITUDE: 32.87336,
+                ATTR_LONGITUDE: -117.22743,
+                ATTR_SOURCE: DEVICE_TRACKER,
+            },
+            id="home_without_in_zones",
+        ),
         # Legacy GPS trackers contribute their own coordinates but no zones.
         pytest.param(
             _LEGACY_GPS_NOT_HOME,
@@ -805,35 +817,6 @@ async def test_legacy_device_tracker(
         }
         | expected_extra
     )
-
-
-async def test_tracker_without_in_zones_home_state(
-    hass: HomeAssistant,
-    hass_admin_user: MockUser,
-) -> None:
-    """Test a device tracker without in_zones and coordinates reporting home sets in_zones on person."""
-    hass.set_state(CoreState.not_running)
-    user_id = hass_admin_user.id
-    config = {
-        DOMAIN: {
-            "id": "1234",
-            "name": "tracked person",
-            "user_id": user_id,
-            "device_trackers": DEVICE_TRACKER,
-        }
-    }
-    assert await async_setup_component(hass, DOMAIN, config)
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
-
-    # Device tracker has state home, but no in_zones attribute and no GPS coordinates
-    hass.states.async_set(DEVICE_TRACKER, "home", {ATTR_SOURCE_TYPE: SourceType.GPS})
-    await hass.async_block_till_done()
-
-    state = hass.states.get("person.tracked_person")
-    assert state is not None
-    assert state.state == "home"
-    assert state.attributes[ATTR_IN_ZONES] == ["zone.home"]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -807,6 +807,35 @@ async def test_legacy_device_tracker(
     )
 
 
+async def test_tracker_without_in_zones_home_state(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test a device tracker without in_zones and coordinates reporting home sets in_zones on person."""
+    hass.set_state(CoreState.not_running)
+    user_id = hass_admin_user.id
+    config = {
+        DOMAIN: {
+            "id": "1234",
+            "name": "tracked person",
+            "user_id": user_id,
+            "device_trackers": DEVICE_TRACKER,
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, config)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    # Device tracker has state home, but no in_zones attribute and no GPS coordinates
+    hass.states.async_set(DEVICE_TRACKER, "home", {ATTR_SOURCE_TYPE: SourceType.GPS})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("person.tracked_person")
+    assert state is not None
+    assert state.state == "home"
+    assert state.attributes[ATTR_IN_ZONES] == ["zone.home"]
+
+
 @pytest.mark.parametrize(
     ("competitor"),
     [

--- a/tests/components/renault/snapshots/test_device_tracker.ambr
+++ b/tests/components/renault/snapshots/test_device_tracker.ambr
@@ -42,8 +42,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'REG-ZOE-50 Location',
-      <DeviceTrackerEntityStateAttribute.IN_ZONES: 'in_zones'>: list([
-      ]),
       <DeviceTrackerEntityStateAttribute.SOURCE_TYPE: 'source_type'>: <SourceType.GPS: 'gps'>,
       <DeviceTrackerEntityCapabilityAttribute.TRACKING_TYPE: 'tracking_type'>: <TrackingType.POSITION: 'position'>,
     }),

--- a/tests/components/template/test_device_tracker.py
+++ b/tests/components/template/test_device_tracker.py
@@ -261,11 +261,11 @@ async def test_syntax_error(hass: HomeAssistant) -> None:
         ("{{ ['zone.something'] }}", [], STATE_NOT_HOME),
         ("{{ ['sensor.something'] }}", [], STATE_NOT_HOME),
         ("{{ ['not_an_entity_id'] }}", [], STATE_NOT_HOME),
-        ("{{ None }}", [], STATE_UNKNOWN),
-        ("{{ 110 }}", [], STATE_UNKNOWN),
-        ("{{ -110 }}", [], STATE_UNKNOWN),
-        ("{{ 'on' }}", [], STATE_UNKNOWN),
-        ("{{ x - 1 }}", [], STATE_UNKNOWN),
+        ("{{ None }}", None, STATE_UNKNOWN),
+        ("{{ 110 }}", None, STATE_UNKNOWN),
+        ("{{ -110 }}", None, STATE_UNKNOWN),
+        ("{{ 'on' }}", None, STATE_UNKNOWN),
+        ("{{ x - 1 }}", None, STATE_UNKNOWN),
     ],
 )
 @pytest.mark.usefixtures("setup_single_attribute_tracker")
@@ -291,11 +291,12 @@ async def test_in_zones(
     "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
 )
 @pytest.mark.parametrize(
-    ("attribute_template", "expected_state", "error"),
+    ("attribute_template", "expected_state", "expected_in_zones", "error"),
     [
         (
             "{{ ['sensor.something'] }}",
             STATE_NOT_HOME,
+            [],
             "Received invalid device_tracker in_zones: "
             "['sensor.something'] for entity device_tracker.template_device_tracker, "
             "expected a list of zone entity_ids",
@@ -303,6 +304,7 @@ async def test_in_zones(
         (
             "{{ ['not_an_entity_id'] }}",
             STATE_NOT_HOME,
+            [],
             "Received invalid device_tracker in_zones: "
             "['not_an_entity_id'] for entity device_tracker.template_device_tracker, "
             "expected a list of zone entity_ids",
@@ -310,6 +312,7 @@ async def test_in_zones(
         (
             "{{ -110 }}",
             STATE_UNKNOWN,
+            None,
             "Received invalid device_tracker in_zones: "
             "-110 for entity device_tracker.template_device_tracker, "
             "expected a list of zone entity_ids",
@@ -317,6 +320,7 @@ async def test_in_zones(
         (
             "{{ 'on' }}",
             STATE_UNKNOWN,
+            None,
             "Received invalid device_tracker in_zones: "
             "on for entity device_tracker.template_device_tracker, "
             "expected a list of zone entity_ids",
@@ -327,6 +331,7 @@ async def test_in_zones(
 async def test_in_zones_creates_error(
     hass: HomeAssistant,
     expected_state: str,
+    expected_in_zones: list[str] | None,
     error: str,
     caplog: pytest.LogCaptureFixture,
     caplog_setup_text: str,
@@ -336,7 +341,10 @@ async def test_in_zones_creates_error(
 
     state = hass.states.get(TEST_TRACKER.entity_id)
     assert state.state == expected_state
-    assert state.attributes["in_zones"] == []
+    if expected_in_zones is None:
+        assert "in_zones" not in state.attributes
+    else:
+        assert state.attributes["in_zones"] == expected_in_zones
 
     assert error in caplog_setup_text or error in caplog.text
 
@@ -698,7 +706,6 @@ async def test_flow_preview(
             },
             STATE_UNKNOWN,
             {
-                "in_zones": [],
                 "latitude": None,
                 "longitude": None,
                 "gps_accuracy": None,
@@ -714,7 +721,6 @@ async def test_flow_preview(
             },
             STATE_UNKNOWN,
             {
-                "in_zones": [],
                 "latitude": None,
                 "longitude": None,
                 "gps_accuracy": None,
@@ -730,7 +736,6 @@ async def test_flow_preview(
             },
             STATE_UNKNOWN,
             {
-                "in_zones": [],
                 "latitude": None,
                 "longitude": None,
                 "gps_accuracy": None,

--- a/tests/components/victron_gx/test_device_tracker.py
+++ b/tests/components/victron_gx/test_device_tracker.py
@@ -128,6 +128,5 @@ async def test_victron_device_tracker(
         "course": None,
         "speed": None,
         "friendly_name": "GPS Location",
-        "in_zones": [],
         "tracking_type": TrackingType.POSITION,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix an issue where `TrackerEntity.state_attributes` defaulted to exporting `in_zones: []` even when `self.__in_zones` was `None` (i.e. when the device tracker does not report GPS coordinates or zone membership).

Exporting an empty list `[]` when `in_zones` is absent breaks the fallback logic in `person`:
When a device tracker (such as `mqtt` device_tracker without coordinates) reports state `home`, `TrackerEntity.state_attributes` set `in_zones: []` instead of omitting the attribute. When a `person` entity parses this source tracker state in `_parse_source_state`, it checks `if in_zones is None and state.state == STATE_HOME:` to synthesize `in_zones = ["zone.home"]` for non-GPS / state-only trackers. Because `in_zones` was `[]` instead of `None`, this check was bypassed, leaving `person.attributes.in_zones` empty.

With this fix, `TrackerEntity.state_attributes` only includes `in_zones` when `self.__in_zones is not None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180274 
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr