### PR TITLE
Add use_stream_for_stills option to tplink camera

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -50,6 +50,7 @@ from .const import (
     CONF_CREDENTIALS_HASH,
     CONF_DEVICE_CONFIG,
     CONF_LIVE_VIEW,
+    CONF_USE_STREAM_FOR_STILLS,
     CONF_USES_HTTP,
     CONNECT_TIMEOUT,
     DISCOVERY_TIMEOUT,
@@ -240,8 +241,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bo
             camera_creds_dict[CONF_USERNAME], camera_creds_dict[CONF_PASSWORD]
         )
     live_view = entry.data.get(CONF_LIVE_VIEW)
+    use_stream_for_stills = entry.options.get(CONF_USE_STREAM_FOR_STILLS, False)
 
-    entry.runtime_data = TPLinkData(parent_coordinator, camera_creds, live_view)
+    entry.runtime_data = TPLinkData(
+        parent_coordinator, camera_creds, live_view, use_stream_for_stills
+    )
 
     # Register the parent device before forwarding platforms so child device
     # entities can resolve their via_device_id from it.

--- a/homeassistant/components/tplink/camera.py
+++ b/homeassistant/components/tplink/camera.py
@@ -115,8 +115,13 @@ class TPLinkCameraEntity(CoordinatedTPLinkModuleEntity, Camera):
         self._camera_credentials = (
             coordinator.config_entry.runtime_data.camera_credentials
         )
+        stills_resolution = (
+            StreamResolution.HD
+            if coordinator.config_entry.runtime_data.use_stream_for_stills
+            else StreamResolution.SD
+        )
         self._video_url = self._camera_module.stream_rtsp_url(
-            self._camera_credentials, stream_resolution=StreamResolution.SD
+            self._camera_credentials, stream_resolution=stills_resolution
         )
         self._image: bytes | None = None
         self._image_lock = asyncio.Lock()

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -61,6 +61,7 @@ from .const import (
     CONNECT_TIMEOUT,
     DOMAIN,
 )
+from .coordinator import TPLinkConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -872,7 +873,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     @override
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: TPLinkConfigEntry,
     ) -> TPLinkOptionsFlowHandler:
         """Create the options flow."""
         return TPLinkOptionsFlowHandler()

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.config_entries import (
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import (
     CONF_ALIAS,
@@ -55,6 +56,7 @@ from .const import (
     CONF_CONNECTION_PARAMETERS,
     CONF_CREDENTIALS_HASH,
     CONF_LIVE_VIEW,
+    CONF_USE_STREAM_FOR_STILLS,
     CONF_USES_HTTP,
     CONNECT_TIMEOUT,
     DOMAIN,
@@ -75,6 +77,8 @@ STEP_CAMERA_AUTH_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_PASSWORD): str,
     }
 )
+
+STEP_OPTIONS_DATA_SCHEMA = vol.Schema({vol.Optional(CONF_USE_STREAM_FOR_STILLS): bool})
 
 
 class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -862,4 +866,36 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                 **placeholders,
                 CONF_MAC: reconfigure_entry.unique_id,
             },
+        )
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> TPLinkOptionsFlowHandler:
+        """Create the options flow."""
+        return TPLinkOptionsFlowHandler()
+
+
+class TPLinkOptionsFlowHandler(OptionsFlowWithReload):
+    """Handle a tplink options flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_OPTIONS_DATA_SCHEMA,
+                {
+                    CONF_USE_STREAM_FOR_STILLS: self.config_entry.options.get(
+                        CONF_USE_STREAM_FOR_STILLS, False
+                    )
+                },
+            ),
         )

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -885,6 +885,9 @@ class TPLinkOptionsFlowHandler(OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
+        if CONF_LIVE_VIEW not in self.config_entry.data:
+            return self.async_abort(reason="no_options")
+
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -26,6 +26,7 @@ CONF_USES_HTTP: Final = "uses_http"
 CONF_AES_KEYS: Final = "aes_keys"
 CONF_CAMERA_CREDENTIALS = "camera_credentials"
 CONF_LIVE_VIEW = "live_view"
+CONF_USE_STREAM_FOR_STILLS = "use_stream_for_stills"
 
 CONF_CONFIG_ENTRY_MINOR_VERSION: Final = 5
 

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -28,6 +28,7 @@ class TPLinkData:
     parent_coordinator: TPLinkDataUpdateCoordinator
     camera_credentials: Credentials | None
     live_view: bool | None
+    use_stream_for_stills: bool
 
 
 type TPLinkConfigEntry = ConfigEntry[TPLinkData]

--- a/homeassistant/components/tplink/quality_scale.yaml
+++ b/homeassistant/components/tplink/quality_scale.yaml
@@ -39,9 +39,7 @@ rules:
   test-coverage: done
   integration-owner: done
   docs-installation-parameters: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: The integration does not have any options configuration parameters.
+  docs-configuration-parameters: done
 
   # Gold
   entity-translations: done

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -404,6 +404,9 @@
     }
   },
   "options": {
+    "abort": {
+      "no_options": "This device has no configurable options."
+    },
     "step": {
       "init": {
         "data": {

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -403,6 +403,18 @@
       "title": "Detected deprecated {platform} entity usage"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "use_stream_for_stills": "Use HD stream for still images"
+        },
+        "data_description": {
+          "use_stream_for_stills": "When enabled, still images and the MJPEG fallback use the same HD stream as live view instead of the lower resolution SD stream."
+        }
+      }
+    }
+  },
   "services": {
     "random_effect": {
       "description": "Sets a random effect.",

--- a/tests/components/tplink/test_camera.py
+++ b/tests/components/tplink/test_camera.py
@@ -1,11 +1,11 @@
 """The tests for the tplink camera platform."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 from aiohttp.test_utils import make_mocked_request
 from freezegun.api import FrozenDateTimeFactory
-from kasa import Module
+from kasa import Module, StreamResolution
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -21,13 +21,20 @@ from homeassistant.components.camera import (
     get_camera_from_entity_id,
 )
 from homeassistant.components.tplink.camera import TPLinkCameraEntity
+from homeassistant.components.tplink.const import CONF_USE_STREAM_FOR_STILLS, DOMAIN
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import _mocked_device, setup_platform_for_device, snapshot_platform
-from .const import DEVICE_ID, IP_ADDRESS3, MAC_ADDRESS3, SMALLEST_VALID_JPEG_BYTES
+from .const import (
+    CREATE_ENTRY_DATA_AES_CAMERA,
+    DEVICE_ID,
+    IP_ADDRESS3,
+    MAC_ADDRESS3,
+    SMALLEST_VALID_JPEG_BYTES,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import WebSocketGenerator
@@ -390,6 +397,55 @@ async def test_camera_stream_source(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
     assert "url" in msg["result"]
+
+
+async def test_camera_stills_use_sd_by_default(
+    hass: HomeAssistant,
+    mock_camera_config_entry: MockConfigEntry,
+) -> None:
+    """Test still image and mjpeg fallback request the SD stream by default."""
+    mock_device = _mocked_device(
+        modules=[Module.Camera],
+        alias="my_camera",
+        ip_address=IP_ADDRESS3,
+        mac=MAC_ADDRESS3,
+    )
+
+    await setup_platform_for_device(
+        hass, mock_camera_config_entry, Platform.CAMERA, mock_device
+    )
+
+    camera_module = mock_device.modules[Module.Camera]
+    camera_module.stream_rtsp_url.assert_any_call(
+        ANY, stream_resolution=StreamResolution.SD
+    )
+
+
+async def test_camera_stills_use_hd_when_enabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test still image and mjpeg fallback request the HD stream when enabled."""
+    config_entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=CREATE_ENTRY_DATA_AES_CAMERA,
+        options={CONF_USE_STREAM_FOR_STILLS: True},
+        unique_id=MAC_ADDRESS3,
+    )
+
+    mock_device = _mocked_device(
+        modules=[Module.Camera],
+        alias="my_camera",
+        ip_address=IP_ADDRESS3,
+        mac=MAC_ADDRESS3,
+    )
+
+    await setup_platform_for_device(hass, config_entry, Platform.CAMERA, mock_device)
+
+    camera_module = mock_device.modules[Module.Camera]
+    camera_module.stream_rtsp_url.assert_any_call(
+        ANY, stream_resolution=StreamResolution.HD
+    )
 
 
 async def test_camera_stream_attributes(

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -2513,8 +2513,18 @@ async def test_options_flow(
         assert mock_camera_config_entry.options == {CONF_USE_STREAM_FOR_STILLS: True}
         assert mock_camera_config_entry.state is ConfigEntryState.LOADED
 
-        # The reload listener re-ran async_setup_entry without a restart, so the
-        # (same, reused) mocked stream_rtsp_url was called again, this time HD.
         camera_module.stream_rtsp_url.assert_any_call(
             ANY, stream_resolution=StreamResolution.HD
         )
+
+
+async def test_options_flow_no_camera(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow aborts for entries with no camera configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_options"

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -3,7 +3,7 @@
 import logging
 from unittest.mock import ANY, AsyncMock, patch
 
-from kasa import Module, TimeoutError
+from kasa import Module, StreamResolution, TimeoutError
 import pytest
 
 from homeassistant import config_entries
@@ -23,6 +23,7 @@ from homeassistant.components.tplink.const import (
     CONF_CREDENTIALS_HASH,
     CONF_DEVICE_CONFIG,
     CONF_LIVE_VIEW,
+    CONF_USE_STREAM_FOR_STILLS,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
@@ -33,6 +34,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -2466,3 +2468,53 @@ async def test_reconfigure_camera(
         )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_camera_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow toggles stills resolution and reloads, no restart."""
+    mock_device = _mocked_device(
+        modules=[Module.Camera],
+        alias="my_camera",
+        ip_address=IP_ADDRESS3,
+        mac=MAC_ADDRESS3,
+    )
+    camera_module = mock_device.modules[Module.Camera]
+
+    with (
+        patch("homeassistant.components.tplink.PLATFORMS", [Platform.CAMERA]),
+        _patch_discovery(device=mock_device),
+        _patch_connect(device=mock_device),
+    ):
+        mock_camera_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_camera_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        camera_module.stream_rtsp_url.assert_any_call(
+            ANY, stream_resolution=StreamResolution.SD
+        )
+        camera_module.stream_rtsp_url.reset_mock()
+
+        result = await hass.config_entries.options.async_init(
+            mock_camera_config_entry.entry_id
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_USE_STREAM_FOR_STILLS: True},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert mock_camera_config_entry.options == {CONF_USE_STREAM_FOR_STILLS: True}
+        assert mock_camera_config_entry.state is ConfigEntryState.LOADED
+
+        # The reload listener re-ran async_setup_entry without a restart, so the
+        # (same, reused) mocked stream_rtsp_url was called again, this time HD.
+        camera_module.stream_rtsp_url.assert_any_call(
+            ANY, stream_resolution=StreamResolution.HD
+        )


### PR DESCRIPTION
## Proposed change

The tplink camera platform always requests the SD stream (640x360, stream2)
for still images (`camera_proxy` / `async_camera_image`) and the MJPEG stream
fallback, while live view (`stream_source`) already requests the HD stream
(2560x1440, stream1). This means the still shown in the camera card /
dashboard thumbnail is noticeably lower resolution than the live stream of
the same camera, for no configurable reason.

This adds a `use_stream_for_stills` option, off by default so existing setups
are unaffected, behind its own options flow (Settings → Devices & Services →
the entry's Configure button). When enabled, stills and the MJPEG fallback
request the same HD stream that live view already uses; flipping it reloads
the config entry automatically, no restart needed. Off by default to keep
today's bandwidth profile for anyone on a metered or slow link. The options
flow is only offered on entries that configure a camera; other TP-Link
entries (plugs, lights, …) abort with a `no_options` reason.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47646
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
