### PR TITLE
Recognize AirGradient 0-1PS as an outdoor model

### DIFF
--- a/homeassistant/components/airgradient/const.py
+++ b/homeassistant/components/airgradient/const.py
@@ -71,6 +71,11 @@ GO_CONFIG = frozenset(
     }
 )
 
+OUTDOOR_CAPABILITIES = ModelCapabilities(
+    config=COMMON_LEGACY_CONFIG,
+    actions=frozenset({CO2_CALIBRATION}),
+)
+
 MODEL_CAPABILITIES: tuple[tuple[str, ModelCapabilities], ...] = (
     (
         "I-9PSL",
@@ -86,13 +91,8 @@ MODEL_CAPABILITIES: tuple[tuple[str, ModelCapabilities], ...] = (
             actions=frozenset({CO2_CALIBRATION, LED_BAR_TEST}),
         ),
     ),
-    (
-        "O-1",
-        ModelCapabilities(
-            config=COMMON_LEGACY_CONFIG,
-            actions=frozenset({CO2_CALIBRATION}),
-        ),
-    ),
+    ("O-1", OUTDOOR_CAPABILITIES),
+    ("0-1PS", OUTDOOR_CAPABILITIES),
     (
         "DIY",
         ModelCapabilities(

--- a/tests/components/airgradient/test_init.py
+++ b/tests/components/airgradient/test_init.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.airgradient.const import DOMAIN
+from homeassistant.components.airgradient.const import DOMAIN, get_model_capabilities
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -17,6 +17,11 @@ from homeassistant.helpers import device_registry as dr
 from . import setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def test_outdoor_model_alias() -> None:
+    """Test the outdoor model firmware typo uses outdoor capabilities."""
+    assert get_model_capabilities("0-1PS") == get_model_capabilities("O-1PPT")
 
 
 async def test_device_info(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Recognize `0-1PS` as an alias for the AirGradient outdoor model capabilities. Some outdoor firmware reports a zero instead of the letter O, which previously prevented its configuration entities and actions from being created.

### Validation

- `uv run --no-sync pytest tests/components/airgradient --cov=homeassistant.components.airgradient --cov-report=term-missing` (85 passed, 172 snapshots, 100% coverage)
- Changed-file prek checks passed.
- Verified with a `0-1PS` device that the outdoor configuration entities and CO2 calibration action are available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of incoming pull requests is higher than what our reviewers can review and merge so there is a long backlog of pull requests waiting to be reviewed.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
