### PR TITLE
Keep LG soundbar modes the library cannot name

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -26,6 +26,37 @@ EQUIVALENT_FUNCTIONS = (
 )
 
 
+def _display_name(names: list[str], index: int) -> str:
+    """Return the display name for an index.
+
+    The temescal name tables stopped being maintained when the library was
+    archived in 2023, so newer models report indices past the end of them.
+    Naming those keeps them selectable instead of silently dropping them.
+    """
+    if index < len(names):
+        return names[index]
+
+    return f"Unknown ({index})"
+
+
+def _offered_names(names: list[str], offered: list[int]) -> list[str]:
+    """Return the display names of the offered indices."""
+    return sorted(_display_name(names, index) for index in offered)
+
+
+def _index_for_name(names: list[str], offered: list[int], name: str) -> int:
+    """Return the index a display name refers to.
+
+    Indices the library cannot name are only known through the offered list, so
+    they are resolved from there; anything else resolves against the library.
+    """
+    for index in offered:
+        if _display_name(names, index) == name:
+            return index
+
+    return names.index(name)
+
+
 def _offered_equivalent(function: str, offered: list[int]) -> str | None:
     """Return an offered function from the same group as the given one."""
     group = next((names for names in EQUIVALENT_FUNCTIONS if function in names), ())
@@ -236,27 +267,23 @@ class LGDevice(MediaPlayerEntity):
     @override
     def sound_mode(self):
         """Return the current sound mode."""
-        if self._equaliser == -1 or self._equaliser >= len(temescal.equalisers):
+        if self._equaliser == -1:
             return None
-        return temescal.equalisers[self._equaliser]
+        return _display_name(temescal.equalisers, self._equaliser)
 
     @property
     @override
     def sound_mode_list(self):
         """Return the available sound modes."""
-        return sorted(
-            temescal.equalisers[equaliser]
-            for equaliser in self._equalisers
-            if equaliser < len(temescal.equalisers)
-        )
+        return _offered_names(temescal.equalisers, self._equalisers)
 
     @property
     @override
     def source(self):
         """Return the current input source."""
-        if self._function == -1 or self._function >= len(temescal.functions):
+        if self._function == -1:
             return None
-        function = temescal.functions[self._function]
+        function = _display_name(temescal.functions, self._function)
         if self._function in self._functions:
             return function
         return _offered_equivalent(function, self._functions) or function
@@ -265,11 +292,7 @@ class LGDevice(MediaPlayerEntity):
     @override
     def source_list(self):
         """List of available input sources."""
-        return sorted(
-            temescal.functions[function]
-            for function in self._functions
-            if function < len(temescal.functions)
-        )
+        return _offered_names(temescal.functions, self._functions)
 
     @override
     def set_volume_level(self, volume: float) -> None:
@@ -285,12 +308,16 @@ class LGDevice(MediaPlayerEntity):
     @override
     def select_source(self, source: str) -> None:
         """Select input source."""
-        self._device.set_func(temescal.functions.index(source))
+        self._device.set_func(
+            _index_for_name(temescal.functions, self._functions, source)
+        )
 
     @override
     def select_sound_mode(self, sound_mode: str) -> None:
         """Set Sound Mode for Receiver.."""
-        self._device.set_eq(temescal.equalisers.index(sound_mode))
+        self._device.set_eq(
+            _index_for_name(temescal.equalisers, self._equalisers, sound_mode)
+        )
 
     @override
     def turn_on(self) -> None:

--- a/tests/components/lg_soundbar/test_media_player.py
+++ b/tests/components/lg_soundbar/test_media_player.py
@@ -4,7 +4,16 @@ from unittest.mock import MagicMock
 
 import temescal
 
-from homeassistant.components.media_player import ATTR_INPUT_SOURCE_LIST
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    ATTR_INPUT_SOURCE_LIST,
+    ATTR_SOUND_MODE,
+    ATTR_SOUND_MODE_LIST,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOUND_MODE,
+    SERVICE_SELECT_SOURCE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from . import find_update_callback, setup_integration
@@ -122,3 +131,119 @@ async def test_source_unknown_before_any_response(
     await setup_integration(hass, mock_config_entry)
 
     assert "source" not in hass.states.get(ENTITY_ID).attributes
+
+
+# An SG10TY reports these alongside indices temescal knows about. They sit past
+# the end of the library's table, which has been read-only since 2023.
+UNMAPPED_EQUALISERS = [23, 24, 25, 26]
+
+AVAILABLE_EQUALISERS = [
+    temescal.equalisers.index("Standard"),
+    temescal.equalisers.index("Cinema"),
+    *UNMAPPED_EQUALISERS,
+]
+
+
+def send_eq_view_info(callback: MagicMock, current_equaliser: int) -> None:
+    """Report the given equaliser as the current one via the callback."""
+    callback(
+        {
+            "msg": "EQ_VIEW_INFO",
+            "data": {
+                "i_curr_eq": current_equaliser,
+                "ai_eq_list": AVAILABLE_EQUALISERS,
+            },
+        }
+    )
+
+
+async def test_sound_modes_beyond_the_library_table_are_offered(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that equalisers the library cannot name are still offered."""
+    await setup_integration(hass, mock_config_entry)
+
+    send_eq_view_info(find_update_callback(mock_temescal), 23)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(ENTITY_ID))
+    assert state.attributes[ATTR_SOUND_MODE_LIST] == [
+        "Cinema",
+        "Standard",
+        "Unknown (23)",
+        "Unknown (24)",
+        "Unknown (25)",
+        "Unknown (26)",
+    ]
+    assert state.attributes[ATTR_SOUND_MODE] == "Unknown (23)"
+
+
+async def test_selecting_a_sound_mode_beyond_the_library_table(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that an equaliser the library cannot name can be selected."""
+    await setup_integration(hass, mock_config_entry)
+
+    send_eq_view_info(find_update_callback(mock_temescal), 0)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SOUND_MODE: "Unknown (25)"},
+        blocking=True,
+    )
+
+    mock_temescal.return_value.set_eq.assert_called_once_with(25)
+
+
+async def test_selecting_a_named_sound_mode(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that an equaliser the library can name is still selectable."""
+    await setup_integration(hass, mock_config_entry)
+
+    send_eq_view_info(find_update_callback(mock_temescal), 0)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SOUND_MODE: "Cinema"},
+        blocking=True,
+    )
+
+    mock_temescal.return_value.set_eq.assert_called_once_with(
+        temescal.equalisers.index("Cinema")
+    )
+
+
+async def test_selecting_a_source_the_device_does_not_offer(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a known function outside of ai_func_list stays selectable."""
+    await setup_integration(hass, mock_config_entry)
+
+    send_func_view_info(find_update_callback(mock_temescal), "Bluetooth")
+    await hass.async_block_till_done()
+
+    assert "E-ARC" not in hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "E-ARC"},
+        blocking=True,
+    )
+
+    mock_temescal.return_value.set_func.assert_called_once_with(
+        temescal.functions.index("E-ARC")
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An LG SG10TY advertises 13 equalisers, `ai_eq_list: [19, 0, 7, 26, 21, 6, 22, 14, 5, 15, 23, 24, 25]`, but the entity only offered 9 of them. `temescal.equalisers` holds 23 names (0-22), and both the list and the current value guarded against anything above that by dropping it:

```python
return sorted(
    temescal.equalisers[equaliser]
    for equaliser in self._equalisers
    if equaliser < len(temescal.equalisers)
)
```

Nothing is logged, so the soundbar simply looks like it has four fewer sound modes. Worse, selecting one of those on the physical remote made `sound_mode` return `None`, so the entity reported no sound mode at all rather than an unrecognised one.

The name tables live in `temescal`, which has been archived and read-only since 2023-03-23, so they will not grow to cover newer models. The integration has to be able to cope with indices it cannot name.

Unmapped indices are now given a name and resolved back through the list the device offered, so they show up in the list and can be selected. `source` and `source_list` are built the same way against `temescal.functions` (21 entries), so they go through the same helper rather than being left inconsistent.

`Unknown (23)` is the placeholder suggested in the issue. It is deliberately model agnostic: new models will keep reporting new indices, so this stops them disappearing regardless. Should the real names for these become known, they can be layered on top without changing this structure.

One existing behaviour is kept on purpose: `select_source` used to accept any name in the library table even when the device never offered it, so the lookup still falls back to the table. There is a test for it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179638
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
