### PR TITLE
Refactor Nord Pool coordinator

### DIFF
--- a/homeassistant/components/nordpool/__init__.py
+++ b/homeassistant/components/nordpool/__init__.py
@@ -2,10 +2,8 @@
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
 
 from .const import CONF_AREAS, DOMAIN, LOGGER, PLATFORMS
 from .coordinator import NordPoolDataUpdateCoordinator
@@ -31,14 +29,7 @@ async def async_setup_entry(
     await cleanup_device(hass, config_entry)
 
     coordinator = NordPoolDataUpdateCoordinator(hass, config_entry)
-    await coordinator.fetch_data(dt_util.utcnow(), True)
-    await coordinator.update_listeners(dt_util.utcnow())
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="initial_update_failed",
-            translation_placeholders={"error": str(coordinator.last_exception)},
-        )
+    await coordinator.async_config_entry_first_refresh()
     config_entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -1,8 +1,8 @@
 """DataUpdateCoordinator for the Nord Pool integration."""
 
 from collections.abc import Callable
-from datetime import datetime, time, timedelta
-from typing import TYPE_CHECKING, override
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any, override
 
 import aiohttp
 from aiozoneinfo import get_time_zone
@@ -12,6 +12,7 @@ from pynordpool import (
     DeliveryPeriodEntry,
     DeliveryPeriodsData,
     NordPoolClient,
+    NordPoolEmptyResponseError,
     NordPoolError,
     NordPoolResponseError,
 )
@@ -48,22 +49,10 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
             LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
+            update_interval=timedelta(minutes=60),
         )
         self.client = NordPoolClient(session=async_get_clientsession(hass))
-        self.data_unsub: Callable[[], None] | None = None
         self.listener_unsub: Callable[[], None] | None = None
-
-    def get_next_data_interval(self, now: datetime) -> datetime:
-        """Compute next time an update should occur."""
-        if self.has_current_day_data and self.has_tomorrow_data:
-            _date = get_nordpool_current_time().date() + timedelta(days=1)
-            _time = time()
-            next_run = datetime.combine(_date, _time, NORDPOOL_TIMEZONE)
-        else:
-            next_data_run = get_nordpool_current_time() + timedelta(hours=1)
-            next_run = next_data_run.replace(minute=0, second=0, microsecond=0)
-        LOGGER.debug("Next data update at %s", next_run.astimezone(NORDPOOL_TIMEZONE))
-        return next_run.astimezone(dt_util.UTC)
 
     def get_next_15_interval(self, now: datetime) -> datetime:
         """Compute next time we need to notify listeners."""
@@ -76,19 +65,8 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         )
         return next_run.astimezone(dt_util.UTC)
 
-    @override
-    async def async_shutdown(self) -> None:
-        """Cancel any scheduled call, and ignore new runs."""
-        await super().async_shutdown()
-        if self.data_unsub:
-            self.data_unsub()
-            self.data_unsub = None
-        if self.listener_unsub:
-            self.listener_unsub()
-            self.listener_unsub = None
-
     async def update_listeners(self, now: datetime) -> None:
-        """Update entity listeners."""
+        """Update entity listeners every 15 minutes."""
         self.listener_unsub = async_track_point_in_utc_time(
             self.hass,
             self.update_listeners,
@@ -96,54 +74,22 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         )
         self.async_update_listeners()
 
-    async def fetch_data(self, now: datetime, initial: bool = False) -> None:
-        """Fetch data from Nord Pool."""
-        self.data_unsub = async_track_point_in_utc_time(
-            self.hass, self.fetch_data, self.get_next_data_interval(now)
-        )
-        if self.config_entry.pref_disable_polling and not initial:
-            return
-        try:
-            data = await self.handle_data(initial)
-        except UpdateFailed as err:
-            self.async_set_update_error(err)
-            return
-        self.async_set_updated_data(data)
-        if self.has_current_day_data and self.has_tomorrow_data:
-            self.data_unsub = async_track_point_in_utc_time(
-                self.hass,
-                self.fetch_data,
-                self.get_next_data_interval(now),
-            )
-
-    async def handle_data(self, initial: bool = False) -> DeliveryPeriodsData:
-        """Fetch data from Nord Pool."""
-        data = await self.api_call()
-        if data and data.entries:
-            current_day = get_nordpool_current_time().date()
-            if current_day in data.entries:
-                LOGGER.debug("Data for current day found")
-                return data
-
-        if data and not data.entries and not initial:
-            # Empty response, use cache
-            LOGGER.debug("No data entries received")
-            return self.data
-        raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_day_data")
-
     @override
-    async def _async_update_data(self) -> DeliveryPeriodsData:
-        """Fetch the latest data from the source."""
-        return await self.handle_data()
-
-    async def api_call(self, retry: int = 3) -> DeliveryPeriodsData | None:
-        """Make api call to retrieve data with retry if failure."""
+    async def _async_setup(self) -> None:
+        """Set up the coordinator."""
         data = None
+        tomorrow = None
         try:
             data = await self.client.async_get_delivery_periods(
                 [
                     get_nordpool_current_time() - timedelta(days=1),
                     get_nordpool_current_time(),
+                ],
+                Currency(self.config_entry.data[CONF_CURRENCY]),
+                self.config_entry.data[CONF_AREAS],
+            )
+            tomorrow = await self.client.async_get_delivery_periods(
+                [
                     get_nordpool_current_time() + timedelta(days=1),
                 ],
                 Currency(self.config_entry.data[CONF_CURRENCY]),
@@ -155,16 +101,115 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
             TimeoutError,
             aiohttp.ClientError,
         ) as error:
-            LOGGER.debug("Connection error: %s", error)
-            if self.data is None:
-                self.async_set_update_error(  # type: ignore[unreachable]
-                    UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key="could_not_fetch_data",
-                        translation_placeholders={"error": str(error)},
-                    )
-                )
+            if data:
+                # Continue if we have data for today, but not tomorrow
+                LOGGER.debug("Error getting prices for tomorrow: %s", error)
+            else:
+                LOGGER.debug("Error fetching data: %s", error)
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="no_day_data",
+                ) from error
+
+        self.data = DeliveryPeriodsData(
+            raw={**data.raw, **tomorrow.raw} if tomorrow else data.raw,
+            entries={**data.entries, **tomorrow.entries} if tomorrow else data.entries,
+        )
+        await self.update_listeners(get_nordpool_current_time())
+        await super()._async_setup()
+
+    @override
+    async def _async_update_data(self) -> DeliveryPeriodsData:
+        """Fetch the latest data from Nord Pool."""
+        data: dict[date, DeliveryPeriodData] = {}
+
+        today_data = self.get_data_current_day() if self.has_current_day_data else None
+        tomorrow_data = self.get_data_tomorrow() if self.has_tomorrow_data else None
+
+        if today_data and tomorrow_data:
+            # Bail early if we already have all data
             return self.data
+
+        if not today_data:
+            try:
+                today_data = await self._api_call(0)
+            except (
+                NordPoolError,
+                TimeoutError,
+                aiohttp.ClientError,
+            ) as error:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="connection_error",
+                ) from error
+
+            if today_data and not today_data.entries:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="no_day_data",
+                )
+
+        if not tomorrow_data:
+            try:
+                tomorrow_data = await self._api_call(1)
+            except NordPoolEmptyResponseError:
+                pass
+            except (
+                NordPoolError,
+                TimeoutError,
+                aiohttp.ClientError,
+            ) as error:
+                LOGGER.debug("Error getting prices for tomorrow: %s", error)
+
+        if tomorrow_data and not tomorrow_data.entries:
+            tomorrow_data = None
+
+        yesterday = (get_nordpool_current_time() - timedelta(days=1)).date()
+        yesterday_raw: dict[str, Any] = self.data.raw[yesterday.isoformat()]
+        yesterday_data = self.data.entries.get(
+            (get_nordpool_current_time() - timedelta(days=1)).date()
+        )
+
+        if TYPE_CHECKING:
+            assert today_data
+            assert yesterday_data
+
+        data[get_nordpool_current_time().date()] = today_data
+        raw_data: dict[str, dict[str, Any]] = {
+            today_data.raw["deliveryDateCET"]: today_data.raw
+        }
+
+        raw_data[yesterday.isoformat()] = yesterday_raw
+        data[yesterday] = yesterday_data
+
+        if tomorrow_data:
+            raw_data[tomorrow_data.raw["deliveryDateCET"]] = tomorrow_data.raw
+            data[(get_nordpool_current_time() + timedelta(days=1)).date()] = (
+                tomorrow_data
+            )
+
+        return DeliveryPeriodsData(raw=raw_data, entries=data)
+
+    async def _api_call(self, days: int) -> DeliveryPeriodData | None:
+        """Make api call to retrieve data."""
+        data: DeliveryPeriodData | None = None
+        try:
+            data = await self.client.async_get_delivery_period(
+                get_nordpool_current_time() + timedelta(days=days),
+                Currency(self.config_entry.data[CONF_CURRENCY]),
+                self.config_entry.data[CONF_AREAS],
+            )
+        except NordPoolEmptyResponseError as error:
+            LOGGER.debug("Empty response error: %s", error)
+            raise
+        except (
+            NordPoolResponseError,
+            NordPoolError,
+            TimeoutError,
+            aiohttp.ClientError,
+        ) as error:
+            LOGGER.debug("Connection error: %s", error)
+            raise
 
         return data
 
@@ -173,7 +218,7 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         merged_entries: list[DeliveryPeriodEntry] = []
         for del_period in self.data.entries.values():
             merged_entries.extend(del_period.entries)
-        return merged_entries
+        return sorted(merged_entries, key=lambda x: x.start)
 
     def get_data_current_day(self) -> DeliveryPeriodData:
         """Return the current day data."""

--- a/tests/components/nordpool/conftest.py
+++ b/tests/components/nordpool/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for the Nord Pool integration."""
 
-import asyncio
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
 import json
@@ -23,7 +22,9 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 @pytest.fixture(name="mock_asyncio_sleep", autouse=True)
 async def mock_asyncio_sleep() -> AsyncGenerator[None]:
     """Mock asyncio.sleep to avoid actual sleeping during tests."""
-    with patch.object(asyncio, "sleep"):
+    with patch(
+        "pynordpool.asyncio.sleep",
+    ):
         yield
 
 

--- a/tests/components/nordpool/conftest.py
+++ b/tests/components/nordpool/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for the Nord Pool integration."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
 import json
@@ -17,6 +18,13 @@ from . import ENTRY_CONFIG
 
 from tests.common import MockConfigEntry, load_fixture, patch
 from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@pytest.fixture(name="mock_asyncio_sleep", autouse=True)
+async def mock_asyncio_sleep() -> AsyncGenerator[None]:
+    """Mock asyncio.sleep to avoid actual sleeping during tests."""
+    with patch.object(asyncio, "sleep"):
+        yield
 
 
 @pytest.fixture(name="load_platforms")

--- a/tests/components/nordpool/test_coordinator.py
+++ b/tests/components/nordpool/test_coordinator.py
@@ -5,27 +5,22 @@ from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
 
-import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 from pynordpool import (
     API,
     NordPoolAuthenticationError,
     NordPoolClient,
+    NordPoolConnectionError,
     NordPoolEmptyResponseError,
     NordPoolError,
     NordPoolResponseError,
 )
 import pytest
 
-from homeassistant.components.homeassistant import (
-    DOMAIN as HOMEASSISTANT_DOMAIN,
-    SERVICE_UPDATE_ENTITY,
-)
 from homeassistant.components.nordpool.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import ENTRY_CONFIG
 
@@ -34,15 +29,167 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.freeze_time("2025-10-01T10:00:00+02:00")
-async def test_coordinator(
+async def test_coordinator_happy_path(
+    hass: HomeAssistant,
+    get_client: NordPoolClient,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    load_int: MockConfigEntry,
+) -> None:
+    """Test the Nord Pool coordinator's happy path."""
+
+    state = hass.states.get("sensor.nord_pool_se3_current_price")
+    assert state.state == "1.03744"
+
+    caplog.clear()
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+            wraps=get_client.async_get_delivery_period,
+        ) as mock_data,
+    ):
+        freezer.tick(timedelta(minutes=15))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_data.call_count == 0
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.95013"
+
+        freezer.tick(timedelta(minutes=2))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_data.call_count == 0
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.95013"
+
+        freezer.tick(timedelta(minutes=13))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_data.call_count == 0
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.82613"
+        state = hass.states.get("binary_sensor.nord_pool_se3_tomorrow_price_available")
+        assert state.state == "on"
+
+        freezer.tick(timedelta(days=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_data.call_count == 1
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.86614"
+        state = hass.states.get("binary_sensor.nord_pool_se3_tomorrow_price_available")
+        assert state.state == "off"
+
+
+@pytest.mark.freeze_time("2025-10-01T10:00:00+02:00")
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NordPoolAuthenticationError("Could not authenticate"),
+        NordPoolConnectionError("Could not connect"),
+        NordPoolEmptyResponseError("Empty response fetching today's data"),
+        NordPoolResponseError("Response error fetching today's data"),
+        NordPoolError("Error fetching today's data"),
+    ],
+)
+async def test_coordinator_setup_errors_today(
     hass: HomeAssistant,
     get_client: NordPoolClient,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
     load_json: list[dict[str, Any]],
+    exc: Exception,
 ) -> None:
-    """Test the Nord Pool coordinator with errors."""
+    """Test the Nord Pool coordinator setup with errors.
+
+    Can not fetch today's data
+    """
+
+    responses = list(load_json)
+    aioclient_mock.clear_requests()
+    aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-09-30",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        json=responses[1],
+    )
+    request = aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-10-01",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        json=responses[0],
+        exc=exc,
+    )
+    aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-10-02",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        json=responses[2],
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data=ENTRY_CONFIG,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    assert str(exc) in caplog.text
+
+    request.exc = None
+
+    freezer.tick(timedelta(minutes=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
+    state = hass.states.get("sensor.nord_pool_se3_current_price")
+    assert state.state == "0.95013"
+
+
+@pytest.mark.freeze_time("2025-10-01T10:00:00+02:00")
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NordPoolAuthenticationError("Could not authenticate"),
+        NordPoolConnectionError("Could not connect"),
+        NordPoolEmptyResponseError("Empty response fetching tomorrow's data"),
+        NordPoolResponseError("Response error fetching tomorrow's data"),
+        NordPoolError("Error fetching tomorrow's data"),
+    ],
+)
+async def test_coordinator_setup_errors_tomorrow(
+    hass: HomeAssistant,
+    get_client: NordPoolClient,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    aioclient_mock: AiohttpClientMocker,
+    load_json: list[dict[str, Any]],
+    exc: Exception,
+) -> None:
+    """Test the Nord Pool coordinator setup.
+
+    Can not fetch tomorrow's data, continues.
+    """
+
     responses = list(load_json)
     aioclient_mock.clear_requests()
     aioclient_mock.request(
@@ -67,7 +214,7 @@ async def test_coordinator(
         },
         json=responses[0],
     )
-    aioclient_mock.request(
+    request = aioclient_mock.request(
         "GET",
         url=API + "/DayAheadPrices",
         params={
@@ -76,198 +223,40 @@ async def test_coordinator(
             "deliveryArea": "SE3,SE4",
             "currency": "SEK",
         },
-        status=HTTPStatus.NO_CONTENT,
+        json=responses[2],
+        exc=exc,
     )
 
-    await async_setup_component(hass, HOMEASSISTANT_DOMAIN, {})
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_USER,
         data=ENTRY_CONFIG,
     )
     config_entry.add_to_hass(hass)
-
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
+
     state = hass.states.get("sensor.nord_pool_se3_current_price")
     assert state.state == "1.03744"
+    state = hass.states.get("binary_sensor.nord_pool_se3_tomorrow_price_available")
+    assert state.state == "off"
 
-    assert "Next data update at 2025-10-01 11:00:00+02:00" in caplog.text
-    assert "Next listener update at 2025-10-01 10:15:00+02:00" in caplog.text
+    assert str(exc) in caplog.text
 
-    caplog.clear()
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            wraps=get_client.async_get_delivery_period,
-        ) as mock_data,
-    ):
-        freezer.tick(timedelta(minutes=17))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 0
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.95013"
+    request.exc = None
 
-    assert "Next data update at 2025-10-01 11:00:00+02:00" not in caplog.text
-    assert "Next listener update at 2025-10-01 10:30:00+02:00" in caplog.text
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=NordPoolError("error"),
-        ) as mock_data,
-    ):
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.72279"
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=NordPoolAuthenticationError("Authentication error"),
-        ) as mock_data,
-    ):
-        assert "Authentication error" not in caplog.text
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.63858"
-        assert "Authentication error" in caplog.text
-
-    caplog.clear()
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=NordPoolEmptyResponseError("Empty response"),
-        ) as mock_data,
-    ):
-        assert "Empty response" not in caplog.text
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Empty responses does not raise
-        assert mock_data.call_count == 3
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.66068"
-        assert "Empty response" in caplog.text
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=aiohttp.ClientError("error"),
-        ) as mock_data,
-    ):
-        assert "Response error" not in caplog.text
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.68544"
-        assert "error" in caplog.text
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=TimeoutError("error"),
-        ) as mock_data,
-    ):
-        assert "Response error" not in caplog.text
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.72953"
-        assert "error" in caplog.text
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=NordPoolResponseError("Response error"),
-        ) as mock_data,
-    ):
-        assert "Response error" not in caplog.text
-        freezer.tick(timedelta(hours=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.90294"
-        assert "Response error" in caplog.text
-
-    freezer.tick(timedelta(hours=1))
+    freezer.tick(timedelta(minutes=60))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.16266"
-
-    # Test manual polling
-    hass.config_entries.async_update_entry(
-        entry=config_entry, pref_disable_polling=True
-    )
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.90004"
-
-    # Prices should update without any polling made (read from cache)
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "3.42983"
-
-    # Test manually updating the data
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_periods",
-            wraps=get_client.async_get_delivery_periods,
-        ) as mock_data,
-    ):
-        await hass.services.async_call(
-            HOMEASSISTANT_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {ATTR_ENTITY_ID: "sensor.nord_pool_se3_current_price"},
-            blocking=True,
-        )
-        assert mock_data.call_count == 1
-
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.42403"
-
-    hass.config_entries.async_update_entry(
-        entry=config_entry, pref_disable_polling=False
-    )
-    await hass.config_entries.async_reload(config_entry.entry_id)
-
-    with (
-        patch(
-            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
-            side_effect=NordPoolError("error"),
-        ) as mock_data,
-    ):
-        freezer.tick(timedelta(hours=48))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_data.call_count == 1
-        state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == STATE_UNAVAILABLE
-        assert "Data for current day is missing" in caplog.text
+    assert state.state == "0.8616"
+    state = hass.states.get("binary_sensor.nord_pool_se3_tomorrow_price_available")
+    assert state.state == "on"
 
 
-@pytest.mark.freeze_time("2025-10-01T10:05:00+02:00")
+@pytest.mark.freeze_time("2025-10-01T00:05:00+02:00")
 async def test_coordinator_update_data(
     hass: HomeAssistant,
     get_client: NordPoolClient,
@@ -290,7 +279,7 @@ async def test_coordinator_update_data(
         },
         json=responses[1],
     )
-    aioclient_mock.request(
+    request_today = aioclient_mock.request(
         "GET",
         url=API + "/DayAheadPrices",
         params={
@@ -301,7 +290,7 @@ async def test_coordinator_update_data(
         },
         json=responses[0],
     )
-    aioclient_mock.request(
+    request_tomorrow = aioclient_mock.request(
         "GET",
         url=API + "/DayAheadPrices",
         params={
@@ -311,89 +300,170 @@ async def test_coordinator_update_data(
             "currency": "SEK",
         },
         status=HTTPStatus.NO_CONTENT,
+        json=responses[2],
+    )
+    aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-10-03",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        status=HTTPStatus.NO_CONTENT,
     )
 
-    await async_setup_component(hass, HOMEASSISTANT_DOMAIN, {})
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_USER,
         data=ENTRY_CONFIG,
     )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
 
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.03744"
-    assert "Next data update at 2025-10-01 11:00:00+02:00" in caplog.text
-    assert "Next listener update at 2025-10-01 10:15:00+02:00" in caplog.text
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+            wraps=get_client.async_get_delivery_period,
+        ) as mock_data,
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    caplog.clear()
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.8616"
-    assert "Next data update at 2025-10-01 12:00:00+02:00" in caplog.text
-    assert "Next listener update at 2025-10-01 11:15:00+02:00" in caplog.text
+        # 3 calls from setup, 1 from refresh as tomorrow was not available
+        assert mock_data.call_count == 4
+        mock_data.reset_mock()
+        assert "Next listener update at 2025-10-01 00:15:00+02:00" in caplog.text
 
-    caplog.clear()
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.67405"
-    assert "Next data update at 2025-10-01 13:00:00+02:00" in caplog.text
-    assert "Next listener update at 2025-10-01 12:15:00+02:00" in caplog.text
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.69717"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.55668"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.51988"
 
-    aioclient_mock.clear_requests()
-    aioclient_mock.request(
-        "GET",
-        url=API + "/DayAheadPrices",
-        params={
-            "date": "2025-09-30",
-            "market": "DayAhead",
-            "deliveryArea": "SE3,SE4",
-            "currency": "SEK",
-        },
-        json=responses[1],
-    )
-    aioclient_mock.request(
-        "GET",
-        url=API + "/DayAheadPrices",
-        params={
-            "date": "2025-10-01",
-            "market": "DayAhead",
-            "deliveryArea": "SE3,SE4",
-            "currency": "SEK",
-        },
-        json=responses[0],
-    )
-    aioclient_mock.request(
-        "GET",
-        url=API + "/DayAheadPrices",
-        params={
-            "date": "2025-10-02",
-            "market": "DayAhead",
-            "deliveryArea": "SE3,SE4",
-            "currency": "SEK",
-        },
-        json=responses[2],
-    )
+        freezer.tick(timedelta(minutes=15))  # "2025-10-01T00:20:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # No callers, only listener update
+        assert mock_data.call_count == 0
+        assert "Next listener update at 2025-10-01 00:30:00+02:00" in caplog.text
 
-    caplog.clear()
-    freezer.tick(timedelta(hours=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.63736"
-    assert "Next data update at 2025-10-02 00:00:00+02:00" in caplog.text
-    assert "Next listener update at 2025-10-01 13:15:00+02:00" in caplog.text
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.55668"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.51988"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.50828"
 
-    caplog.clear()
-    freezer.tick(timedelta(minutes=15))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.66068"
-    assert "Next data update" not in caplog.text
-    assert "Next listener update at 2025-10-01 13:30:00+02:00" in caplog.text
+        freezer.tick(timedelta(minutes=45))  # "2025-10-01T01:05:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        assert mock_data.call_count == 1
+        assert "Next listener update at 2025-10-01 01:15:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.50993"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.50164"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.50905"
+
+        request_today.json = None
+        request_today.exc = NordPoolError("Error fetching today's data")
+
+        freezer.tick(timedelta(hours=1))  # "2025-10-01T02:05:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        assert mock_data.call_count == 2
+        assert "Next listener update at 2025-10-01 02:15:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.44207"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.50408"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.50485"
+
+        request_today.exc = None
+        request_tomorrow.status = None
+        request_tomorrow.exc = NordPoolError("Error fetching tomorrow's data")
+
+        freezer.tick(timedelta(hours=1))  # "2025-10-01T03:05:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        # Exception only for today which is not called
+        assert mock_data.call_count == 3
+        assert "Next listener update at 2025-10-01 03:15:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.50629"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.44207"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.44196"
+
+        freezer.move_to("2025-10-01T23:55:00+02:00")  # "2025-10-01T23:55:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        assert mock_data.call_count == 4
+        assert "Next listener update at 2025-10-02 00:00:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.82005"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.78568"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == STATE_UNKNOWN
+
+        request_tomorrow.status = HTTPStatus.NO_CONTENT
+        request_tomorrow.exc = None
+
+        freezer.tick(timedelta(hours=1))  # "2025-10-02T00:55:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        assert mock_data.call_count == 5
+        assert "Next listener update at 2025-10-02 01:00:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == STATE_UNAVAILABLE
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == STATE_UNAVAILABLE
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == STATE_UNAVAILABLE
+
+        request_tomorrow.status = HTTPStatus.OK
+        request_tomorrow.exc = None
+
+        freezer.tick(timedelta(hours=1))  # "2025-10-02T01:55:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for today and tomorrow as data was not available
+        assert mock_data.call_count == 7
+        assert "Next listener update at 2025-10-02 02:00:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.79663"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.7067"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == "0.69523"
+
+        freezer.move_to("2025-10-02T23:55:00+02:00")  # "2025-10-02T23:55:00+02:00"
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Calls for tomorrow as data was not available
+        assert mock_data.call_count == 8
+        assert "Next listener update at 2025-10-03 00:00:00+02:00" in caplog.text
+
+        state = hass.states.get("sensor.nord_pool_se3_previous_price")
+        assert state.state == "0.87364"
+        state = hass.states.get("sensor.nord_pool_se3_current_price")
+        assert state.state == "0.6469"
+        state = hass.states.get("sensor.nord_pool_se3_next_price")
+        assert state.state == STATE_UNKNOWN

--- a/tests/components/nordpool/test_sensor.py
+++ b/tests/components/nordpool/test_sensor.py
@@ -10,7 +10,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -199,8 +199,8 @@ async def test_sensor_empty_response(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # Current and last price should be known, next price should be unknown
-    # as api responds with empty data (204)
+    # Current and last price should be known
+    # Next price is also know as we have it in cache from previous fetch
 
     current_price = hass.states.get("sensor.nord_pool_se3_current_price")
     last_price = hass.states.get("sensor.nord_pool_se3_previous_price")
@@ -210,4 +210,4 @@ async def test_sensor_empty_response(
     assert next_price is not None
     assert current_price.state == "0.78568"
     assert last_price.state == "0.82005"
-    assert next_price.state == STATE_UNKNOWN
+    assert next_price.state == "0.93322"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Refactor Nord Pool coordinator to use the "normal" update mechanism for collecting data.
Currently everyone sends their api requests price on the hour hammering the API giving timeouts and not nice behavior.

- Tests have been completely rewritten, that's why it seems a big change
- Calls to api is only made for missing data

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 