### PR TITLE
Warm the ViCare service cache on refresh instead of bypassing it

### DIFF
--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -60,7 +60,7 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
         """Force a fresh fetch from the Viessmann API."""
         try:
             self._device.service.clear_cache()
-            self._device.service.fetch_all_features()
+            self._device.service.fetch_all_features(self._device.accessor)
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
         except (

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -10,6 +10,7 @@ from PyViCare.PyViCareUtils import (
     PyViCareDeviceCommunicationError,
     PyViCareInternalServerError,
     PyViCareInvalidCredentialsError,
+    PyViCareInvalidDataError,
     PyViCareNotSupportedFeatureError,
     PyViCareRateLimitError,
 )
@@ -71,8 +72,9 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             raise ConfigEntryAuthFailed from err
         except (
             PyViCareDeviceCommunicationError,
-            PyViCareRateLimitError,
             PyViCareInternalServerError,
+            PyViCareInvalidDataError,
+            PyViCareRateLimitError,
             requests.RequestException,
         ) as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -46,7 +46,7 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             config_entry=config_entry,
-            name=f"{DOMAIN}_{device.service.accessor.id}",
+            name=f"{DOMAIN}_{device.accessor.serial}_{device.accessor.device_id}",
             update_interval=timedelta(seconds=DEFAULT_CACHE_DURATION * device_count),
         )
         self._device = device

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the ViCare integration."""
 
+from contextlib import suppress
 from datetime import timedelta
 import logging
 from typing import override
@@ -9,6 +10,7 @@ from PyViCare.PyViCareUtils import (
     PyViCareDeviceCommunicationError,
     PyViCareInternalServerError,
     PyViCareInvalidCredentialsError,
+    PyViCareNotSupportedFeatureError,
     PyViCareRateLimitError,
 )
 import requests
@@ -60,7 +62,11 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
         """Force a fresh fetch from the Viessmann API."""
         try:
             self._device.service.clear_cache()
-            self._device.service.fetch_all_features(self._device.accessor)
+            # Read one property instead of calling fetch_all_features(): on the
+            # cached service the latter bypasses the cache, so every entity read
+            # would hit the API again, from the event loop.
+            with suppress(PyViCareNotSupportedFeatureError):
+                self._device.getProperty("device.serial")
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
         except (

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -41,15 +41,15 @@ class MockPyViCare:
         """Init a single device from json dump."""
         self.devices = []
         for idx, fixture in enumerate(fixtures):
-            service = MockViCareService(
+            accessor = ViCareDeviceAccessor(
                 f"installation{idx}",
                 fixture.gateway_id or f"gateway{idx}",
                 f"deviceId{idx}",
-                fixture,
             )
+            service = MockViCareService(fixture)
             self.devices.append(
                 PyViCareDeviceConfig(
-                    service.accessor,
+                    accessor,
                     service,
                     "Vitovalor"
                     if fixture.data_file.endswith("VitoValor.json")
@@ -61,16 +61,18 @@ class MockPyViCare:
         # Simulate a device with an unsupported deviceType that PyViCare's
         # `devices` filter would drop but should still appear in `all_devices`
         # (used by diagnostics).
-        unsupported_service = MockViCareService(
+        unsupported_accessor = ViCareDeviceAccessor(
             "installation_unsupported",
             "gateway_unsupported",
             "deviceId_unsupported",
-            Fixture(set(), "vicare/dummy-device-no-serial.json"),
+        )
+        unsupported_service = MockViCareService(
+            Fixture(set(), "vicare/dummy-device-no-serial.json")
         )
         self.all_devices = [
             *self.devices,
             PyViCareDeviceConfig(
-                unsupported_service.accessor,
+                unsupported_accessor,
                 unsupported_service,
                 "unsupported_model",
                 "Online",
@@ -92,17 +94,15 @@ class MockPyViCare:
 class MockViCareService:
     """PyVicareService mock using a json dump."""
 
-    def __init__(
-        self, installation_id: str, gateway_id: str, device_id: str, fixture: Fixture
-    ) -> None:
+    def __init__(self, fixture: Fixture) -> None:
         """Initialize the mock from a json dump."""
         self._test_data = load_json_object_fixture(fixture.data_file)
-        # Mirror the real signature: fetch_all_features() requires an accessor.
+        # Mirror the real signature: fetch_all_features() requires an accessor,
+        # and no real service carries one.
         self.fetch_all_features = Mock(side_effect=lambda accessor: self._test_data)
         self.setProperty = Mock()
         self.clear_cache = Mock()
         self.roles = fixture.roles
-        self.accessor = ViCareDeviceAccessor(installation_id, gateway_id, device_id)
 
     def hasRoles(self, requested_roles: list[str]) -> bool:
         """Return true if requested roles are assigned."""

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -103,12 +103,14 @@ class MockViCareService:
         self.setProperty = Mock()
         self.clear_cache = Mock()
         self.roles = fixture.roles
+        # A Mock so tests can inject API errors on the read path.
+        self.getProperty = Mock(side_effect=self._read_property)
 
     def hasRoles(self, requested_roles: list[str]) -> bool:
         """Return true if requested roles are assigned."""
         return requested_roles and set(requested_roles).issubset(self.roles)
 
-    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str):
+    def _read_property(self, accessor: ViCareDeviceAccessor, property_name: str):
         """Read a property from json dump."""
         return readFeature(self._test_data["data"], property_name)
 

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -97,7 +97,8 @@ class MockViCareService:
     ) -> None:
         """Initialize the mock from a json dump."""
         self._test_data = load_json_object_fixture(fixture.data_file)
-        self.fetch_all_features = Mock(return_value=self._test_data)
+        # Mirror the real signature: fetch_all_features() requires an accessor.
+        self.fetch_all_features = Mock(side_effect=lambda accessor: self._test_data)
         self.setProperty = Mock()
         self.clear_cache = Mock()
         self.roles = fixture.roles

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -479,7 +479,7 @@ async def test_coordinator_recovers_after_transient_failure(
         assert state is not None, f"{sensor_id} not found in states"
         assert state.state != STATE_UNAVAILABLE
 
-        service.fetch_all_features.side_effect = PyViCareInternalServerError(
+        service.getProperty.side_effect = PyViCareInternalServerError(
             {
                 "statusCode": 500,
                 "errorType": "INTERNAL_SERVER_ERROR",
@@ -494,7 +494,7 @@ async def test_coordinator_recovers_after_transient_failure(
         state = hass.states.get(sensor_id)
         assert state.state == STATE_UNAVAILABLE
 
-        service.fetch_all_features.side_effect = None
+        service.getProperty.side_effect = service._read_property
         freezer.tick(timedelta(seconds=120))
         async_fire_time_changed(hass, fire_all=True)
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -538,7 +538,7 @@ async def test_per_device_failure_isolation(
     assert hass.states.get(sensor_device0).state != STATE_UNAVAILABLE
     assert hass.states.get(sensor_device1).state != STATE_UNAVAILABLE
 
-    service0.fetch_all_features.side_effect = PyViCareInternalServerError(
+    service0.getProperty.side_effect = PyViCareInternalServerError(
         {
             "statusCode": 500,
             "errorType": "INTERNAL_SERVER_ERROR",
@@ -586,7 +586,7 @@ async def test_coordinator_auth_failure_triggers_reauth(
             if flow["context"]["source"] == SOURCE_REAUTH
         ]
 
-        service.fetch_all_features.side_effect = PyViCareInvalidCredentialsError(
+        service.getProperty.side_effect = PyViCareInvalidCredentialsError(
             "invalid_grant"
         )
         freezer.tick(timedelta(seconds=120))

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -10,6 +10,7 @@ from PyViCare.PyViCareUtils import (
     PyViCareInternalServerError,
     PyViCareInvalidConfigurationError,
     PyViCareInvalidCredentialsError,
+    PyViCareInvalidDataError,
 )
 
 from homeassistant.components.vicare.const import DOMAIN
@@ -501,6 +502,42 @@ async def test_coordinator_recovers_after_transient_failure(
 
         state = hass.states.get(sensor_id)
         assert state.state != STATE_UNAVAILABLE
+
+
+async def test_coordinator_invalid_data_is_handled(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A malformed payload fails the refresh without an unexpected error."""
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
+    mock_vicare = MockPyViCare(fixtures)
+    service = mock_vicare.devices[0].service
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=mock_vicare.as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.SENSOR]),
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        sensor_id = "sensor.model0_outside_temperature"
+        service.getProperty.side_effect = PyViCareInvalidDataError({"error": "no data"})
+        caplog.clear()
+        freezer.tick(timedelta(seconds=120))
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert hass.states.get(sensor_id).state == STATE_UNAVAILABLE
+        assert "Unexpected error fetching" not in caplog.text
 
 
 async def test_per_device_failure_isolation(


### PR DESCRIPTION
## Proposed change

The coordinator refreshes with `clear_cache()` + `fetch_all_features()`, which on `ViCareCachedService` does not warm the cache: that class inherits `ViCareService.fetch_all_features()`, which fetches and returns without writing `_cache`. Only `ViCareCachedServiceViaGateway` overrides it, and Home Assistant never enables that mode.

The payload is therefore discarded and every entity read fetches again. Since #173776 `native_value` is a property instead of a sync `update()` run in the executor, so that second fetch happens in the event loop:

```
RuntimeError: Caught blocking call to putrequest with args (... 'GET',
  '/iot/v2/features/installations/.../devices/0/features/') inside the event loop
```

Measured on a live installation with 5 devices: 49 of these per refresh, one per entity, and no state is written. The integration sets up and then never updates again.

Reading one property instead goes through the cached path, so a refresh costs one request and the entity reads are served from the cache.

This is a workaround. The proper fix is upstream in PyViCare, hoisting the override into `ViCareCachedServiceBase` (openviess/PyViCare#813), which would let this call go back to `fetch_all_features()`. That needs a release, so this PR is the version that can make the 2026.9 beta on its own. Happy to drop it for the library fix if a release lands in time.

### Why this was missed

Both this and the setup crash in #180315 come from the same blind spot: `MockViCareService` does not behave like a real service. `fetch_all_features` was a bare `Mock` accepting any signature, `clear_cache` is a no-op, and `getProperty` reads the fixture directly without consulting a cache. Cache behaviour and request counts are therefore invisible to the suite, which is why it stayed green while the real code path did the opposite of what the docstring claims.

Stacked on #180315.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
