### PR TITLE
Update pipdeptree to 4.2.2

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,7 +22,7 @@ pydantic==2.13.4
 PyGithub==2.9.1
 pylint==4.0.7
 pylint-per-file-ignores==3.2.1
-pipdeptree==2.26.1
+pipdeptree==4.2.2
 pytest-asyncio==1.4.0
 pytest-aiohttp==1.1.1
 pytest-cov==7.1.0

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -552,13 +552,12 @@ def test_check_package_global(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_check_package_fragment(caplog: pytest.LogCaptureFixture) -> None:
     """Test for an installed package with a fragment."""
+    url = "git+https://github.com/home-assistant/core"
+
     assert not package.is_installed(TEST_ZIP_REQ)
-    assert package.is_installed("git+https://github.com/pypa/pip#pip>=1")
-    assert not package.is_installed("git+https://github.com/pypa/pip#-1 invalid")
-    assert (
-        "Invalid requirement 'git+https://github.com/pypa/pip#-1 invalid'"
-        in caplog.text
-    )
+    assert package.is_installed(f"{url}#homeassistant>=1")
+    assert not package.is_installed(f"{url}#-1 invalid")
+    assert f"Invalid requirement '{url}#-1 invalid'" in caplog.text
 
 
 def test_get_is_installed() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates `pipdeptree` from 2.26.1 to 4.2.2 in `requirements_test.txt`. This is a development/CI dependency only: hassfest shells out to `pipdeptree -w silence --json` to build the dependency tree it uses for the requirements checks. It is not shipped to users.

Two major versions in one step, so I checked the impact rather than trusting the version number.

**Speed.** 4.0.0 replaced the Python engine with a Rust extension. On this environment (1714 installed packages) a single `pipdeptree -w silence --json` call goes from 2.42s to 0.08s, best of three. Full `hassfest --requirements` over all 1508 integrations drops from 5.35s to 3.05s wall.

**Behaviour.** 3.0.0 changed the `--extras` default to `explicit`, so extra dependencies now show up as edges in the tree. Concretely `aiohttp` gains `aiodns` and `brotli`, `httpx` gains `h2`, `pyjwt` gains `cryptography`, `urllib3` gains `pysocks`, `google-api-core` gains `grpcio`/`grpcio-status`. Version specifiers are also normalized now (`>=2023.07.22` becomes `>=2023.7.22`, `<3,!=2.2.0` becomes `!=2.2.0,<3`).

That could have shifted what hassfest resolves, so I diffed the actual output. Running `hassfest --action validate --requirements` over all integrations on both versions in the same environment gives byte-identical findings: 118 warnings, 0 errors, no additions or removals. The JSON schema hassfest depends on (`package.key`, `dependencies[].key`, `dependencies[].required_version`) is unchanged.

**Dependencies.** pipdeptree drops its `pip` and `packaging` requirements and picks up `nab-index>=0.0.11` and `nab-project>=0.0.14`, which in turn pull in `nab-provider`, `nab-resolver`, `build`, `installer`, `pyproject-hooks`, `truststore` and `tomli-w`. The nab-* packages are new and still on 0.0.x, from the same maintainer as pipdeptree. All of them ship pure Python wheels, and pipdeptree itself ships a `cp310-abi3-musllinux_1_2_x86_64`/`aarch64` wheel, so the Alpine-based hassfest action image still builds with `uv pip install --no-build`.

Links:

- PyPI: https://pypi.org/project/pipdeptree/4.2.2/
- Release notes: https://github.com/tox-dev/pipdeptree/releases/tag/4.2.2
- Full diff: https://github.com/tox-dev/pipdeptree/compare/2.26.1...4.2.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
