### PR TITLE
Add support for priority to SMTP integration

### DIFF
--- a/homeassistant/components/smtp/const.py
+++ b/homeassistant/components/smtp/const.py
@@ -11,6 +11,7 @@ ATTR_ATTACHMENTS: Final = "attachments"
 ATTR_MEDIA_SOURCE: Final = "media_source"
 ATTR_FILENAME: Final = "filename"
 ATTR_CONTENT_ID: Final = "content_id"
+ATTR_PRIORITY: Final = "priority"
 
 CONF_ENCRYPTION: Final = "encryption"
 CONF_SERVER: Final = "server"

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -64,6 +64,7 @@ from .const import (
     ATTR_HTML,
     ATTR_IMAGES,
     ATTR_MEDIA_SOURCE,
+    ATTR_PRIORITY,
     CONF_ENCRYPTION,
     CONF_ENTRY,
     CONF_SENDER_NAME,
@@ -108,6 +109,14 @@ PLATFORM_SCHEMA = NOTIFY_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
+
+MAP_X_PRIORITY = {
+    "highest": "1 (Highest)",
+    "high": "2 (High)",
+    "normal": "3 (Normal)",
+    "low": "4 (Low)",
+    "lowest": "5 (Lowest)",
+}
 
 
 async def async_get_service(
@@ -224,6 +233,9 @@ class MailNotifyEntity(NotifyEntity):
         msg = EmailMessage()
         msg.set_content(message)
         msg.add_header("Subject", title or ATTR_TITLE_DEFAULT)
+
+        if ATTR_PRIORITY in kwargs:
+            msg.add_header("X-Priority", MAP_X_PRIORITY[kwargs[ATTR_PRIORITY]])
 
         if ATTR_HTML in kwargs:
             msg.add_alternative(kwargs[ATTR_HTML], subtype="html")

--- a/homeassistant/components/smtp/services.py
+++ b/homeassistant/components/smtp/services.py
@@ -18,6 +18,7 @@ from .const import (
     ATTR_FILENAME,
     ATTR_HTML,
     ATTR_MEDIA_SOURCE,
+    ATTR_PRIORITY,
     DOMAIN,
 )
 
@@ -39,6 +40,9 @@ SERVICE_SEND_MESSAGE_SCHEMA = cv.make_entity_service_schema(
                     }
                 )
             ],
+        ),
+        vol.Optional(ATTR_PRIORITY): vol.In(
+            ["highest", "high", "normal", "low", "lowest"]
         ),
     }
 )

--- a/homeassistant/components/smtp/services.yaml
+++ b/homeassistant/components/smtp/services.yaml
@@ -57,3 +57,4 @@ send_message:
           mode: dropdown
           translation_key: "priority"
           sort: false
+      example: highest

--- a/homeassistant/components/smtp/services.yaml
+++ b/homeassistant/components/smtp/services.yaml
@@ -44,3 +44,16 @@ send_message:
               selector:
                 text:
           translation_key: attachments
+    priority:
+      required: false
+      selector:
+        select:
+          options:
+            - highest
+            - high
+            - normal
+            - low
+            - lowest
+          mode: dropdown
+          translation_key: "priority"
+          sort: false

--- a/homeassistant/components/smtp/strings.json
+++ b/homeassistant/components/smtp/strings.json
@@ -183,6 +183,15 @@
         "starttls": "STARTTLS",
         "tls": "SSL/TLS"
       }
+    },
+    "priority": {
+      "options": {
+        "high": "High",
+        "highest": "Highest",
+        "low": "Low",
+        "lowest": "Lowest",
+        "normal": "Normal"
+      }
     }
   },
   "services": {
@@ -200,6 +209,10 @@
         "message": {
           "description": "The plain text message body of the email notification.",
           "name": "Message"
+        },
+        "priority": {
+          "description": "Priority of the email notification. Support for this setting varies between email clients.",
+          "name": "Priority"
         },
         "title": {
           "description": "Subject for your email notification.",

--- a/tests/components/smtp/snapshots/test_notify.ambr
+++ b/tests/components/smtp/snapshots/test_notify.ambr
@@ -70,6 +70,7 @@
   '''
   MIME-Version: 1.0
   Subject: Home Assistant
+  X-Priority: 1 (Highest)
   Content-Type: multipart/alternative;
    boundary="===============0000000000000000001=="
   From: Home Assistant <email@example.com>
@@ -89,7 +90,7 @@
   Content-Transfer-Encoding: 7bit
   MIME-Version: 1.0
   
-  <html><body><img src="cid:avatar.png"></body></html>
+  <html><body><img src="https://example.com/avatar.png"></body></html>
   
   --===============0000000000000000001==--
   

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -28,6 +28,7 @@ from homeassistant.components.smtp.const import (
     ATTR_FILENAME,
     ATTR_HTML,
     ATTR_MEDIA_SOURCE,
+    ATTR_PRIORITY,
     CONF_ENTRY,
     DOMAIN,
 )
@@ -400,7 +401,8 @@ async def test_smtp_send_message(
         {
             ATTR_ENTITY_ID: "notify.home_assistant_recipient",
             ATTR_MESSAGE: "Hello World",
-            ATTR_HTML: """<html><body><img src="cid:avatar.png"></body></html>""",
+            ATTR_HTML: """<html><body><img src="https://example.com/avatar.png"></body></html>""",
+            ATTR_PRIORITY: "highest",
         },
         blocking=True,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds priority support to the `smtp.send_message` action and includes the X-Priority header in outgoing emails.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47645
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
