### PR TITLE
Name the Fronius power limit after the side it acts on

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -346,8 +346,8 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         values: dict[str, float | bool | None] = {}
 
         if (controls := inverter.controls) is not None:
-            values["power_limit"] = controls.power_limit
-            values["power_limit_enabled"] = controls.enabled
+            values["ac_power_limit"] = controls.power_limit
+            values["ac_power_limit_enabled"] = controls.enabled
         if (storage := inverter.storage) is not None:
             values["battery_charge_power_limit"] = storage.charge_limit
             values["battery_charge_power_limit_enabled"] = storage.charge_limit_enabled

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -9,6 +9,9 @@
       }
     },
     "number": {
+      "ac_power_limit": {
+        "default": "mdi:speedometer-slow"
+      },
       "battery_charge_power_limit": {
         "default": "mdi:battery-arrow-up"
       },
@@ -17,9 +20,6 @@
       },
       "battery_minimum_reserve": {
         "default": "mdi:battery-lock"
-      },
-      "power_limit": {
-        "default": "mdi:speedometer-slow"
       }
     },
     "sensor": {
@@ -76,6 +76,9 @@
       }
     },
     "switch": {
+      "ac_power_limit_enabled": {
+        "default": "mdi:speedometer-slow"
+      },
       "battery_charge_power_limit_enabled": {
         "default": "mdi:battery-arrow-up"
       },
@@ -84,9 +87,6 @@
       },
       "battery_grid_charging": {
         "default": "mdi:transmission-tower-import"
-      },
-      "power_limit_enabled": {
-        "default": "mdi:speedometer-slow"
       }
     }
   }

--- a/homeassistant/components/fronius/number.py
+++ b/homeassistant/components/fronius/number.py
@@ -33,7 +33,7 @@ class FroniusNumberEntityDescription(FroniusEntityDescription, NumberEntityDescr
 
 MODBUS_NUMBER_ENTITY_DESCRIPTIONS: list[FroniusNumberEntityDescription] = [
     FroniusNumberEntityDescription(
-        key="power_limit",
+        key="ac_power_limit",
         component_fn=lambda inverter: inverter.controls,
         field="power_limit",
         enable_field="enabled",

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -49,6 +49,9 @@
       }
     },
     "number": {
+      "ac_power_limit": {
+        "name": "AC power limit"
+      },
       "battery_charge_power_limit": {
         "name": "Battery charge power limit"
       },
@@ -57,9 +60,6 @@
       },
       "battery_minimum_reserve": {
         "name": "Battery minimum reserve"
-      },
-      "power_limit": {
-        "name": "Power limit"
       }
     },
     "sensor": {
@@ -431,6 +431,9 @@
       }
     },
     "switch": {
+      "ac_power_limit_enabled": {
+        "name": "AC power limiting"
+      },
       "battery_charge_power_limit_enabled": {
         "name": "Battery charge power limiting"
       },
@@ -439,9 +442,6 @@
       },
       "battery_grid_charging": {
         "name": "Battery grid charging"
-      },
-      "power_limit_enabled": {
-        "name": "Power limiting"
       }
     }
   },

--- a/homeassistant/components/fronius/switch.py
+++ b/homeassistant/components/fronius/switch.py
@@ -31,7 +31,7 @@ class FroniusSwitchEntityDescription(FroniusEntityDescription, SwitchEntityDescr
 
 MODBUS_SWITCH_ENTITY_DESCRIPTIONS: list[FroniusSwitchEntityDescription] = [
     FroniusSwitchEntityDescription(
-        key="power_limit_enabled",
+        key="ac_power_limit_enabled",
         component_fn=lambda inverter: inverter.controls,
         field="enabled",
         entity_category=EntityCategory.CONFIG,

--- a/tests/components/fronius/test_number.py
+++ b/tests/components/fronius/test_number.py
@@ -22,7 +22,7 @@ from .test_modbus import GEN24_HYBRID_MODULES, assert_state
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-POWER_LIMIT = "number.gen24_storage_power_limit"
+POWER_LIMIT = "number.gen24_storage_ac_power_limit"
 CHARGE_LIMIT = "number.gen24_storage_battery_charge_power_limit"
 
 

--- a/tests/components/fronius/test_switch.py
+++ b/tests/components/fronius/test_switch.py
@@ -25,7 +25,7 @@ from .test_modbus import GEN24_HYBRID_MODULES, assert_state
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-POWER_LIMITING = "switch.gen24_storage_power_limiting"
+POWER_LIMITING = "switch.gen24_storage_ac_power_limiting"
 CHARGE_LIMITING = "switch.gen24_storage_battery_charge_power_limiting"
 DISCHARGE_LIMITING = "switch.gen24_storage_battery_discharge_power_limiting"
 GRID_CHARGING = "switch.gen24_storage_battery_grid_charging"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

It changes unique_ids of entities that are new in 2026.9, so as long as this is added to beta it isn't a breaking change.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Renames the setpoint added in #180241 and its switch from #180261. "AC Power limit" doesn't affect battery charging power - the name shall reflect that.

| before | after |
|---|---|
| `Power limit` | `AC power limit` |
| `Power limiting` | `AC power limiting` |

`WMaxLimPct` caps what the inverter puts out **on AC**, whatever that then serves. It is *not* a feed-in limit: at a 6 kW cap with 4 kW of household load, 2 kW is exported; with 7 kW of load nothing is exported and the cap still applies. Fronius describes it as limiting "the device's maximum possible output power". A real export limit is *Dynamic power reduction*, which measures at the grid connection point and is a separate control source with its own priority — not this register.

`Power limit` said neither which side it acts on nor that self-consumption counts against it. This integration already names values by side — `AC power`, `AC current`, `DC voltage`, `MPPT 1 DC power` — so the prefix form follows the existing convention, and `AC power limit` reads as the cap on the `AC power` sensor that is already there.

Rename only: no logic changes, 18 lines across seven files.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The `unique_id`s change from `…-modbus-power_limit` to `…-modbus-ac_power_limit`. Both #180241 and #180261 are merged but **not yet released**, so no entity registry migration is needed — this only affects installations running `dev`.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47649
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
