### PR TITLE
Keep UniFi Protect month browsing inside the month asked for

### DIFF
--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -601,21 +601,23 @@ class ProtectMediaSource(MediaSource):
         if not build_children:
             return source
 
-        if data.api.bootstrap.recording_start is not None:
-            recording_start = data.api.bootstrap.recording_start.date()
-        start = max(recording_start, start)
-
-        recording_end = dt_util.now().date()
-
-        end = start.replace(day=monthrange(start.year, start.month)[1])
-        end = min(recording_end, end)
+        # The requested month bounds the days offered: recording may have
+        # started partway into it, and it cannot reach past today. Keep those
+        # bounds off `start` so every child stays within the month asked for.
+        end = min(
+            dt_util.now().date(),
+            start.replace(day=monthrange(start.year, start.month)[1]),
+        )
+        day = start
+        if (recording_start := data.api.bootstrap.recording_start) is not None:
+            day = max(recording_start.date(), day)
 
         children = [self._build_days(data, camera_id, event_type, start, is_all=True)]
-        while start <= end:
+        while day <= end:
             children.append(
-                self._build_days(data, camera_id, event_type, start, is_all=False)
+                self._build_days(data, camera_id, event_type, day, is_all=False)
             )
-            start = start + timedelta(hours=24)
+            day = day + timedelta(days=1)
 
         camera: Camera | None = None
         if camera_id != "all":

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -610,7 +610,7 @@ class ProtectMediaSource(MediaSource):
         )
         day = start
         if (recording_start := data.api.bootstrap.recording_start) is not None:
-            day = max(recording_start.date(), day)
+            day = max(dt_util.as_local(recording_start).date(), day)
 
         children = [self._build_days(data, camera_id, event_type, start, is_all=True)]
         while day <= end:

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -1127,3 +1127,49 @@ async def test_public_only_entry_skipped(
 
     source = await async_get_media_source(hass)
     assert source.data_sources == {}
+
+
+@pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
+async def test_browse_media_month_before_recording_started(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
+) -> None:
+    """Test browsing a month that is entirely before recording started."""
+    start = datetime.fromisoformat("2022-09-03 03:00:00-07:00")
+    ufp.api.bootstrap._recording_start = dt_util.as_utc(start)
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
+
+    base_id = f"test_id:browse:{doorbell.id}:all:range:2022:2"
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
+
+    browse = await source.async_browse_media(media_item)
+
+    assert browse.title.endswith("February 2022")
+    assert browse.identifier == base_id
+    # Every child must belong to the month that was asked for, not to the
+    # month recording happens to have started in.
+    for child in browse.children:
+        assert child.identifier.startswith(f"{base_id}:")
+
+
+@pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
+async def test_browse_media_month_without_recording_start(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
+) -> None:
+    """Test browsing a month when the console reports no recording start."""
+    # Falls back to the earliest camera recording, so clear that as well.
+    doorbell.stats.video.recording_start = None
+    ufp.api.bootstrap._recording_start = None
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
+
+    base_id = f"test_id:browse:{doorbell.id}:all:range:2022:9"
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
+
+    browse = await source.async_browse_media(media_item)
+
+    assert browse.identifier == base_id

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -1148,10 +1148,11 @@ async def test_browse_media_month_before_recording_started(
 
     assert browse.title.endswith("February 2022")
     assert browse.identifier == base_id
-    # Every child must belong to the month that was asked for, not to the
-    # month recording happens to have started in.
-    for child in browse.children:
-        assert child.identifier.startswith(f"{base_id}:")
+    # Nothing was recorded that month, so only the whole month selector is
+    # offered, and no days belonging to the month recording started in.
+    assert len(browse.children) == 1
+    assert browse.children[0].title == "Whole Month"
+    assert browse.children[0].identifier == f"{base_id}:all"
 
 
 @pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
@@ -1173,3 +1174,30 @@ async def test_browse_media_month_without_recording_start(
     browse = await source.async_browse_media(media_item)
 
     assert browse.identifier == base_id
+
+
+@pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
+async def test_browse_media_recording_started_on_last_local_day(
+    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
+) -> None:
+    """Test the last day of a month is offered across a UTC date boundary."""
+    await hass.config.async_set_time_zone("US/Pacific")
+
+    # 2022-08-31 19:00 local, which is already 2022-09-01 in UTC.
+    ufp.api.bootstrap._recording_start = datetime.fromisoformat(
+        "2022-09-01 02:00:00+00:00"
+    )
+
+    ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
+    await init_entry(hass, ufp, [doorbell], regenerate_ids=False)
+
+    base_id = f"test_id:browse:{doorbell.id}:all:range:2022:8"
+    source = await async_get_media_source(hass)
+    media_item = MediaSourceItem(hass, DOMAIN, base_id, None)
+
+    browse = await source.async_browse_media(media_item)
+
+    assert [child.identifier for child in browse.children] == [
+        f"{base_id}:all",
+        f"{base_id}:31",
+    ]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Browsing a month that predates the start of the recording returns another month's days and events, under the requested month's title.

`_build_month` clamped the requested month to the recording start and then built every day child from that clamped value:

```python
start = max(recording_start, start)
...
children = [self._build_days(data, camera_id, event_type, start, is_all=True)]
while start <= end:
    children.append(self._build_days(data, camera_id, event_type, start, is_all=False))
```

The clamp is right in itself, since there is nothing to show before recording began, but it moves `start` out of the requested month entirely when that month is earlier. Everything built afterwards then belongs to the month the recording started in, while the title still names the month that was asked for. Browsing `...:range:2022:2` on a console that started recording in September returns a child identified `...:range:2022:9:all`.

The month bounds now stay on the requested `start` and a separate `day` walks the range, so children can never leave the month asked for. A month with nothing recorded in it comes back with no day children, which is honest, rather than carrying another month's data.

While fixing that: `recording_start` was only assigned inside its `if`, so a console that reports no recording start raised `UnboundLocalError: cannot access local variable 'recording_start'`. `_build_events_type` returns early in that case, but `_build_month` is reachable directly by identifier and had no such guard. Both are covered by tests that fail without this change.

One note on the issue itself, in case it comes up in review. The report reads titles such as `02/08/26` as 2 August, but `_build_days` formats them with `%x`, which is `%m/%d/%y` in the C locale, so that is 8 February and correct. The child identifiers are the part that showed the real fault.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue:  #180228
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
