### PR TITLE
Allow overiding abort reasons in config flow

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,12 +1,12 @@
 """Helpers for data entry flows for config entries."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 import logging
 from typing import TYPE_CHECKING, Any, cast, override
 
 from homeassistant import config_entries
 from homeassistant.components import onboarding
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
 
 from .typing import DiscoveryInfoType
 
@@ -24,8 +24,42 @@ type DiscoveryFunctionType[_R] = Callable[[HomeAssistant], _R]
 
 _LOGGER = logging.getLogger(__name__)
 
+# Abort reasons raised below which the `homeassistant` integration translates, so
+# integrations do not have to repeat the string.
+_SHARED_ABORT_REASONS = frozenset({"cloud_not_connected"})
 
-class DiscoveryFlowHandler[_R: Awaitable[bool] | bool](config_entries.ConfigFlow):
+
+class _SharedAbortReasonsFlow(config_entries.ConfigFlow):
+    """Config flow whose shared abort reasons are translated centrally."""
+
+    # Replaces a shared abort reason with an integration specific one, for handlers
+    # the shared wording does not describe accurately.
+    abort_reason_overrides: Mapping[str, str] = {}
+
+    @override
+    @callback
+    def async_abort(
+        self,
+        *,
+        reason: str,
+        description_placeholders: Mapping[str, str] | None = None,
+        translation_domain: str | None = None,
+        next_flow: tuple[config_entries.FlowType, str] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Abort the config flow."""
+        if (custom_reason := self.abort_reason_overrides.get(reason)) is not None:
+            reason = custom_reason
+        elif translation_domain is None and reason in _SHARED_ABORT_REASONS:
+            translation_domain = HOMEASSISTANT_DOMAIN
+        return super().async_abort(
+            reason=reason,
+            description_placeholders=description_placeholders,
+            translation_domain=translation_domain,
+            next_flow=next_flow,
+        )
+
+
+class DiscoveryFlowHandler[_R: Awaitable[bool] | bool](_SharedAbortReasonsFlow):
     """Handle a discovery config flow."""
 
     VERSION = 1
@@ -199,7 +233,7 @@ def register_discovery_flow(
     config_entries.HANDLERS.register(domain)(DiscoveryFlow)
 
 
-class WebhookFlowHandler(config_entries.ConfigFlow):
+class WebhookFlowHandler(_SharedAbortReasonsFlow):
     """Handle a webhook config flow."""
 
     VERSION = 1
@@ -259,10 +293,7 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             self.hass
         ):
             if not async_is_connected(self.hass):
-                return self.async_abort(
-                    reason="cloud_not_connected",
-                    translation_domain=HOMEASSISTANT_DOMAIN,
-                )
+                return self.async_abort(reason="cloud_not_connected")
 
             webhook_url = await async_create_cloudhook(self.hass, webhook_id)
             cloudhook = True

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -77,6 +77,31 @@ async def test_single_entry_allowed(
 
     assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+    # Not a shared reason, so the integration's own translation is used
+    assert "translation_domain" not in result
+
+
+async def test_abort_reason_overrides(hass: HomeAssistant) -> None:
+    """Test a handler can replace an abort reason with an integration specific one."""
+
+    class TestFlow(config_entry_flow.DiscoveryFlowHandler[bool]):
+        """Discovery flow handler the shared wording does not fit."""
+
+        abort_reason_overrides = {"no_devices_found": "not_supported"}
+
+        def __init__(self) -> None:
+            super().__init__("test", "Test", lambda hass: False)
+
+    with patch.dict(config_entries.HANDLERS):
+        config_entries.HANDLERS.register("test")(TestFlow)
+        flow = TestFlow()
+        flow.hass = hass
+        flow.context = {"source": config_entries.SOURCE_USER}
+        result = await flow.async_step_confirm(user_input={})
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "not_supported"
+    assert "translation_domain" not in result
 
 
 async def test_user_no_devices_found(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
