### PR TITLE
Apply AiDot color when brightness is sent along with it

### DIFF
--- a/homeassistant/components/aidot/light.py
+++ b/homeassistant/components/aidot/light.py
@@ -92,13 +92,16 @@ class AidotLight(CoordinatorEntity[AidotDeviceUpdateCoordinator], LightEntity):
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on, applying brightness, color temperature, RGBW, or plain on."""
+        """Turn the light on, applying any requested brightness and color."""
+        # Brightness is independent of color: a scene sends both at once, and
+        # the color must not be dropped just because brightness came with it.
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
             await self.coordinator.device_client.async_set_brightness(brightness)
             self.coordinator.data.dimming = brightness
             self._attr_brightness = brightness
-        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
+
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
             color_temp_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
             await self.coordinator.device_client.async_set_cct(color_temp_kelvin)
             self.coordinator.data.cct = color_temp_kelvin
@@ -110,7 +113,8 @@ class AidotLight(CoordinatorEntity[AidotDeviceUpdateCoordinator], LightEntity):
             self.coordinator.data.rgbw = rgbw_color
             self._attr_rgbw_color = rgbw_color
             self._attr_color_mode = ColorMode.RGBW
-        else:
+        elif ATTR_BRIGHTNESS not in kwargs:
+            # Nothing was requested to apply, so just switch it on.
             await self.coordinator.device_client.async_turn_on()
 
         self.coordinator.data.on = True

--- a/tests/components/aidot/test_light.py
+++ b/tests/components/aidot/test_light.py
@@ -1,11 +1,13 @@
 """Test the aidot device."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 from aidot.const import CONF_DEVICE_LIST
 from aidot.device_client import DeviceStatusData
 from aidot.exceptions import AidotAuthFailed
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.aidot.coordinator import UPDATE_DEVICE_LIST_INTERVAL
@@ -134,6 +136,48 @@ async def test_turn_on_with_rgbw(
         blocking=True,
     )
     mocked_device_client.async_set_rgbw.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("color_data", "applied_call", "ignored_call"),
+    [
+        pytest.param(
+            {ATTR_RGBW_COLOR: (0, 0, 255, 0)},
+            "async_set_rgbw",
+            "async_set_cct",
+            id="rgbw",
+        ),
+        pytest.param(
+            {ATTR_COLOR_TEMP_KELVIN: 3000},
+            "async_set_cct",
+            "async_set_rgbw",
+            id="color_temp",
+        ),
+    ],
+)
+async def test_turn_on_with_brightness_and_color(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mocked_device_client: MagicMock,
+    color_data: dict[str, Any],
+    applied_call: str,
+    ignored_call: str,
+) -> None:
+    """Test brightness and color are both applied when sent together."""
+    await async_init_integration(hass, mock_config_entry)
+
+    # Scenes send brightness and color in a single call.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_BRIGHTNESS: 100, **color_data},
+        blocking=True,
+    )
+
+    mocked_device_client.async_set_brightness.assert_called_once_with(100)
+    getattr(mocked_device_client, applied_call).assert_called_once()
+    getattr(mocked_device_client, ignored_call).assert_not_called()
+    mocked_device_client.async_turn_on.assert_not_called()
 
 
 async def test_light_unavailable(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Turning an AiDot light on with brightness and a color in the same call applies the brightness and silently drops the color. The service call succeeds and nothing is logged, so a scene dims the bulb to the right level while it keeps whatever color it already had.

`async_turn_on` chained all three attributes into a single if/elif, with brightness first:

```python
if ATTR_BRIGHTNESS in kwargs:
    ...
elif ATTR_COLOR_TEMP_KELVIN in kwargs:
    ...
elif ATTR_RGBW_COLOR in kwargs:
    ...
```

so nothing after the brightness branch could ever run when brightness was present. This affects both color attributes, not only RGBW.

Brightness is applied on its own now. The two color attributes stay exclusive to each other, which is not a guess: `light.turn_on` declares `ATTR_COLOR_TEMP_KELVIN` and `ATTR_RGBW_COLOR` in the same `vol.Exclusive(COLOR_GROUP)`, while `ATTR_BRIGHTNESS` sits in a group of its own, so only one color can ever arrive alongside a brightness.

The trailing branch is `elif ATTR_BRIGHTNESS not in kwargs` rather than the more obvious `if not kwargs`. With `not kwargs`, a keyword this entity does not recognise would stop the light from being switched on at all, whereas the original `else` did switch it on. This keeps that behaviour and only skips the plain turn on when something was actually applied.

The test is parametrised over both color attributes; both fail without this change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180250
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
