### PR TITLE
Bump sofar-modbus to 0.6.0

### DIFF
--- a/homeassistant/components/sofar/__init__.py
+++ b/homeassistant/components/sofar/__init__.py
@@ -1,8 +1,9 @@
 """Integrate Sofar devices into Home Assistant."""
 
 from datetime import timedelta
+import logging
 
-from modbus_connection import ModbusTcpParams
+from modbus_connection import ModbusError, ModbusTcpParams
 from sofar_modbus.modern.device import SofarInverter, identify
 
 from homeassistant.components.modbus import async_get_unit
@@ -13,6 +14,8 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_UNIT_ID, DOMAIN, SCAN_INTERVAL, SETTINGS_SCAN_INTERVAL
 from .coordinator import SofarConfigEntry, SofarDataUpdateCoordinator, SofarRuntimeData
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
@@ -59,6 +62,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SofarConfigEntry) -> boo
     )
     await readings.async_config_entry_first_refresh()
     await settings.async_refresh()
+
+    # Not tied to a coordinator: the serial and firmware versions don't
+    # change, so sofar-modbus reads identity once and never re-polls it.
+    try:
+        await device.identity.async_update()
+    except ModbusError as err:
+        _LOGGER.warning("%s: could not read identity: %s", entry.title, err)
 
     # Up front: a part's device must name an inverter that has an id.
     inverter = dr.async_get(hass).async_get_or_create(

--- a/homeassistant/components/sofar/__init__.py
+++ b/homeassistant/components/sofar/__init__.py
@@ -19,6 +19,20 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
+_IDENTITY_ATTEMPTS = 3
+
+
+async def _async_read_identity(entry: SofarConfigEntry, device: SofarInverter) -> None:
+    """Read identity once, retrying a few times against a transient blip."""
+    for attempt in range(_IDENTITY_ATTEMPTS):
+        try:
+            await device.identity.async_update()
+        except ModbusError as err:
+            if attempt == _IDENTITY_ATTEMPTS - 1:
+                _LOGGER.warning("%s: could not read identity: %s", entry.title, err)
+        else:
+            return
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: SofarConfigEntry) -> bool:
     """Set up Sofar Inverter Modbus from a config entry."""
@@ -63,12 +77,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SofarConfigEntry) -> boo
     await readings.async_config_entry_first_refresh()
     await settings.async_refresh()
 
-    # Not tied to a coordinator: the serial and firmware versions don't
-    # change, so sofar-modbus reads identity once and never re-polls it.
-    try:
-        await device.identity.async_update()
-    except ModbusError as err:
-        _LOGGER.warning("%s: could not read identity: %s", entry.title, err)
+    # Not tied to a coordinator: identity never changes once read.
+    await _async_read_identity(entry, device)
 
     # Up front: a part's device must name an inverter that has an id.
     inverter = dr.async_get(hass).async_get_or_create(

--- a/homeassistant/components/sofar/coordinator.py
+++ b/homeassistant/components/sofar/coordinator.py
@@ -12,7 +12,7 @@ from sofar_modbus.model import UpdateReport
 from sofar_modbus.modern.device import SofarInverter
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -89,27 +89,7 @@ class SofarDataUpdateCoordinator(DataUpdateCoordinator[UpdateReport]):
                 translation_placeholders={"error": str(err)},
             ) from err
         else:
-            if "identity" in report.updated:
-                self._async_update_device_versions()
             return report
-
-    @callback
-    def _async_update_device_versions(self) -> None:
-        """Push versions onto the device; device_info is read once."""
-        identity = self.device.identity
-        hw_version = identity.hardware_version or None
-        sw_version = identity.software_version or None
-        serial = self.device.serial_number
-        assert serial is not None
-        registry = dr.async_get(self.hass)
-        device = registry.async_get_device_by_identifier(
-            (DOMAIN, serial), self.config_entry.entry_id
-        )
-        if device is None:
-            return
-        registry.async_update_device(
-            device.id, hw_version=hw_version, sw_version=sw_version
-        )
 
     async def _retry_failed(self, report: UpdateReport) -> UpdateReport:
         """Retry failures once; skip if none answered, to avoid doubling timeout."""

--- a/homeassistant/components/sofar/manifest.json
+++ b/homeassistant/components/sofar/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["sofar-modbus==0.5.0"]
+  "requirements": ["sofar-modbus==0.6.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3105,7 +3105,7 @@ snapcast==2.3.8
 soco==0.31.2
 
 # homeassistant.components.sofar
-sofar-modbus==0.5.0
+sofar-modbus==0.6.0
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.3

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -269,6 +269,33 @@ async def test_device_versions_need_a_reload_to_recover(
     assert device.sw_version == MOCK_SW_VERSION
 
 
+async def test_identity_retries_after_one_failure(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_connection: MockModbusConnection,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a transient identity failure is retried within the same setup."""
+    mock_config_entry.add_to_hass(hass)
+    unit = mock_connection.for_unit(1)
+    _heal_after_one_failure(unit, 0x044D)
+
+    with patch(
+        "homeassistant.components.sofar.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+            unit_id
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert device.hw_version == MOCK_HW_VERSION
+
+
 async def test_every_component_failing_recovers_on_a_later_poll(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -214,12 +214,12 @@ async def test_device_info_carries_the_firmware_versions(
     assert device.serial_number == MOCK_SERIAL
 
 
-async def test_device_versions_recover_without_a_reload(
+async def test_device_versions_need_a_reload_to_recover(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test firmware versions reach the device once identity answers."""
+    """Test a failed identity read is not retried until the entry reloads."""
     connection = MockModbusConnection()
     seed_hybrid_inverter(connection.for_unit(1))
     unit = connection.for_unit(1)
@@ -240,17 +240,26 @@ async def test_device_versions_recover_without_a_reload(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, MOCK_HYBRID_SERIAL), entry.entry_id
-    )
-    assert device is not None
-    assert device.hw_version is None
-    assert device.sw_version is None
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, MOCK_HYBRID_SERIAL), entry.entry_id
+        )
+        assert device is not None
+        assert device.hw_version is None
+        assert device.sw_version is None
 
-    unit.fail_read(0x044D, None)
-    freezer.tick(timedelta(seconds=SETTINGS_SCAN_INTERVAL))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+        unit.fail_read(0x044D, None)
+        freezer.tick(timedelta(seconds=SETTINGS_SCAN_INTERVAL))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, MOCK_HYBRID_SERIAL), entry.entry_id
+        )
+        assert device is not None
+        assert device.hw_version is None
+
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
 
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, MOCK_HYBRID_SERIAL), entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps sofar-modbus from 0.5.0 to 0.6.0.

0.6.0 stops re-reading the identity block (serial number, firmware versions) on every settings poll and instead reads it once during setup, since none of that data changes. Full changelog: https://github.com/darkrain-nl/sofar-modbus/releases/tag/0.6.0

Because we always pass a known serial_number into SofarInverter(...), the library's own automatic identity read never triggers for us, so this PR also adds one explicit await device.identity.async_update() call during setup and drops the now-dead coordinator logic that used to catch identity off a settings refresh (it can no longer appear there). Without this companion change, hw_version/sw_version would silently stop being populated for every existing installation.

One resilience note: if that one-time identity read fails at setup, it is no longer retried automatically on the next settings poll (the library never touches identity again). Recovery now requires a reload, matching how 0.6.0 treats identity. hw_version/sw_version are metadata only, so this does not affect any other sensor or entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
