### PR TITLE
Fix ViCare setup by passing the accessor to fetch_all_features

### DIFF
--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -60,7 +60,7 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
         """Force a fresh fetch from the Viessmann API."""
         try:
             self._device.service.clear_cache()
-            self._device.service.fetch_all_features()
+            self._device.service.fetch_all_features(self._device.accessor)
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
         except (

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -46,7 +46,7 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             config_entry=config_entry,
-            name=f"{DOMAIN}_{device.service.accessor.id}",
+            name=f"{DOMAIN}_{device.accessor.serial}_{device.accessor.device_id}",
             update_interval=timedelta(seconds=DEFAULT_CACHE_DURATION * device_count),
         )
         self._device = device

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -41,15 +41,15 @@ class MockPyViCare:
         """Init a single device from json dump."""
         self.devices = []
         for idx, fixture in enumerate(fixtures):
-            service = MockViCareService(
+            accessor = ViCareDeviceAccessor(
                 f"installation{idx}",
                 fixture.gateway_id or f"gateway{idx}",
                 f"deviceId{idx}",
-                fixture,
             )
+            service = MockViCareService(fixture)
             self.devices.append(
                 PyViCareDeviceConfig(
-                    service.accessor,
+                    accessor,
                     service,
                     "Vitovalor"
                     if fixture.data_file.endswith("VitoValor.json")
@@ -61,16 +61,18 @@ class MockPyViCare:
         # Simulate a device with an unsupported deviceType that PyViCare's
         # `devices` filter would drop but should still appear in `all_devices`
         # (used by diagnostics).
-        unsupported_service = MockViCareService(
+        unsupported_accessor = ViCareDeviceAccessor(
             "installation_unsupported",
             "gateway_unsupported",
             "deviceId_unsupported",
-            Fixture(set(), "vicare/dummy-device-no-serial.json"),
+        )
+        unsupported_service = MockViCareService(
+            Fixture(set(), "vicare/dummy-device-no-serial.json")
         )
         self.all_devices = [
             *self.devices,
             PyViCareDeviceConfig(
-                unsupported_service.accessor,
+                unsupported_accessor,
                 unsupported_service,
                 "unsupported_model",
                 "Online",
@@ -92,17 +94,15 @@ class MockPyViCare:
 class MockViCareService:
     """PyVicareService mock using a json dump."""
 
-    def __init__(
-        self, installation_id: str, gateway_id: str, device_id: str, fixture: Fixture
-    ) -> None:
+    def __init__(self, fixture: Fixture) -> None:
         """Initialize the mock from a json dump."""
         self._test_data = load_json_object_fixture(fixture.data_file)
-        # Mirror the real signature: fetch_all_features() requires an accessor.
+        # Mirror the real signature: fetch_all_features() requires an accessor,
+        # and no real service carries one.
         self.fetch_all_features = Mock(side_effect=lambda accessor: self._test_data)
         self.setProperty = Mock()
         self.clear_cache = Mock()
         self.roles = fixture.roles
-        self.accessor = ViCareDeviceAccessor(installation_id, gateway_id, device_id)
 
     def hasRoles(self, requested_roles: list[str]) -> bool:
         """Return true if requested roles are assigned."""

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -97,7 +97,8 @@ class MockViCareService:
     ) -> None:
         """Initialize the mock from a json dump."""
         self._test_data = load_json_object_fixture(fixture.data_file)
-        self.fetch_all_features = Mock(return_value=self._test_data)
+        # Mirror the real signature: fetch_all_features() requires an accessor.
+        self.fetch_all_features = Mock(side_effect=lambda accessor: self._test_data)
         self.setProperty = Mock()
         self.clear_cache = Mock()
         self.roles = fixture.roles


### PR DESCRIPTION
## Proposed change

`fetch_all_features()` requires an accessor in PyViCare 2.61.0, so every coordinator refresh raised `TypeError` and setup failed. Pass the device's accessor.

The test mock accepted any signature, which is why this was not caught; it now mirrors the real one.

Nothing released is affected, the bug only exists on `dev` since today, but if it ships as is ViCare will not set up at all in 2026.9. If the 2026.9 beta is already cut, this needs to go into it.

@joostlek this is a bug in #173776, which you merged earlier today. It slipped past me because my local instance runs the follow-up branch (#176163) on top, and that one already passes the accessor. Sorry for the extra round.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #173776
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
