### PR TITLE
Avoid blocking SSL context creation in the MCP SSE transport

### DIFF
--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -27,6 +27,7 @@ from homeassistant.helpers import llm
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.json import JsonObjectType
+from homeassistant.util.ssl import SSL_ALPN_HTTP11, SSLCipherList, client_context
 
 from .auth import AuthenticateHeader
 from .const import DOMAIN
@@ -37,6 +38,26 @@ UPDATE_INTERVAL = datetime.timedelta(minutes=30)
 TIMEOUT = 10
 
 type TokenManager = Callable[[], Awaitable[str]]
+
+
+def _create_sse_httpx_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """Create the httpx client used by the SSE transport.
+
+    The SSE transport closes the client itself, so it cannot be handed one of
+    the Home Assistant managed clients. Building it here keeps it off the SDK
+    default, which reads the CA bundle from disk inside the event loop.
+    """
+    return httpx.AsyncClient(
+        verify=client_context(SSLCipherList.PYTHON_DEFAULT, SSL_ALPN_HTTP11),
+        follow_redirects=True,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
+    )
 
 
 @asynccontextmanager
@@ -81,7 +102,11 @@ async def mcp_client(
             )
             try:
                 async with (
-                    sse_client(url=url, headers=headers) as streams,
+                    sse_client(
+                        url=url,
+                        headers=headers,
+                        httpx_client_factory=_create_sse_httpx_client,
+                    ) as streams,
                     ClientSession(*streams) as session,
                 ):
                     await session.initialize()

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the Model Context Protocol component."""
 
 import re
+import ssl
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -705,3 +706,31 @@ async def test_tool_call_http_error(
             ),
             create_llm_context(),
         )
+
+
+async def test_sse_client_does_not_build_ssl_context(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_http_streamable_client: AsyncMock,
+    mock_sse_client: AsyncMock,
+) -> None:
+    """Test the SSE transport does not load certificates in the event loop."""
+    http_405 = httpx.HTTPStatusError(
+        "Method not allowed", request=None, response=httpx.Response(405)
+    )
+    mock_http_streamable_client.side_effect = ExceptionGroup(
+        "Method not allowed", [http_405]
+    )
+    mock_sse_client.side_effect = ExceptionGroup(
+        "Connection error", [httpx.ConnectError("Connection failed")]
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    client_factory = mock_sse_client.call_args.kwargs["httpx_client_factory"]
+    with patch.object(ssl.SSLContext, "load_verify_locations") as mock_load_certs:
+        client = client_factory(headers={}, timeout=httpx.Timeout(5))
+
+    assert not mock_load_certs.called
+    await client.aclose()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Setting up an MCP server against an SSE endpoint logs a blocking call warning:

```
Detected blocking call to load_verify_locations ... inside the event loop by integration 'mcp'
at homeassistant/components/mcp/coordinator.py, line 84: sse_client(url=url, headers=headers)
```

`mcp_client` tries the streamable HTTP transport first and falls back to SSE when the server answers 405. The streamable transport is handed a Home Assistant httpx client via `create_async_httpx_client`, but the SSE fallback was called with only a URL and headers, so the SDK used its own `create_mcp_http_client()`. That builds a fresh `httpx.AsyncClient`, which reads the CA bundle from disk while on the event loop.

`sse_client` accepts an `httpx_client_factory`, so the fix is to supply one. It cannot simply reuse `create_async_httpx_client` though: `sse_client` takes the client as `async with`, so the SDK closes it, and the `aclose` of a Home Assistant managed client is wrapped by `warn_use`. Passing one would swap the blocking call for a usage report and connections that are never closed. The factory therefore builds a plain client that the SDK owns, on top of the shared SSL context that is pre-warmed at import.

The ALPN protocols are passed explicitly for the same reason `create_async_httpx_client` does it: httpx mutates the context with `set_alpn_protocols()`, so the contexts are bucketed per protocol set. The client does not enable http2, so it takes the `SSL_ALPN_HTTP11` bucket.

Checked that the resulting client keeps the SDK's behaviour otherwise: `follow_redirects` is enabled, and the headers and timeout passed by `sse_client` come through (`connect=5`, `read=300`).

The test asserts what the report describes, that driving the SSE path and then building a client never calls `SSLContext.load_verify_locations`. It fails without the change, since no factory is passed at all.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178085
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
