### PR TITLE
Map SmartThings stick cleaner operating state onto its options

### DIFF
--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -1264,6 +1264,7 @@ CAPABILITY_TO_SENSORS: dict[
                 translation_key="stick_cleaner_operating_state",
                 options=list(STICK_CLEANER_STATUS.values()),
                 device_class=SensorDeviceClass.ENUM,
+                value_fn=lambda value: STICK_CLEANER_STATUS.get(value, value),
             )
         ]
     },

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -416,3 +416,37 @@ async def test_availability_at_start(
         hass.states.get("sensor.theater_ac_office_granit_temperature").state
         == STATE_UNAVAILABLE
     )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_vc_stick_01001"])
+@pytest.mark.parametrize(
+    ("reported_state", "expected_state"),
+    [
+        ("usingVacuum", "using_vacuum"),
+        ("emptyingDustbin", "emptying_dustbin"),
+        ("UVCleaning", "uv_cleaning"),
+        ("UVPaused", "uv_paused"),
+        ("ready", "ready"),
+    ],
+)
+async def test_stick_cleaner_operating_state_is_mapped(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    reported_state: str,
+    expected_state: str,
+) -> None:
+    """Test the stick cleaner states are mapped onto the entity options."""
+    await setup_integration(hass, mock_config_entry)
+
+    await trigger_update(
+        hass,
+        devices,
+        "e1f93c0c-6fe0-c65a-a314-c8f7b163c86b",
+        Capability.SAMSUNG_CE_STICK_CLEANER_STATUS,
+        Attribute.OPERATING_STATE,
+        reported_state,
+    )
+
+    assert (state := hass.states.get("sensor.stick_vacuum"))
+    assert state.state == expected_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The stick cleaner operating state sensor raises every time the device reports a state:

```
ERROR (MainThread) [pysmartthings] Error occurred while processing device event:
DeviceEvent(... attribute=<Attribute.OPERATING_STATE: 'operatingState'>, value='usingVacuum' ...)
ValueError: Sensor sensor.stick_vacuum provides state value 'usingVacuum',
which is not in the list of options provided
```

`STICK_CLEANER_STATUS` translates the values the device reports onto the option names the entity offers, and `options` is built from `STICK_CLEANER_STATUS.values()`, but the description never used the map to translate the value itself. The untranslated value reaches the state machine, the enum device class rejects it, and because that happens inside `async_write_ha_state` the exception propagates back into `pysmartthings._dispatch_event` and stops the event processing.

Every other mapped enum sensor in this platform already does this, for example the oven mode, job state, media playback state and robot cleaner movement sensors:

```python
value_fn=lambda value: OVEN_MODE.get(value, value),
```

The stick cleaner entities were added in #166127 with the map in place but without that line.

The issue names `usingVacuum` and `emptyingDustbin`, but `UVCleaning` and `UVPaused` were broken in exactly the same way. Only `ready` worked, because it maps to itself, which is also why the existing fixture (`operatingState: "ready"`) never caught this. The test covers all five.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179336
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
