### PR TITLE
Allow saving HTTP config without trusted proxies

### DIFF
--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -150,10 +150,8 @@ HTTP_STORAGE_SCHEMA: Final = vol.Schema(
         vol.Optional(CONF_CORS_ORIGINS, default=DEFAULT_CORS): vol.All(
             cv.ensure_list, [cv.string]
         ),
-        vol.Inclusive(CONF_USE_X_FORWARDED_FOR, "proxy"): cv.boolean,
-        vol.Inclusive(CONF_TRUSTED_PROXIES, "proxy"): vol.All(
-            cv.ensure_list, [_ip_network_str]
-        ),
+        vol.Optional(CONF_USE_X_FORWARDED_FOR): cv.boolean,
+        vol.Optional(CONF_TRUSTED_PROXIES): vol.All(cv.ensure_list, [_ip_network_str]),
         vol.Optional(
             CONF_LOGIN_ATTEMPTS_THRESHOLD, default=NO_LOGIN_ATTEMPT_THRESHOLD
         ): vol.Any(cv.positive_int, NO_LOGIN_ATTEMPT_THRESHOLD),

--- a/homeassistant/components/http/websocket_api.py
+++ b/homeassistant/components/http/websocket_api.py
@@ -13,11 +13,31 @@ from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .config import HTTP_STORAGE_SCHEMA, ConfData, async_get_and_load_store
-from .const import ATTR_CONFIG, CONF_SERVER_PORT
+from .const import (
+    ATTR_CONFIG,
+    CONF_SERVER_PORT,
+    CONF_TRUSTED_PROXIES,
+    CONF_USE_X_FORWARDED_FOR,
+)
 from .server import async_verify_can_bind
 
 ERR_BIND_FAILED: Final = "bind_failed"
 ERR_NOT_RUNNING: Final = "not_running"
+
+
+def _validate_trusted_proxies(config: ConfData) -> ConfData:
+    """Reject trusting X-Forwarded-For without a proxy to trust it from.
+
+    Forwarded requests are refused when no proxy is trusted, so the combination
+    breaks the very setup it is meant to enable.
+    """
+    if config.get(CONF_USE_X_FORWARDED_FOR) and not config.get(CONF_TRUSTED_PROXIES):
+        raise vol.Invalid(
+            "at least one trusted proxy is required to use X-Forwarded-For",
+            path=[CONF_TRUSTED_PROXIES],
+        )
+
+    return config
 
 
 @callback
@@ -64,7 +84,9 @@ async def websocket_get_config(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "http/config/configure",
-        vol.Required(ATTR_CONFIG): vol.Any(None, HTTP_STORAGE_SCHEMA),
+        vol.Required(ATTR_CONFIG): vol.Any(
+            None, vol.All(HTTP_STORAGE_SCHEMA, _validate_trusted_proxies)
+        ),
     }
 )
 @websocket_api.async_response

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -3009,11 +3009,19 @@ async def test_pending_config_promote_cancels_revert(
 @pytest.mark.parametrize(
     "config",
     [
-        {"server_port": "not-a-port"},
-        {
-            "use_x_forwarded_for": True,
-            "trusted_proxies": ["not-an-ip-network"],
-        },
+        pytest.param({"server_port": "not-a-port"}, id="invalid_port"),
+        pytest.param(
+            {
+                "use_x_forwarded_for": True,
+                "trusted_proxies": ["not-an-ip-network"],
+            },
+            id="invalid_proxy_network",
+        ),
+        pytest.param({"use_x_forwarded_for": True}, id="proxies_omitted"),
+        pytest.param(
+            {"use_x_forwarded_for": True, "trusted_proxies": []},
+            id="proxies_empty",
+        ),
     ],
 )
 async def test_websocket_http_config_invalid(
@@ -3035,3 +3043,34 @@ async def test_websocket_http_config_invalid(
     response = await ws_client.receive_json()
     assert not response["success"]
     assert response["error"]["code"] == "invalid_format"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"use_x_forwarded_for": False}, id="omitted"),
+        pytest.param(
+            {"use_x_forwarded_for": False, "trusted_proxies": []}, id="empty_list"
+        ),
+        pytest.param({"trusted_proxies": ["127.0.0.0/8"]}, id="proxies_only"),
+    ],
+)
+async def test_websocket_configure_without_trusted_proxies(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    config: dict[str, Any],
+) -> None:
+    """Test that reverse proxy support can be turned off without trusted proxies."""
+    assert await async_setup_component(hass, "http", {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    async_mock_service(hass, "homeassistant", "restart")
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {"type": "http/config/configure", "config": config}
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Clearing every trusted proxy in the network settings and saving fails with `some but not all values in the same group of inclusion 'proxy'`. Turning the reverse proxy off through the UI is impossible; the only way out is to keep a dummy CIDR in the list.

`HTTP_STORAGE_SCHEMA` inherited `vol.Inclusive` from the YAML schema, so `use_x_forwarded_for` and `trusted_proxies` have to be present together or not at all. The network settings form drops empty multi-value fields before sending, so `use_x_forwarded_for: false` arrives on its own and the schema refuses it.

Both keys are plain `vol.Optional` now. Absent stays absent, so `_DEFAULT_CONFIG`, the store migration and the YAML path are unaffected.

The save path gains the check that actually matters instead: enabling `use_x_forwarded_for` with an empty proxy list is rejected. That combination is accepted today and is a quiet footgun, since the forwarded middleware then refuses every proxied request as coming from an untrusted proxy. The check lives on the websocket command rather than in the storage schema, so a config stored by an older version can never fail validation during migration and get discarded.

The YAML schema in `__init__.py` keeps its `vol.Inclusive`; that contract is documented and unrelated to the reported problem.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178391
- This PR is related to issue: #178674
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
