### PR TITLE
Report KNX group address DPT for undecodable telegrams

### DIFF
--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -372,6 +372,10 @@ class Telegrams:
         if telegram.decoded_data is not None:
             transcoder = telegram.decoded_data.transcoder
             value = _serializable_decoded_data(telegram.decoded_data.value)
+        elif ga_info is not None:
+            # Telegrams that carry no decodable payload - GroupValueRead and
+            # undecoded DataSecure telegrams - still report the projects DPT.
+            transcoder = ga_info.transcoder
 
         return TelegramDict(
             data_secure=telegram.data_secure,

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -10,6 +10,9 @@ from unittest.mock import AsyncMock, patch
 from freezegun.api import FrozenDateTimeFactory
 from knx_telegram_store import KnxTelegramStoreException, StoredTelegram, TelegramQuery
 import pytest
+from xknx.telegram import Telegram, TelegramDirection
+from xknx.telegram.address import GroupAddress, IndividualAddress
+from xknx.telegram.apci import GroupValueRead
 
 from homeassistant.components.knx.const import (
     CONF_KNX_TELEGRAM_DB_BACKEND,
@@ -449,6 +452,43 @@ async def test_model_to_dict_resolution(
     assert result["destination_name"] == "Temperature"
     assert result["dpt_name"] == "temperature"
     assert result["unit"] == "°C"
+
+
+@pytest.mark.usefixtures("load_knxproj")
+async def test_telegram_to_dict_dpt_from_project(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Test undecodable telegrams get their DPT from the project."""
+    await knx.setup_integration()
+    telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+    assert telegrams_module.project.loaded
+
+    def read_telegram(destination: str) -> TelegramDict:
+        return telegrams_module.telegram_to_dict(
+            Telegram(
+                destination_address=GroupAddress(destination),
+                direction=TelegramDirection.INCOMING,
+                payload=GroupValueRead(),
+                source_address=IndividualAddress("1.2.3"),
+            )
+        )
+
+    # GroupValueRead has no payload to decode - the DPT of the group address
+    # is still reported from the project, without a value.
+    result = read_telegram("0/0/1")
+    assert result["telegramtype"] == "GroupValueRead"
+    assert result["dpt_main"] == 1
+    assert result["dpt_sub"] == 1
+    assert result["dpt_name"] == "switch"
+    assert result["payload"] is None
+    assert result["value"] is None
+
+    # Group addresses unknown to the project stay without DPT.
+    result = read_telegram("7/7/7")
+    assert result["dpt_main"] is None
+    assert result["dpt_sub"] is None
+    assert result["dpt_name"] is None
 
 
 async def test_load_history_needs_migration(


### PR DESCRIPTION
## Proposed change

Telegram DPT information is taken exclusively from the decoded payload data. Telegrams that carry nothing to decode therefore end up without any DPT information, even when the DPT of the group address is known from the project:

- `GroupValueRead` telegrams have no payload at all
- DataSecure telegrams that could not be decoded

In the KNX group monitor those telegrams show an empty DPT column and can't be filtered by DPT - group address reads are a large share of the traffic on most installations.

Fall back to the group address transcoder - already resolved from the project in `GroupAddressInfo` - when a telegram has no decoded data. `value` and `payload` stay empty, since there is still nothing to decode; only the DPT of the group address is reported. Telegrams to group addresses that are not in the project (or when no project is loaded) are unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: XKNX/knx-frontend#442

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

