### PR TITLE
Log when Google Generative AI STT returns no text

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/stt.py
+++ b/homeassistant/components/google_generative_ai_conversation/stt.py
@@ -266,5 +266,19 @@ class GoogleGenerativeAISttEntity(
                     response.text,
                     stt.SpeechResultState.SUCCESS,
                 )
+            if response.prompt_feedback:
+                LOGGER.error(
+                    "STT response contained no text (block_reason=%s)",
+                    response.prompt_feedback.block_reason_message,
+                )
+            else:
+                finish_reason = (
+                    response.candidates[0].finish_reason
+                    if response.candidates
+                    else None
+                )
+                LOGGER.error(
+                    "STT response contained no text (finish_reason=%s)", finish_reason
+                )
 
         return stt.SpeechResult(None, stt.SpeechResultState.ERROR)

--- a/homeassistant/components/google_generative_ai_conversation/stt.py
+++ b/homeassistant/components/google_generative_ai_conversation/stt.py
@@ -267,9 +267,12 @@ class GoogleGenerativeAISttEntity(
                     stt.SpeechResultState.SUCCESS,
                 )
             if response.prompt_feedback:
+                # block_reason_message is not supported by the Gemini API
+                # (only Vertex AI), so it is always None for this
+                # API-key-based client; block_reason is always populated.
                 LOGGER.error(
                     "STT response contained no text (block_reason=%s)",
-                    response.prompt_feedback.block_reason_message,
+                    response.prompt_feedback.block_reason,
                 )
             else:
                 finish_reason = (

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -195,6 +195,7 @@ async def test_stt_process_audio_stream_api_error(
 async def test_stt_process_audio_stream_empty_response(
     hass: HomeAssistant,
     mock_genai_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test STT processing with an empty response from the API."""
     entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
@@ -216,6 +217,79 @@ async def test_stt_process_audio_stream_empty_response(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+    assert "STT response contained no text (finish_reason=None)" in caplog.text
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_blank_text_response(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test STT logs an error when the API returns no text despite a candidate."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+    mock_genai_client.aio.models.generate_content.return_value = (
+        types.GenerateContentResponse(
+            candidates=[{"finish_reason": "STOP", "content": {"role": "model"}}]
+        )
+    )
+
+    metadata = stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert (
+        "STT response contained no text (finish_reason=FinishReason.STOP)"
+        in caplog.text
+    )
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_blocked_prompt(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test STT logs the block reason when the prompt is blocked."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+    mock_genai_client.aio.models.generate_content.return_value = (
+        types.GenerateContentResponse(
+            candidates=[],
+            prompt_feedback={
+                "block_reason": "SAFETY",
+                "block_reason_message": "Blocked for safety reasons",
+            },
+        )
+    )
+
+    metadata = stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert (
+        "STT response contained no text (block_reason=Blocked for safety reasons)"
+        in caplog.text
+    )
 
 
 @pytest.mark.usefixtures("mock_genai_client")

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -191,17 +191,45 @@ async def test_stt_process_audio_stream_api_error(
     assert result.text is None
 
 
+@pytest.mark.parametrize(
+    ("response", "expected_log"),
+    [
+        pytest.param(
+            types.GenerateContentResponse(candidates=[]),
+            "STT response contained no text (finish_reason=None)",
+            id="empty_response",
+        ),
+        pytest.param(
+            types.GenerateContentResponse(
+                candidates=[{"finish_reason": "STOP", "content": {"role": "model"}}]
+            ),
+            "STT response contained no text (finish_reason=FinishReason.STOP)",
+            id="blank_text_response",
+        ),
+        pytest.param(
+            types.GenerateContentResponse(
+                candidates=[],
+                prompt_feedback={
+                    "block_reason": "SAFETY",
+                    "block_reason_message": "Blocked for safety reasons",
+                },
+            ),
+            "STT response contained no text (block_reason=Blocked for safety reasons)",
+            id="blocked_prompt",
+        ),
+    ],
+)
 @pytest.mark.usefixtures("setup_integration")
-async def test_stt_process_audio_stream_empty_response(
+async def test_stt_process_audio_stream_no_text_response(
     hass: HomeAssistant,
     mock_genai_client: AsyncMock,
     caplog: pytest.LogCaptureFixture,
+    response: types.GenerateContentResponse,
+    expected_log: str,
 ) -> None:
-    """Test STT processing with an empty response from the API."""
+    """Test STT logs when the API response contains no text."""
     entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
-    mock_genai_client.aio.models.generate_content.return_value = (
-        types.GenerateContentResponse(candidates=[])
-    )
+    mock_genai_client.aio.models.generate_content.return_value = response
 
     metadata = stt.SpeechMetadata(
         language="en-US",
@@ -217,79 +245,7 @@ async def test_stt_process_audio_stream_empty_response(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
-    assert "STT response contained no text (finish_reason=None)" in caplog.text
-
-
-@pytest.mark.usefixtures("setup_integration")
-async def test_stt_process_audio_stream_blank_text_response(
-    hass: HomeAssistant,
-    mock_genai_client: AsyncMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test STT logs an error when the API returns no text despite a candidate."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
-    mock_genai_client.aio.models.generate_content.return_value = (
-        types.GenerateContentResponse(
-            candidates=[{"finish_reason": "STOP", "content": {"role": "model"}}]
-        )
-    )
-
-    metadata = stt.SpeechMetadata(
-        language="en-US",
-        format=stt.AudioFormats.OGG,
-        codec=stt.AudioCodecs.OPUS,
-        bit_rate=stt.AudioBitRates.BITRATE_16,
-        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-        channel=stt.AudioChannels.CHANNEL_MONO,
-    )
-    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
-
-    result = await entity.async_process_audio_stream(metadata, audio_stream)
-
-    assert result.result == stt.SpeechResultState.ERROR
-    assert result.text is None
-    assert (
-        "STT response contained no text (finish_reason=FinishReason.STOP)"
-        in caplog.text
-    )
-
-
-@pytest.mark.usefixtures("setup_integration")
-async def test_stt_process_audio_stream_blocked_prompt(
-    hass: HomeAssistant,
-    mock_genai_client: AsyncMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test STT logs the block reason when the prompt is blocked."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
-    mock_genai_client.aio.models.generate_content.return_value = (
-        types.GenerateContentResponse(
-            candidates=[],
-            prompt_feedback={
-                "block_reason": "SAFETY",
-                "block_reason_message": "Blocked for safety reasons",
-            },
-        )
-    )
-
-    metadata = stt.SpeechMetadata(
-        language="en-US",
-        format=stt.AudioFormats.OGG,
-        codec=stt.AudioCodecs.OPUS,
-        bit_rate=stt.AudioBitRates.BITRATE_16,
-        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-        channel=stt.AudioChannels.CHANNEL_MONO,
-    )
-    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
-
-    result = await entity.async_process_audio_stream(metadata, audio_stream)
-
-    assert result.result == stt.SpeechResultState.ERROR
-    assert result.text is None
-    assert (
-        "STT response contained no text (block_reason=Blocked for safety reasons)"
-        in caplog.text
-    )
+    assert expected_log in caplog.text
 
 
 @pytest.mark.usefixtures("mock_genai_client")

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -211,10 +211,13 @@ async def test_stt_process_audio_stream_api_error(
                 candidates=[],
                 prompt_feedback={
                     "block_reason": "SAFETY",
+                    # Not populated by the Gemini API in practice (only
+                    # Vertex AI); included to prove it is not what gets
+                    # logged.
                     "block_reason_message": "Blocked for safety reasons",
                 },
             ),
-            "STT response contained no text (block_reason=Blocked for safety reasons)",
+            "STT response contained no text (block_reason=BlockedReason.SAFETY)",
             id="blocked_prompt",
         ),
     ],


### PR DESCRIPTION
## Breaking change


## Proposed change

- `GoogleGenerativeAISttEntity.async_process_audio_stream` returned `SpeechResultState.ERROR` with no log entry when the API call succeeded but `response.text` was empty (e.g. `finish_reason=STOP` with zero output tokens, or a blocked prompt)
- Now logs an error with the block reason (if the prompt was blocked) or the candidate's `finish_reason` (otherwise), mirroring the existing pattern in `entity.py`
- Added tests covering the blank-text and blocked-prompt cases

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #180386
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr