### PR TITLE
Keep the Spotify source list in a stable order

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -284,7 +284,9 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @override
     def source_list(self) -> list[str] | None:
         """Return a list of source devices."""
-        return [device.name for device in self.devices.data]
+        # Spotify returns the devices in no particular order. Sort them so an
+        # unchanged set of devices does not read as a capability change.
+        return sorted(device.name for device in self.devices.data)
 
     @property
     @override

--- a/tests/components/spotify/test_media_player.py
+++ b/tests/components/spotify/test_media_player.py
@@ -1,5 +1,6 @@
 """Tests for the Spotify media player platform."""
 
+from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -11,6 +12,7 @@ from spotifyaio import (
     SpotifyConnectionError,
     SpotifyNotFoundError,
 )
+from spotifyaio.models import Devices
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.media_player import (
@@ -780,3 +782,34 @@ async def test_smart_polling_interval_handles_paused(
 
     mock_spotify.return_value.get_playback.assert_called_once()
     mock_spotify.return_value.get_playback.reset_mock()
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_source_list_is_stable(
+    hass: HomeAssistant,
+    mock_spotify: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the source list does not change when Spotify reorders the devices."""
+    devices = Devices.from_json(
+        await async_load_fixture(hass, "devices.json", DOMAIN)
+    ).devices
+    second_device = replace(devices[0], device_id="second-device", name="Kitchen")
+    mock_spotify.return_value.get_devices.return_value = [devices[0], second_device]
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert (state := hass.states.get("media_player.spotify_spotify_1"))
+    source_list = state.attributes[ATTR_INPUT_SOURCE_LIST]
+    assert set(source_list) == {"DESKTOP-BKC5SIK", "Kitchen"}
+
+    # The Spotify API does not guarantee an order, so the same devices can come
+    # back the other way around on the next poll.
+    mock_spotify.return_value.get_devices.return_value = [second_device, devices[0]]
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("media_player.spotify_spotify_1"))
+    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == source_list


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`source_list` returned the device names in whatever order Spotify sent them, and that order is not stable between calls. The list ends up in `capability_attributes`, which the entity registry stores, so every reshuffle of an unchanged set of devices is written as a capability change and fires `entity_registry_updated` with `changes: {"capabilities": ...}`.

The device coordinator polls every five minutes, so this repeats indefinitely for a device list that never changed. On the reporting instance that was roughly 288 registry updates a day, each one waking anything that keeps a cache of the 3,215 entities in that house.

Sorting the names keeps an unchanged set of devices identical between polls.

The sort is in the property rather than in the coordinator on purpose: `async_media_play` falls back to `self.devices.data[0]` when nothing is playing, and reordering the coordinator data would quietly change which device that picks.

Two things this does not change. Duplicate device names still produce duplicate entries, exactly as before. The issue also mentions Samsung TV entities churning on `supported_features`, but that is a different integration and an `IntFlag` whose order cannot vary, so it is not the same bug.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179605
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
