### PR TITLE
Set up the LED Infrared entry once per device type in tests

### DIFF
--- a/tests/components/led_infrared/__init__.py
+++ b/tests/components/led_infrared/__init__.py
@@ -1,1 +1,15 @@
 """Tests for the LED Infrared integration."""
+
+from infrared_protocols.codes.generic.led import (
+    Generic13KeyCode,
+    Generic24KeyCode,
+    Generic40KeyCode,
+    Generic44KeyCode,
+)
+
+type LEDIrKeyCode = (
+    Generic13KeyCode | Generic24KeyCode | Generic40KeyCode | Generic44KeyCode
+)
+
+EVENT_ENTITY_ID = "event.led_infrared_via_test_ir_emitter_received_command"
+LIGHT_ENTITY_ID = "light.led_infrared_via_test_ir_emitter"

--- a/tests/components/led_infrared/test_button.py
+++ b/tests/components/led_infrared/test_button.py
@@ -24,6 +24,8 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from . import LEDIrKeyCode
+
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.infrared import EMITTER_ENTITY_ID
 from tests.components.infrared.common import MockInfraredEmitterEntity
@@ -67,156 +69,53 @@ async def test_setup(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-@pytest.mark.parametrize(
-    ("device_type", "key", "expected_codes"),
-    [
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            "brightness_up",
-            [Generic24KeyCode.BRIGHTNESS_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            "brightness_down",
-            [Generic24KeyCode.BRIGHTNESS_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
-            "brightness_up",
-            [Generic13KeyCode.BRIGHTNESS_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
-            "brightness_down",
-            [Generic13KeyCode.BRIGHTNESS_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
-            "timer",
-            [Generic13KeyCode.TIMER],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "brightness_up",
-            [Generic40KeyCode.BRIGHTNESS_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "brightness_down",
-            [Generic40KeyCode.BRIGHTNESS_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_up",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_down",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_on",
-            [Generic40KeyCode.WHITE_ON],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_off",
-            [Generic40KeyCode.WHITE_OFF],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_25",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_25],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_50",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_50],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_75",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_75],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "white_brightness_100",
-            [Generic40KeyCode.WHITE_BRIGHTNESS_100],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "quick",
-            [Generic40KeyCode.QUICK],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            "slow",
-            [Generic40KeyCode.SLOW],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "brightness_up",
-            [Generic44KeyCode.BRIGHTNESS_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "brightness_down",
-            [Generic44KeyCode.BRIGHTNESS_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "red_up",
-            [Generic44KeyCode.RED_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "green_up",
-            [Generic44KeyCode.GREEN_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "blue_up",
-            [Generic44KeyCode.BLUE_UP],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "red_down",
-            [Generic44KeyCode.RED_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "green_down",
-            [Generic44KeyCode.GREEN_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "blue_down",
-            [Generic44KeyCode.BLUE_DOWN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "quick",
-            [Generic44KeyCode.QUICK],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            "slow",
-            [Generic44KeyCode.SLOW],
-        ),
+# Button key and the codes the emitter is expected to send when it is pressed.
+_BUTTON_PRESSES: dict[LEDIrDeviceType, list[tuple[str, list[LEDIrKeyCode]]]] = {
+    LEDIrDeviceType.GENERIC_13_KEY: [
+        ("brightness_up", [Generic13KeyCode.BRIGHTNESS_UP]),
+        ("brightness_down", [Generic13KeyCode.BRIGHTNESS_DOWN]),
+        ("timer", [Generic13KeyCode.TIMER]),
     ],
-)
+    LEDIrDeviceType.GENERIC_24_KEY: [
+        ("brightness_up", [Generic24KeyCode.BRIGHTNESS_UP]),
+        ("brightness_down", [Generic24KeyCode.BRIGHTNESS_DOWN]),
+    ],
+    LEDIrDeviceType.GENERIC_40_KEY: [
+        ("brightness_up", [Generic40KeyCode.BRIGHTNESS_UP]),
+        ("brightness_down", [Generic40KeyCode.BRIGHTNESS_DOWN]),
+        ("white_brightness_up", [Generic40KeyCode.WHITE_BRIGHTNESS_UP]),
+        ("white_brightness_down", [Generic40KeyCode.WHITE_BRIGHTNESS_DOWN]),
+        ("white_on", [Generic40KeyCode.WHITE_ON]),
+        ("white_off", [Generic40KeyCode.WHITE_OFF]),
+        ("white_brightness_25", [Generic40KeyCode.WHITE_BRIGHTNESS_25]),
+        ("white_brightness_50", [Generic40KeyCode.WHITE_BRIGHTNESS_50]),
+        ("white_brightness_75", [Generic40KeyCode.WHITE_BRIGHTNESS_75]),
+        ("white_brightness_100", [Generic40KeyCode.WHITE_BRIGHTNESS_100]),
+        ("quick", [Generic40KeyCode.QUICK]),
+        ("slow", [Generic40KeyCode.SLOW]),
+    ],
+    LEDIrDeviceType.GENERIC_44_KEY: [
+        ("brightness_up", [Generic44KeyCode.BRIGHTNESS_UP]),
+        ("brightness_down", [Generic44KeyCode.BRIGHTNESS_DOWN]),
+        ("red_up", [Generic44KeyCode.RED_UP]),
+        ("green_up", [Generic44KeyCode.GREEN_UP]),
+        ("blue_up", [Generic44KeyCode.BLUE_UP]),
+        ("red_down", [Generic44KeyCode.RED_DOWN]),
+        ("green_down", [Generic44KeyCode.GREEN_DOWN]),
+        ("blue_down", [Generic44KeyCode.BLUE_DOWN]),
+        ("quick", [Generic44KeyCode.QUICK]),
+        ("slow", [Generic44KeyCode.SLOW]),
+    ],
+}
+
+
+@pytest.mark.parametrize("device_type", list(_BUTTON_PRESSES))
 @pytest.mark.usefixtures("infrared_codes")
 async def test_button_press(
     hass: HomeAssistant,
     mock_infrared_emitter_entity: MockInfraredEmitterEntity,
     entity_registry: er.EntityRegistry,
     device_type: LEDIrDeviceType,
-    key: str,
-    expected_codes: list[
-        Generic24KeyCode | Generic13KeyCode | Generic40KeyCode | Generic44KeyCode
-    ],
 ) -> None:
     """Test button press action."""
     config_entry = MockConfigEntry(
@@ -234,17 +133,19 @@ async def test_button_press(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entity_id = entity_registry.async_get_entity_id(
-        BUTTON_DOMAIN, DOMAIN, f"{config_entry.entry_id}_{key}"
-    )
-    assert entity_id is not None
+    for key, expected_codes in _BUTTON_PRESSES[device_type]:
+        entity_id = entity_registry.async_get_entity_id(
+            BUTTON_DOMAIN, DOMAIN, f"{config_entry.entry_id}_{key}"
+        )
+        assert entity_id is not None
 
-    await hass.services.async_call(
-        BUTTON_DOMAIN,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+        mock_infrared_emitter_entity.send_command_calls.clear()
 
-    assert len(mock_infrared_emitter_entity.send_command_calls) == len(expected_codes)
-    assert mock_infrared_emitter_entity.send_command_calls == expected_codes
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        assert mock_infrared_emitter_entity.send_command_calls == expected_codes

--- a/tests/components/led_infrared/test_event.py
+++ b/tests/components/led_infrared/test_event.py
@@ -1,6 +1,7 @@
 """Tests for the LED Infrared event platform."""
 
 from collections.abc import Generator
+from datetime import timedelta
 from unittest.mock import patch
 
 from infrared_protocols.codes.generic.led import (
@@ -27,6 +28,9 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from . import EVENT_ENTITY_ID, LIGHT_ENTITY_ID, LEDIrKeyCode
 
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.infrared import EMITTER_ENTITY_ID, RECEIVER_ENTITY_ID
@@ -71,297 +75,148 @@ async def test_setup(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-@pytest.mark.parametrize(
-    ("device_type", "command_code", "expected_light_state", "expected_light_effect"),
-    [
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.ON, "on", None),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.OFF, "off", None),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            Generic24KeyCode.BRIGHTNESS_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            Generic24KeyCode.BRIGHTNESS_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.FLASH, "on", "flash"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.STROBE, "on", "strobe"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.FADE, "on", "fade"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.SMOOTH, "on", "smooth"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.RED, "on", "red"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.GREEN, "on", "green"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.BLUE, "on", "blue"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.WHITE, "on", "white"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.TOMATO, "on", "tomato"),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            Generic24KeyCode.LIGHT_GREEN,
-            "on",
-            "light_green",
-        ),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.SKY_BLUE, "on", "sky_blue"),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            Generic24KeyCode.ORANGE_RED,
-            "on",
-            "orange_red",
-        ),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.CYAN, "on", "cyan"),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            Generic24KeyCode.REBECCA_PURPLE,
-            "on",
-            "rebecca_purple",
-        ),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.ORANGE, "on", "orange"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.TURQUOISE, "on", "turquoise"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.PURPLE, "on", "purple"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.YELLOW, "on", "yellow"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.DARK_CYAN, "on", "dark_cyan"),
-        (LEDIrDeviceType.GENERIC_24_KEY, Generic24KeyCode.PLUM, "on", "plum"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.ON, "on", None),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.OFF, "off", None),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.TIMER, STATE_UNKNOWN, None),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_1, "on", "mode_1"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_2, "on", "mode_2"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_3, "on", "mode_3"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_4, "on", "mode_4"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_5, "on", "mode_5"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_6, "on", "mode_6"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_7, "on", "mode_7"),
-        (LEDIrDeviceType.GENERIC_13_KEY, Generic13KeyCode.MODE_8, "on", "mode_8"),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
-            Generic13KeyCode.BRIGHTNESS_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
-            Generic13KeyCode.BRIGHTNESS_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.ON, "on", None),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.OFF, "off", None),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.BRIGHTNESS_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.BRIGHTNESS_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_ON,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_OFF,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_25,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_50,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_75,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.WHITE_BRIGHTNESS_100,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.QUICK, STATE_UNKNOWN, None),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.SLOW, STATE_UNKNOWN, None),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.JUMP3, "on", "jump3"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.JUMP7, "on", "jump7"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.FADE3, "on", "fade3"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.FADE7, "on", "fade7"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.FLASH, "on", "flash"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.AUTO, "on", "auto"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.RED, "on", "red"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.GREEN, "on", "green"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.BLUE, "on", "blue"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.WHITE, "on", "white"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.TOMATO, "on", "tomato"),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.LIGHT_GREEN,
-            "on",
-            "light_green",
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.DEEP_BLUE, "on", "deep_blue"),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.FLORAL_WHITE,
-            "on",
-            "floral_white",
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.ORANGE, "on", "orange"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.TURQUOISE, "on", "turquoise"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.PURPLE, "on", "purple"),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.LAVENDER_BLUSH,
-            "on",
-            "lavender_blush",
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.YELLOWISH, "on", "yellowish"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.CYAN, "on", "cyan"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.MAGENTA, "on", "magenta"),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.GHOST_WHITE,
-            "on",
-            "ghost_white",
-        ),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.YELLOW, "on", "yellow"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.AQUA, "on", "aqua"),
-        (LEDIrDeviceType.GENERIC_40_KEY, Generic40KeyCode.PINK, "on", "pink"),
-        (
-            LEDIrDeviceType.GENERIC_40_KEY,
-            Generic40KeyCode.LIGHT_CYAN,
-            "on",
-            "light_cyan",
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.ON, "on", None),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.OFF, "off", None),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.BRIGHTNESS_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.BRIGHTNESS_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.RED_UP, STATE_UNKNOWN, None),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.GREEN_UP,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.BLUE_UP, STATE_UNKNOWN, None),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.RED_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.GREEN_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.BLUE_DOWN,
-            STATE_UNKNOWN,
-            None,
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.QUICK, STATE_UNKNOWN, None),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.SLOW, STATE_UNKNOWN, None),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY1, "on", "diy1"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY2, "on", "diy2"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY3, "on", "diy3"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY4, "on", "diy4"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY5, "on", "diy5"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DIY6, "on", "diy6"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.AUTO, "on", "auto"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.FLASH, "on", "flash"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.JUMP3, "on", "jump3"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.JUMP7, "on", "jump7"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.FADE3, "on", "fade3"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.FADE7, "on", "fade7"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.RED, "on", "red"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.GREEN, "on", "green"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.BLUE, "on", "blue"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.WHITE, "on", "white"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.TOMATO, "on", "tomato"),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.LIGHT_GREEN,
-            "on",
-            "light_green",
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.DEEP_BLUE, "on", "deep_blue"),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.FLORAL_WHITE,
-            "on",
-            "floral_white",
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.ORANGE, "on", "orange"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.TURQUOISE, "on", "turquoise"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.PURPLE, "on", "purple"),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.LAVENDER_BLUSH,
-            "on",
-            "lavender_blush",
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.YELLOWISH, "on", "yellowish"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.CYAN, "on", "cyan"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.MAGENTA, "on", "magenta"),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.GHOST_WHITE,
-            "on",
-            "ghost_white",
-        ),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.YELLOW, "on", "yellow"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.AQUA, "on", "aqua"),
-        (LEDIrDeviceType.GENERIC_44_KEY, Generic44KeyCode.PINK, "on", "pink"),
-        (
-            LEDIrDeviceType.GENERIC_44_KEY,
-            Generic44KeyCode.LIGHT_CYAN,
-            "on",
-            "light_cyan",
-        ),
+# Every code the remote can send, with the light state and effect it leaves
+# behind. One entry replays a whole remote, so the codes are grouped in an order
+# that keeps each expectation independent of the presses before it: codes the
+# light ignores run first, while it is still unknown, then on and off, which must
+# not have an effect set yet, then the effect and colour codes, each of which
+# overwrites the previous effect.
+_RECEIVED_COMMANDS: dict[
+    LEDIrDeviceType, list[tuple[LEDIrKeyCode, str, str | None]]
+] = {
+    LEDIrDeviceType.GENERIC_13_KEY: [
+        (Generic13KeyCode.TIMER, STATE_UNKNOWN, None),
+        (Generic13KeyCode.BRIGHTNESS_UP, STATE_UNKNOWN, None),
+        (Generic13KeyCode.BRIGHTNESS_DOWN, STATE_UNKNOWN, None),
+        (Generic13KeyCode.ON, "on", None),
+        (Generic13KeyCode.OFF, "off", None),
+        (Generic13KeyCode.MODE_1, "on", "mode_1"),
+        (Generic13KeyCode.MODE_2, "on", "mode_2"),
+        (Generic13KeyCode.MODE_3, "on", "mode_3"),
+        (Generic13KeyCode.MODE_4, "on", "mode_4"),
+        (Generic13KeyCode.MODE_5, "on", "mode_5"),
+        (Generic13KeyCode.MODE_6, "on", "mode_6"),
+        (Generic13KeyCode.MODE_7, "on", "mode_7"),
+        (Generic13KeyCode.MODE_8, "on", "mode_8"),
     ],
-)
+    LEDIrDeviceType.GENERIC_24_KEY: [
+        (Generic24KeyCode.BRIGHTNESS_UP, STATE_UNKNOWN, None),
+        (Generic24KeyCode.BRIGHTNESS_DOWN, STATE_UNKNOWN, None),
+        (Generic24KeyCode.ON, "on", None),
+        (Generic24KeyCode.OFF, "off", None),
+        (Generic24KeyCode.FLASH, "on", "flash"),
+        (Generic24KeyCode.STROBE, "on", "strobe"),
+        (Generic24KeyCode.FADE, "on", "fade"),
+        (Generic24KeyCode.SMOOTH, "on", "smooth"),
+        (Generic24KeyCode.RED, "on", "red"),
+        (Generic24KeyCode.GREEN, "on", "green"),
+        (Generic24KeyCode.BLUE, "on", "blue"),
+        (Generic24KeyCode.WHITE, "on", "white"),
+        (Generic24KeyCode.TOMATO, "on", "tomato"),
+        (Generic24KeyCode.LIGHT_GREEN, "on", "light_green"),
+        (Generic24KeyCode.SKY_BLUE, "on", "sky_blue"),
+        (Generic24KeyCode.ORANGE_RED, "on", "orange_red"),
+        (Generic24KeyCode.CYAN, "on", "cyan"),
+        (Generic24KeyCode.REBECCA_PURPLE, "on", "rebecca_purple"),
+        (Generic24KeyCode.ORANGE, "on", "orange"),
+        (Generic24KeyCode.TURQUOISE, "on", "turquoise"),
+        (Generic24KeyCode.PURPLE, "on", "purple"),
+        (Generic24KeyCode.YELLOW, "on", "yellow"),
+        (Generic24KeyCode.DARK_CYAN, "on", "dark_cyan"),
+        (Generic24KeyCode.PLUM, "on", "plum"),
+    ],
+    LEDIrDeviceType.GENERIC_40_KEY: [
+        (Generic40KeyCode.BRIGHTNESS_UP, STATE_UNKNOWN, None),
+        (Generic40KeyCode.BRIGHTNESS_DOWN, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_UP, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_DOWN, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_ON, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_OFF, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_25, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_50, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_75, STATE_UNKNOWN, None),
+        (Generic40KeyCode.WHITE_BRIGHTNESS_100, STATE_UNKNOWN, None),
+        (Generic40KeyCode.QUICK, STATE_UNKNOWN, None),
+        (Generic40KeyCode.SLOW, STATE_UNKNOWN, None),
+        (Generic40KeyCode.ON, "on", None),
+        (Generic40KeyCode.OFF, "off", None),
+        (Generic40KeyCode.JUMP3, "on", "jump3"),
+        (Generic40KeyCode.JUMP7, "on", "jump7"),
+        (Generic40KeyCode.FADE3, "on", "fade3"),
+        (Generic40KeyCode.FADE7, "on", "fade7"),
+        (Generic40KeyCode.FLASH, "on", "flash"),
+        (Generic40KeyCode.AUTO, "on", "auto"),
+        (Generic40KeyCode.RED, "on", "red"),
+        (Generic40KeyCode.GREEN, "on", "green"),
+        (Generic40KeyCode.BLUE, "on", "blue"),
+        (Generic40KeyCode.WHITE, "on", "white"),
+        (Generic40KeyCode.TOMATO, "on", "tomato"),
+        (Generic40KeyCode.LIGHT_GREEN, "on", "light_green"),
+        (Generic40KeyCode.DEEP_BLUE, "on", "deep_blue"),
+        (Generic40KeyCode.FLORAL_WHITE, "on", "floral_white"),
+        (Generic40KeyCode.ORANGE, "on", "orange"),
+        (Generic40KeyCode.TURQUOISE, "on", "turquoise"),
+        (Generic40KeyCode.PURPLE, "on", "purple"),
+        (Generic40KeyCode.LAVENDER_BLUSH, "on", "lavender_blush"),
+        (Generic40KeyCode.YELLOWISH, "on", "yellowish"),
+        (Generic40KeyCode.CYAN, "on", "cyan"),
+        (Generic40KeyCode.MAGENTA, "on", "magenta"),
+        (Generic40KeyCode.GHOST_WHITE, "on", "ghost_white"),
+        (Generic40KeyCode.YELLOW, "on", "yellow"),
+        (Generic40KeyCode.AQUA, "on", "aqua"),
+        (Generic40KeyCode.PINK, "on", "pink"),
+        (Generic40KeyCode.LIGHT_CYAN, "on", "light_cyan"),
+    ],
+    LEDIrDeviceType.GENERIC_44_KEY: [
+        (Generic44KeyCode.BRIGHTNESS_UP, STATE_UNKNOWN, None),
+        (Generic44KeyCode.BRIGHTNESS_DOWN, STATE_UNKNOWN, None),
+        (Generic44KeyCode.RED_UP, STATE_UNKNOWN, None),
+        (Generic44KeyCode.GREEN_UP, STATE_UNKNOWN, None),
+        (Generic44KeyCode.BLUE_UP, STATE_UNKNOWN, None),
+        (Generic44KeyCode.RED_DOWN, STATE_UNKNOWN, None),
+        (Generic44KeyCode.GREEN_DOWN, STATE_UNKNOWN, None),
+        (Generic44KeyCode.BLUE_DOWN, STATE_UNKNOWN, None),
+        (Generic44KeyCode.QUICK, STATE_UNKNOWN, None),
+        (Generic44KeyCode.SLOW, STATE_UNKNOWN, None),
+        (Generic44KeyCode.ON, "on", None),
+        (Generic44KeyCode.OFF, "off", None),
+        (Generic44KeyCode.DIY1, "on", "diy1"),
+        (Generic44KeyCode.DIY2, "on", "diy2"),
+        (Generic44KeyCode.DIY3, "on", "diy3"),
+        (Generic44KeyCode.DIY4, "on", "diy4"),
+        (Generic44KeyCode.DIY5, "on", "diy5"),
+        (Generic44KeyCode.DIY6, "on", "diy6"),
+        (Generic44KeyCode.AUTO, "on", "auto"),
+        (Generic44KeyCode.FLASH, "on", "flash"),
+        (Generic44KeyCode.JUMP3, "on", "jump3"),
+        (Generic44KeyCode.JUMP7, "on", "jump7"),
+        (Generic44KeyCode.FADE3, "on", "fade3"),
+        (Generic44KeyCode.FADE7, "on", "fade7"),
+        (Generic44KeyCode.RED, "on", "red"),
+        (Generic44KeyCode.GREEN, "on", "green"),
+        (Generic44KeyCode.BLUE, "on", "blue"),
+        (Generic44KeyCode.WHITE, "on", "white"),
+        (Generic44KeyCode.TOMATO, "on", "tomato"),
+        (Generic44KeyCode.LIGHT_GREEN, "on", "light_green"),
+        (Generic44KeyCode.DEEP_BLUE, "on", "deep_blue"),
+        (Generic44KeyCode.FLORAL_WHITE, "on", "floral_white"),
+        (Generic44KeyCode.ORANGE, "on", "orange"),
+        (Generic44KeyCode.TURQUOISE, "on", "turquoise"),
+        (Generic44KeyCode.PURPLE, "on", "purple"),
+        (Generic44KeyCode.LAVENDER_BLUSH, "on", "lavender_blush"),
+        (Generic44KeyCode.YELLOWISH, "on", "yellowish"),
+        (Generic44KeyCode.CYAN, "on", "cyan"),
+        (Generic44KeyCode.MAGENTA, "on", "magenta"),
+        (Generic44KeyCode.GHOST_WHITE, "on", "ghost_white"),
+        (Generic44KeyCode.YELLOW, "on", "yellow"),
+        (Generic44KeyCode.AQUA, "on", "aqua"),
+        (Generic44KeyCode.PINK, "on", "pink"),
+        (Generic44KeyCode.LIGHT_CYAN, "on", "light_cyan"),
+    ],
+}
+
+
+@pytest.mark.parametrize("device_type", list(_RECEIVED_COMMANDS))
 @pytest.mark.usefixtures(
     "mock_infrared_emitter_entity", "mock_infrared_receiver_entity"
 )
@@ -370,12 +225,6 @@ async def test_event(
     hass: HomeAssistant,
     mock_infrared_receiver_entity: MockInfraredReceiverEntity,
     device_type: LEDIrDeviceType,
-    command_code: Generic13KeyCode
-    | Generic24KeyCode
-    | Generic40KeyCode
-    | Generic44KeyCode,
-    expected_light_state: str,
-    expected_light_effect: str | None,
 ) -> None:
     """Test received command events."""
     config_entry = MockConfigEntry(
@@ -394,32 +243,35 @@ async def test_event(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    assert (
-        state := hass.states.get(
-            "event.led_infrared_via_test_ir_emitter_received_command"
-        )
-    )
+    assert (state := hass.states.get(EVENT_ENTITY_ID))
     assert state.state == STATE_UNKNOWN
 
-    command = command_code.to_command()
-    mock_infrared_receiver_entity._handle_received_signal(
-        InfraredReceivedSignal(timings=command.get_raw_timings())
-    )
+    # The event entity keeps its timestamps strictly increasing, so a later
+    # timestamp is what shows a command fired an event of its own.
+    previous_triggered = dt_util.utcnow() - timedelta(milliseconds=1)
 
-    assert (
-        state := hass.states.get(
-            "event.led_infrared_via_test_ir_emitter_received_command"
+    for command_code, expected_light_state, expected_light_effect in _RECEIVED_COMMANDS[
+        device_type
+    ]:
+        command = command_code.to_command()
+        mock_infrared_receiver_entity._handle_received_signal(
+            InfraredReceivedSignal(timings=command.get_raw_timings())
         )
-    )
-    assert (
-        state.attributes[EventEntityStateAttribute.EVENT_TYPE]
-        == command_code.name.lower()
-    )
-    assert state.state == "2026-01-01T13:12:00.000+00:00"
 
-    assert (state := hass.states.get("light.led_infrared_via_test_ir_emitter"))
-    assert state.state == expected_light_state
-    assert state.attributes[LightEntityStateAttribute.EFFECT] == expected_light_effect
+        assert (state := hass.states.get(EVENT_ENTITY_ID))
+        assert (
+            state.attributes[EventEntityStateAttribute.EVENT_TYPE]
+            == command_code.name.lower()
+        )
+        assert (triggered := dt_util.parse_datetime(state.state))
+        assert triggered > previous_triggered
+        previous_triggered = triggered
+
+        assert (state := hass.states.get(LIGHT_ENTITY_ID))
+        assert state.state == expected_light_state
+        assert (
+            state.attributes[LightEntityStateAttribute.EFFECT] == expected_light_effect
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/led_infrared/test_light.py
+++ b/tests/components/led_infrared/test_light.py
@@ -29,6 +29,8 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from . import LIGHT_ENTITY_ID, LEDIrKeyCode
+
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.infrared import EMITTER_ENTITY_ID
 from tests.components.infrared.common import MockInfraredEmitterEntity
@@ -72,555 +74,465 @@ async def test_setup(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-@pytest.mark.parametrize(
-    ("device_type", "service", "service_data", "expected_codes"),
-    [
+# Action, action data and the codes the emitter is expected to send for it.
+_LIGHT_ACTIONS: dict[
+    LEDIrDeviceType, list[tuple[str, dict[str, str], list[LEDIrKeyCode]]]
+] = {
+    LEDIrDeviceType.GENERIC_13_KEY: [
+        (SERVICE_TURN_ON, {}, [Generic13KeyCode.ON]),
+        (SERVICE_TURN_OFF, {}, [Generic13KeyCode.OFF]),
         (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {},
-            [Generic24KeyCode.ON],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "flash"},
-            [Generic24KeyCode.ON, Generic24KeyCode.FLASH],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "strobe"},
-            [Generic24KeyCode.ON, Generic24KeyCode.STROBE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "fade"},
-            [Generic24KeyCode.ON, Generic24KeyCode.FADE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "smooth"},
-            [Generic24KeyCode.ON, Generic24KeyCode.SMOOTH],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "red"},
-            [Generic24KeyCode.ON, Generic24KeyCode.RED],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "green"},
-            [Generic24KeyCode.ON, Generic24KeyCode.GREEN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "blue"},
-            [Generic24KeyCode.ON, Generic24KeyCode.BLUE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "white"},
-            [Generic24KeyCode.ON, Generic24KeyCode.WHITE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "orange_red"},
-            [Generic24KeyCode.ON, Generic24KeyCode.ORANGE_RED],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "tomato"},
-            [Generic24KeyCode.ON, Generic24KeyCode.TOMATO],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "light_green"},
-            [Generic24KeyCode.ON, Generic24KeyCode.LIGHT_GREEN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "sky_blue"},
-            [Generic24KeyCode.ON, Generic24KeyCode.SKY_BLUE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "cyan"},
-            [Generic24KeyCode.ON, Generic24KeyCode.CYAN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "rebecca_purple"},
-            [Generic24KeyCode.ON, Generic24KeyCode.REBECCA_PURPLE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "orange"},
-            [Generic24KeyCode.ON, Generic24KeyCode.ORANGE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "turquoise"},
-            [Generic24KeyCode.ON, Generic24KeyCode.TURQUOISE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "purple"},
-            [Generic24KeyCode.ON, Generic24KeyCode.PURPLE],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "yellow"},
-            [Generic24KeyCode.ON, Generic24KeyCode.YELLOW],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "dark_cyan"},
-            [Generic24KeyCode.ON, Generic24KeyCode.DARK_CYAN],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_ON,
-            {ATTR_EFFECT: "plum"},
-            [Generic24KeyCode.ON, Generic24KeyCode.PLUM],
-        ),
-        (
-            LEDIrDeviceType.GENERIC_24_KEY,
-            SERVICE_TURN_OFF,
-            {},
-            [Generic24KeyCode.OFF],
-        ),
-        (LEDIrDeviceType.GENERIC_13_KEY, SERVICE_TURN_ON, {}, [Generic13KeyCode.ON]),
-        (LEDIrDeviceType.GENERIC_13_KEY, SERVICE_TURN_OFF, {}, [Generic13KeyCode.OFF]),
-        (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_1"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_1],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_2"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_2],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_3"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_3],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_4"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_4],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_5"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_5],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_6"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_6],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_7"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_7],
         ),
         (
-            LEDIrDeviceType.GENERIC_13_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "mode_8"},
             [Generic13KeyCode.ON, Generic13KeyCode.MODE_8],
         ),
-        (LEDIrDeviceType.GENERIC_40_KEY, SERVICE_TURN_ON, {}, [Generic40KeyCode.ON]),
-        (LEDIrDeviceType.GENERIC_40_KEY, SERVICE_TURN_OFF, {}, [Generic40KeyCode.OFF]),
+    ],
+    LEDIrDeviceType.GENERIC_24_KEY: [
+        (SERVICE_TURN_ON, {}, [Generic24KeyCode.ON]),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "flash"},
+            [Generic24KeyCode.ON, Generic24KeyCode.FLASH],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "strobe"},
+            [Generic24KeyCode.ON, Generic24KeyCode.STROBE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "fade"},
+            [Generic24KeyCode.ON, Generic24KeyCode.FADE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "smooth"},
+            [Generic24KeyCode.ON, Generic24KeyCode.SMOOTH],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "red"},
+            [Generic24KeyCode.ON, Generic24KeyCode.RED],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "green"},
+            [Generic24KeyCode.ON, Generic24KeyCode.GREEN],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "blue"},
+            [Generic24KeyCode.ON, Generic24KeyCode.BLUE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "white"},
+            [Generic24KeyCode.ON, Generic24KeyCode.WHITE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "orange_red"},
+            [Generic24KeyCode.ON, Generic24KeyCode.ORANGE_RED],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "tomato"},
+            [Generic24KeyCode.ON, Generic24KeyCode.TOMATO],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "light_green"},
+            [Generic24KeyCode.ON, Generic24KeyCode.LIGHT_GREEN],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "sky_blue"},
+            [Generic24KeyCode.ON, Generic24KeyCode.SKY_BLUE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "cyan"},
+            [Generic24KeyCode.ON, Generic24KeyCode.CYAN],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "rebecca_purple"},
+            [Generic24KeyCode.ON, Generic24KeyCode.REBECCA_PURPLE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "orange"},
+            [Generic24KeyCode.ON, Generic24KeyCode.ORANGE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "turquoise"},
+            [Generic24KeyCode.ON, Generic24KeyCode.TURQUOISE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "purple"},
+            [Generic24KeyCode.ON, Generic24KeyCode.PURPLE],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "yellow"},
+            [Generic24KeyCode.ON, Generic24KeyCode.YELLOW],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "dark_cyan"},
+            [Generic24KeyCode.ON, Generic24KeyCode.DARK_CYAN],
+        ),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "plum"},
+            [Generic24KeyCode.ON, Generic24KeyCode.PLUM],
+        ),
+        (SERVICE_TURN_OFF, {}, [Generic24KeyCode.OFF]),
+    ],
+    LEDIrDeviceType.GENERIC_40_KEY: [
+        (SERVICE_TURN_ON, {}, [Generic40KeyCode.ON]),
+        (SERVICE_TURN_OFF, {}, [Generic40KeyCode.OFF]),
+        (
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "auto"},
             [Generic40KeyCode.ON, Generic40KeyCode.AUTO],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "fade3"},
             [Generic40KeyCode.ON, Generic40KeyCode.FADE3],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "fade7"},
             [Generic40KeyCode.ON, Generic40KeyCode.FADE7],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "flash"},
             [Generic40KeyCode.ON, Generic40KeyCode.FLASH],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "jump3"},
             [Generic40KeyCode.ON, Generic40KeyCode.JUMP3],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "jump7"},
             [Generic40KeyCode.ON, Generic40KeyCode.JUMP7],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "red"},
             [Generic40KeyCode.ON, Generic40KeyCode.RED],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "green"},
             [Generic40KeyCode.ON, Generic40KeyCode.GREEN],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "blue"},
             [Generic40KeyCode.ON, Generic40KeyCode.BLUE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "white"},
             [Generic40KeyCode.ON, Generic40KeyCode.WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "tomato"},
             [Generic40KeyCode.ON, Generic40KeyCode.TOMATO],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "light_green"},
             [Generic40KeyCode.ON, Generic40KeyCode.LIGHT_GREEN],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "deep_blue"},
             [Generic40KeyCode.ON, Generic40KeyCode.DEEP_BLUE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "floral_white"},
             [Generic40KeyCode.ON, Generic40KeyCode.FLORAL_WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "orange"},
             [Generic40KeyCode.ON, Generic40KeyCode.ORANGE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "turquoise"},
             [Generic40KeyCode.ON, Generic40KeyCode.TURQUOISE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "purple"},
             [Generic40KeyCode.ON, Generic40KeyCode.PURPLE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "lavender_blush"},
             [Generic40KeyCode.ON, Generic40KeyCode.LAVENDER_BLUSH],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "yellowish"},
             [Generic40KeyCode.ON, Generic40KeyCode.YELLOWISH],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "cyan"},
             [Generic40KeyCode.ON, Generic40KeyCode.CYAN],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "magenta"},
             [Generic40KeyCode.ON, Generic40KeyCode.MAGENTA],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "ghost_white"},
             [Generic40KeyCode.ON, Generic40KeyCode.GHOST_WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "yellow"},
             [Generic40KeyCode.ON, Generic40KeyCode.YELLOW],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "aqua"},
             [Generic40KeyCode.ON, Generic40KeyCode.AQUA],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "pink"},
             [Generic40KeyCode.ON, Generic40KeyCode.PINK],
         ),
         (
-            LEDIrDeviceType.GENERIC_40_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "light_cyan"},
             [Generic40KeyCode.ON, Generic40KeyCode.LIGHT_CYAN],
         ),
-        (LEDIrDeviceType.GENERIC_44_KEY, SERVICE_TURN_ON, {}, [Generic44KeyCode.ON]),
-        (LEDIrDeviceType.GENERIC_44_KEY, SERVICE_TURN_OFF, {}, [Generic44KeyCode.OFF]),
+    ],
+    LEDIrDeviceType.GENERIC_44_KEY: [
+        (SERVICE_TURN_ON, {}, [Generic44KeyCode.ON]),
+        (SERVICE_TURN_OFF, {}, [Generic44KeyCode.OFF]),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "auto"},
             [Generic44KeyCode.ON, Generic44KeyCode.AUTO],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "fade3"},
             [Generic44KeyCode.ON, Generic44KeyCode.FADE3],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "fade7"},
             [Generic44KeyCode.ON, Generic44KeyCode.FADE7],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "flash"},
             [Generic44KeyCode.ON, Generic44KeyCode.FLASH],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "jump3"},
             [Generic44KeyCode.ON, Generic44KeyCode.JUMP3],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "jump7"},
             [Generic44KeyCode.ON, Generic44KeyCode.JUMP7],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy1"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY1],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy2"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY2],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy3"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY3],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy4"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY4],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy5"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY5],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "diy6"},
             [Generic44KeyCode.ON, Generic44KeyCode.DIY6],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "red"},
             [Generic44KeyCode.ON, Generic44KeyCode.RED],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "green"},
             [Generic44KeyCode.ON, Generic44KeyCode.GREEN],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "blue"},
             [Generic44KeyCode.ON, Generic44KeyCode.BLUE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "white"},
             [Generic44KeyCode.ON, Generic44KeyCode.WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "tomato"},
             [Generic44KeyCode.ON, Generic44KeyCode.TOMATO],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "light_green"},
             [Generic44KeyCode.ON, Generic44KeyCode.LIGHT_GREEN],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "deep_blue"},
             [Generic44KeyCode.ON, Generic44KeyCode.DEEP_BLUE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "floral_white"},
             [Generic44KeyCode.ON, Generic44KeyCode.FLORAL_WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "orange"},
             [Generic44KeyCode.ON, Generic44KeyCode.ORANGE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "turquoise"},
             [Generic44KeyCode.ON, Generic44KeyCode.TURQUOISE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "purple"},
             [Generic44KeyCode.ON, Generic44KeyCode.PURPLE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "lavender_blush"},
             [Generic44KeyCode.ON, Generic44KeyCode.LAVENDER_BLUSH],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "yellowish"},
             [Generic44KeyCode.ON, Generic44KeyCode.YELLOWISH],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "cyan"},
             [Generic44KeyCode.ON, Generic44KeyCode.CYAN],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "magenta"},
             [Generic44KeyCode.ON, Generic44KeyCode.MAGENTA],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "ghost_white"},
             [Generic44KeyCode.ON, Generic44KeyCode.GHOST_WHITE],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "yellow"},
             [Generic44KeyCode.ON, Generic44KeyCode.YELLOW],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "aqua"},
             [Generic44KeyCode.ON, Generic44KeyCode.AQUA],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "pink"},
             [Generic44KeyCode.ON, Generic44KeyCode.PINK],
         ),
         (
-            LEDIrDeviceType.GENERIC_44_KEY,
             SERVICE_TURN_ON,
             {ATTR_EFFECT: "light_cyan"},
             [Generic44KeyCode.ON, Generic44KeyCode.LIGHT_CYAN],
         ),
     ],
-)
+}
+
+
+@pytest.mark.parametrize("device_type", list(_LIGHT_ACTIONS))
 @pytest.mark.usefixtures("infrared_codes")
 async def test_light_actions(
     hass: HomeAssistant,
     mock_infrared_emitter_entity: MockInfraredEmitterEntity,
     device_type: LEDIrDeviceType,
-    service: str,
-    service_data: dict[str, str],
-    expected_codes: list[
-        Generic13KeyCode | Generic24KeyCode | Generic40KeyCode | Generic44KeyCode
-    ],
 ) -> None:
     """Test light actions."""
     config_entry = MockConfigEntry(
@@ -638,12 +550,14 @@ async def test_light_actions(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        service,
-        {ATTR_ENTITY_ID: "light.led_infrared_via_test_ir_emitter", **service_data},
-        blocking=True,
-    )
+    for service, service_data, expected_codes in _LIGHT_ACTIONS[device_type]:
+        mock_infrared_emitter_entity.send_command_calls.clear()
 
-    assert len(mock_infrared_emitter_entity.send_command_calls) == len(expected_codes)
-    assert mock_infrared_emitter_entity.send_command_calls == expected_codes
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: LIGHT_ENTITY_ID, **service_data},
+            blocking=True,
+        )
+
+        assert mock_infrared_emitter_entity.send_command_calls == expected_codes


### PR DESCRIPTION
## Breaking change



## Proposed change

The `led_infrared` event, light and button tests took one parameter set per key on the remote — 121, 94 and 27 — and every set built a `MockConfigEntry` and set the integration up again. That is 259 config entry setups across the directory to assert three static tables. `test_event` alone had 121 cases because the four supported remotes have 13, 24, 40 and 44 keys.

Each table now lives in a dict keyed by device type, and the test iterates it while parametrized over the four device types. The tables and the assertions are unchanged, so the same mappings are still covered.

`test_event` replays a whole remote inside one entry, so its codes are ordered to keep every expectation independent of the presses before it: the codes the light ignores run first, while the light is still unknown, then on and off, which must not have an effect set yet, then the effect and colour codes, each of which overwrites the previous effect. The event entity keeps its timestamps strictly increasing, so the assertion on the exact frozen time is replaced by an assertion that each timestamp is later than the one before. That is what shows a command fired an event of its own.

`LEDIrKeyCode` and the two repeated entity ids moved to the test package `__init__.py` so the three modules share them.

272 tests in 21.6s becomes 42 tests in 2.1s.

I checked that the reduced tests still catch regressions by mutating the integration four ways: dropping a colour from `SUPPORTED_COLORS`, inverting the on/off event handling, skipping the effect code in `async_turn_on`, and sending the wrong code from a button press. Each mutation fails the tests.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L8QZUaEFt6DVx1jQYU1Mf