### PR TITLE
Report Google Sheets API failures as Home Assistant errors

### DIFF
--- a/homeassistant/components/google_sheets/services.py
+++ b/homeassistant/components/google_sheets/services.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials
-from gspread import Client
+from gspread import Client, Spreadsheet, Worksheet
 from gspread.exceptions import APIError
 from gspread.utils import ValueInputOption
 import voluptuous as vol
@@ -55,18 +55,23 @@ get_SHEET_SERVICE_SCHEMA = vol.All(
 )
 
 
+def _get_worksheet(sheet: Spreadsheet, name: str | None) -> Worksheet:
+    """Return the requested worksheet, or the first one when none was given.
+
+    Looking the name up eagerly would fetch the document metadata even when a
+    worksheet was requested and the first one is discarded.
+    """
+    if name is None:
+        return sheet.sheet1
+
+    return sheet.worksheet(name)
+
+
 def _append_to_sheet(call: ServiceCall, entry: GoogleSheetsConfigEntry) -> None:
     """Run append in the executor."""
     client = Client(Credentials(entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]))  # type: ignore[no-untyped-call]
-    try:
-        sheet = client.open_by_key(entry.unique_id)
-    except RefreshError:
-        entry.async_start_reauth(call.hass)
-        raise
-    except APIError as ex:
-        raise HomeAssistantError("Failed to write data") from ex
-
-    worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
+    sheet = client.open_by_key(entry.unique_id)
+    worksheet = _get_worksheet(sheet, call.data.get(WORKSHEET))
     columns: list[str] = next(iter(worksheet.get_values("A1:ZZ1")), [])
     add_created_column = call.data[ADD_CREATED_COLUMN]
     now = str(dt_util.now())
@@ -88,15 +93,8 @@ def _get_from_sheet(
 ) -> JsonObjectType:
     """Run get in the executor."""
     client = Client(Credentials(entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]))  # type: ignore[no-untyped-call]
-    try:
-        sheet = client.open_by_key(entry.unique_id)
-    except RefreshError:
-        entry.async_start_reauth(call.hass)
-        raise
-    except APIError as ex:
-        raise HomeAssistantError("Failed to retrieve data") from ex
-
-    worksheet = sheet.worksheet(call.data.get(WORKSHEET, sheet.sheet1.title))
+    sheet = client.open_by_key(entry.unique_id)
+    worksheet = _get_worksheet(sheet, call.data.get(WORKSHEET))
     all_values = worksheet.get_values()
     return {"range": all_values[-call.data[ROWS] :]}
 
@@ -107,7 +105,15 @@ async def _async_append_to_sheet(call: ServiceCall) -> None:
         call.hass, DOMAIN, call.data[DATA_CONFIG_ENTRY]
     )
     await entry.runtime_data.async_ensure_token_valid()
-    await call.hass.async_add_executor_job(_append_to_sheet, call, entry)
+    try:
+        await call.hass.async_add_executor_job(_append_to_sheet, call, entry)
+    except RefreshError:
+        entry.async_start_reauth(call.hass)
+        raise
+    except APIError as ex:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN, translation_key="append_failed"
+        ) from ex
 
 
 async def _async_get_from_sheet(call: ServiceCall) -> ServiceResponse:
@@ -116,7 +122,15 @@ async def _async_get_from_sheet(call: ServiceCall) -> ServiceResponse:
         call.hass, DOMAIN, call.data[DATA_CONFIG_ENTRY]
     )
     await entry.runtime_data.async_ensure_token_valid()
-    return await call.hass.async_add_executor_job(_get_from_sheet, call, entry)
+    try:
+        return await call.hass.async_add_executor_job(_get_from_sheet, call, entry)
+    except RefreshError:
+        entry.async_start_reauth(call.hass)
+        raise
+    except APIError as ex:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN, translation_key="get_failed"
+        ) from ex
 
 
 @callback

--- a/homeassistant/components/google_sheets/strings.json
+++ b/homeassistant/components/google_sheets/strings.json
@@ -34,6 +34,12 @@
     }
   },
   "exceptions": {
+    "append_failed": {
+      "message": "Failed to write data to the Google Sheets document"
+    },
+    "get_failed": {
+      "message": "Failed to retrieve data from the Google Sheets document"
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
     }

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
+from google.auth.exceptions import RefreshError
 from gspread.exceptions import APIError
 import pytest
 from requests.models import Response
@@ -409,6 +410,142 @@ async def test_append_sheet_multiple_rows(
     assert len(mock_client.mock_calls) == 8
 
 
+async def test_append_sheet_defaults_to_first_worksheet(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test append to sheet without naming a worksheet."""
+    await setup_integration()
+
+    with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
+        sheet = mock_client.return_value.open_by_key.return_value
+        sheet.sheet1.get_values.return_value = [["foo"]]
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_APPEND_SHEET,
+            {
+                DATA_CONFIG_ENTRY: config_entry.entry_id,
+                DATA: {"foo": "bar"},
+            },
+            blocking=True,
+        )
+
+    sheet.worksheet.assert_not_called()
+    sheet.sheet1.append_rows.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data"),
+    [
+        pytest.param(SERVICE_APPEND_SHEET, {DATA: {"foo": "bar"}}, id="append_sheet"),
+        pytest.param(SERVICE_GET_SHEET, {ROWS: 2}, id="get_sheet"),
+    ],
+)
+async def test_refresh_error_starts_reauth(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, Any],
+) -> None:
+    """Test an expired token while calling the API starts reauthentication."""
+    await setup_integration()
+
+    with (
+        patch(
+            "homeassistant.components.google_sheets.services.Client.request",
+            side_effect=RefreshError,
+        ),
+        pytest.raises(RefreshError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {DATA_CONFIG_ENTRY: config_entry.entry_id, **service_data},
+            blocking=True,
+            return_response=service == SERVICE_GET_SHEET,
+        )
+
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+
+@pytest.mark.parametrize(
+    "failing_call",
+    [
+        pytest.param("get_values", id="read_columns"),
+        pytest.param("update_cell", id="add_column"),
+        pytest.param("append_rows", id="append_rows"),
+    ],
+)
+async def test_append_sheet_api_error_while_writing(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+    failing_call: str,
+) -> None:
+    """Test append to sheet reports a failing write as a HomeAssistantError."""
+    await setup_integration()
+
+    response = Response()
+    response.status_code = 503
+
+    with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
+        mock_worksheet = (
+            mock_client.return_value.open_by_key.return_value.worksheet.return_value
+        )
+        mock_worksheet.get_values.return_value = [["foo"]]
+        setattr(mock_worksheet, failing_call, Mock(side_effect=APIError(response)))
+
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_APPEND_SHEET,
+                {
+                    DATA_CONFIG_ENTRY: config_entry.entry_id,
+                    WORKSHEET: "Sheet1",
+                    DATA: {"foo": "bar", "new_column": "baz"},
+                },
+                blocking=True,
+            )
+
+
+async def test_get_sheet_api_error_while_reading(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test get sheet reports a failing read as a HomeAssistantError."""
+    await setup_integration()
+
+    response = Response()
+    response.status_code = 503
+
+    with patch("homeassistant.components.google_sheets.services.Client") as mock_client:
+        mock_worksheet = (
+            mock_client.return_value.open_by_key.return_value.worksheet.return_value
+        )
+        mock_worksheet.get_values.side_effect = APIError(response)
+
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_SHEET,
+                {
+                    DATA_CONFIG_ENTRY: config_entry.entry_id,
+                    WORKSHEET: "Sheet1",
+                    ROWS: 2,
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+
 async def test_append_sheet_api_error(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
@@ -586,7 +723,7 @@ async def test_get_sheet_invalid_worksheet(
         mock_client.return_value.open_by_key.return_value.worksheet.side_effect = (
             APIError(Response())
         )
-        with pytest.raises(APIError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_GET_SHEET,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`google_sheets.append_sheet` and `google_sheets.get_sheet` only guarded opening the document. Every other call that talks to Google sat outside the `try`:

| Call | Round trip | Guarded before |
|---|---|---|
| `client.open_by_key()` | document metadata | yes |
| `sheet.worksheet(...)` / `sheet.sheet1` | document metadata | no |
| `worksheet.get_values(...)` | values get | no |
| `worksheet.update_cell(...)` | values update | no |
| `worksheet.append_rows(...)` | values append | no |

A transient 429 or 5xx from any of those raises `gspread.exceptions.APIError`, which derives from `Exception` and not from `HomeAssistantError`. `helpers/script.py::_handle_exception` re-raises anything that is not a `HomeAssistantError` regardless of `continue_on_error`, so the error cannot be contained in YAML and the calling automation aborts part-way through its sequence. The row is dropped, and the sheet is usually the only record of it.

The handling moves to the async wrappers, around the single executor call. Everything inside that call talks to Google, so the `try` stays narrow while covering the calls that can actually fail. Both messages are translated now.

Reading the worksheet name was also written as `call.data.get(WORKSHEET, sheet.sheet1.title)`. Python evaluates that default on every call, so each service call fetched the document metadata for a first worksheet it then discarded, and `sheet.worksheet(...)` fetched the same metadata again. `_get_worksheet` now picks one path. The existing tests did not catch this because attribute access on a `MagicMock` does not record a call.

Note on the issue report: it says the `APIError` handler is unreachable because `open_by_key()` does no I/O. That part is not correct for the pinned `gspread==5.5.0`, where `Spreadsheet.__init__` calls `fetch_sheet_metadata()`, so opening the document does make a request and that handler does fire. The reachable-but-incomplete coverage of the calls after it is the real problem, and it is what this fixes.

`test_get_sheet_invalid_worksheet` asserted that a raw `APIError` propagates, which is the behaviour being fixed, so it expects a `HomeAssistantError` now. Coverage of `services.py` goes from 90% to 100%; the `RefreshError` branches were never exercised before.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180297
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
