### PR TITLE
Fix swallowed exceptions in action handlers for MJPEG IP Camera

### DIFF
--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     HTTP_DIGEST_AUTHENTICATION,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web,
     async_get_clientsession,
@@ -29,7 +30,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .const import CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, DOMAIN, LOGGER
+from .const import CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, DOMAIN
 
 TIMEOUT = 10
 BUFFER_SIZE = 102400
@@ -155,14 +156,19 @@ class MjpegCamera(Camera):
 
                 return await response.read()
 
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except TimeoutError:
-            LOGGER.error("Timeout getting camera image from %s", self.name)
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="timeout_getting_image",
+                translation_placeholders={"name": str(self.name)},
+            ) from err
 
         except aiohttp.ClientError as err:
-            LOGGER.error("Error getting new camera image from %s: %s", self.name, err)
-
-        return None
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="error_getting_image",
+                translation_placeholders={"name": str(self.name)},
+            ) from err
 
     def _get_httpx_auth(self) -> httpx.Auth:
         """Return a httpx auth object."""
@@ -192,13 +198,19 @@ class MjpegCamera(Camera):
                     stream.aiter_bytes(BUFFER_SIZE)
                 )
 
-        except TimeoutError:
-            LOGGER.error("Timeout getting camera image from %s", self.name)
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="timeout_getting_image",
+                translation_placeholders={"name": str(self.name)},
+            ) from err
 
         except httpx.HTTPError as err:
-            LOGGER.error("Error getting new camera image from %s: %s", self.name, err)
-
-        return None
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="error_getting_image",
+                translation_placeholders={"name": str(self.name)},
+            ) from err
 
     async def _handle_async_mjpeg_digest_stream(
         self, request: web.Request

--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -198,7 +198,7 @@ class MjpegCamera(Camera):
                     stream.aiter_bytes(BUFFER_SIZE)
                 )
 
-        except TimeoutError as err:
+        except (TimeoutError, httpx.TimeoutException) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="timeout_getting_image",

--- a/homeassistant/components/mjpeg/strings.json
+++ b/homeassistant/components/mjpeg/strings.json
@@ -20,6 +20,14 @@
       }
     }
   },
+  "exceptions": {
+    "error_getting_image": {
+      "message": "Error getting a new image from {name}."
+    },
+    "timeout_getting_image": {
+      "message": "Timeout getting an image from {name}."
+    }
+  },
   "options": {
     "error": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/tests/components/mjpeg/test_camera.py
+++ b/tests/components/mjpeg/test_camera.py
@@ -87,6 +87,9 @@ def mock_digest_config_entry() -> MockConfigEntry:
     ("exception", "translation_key"),
     [
         pytest.param(TimeoutError, "timeout_getting_image", id="timeout"),
+        pytest.param(
+            httpx.TimeoutException, "timeout_getting_image", id="httpx_timeout"
+        ),
         pytest.param(httpx.HTTPError, "error_getting_image", id="http_error"),
     ],
 )

--- a/tests/components/mjpeg/test_camera.py
+++ b/tests/components/mjpeg/test_camera.py
@@ -1,0 +1,111 @@
+"""Test the MJPEG IP Camera camera platform."""
+
+import aiohttp
+import httpx
+import pytest
+import respx
+
+from homeassistant.components.camera import async_get_image
+from homeassistant.components.mjpeg.const import (
+    CONF_MJPEG_URL,
+    CONF_STILL_IMAGE_URL,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_AUTHENTICATION,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+ENTITY_CAMERA = "camera.my_mjpeg_camera"
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("exception", "translation_key"),
+    [
+        pytest.param(TimeoutError, "timeout_getting_image", id="timeout"),
+        pytest.param(aiohttp.ClientError, "error_getting_image", id="client_error"),
+    ],
+)
+async def test_camera_image_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    exception: type[Exception],
+    translation_key: str,
+) -> None:
+    """Test that a failed still image request raises instead of returning nothing."""
+    aioclient_mock.get("http://example.com/still", exc=exception)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await async_get_image(hass, ENTITY_CAMERA)
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_camera_image(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test that a still image is returned."""
+    aioclient_mock.get("http://example.com/still", content=b"image_bytes")
+
+    image = await async_get_image(hass, ENTITY_CAMERA)
+
+    assert image.content == b"image_bytes"
+
+
+@pytest.fixture
+def mock_digest_config_entry() -> MockConfigEntry:
+    """Return a mocked config entry that uses digest authentication."""
+    return MockConfigEntry(
+        title="My MJPEG Camera",
+        domain=DOMAIN,
+        data={},
+        options={
+            CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
+            CONF_MJPEG_URL: "https://example.com/mjpeg",
+            CONF_PASSWORD: "supersecret",
+            CONF_STILL_IMAGE_URL: "http://example.com/still",
+            CONF_USERNAME: "frenck",
+            CONF_VERIFY_SSL: True,
+        },
+    )
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("exception", "translation_key"),
+    [
+        pytest.param(TimeoutError, "timeout_getting_image", id="timeout"),
+        pytest.param(httpx.HTTPError, "error_getting_image", id="http_error"),
+    ],
+)
+async def test_digest_camera_image_error(
+    hass: HomeAssistant,
+    mock_digest_config_entry: MockConfigEntry,
+    exception: type[Exception],
+    translation_key: str,
+) -> None:
+    """Test that a failed digest image request raises instead of returning nothing."""
+    mock_digest_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_digest_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    respx.get("http://example.com/still").mock(side_effect=exception("boom"))
+    respx.get("https://example.com/mjpeg").mock(side_effect=exception("boom"))
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await async_get_image(hass, ENTITY_CAMERA)
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->



When a still image request failed, both image paths only logged the error and returned None, so the caller received an empty response instead of a failure. They now raise HomeAssistantError with a translated message.

The issue only mentions async_camera_image, but the digest path has the same handling. Converting only one would make the behaviour depend on the configured authentication method, so both are converted. Raising from async_camera_image follows fully_kiosk, which already does this in the same method.

The integration had no camera tests, so this adds them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- This PR fixes or closes issue: fixes #170670
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
