### PR TITLE
Add reconfigure flow to NeoPool

### DIFF
--- a/homeassistant/components/neopool/config_flow.py
+++ b/homeassistant/components/neopool/config_flow.py
@@ -132,9 +132,9 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             serial, error_key = await _async_probe(merged)
             if error_key:
                 errors[CONF_HOST] = error_key
-            elif entry.unique_id and serial != entry.unique_id:
-                errors[CONF_HOST] = "serial_mismatch"
             else:
+                await self.async_set_unique_id(serial)
+                self._abort_if_unique_id_mismatch(reason="serial_mismatch")
                 return self.async_update_reload_and_abort(entry, data=merged)
 
         return self.async_show_form(

--- a/homeassistant/components/neopool/config_flow.py
+++ b/homeassistant/components/neopool/config_flow.py
@@ -20,6 +20,8 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 
 from .const import (
+    CONF_MODBUS_FRAMER,
+    CONF_UNIT_ID,
     CONF_USE_AUX1,
     CONF_USE_AUX2,
     CONF_USE_AUX3,
@@ -40,8 +42,8 @@ async def _async_probe(user_input: dict[str, Any]) -> tuple[str | None, str | No
         serial = await async_probe_serial(
             user_input[CONF_HOST],
             port=user_input[CONF_PORT],
-            unit_id=user_input["unit_id"],
-            framer=user_input["modbus_framer"],
+            unit_id=user_input[CONF_UNIT_ID],
+            framer=user_input[CONF_MODBUS_FRAMER],
         )
     except NeoPoolConnectionError, NeoPoolTimeoutError:
         return None, "cannot_connect"
@@ -73,9 +75,9 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_HOST): str,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
-                vol.Optional("unit_id", default=DEFAULT_UNIT_ID): vol.Coerce(int),
+                vol.Optional(CONF_UNIT_ID, default=DEFAULT_UNIT_ID): vol.Coerce(int),
                 vol.Optional(
-                    "modbus_framer",
+                    CONF_MODBUS_FRAMER,
                     default=DEFAULT_MODBUS_FRAMER,
                 ): vol.In(("tcp", "rtu")),
             }
@@ -96,6 +98,47 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry."""
+        entry = self._get_reconfigure_entry()
+        current = entry.data
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=current[CONF_HOST]): str,
+                vol.Optional(
+                    CONF_PORT, default=current.get(CONF_PORT, DEFAULT_PORT)
+                ): vol.Coerce(int),
+                vol.Optional(
+                    CONF_UNIT_ID,
+                    default=current.get(CONF_UNIT_ID, DEFAULT_UNIT_ID),
+                ): vol.Coerce(int),
+                vol.Optional(
+                    CONF_MODBUS_FRAMER,
+                    default=current.get(CONF_MODBUS_FRAMER, DEFAULT_MODBUS_FRAMER),
+                ): vol.In(("tcp", "rtu")),
+            }
+        )
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            merged = {**current, **user_input}
+            serial, error_key = await _async_probe(merged)
+            if error_key:
+                errors[CONF_HOST] = error_key
+            elif entry.unique_id and serial != entry.unique_id:
+                errors[CONF_HOST] = "serial_mismatch"
+            else:
+                return self.async_update_reload_and_abort(entry, data=merged)
+
+        return self.async_show_form(
+            step_id="reconfigure",
             data_schema=data_schema,
             errors=errors,
         )

--- a/homeassistant/components/neopool/config_flow.py
+++ b/homeassistant/components/neopool/config_flow.py
@@ -139,7 +139,9 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=data_schema,
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema, user_input or current
+            ),
             errors=errors,
         )
 

--- a/homeassistant/components/neopool/const.py
+++ b/homeassistant/components/neopool/const.py
@@ -17,11 +17,9 @@ FOLLOW_UP_REFRESH_DELAY = 2.0  # seconds  (delay before a 2nd refresh for IO ent
 DEFAULT_PORT = 502
 DEFAULT_UNIT_ID = 1
 
-# Config-entry data keys (connection settings).
 CONF_UNIT_ID = "unit_id"
 CONF_MODBUS_FRAMER = "modbus_framer"
 
-# Options-flow keys.
 CONF_USE_LIGHT = "use_light"
 CONF_USE_COVER_SENSOR = "use_cover_sensor"
 CONF_USE_AUX1 = "use_aux1"

--- a/homeassistant/components/neopool/const.py
+++ b/homeassistant/components/neopool/const.py
@@ -17,6 +17,10 @@ FOLLOW_UP_REFRESH_DELAY = 2.0  # seconds  (delay before a 2nd refresh for IO ent
 DEFAULT_PORT = 502
 DEFAULT_UNIT_ID = 1
 
+# Config-entry data keys (connection settings).
+CONF_UNIT_ID = "unit_id"
+CONF_MODBUS_FRAMER = "modbus_framer"
+
 # Options-flow keys.
 CONF_USE_LIGHT = "use_light"
 CONF_USE_COVER_SENSOR = "use_cover_sensor"

--- a/homeassistant/components/neopool/manifest.json
+++ b/homeassistant/components/neopool/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["neopool_modbus"],
-  "quality_scale": "silver",
+  "quality_scale": "platinum",
   "requirements": ["neopool-modbus==4.5.3"]
 }

--- a/homeassistant/components/neopool/manifest.json
+++ b/homeassistant/components/neopool/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["neopool_modbus"],
-  "quality_scale": "platinum",
+  "quality_scale": "silver",
   "requirements": ["neopool-modbus==4.5.3"]
 }

--- a/homeassistant/components/neopool/quality_scale.yaml
+++ b/homeassistant/components/neopool/quality_scale.yaml
@@ -80,7 +80,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: done
   stale-devices:
     status: exempt

--- a/homeassistant/components/neopool/strings.json
+++ b/homeassistant/components/neopool/strings.json
@@ -2,12 +2,12 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings.",
-      "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
+      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings."
     },
     "step": {
       "reconfigure": {

--- a/homeassistant/components/neopool/strings.json
+++ b/homeassistant/components/neopool/strings.json
@@ -1,13 +1,31 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings."
+      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings.",
+      "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "modbus_framer": "[%key:component::neopool::config::step::user::data::modbus_framer%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "unit_id": "[%key:component::neopool::config::step::user::data::unit_id%]"
+        },
+        "data_description": {
+          "host": "[%key:component::neopool::config::step::user::data_description::host%]",
+          "modbus_framer": "[%key:component::neopool::config::step::user::data_description::modbus_framer%]",
+          "port": "[%key:component::neopool::config::step::user::data_description::port%]",
+          "unit_id": "[%key:component::neopool::config::step::user::data_description::unit_id%]"
+        },
+        "description": "Update the connection settings for your NeoPool controller.",
+        "title": "Reconfigure NeoPool Connection"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/tests/components/neopool/test_config_flow.py
+++ b/tests/components/neopool/test_config_flow.py
@@ -187,8 +187,8 @@ async def test_reconfigure_flow_serial_mismatch(
         result["flow_id"],
         {**USER_INPUT, CONF_HOST: "192.0.2.50"},
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {CONF_HOST: "serial_mismatch"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "serial_mismatch"
 
 
 @pytest.mark.usefixtures("mock_neopool_client")

--- a/tests/components/neopool/test_config_flow.py
+++ b/tests/components/neopool/test_config_flow.py
@@ -112,6 +112,86 @@ async def test_user_flow_already_configured(
 
 
 @pytest.mark.usefixtures("mock_neopool_client")
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A reconfigure flow updates the connection settings and reloads the entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**USER_INPUT, CONF_HOST: "192.0.2.50", CONF_PORT: 1502},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.0.2.50"
+    assert mock_config_entry.data[CONF_PORT] == 1502
+
+
+@pytest.mark.parametrize(
+    ("exc_cls", "error_key"),
+    [
+        (NeoPoolConnectionError, "cannot_connect"),
+        (NeoPoolTimeoutError, "cannot_connect"),
+        (NeoPoolModbusError, "cannot_read_modbus"),
+    ],
+)
+async def test_reconfigure_flow_probe_errors_recover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_socket_connection: AsyncMock,
+    exc_cls: type[Exception],
+    error_key: str,
+) -> None:
+    """Probe errors surface as form errors, and the flow recovers on retry."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_socket_connection.side_effect = exc_cls("boom")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**USER_INPUT, CONF_HOST: "192.0.2.50"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_HOST: error_key}
+
+    mock_socket_connection.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**USER_INPUT, CONF_HOST: "192.0.2.50"},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_serial_mismatch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_socket_connection: AsyncMock,
+) -> None:
+    """A reconfigure targeting a different physical controller is rejected."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_socket_connection.return_value = "9999999999"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**USER_INPUT, CONF_HOST: "192.0.2.50"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_HOST: "serial_mismatch"}
+
+
+@pytest.mark.usefixtures("mock_neopool_client")
 async def test_options_flow_show_form(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add a reconfigure flow to the NeoPool integration so users can update an existing entry's connection settings (host, port, unit ID, Modbus framer) without removing and re-adding it. The step probes the device and, using the `_abort_if_unique_id_mismatch` helper, aborts with `serial_mismatch` when the probed serial number does not match the entry's unique ID, guarding against pointing the entry at a different physical controller.

This completes the `reconfiguration-flow` rule in the integration's `quality_scale.yaml`. The manifest quality scale bump will follow in a separate PR once this lands.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47635
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

