### PR TITLE
Add RTC sync and IV curve scan buttons for Sofar inverters

### DIFF
--- a/homeassistant/components/sofar/__init__.py
+++ b/homeassistant/components/sofar/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import SofarConfigEntry, SofarDataUpdateCoordinator, SofarRunt
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
 
 _IDENTITY_ATTEMPTS = 3
 

--- a/homeassistant/components/sofar/button.py
+++ b/homeassistant/components/sofar/button.py
@@ -1,0 +1,86 @@
+"""Support for Sofar buttons."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import override
+
+from modbus_connection import ModbusError
+from sofar_modbus.modern.device import SofarInverter
+from sofar_modbus.variants import HYBRID, PV, InverterType, matches
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SofarConfigEntry
+from .entity import SofarEntity, SofarEntityDescription
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class SofarButtonEntityDescription(ButtonEntityDescription, SofarEntityDescription):
+    """Describe a Sofar button entity."""
+
+    applies_to: InverterType
+    press_fn: Callable[[SofarInverter], Awaitable[None]]
+    refresh_after: bool = True
+
+
+BUTTON_DESCRIPTIONS: tuple[SofarButtonEntityDescription, ...] = (
+    SofarButtonEntityDescription(
+        key="rtc_sync",
+        component="rtc_sync",
+        translation_key="rtc_sync",
+        entity_category=EntityCategory.CONFIG,
+        applies_to=PV | HYBRID,
+        press_fn=lambda device: device.async_set_time(),
+    ),
+    SofarButtonEntityDescription(
+        key="iv_curve_scan",
+        component="state",
+        translation_key="iv_curve_scan",
+        entity_category=EntityCategory.CONFIG,
+        applies_to=HYBRID,
+        press_fn=lambda device: device.async_start_iv_curve_scan(),
+        refresh_after=False,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SofarConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Sofar Inverter Modbus button platform."""
+    runtime_data = entry.runtime_data
+    inverter_type = runtime_data.readings.device.inverter_type
+    async_add_entities(
+        SofarButton(runtime_data, description)
+        for description in BUTTON_DESCRIPTIONS
+        if inverter_type is not None and matches(inverter_type, description.applies_to)
+    )
+
+
+class SofarButton(SofarEntity, ButtonEntity):
+    """Defines a Sofar button entity."""
+
+    entity_description: SofarButtonEntityDescription
+
+    @override
+    async def async_press(self) -> None:
+        """Press the button."""
+        try:
+            await self.entity_description.press_fn(self.coordinator.device)
+        except ModbusError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="modbus_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        if self.entity_description.refresh_after:
+            await self.coordinator.async_request_refresh()

--- a/homeassistant/components/sofar/button.py
+++ b/homeassistant/components/sofar/button.py
@@ -4,17 +4,14 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import override
 
-from modbus_connection import ModbusError
 from sofar_modbus.modern.device import SofarInverter
 from sofar_modbus.variants import HYBRID, PV, InverterType, matches
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import SofarConfigEntry
 from .entity import SofarEntity, SofarEntityDescription
 
@@ -74,13 +71,6 @@ class SofarButton(SofarEntity, ButtonEntity):
     @override
     async def async_press(self) -> None:
         """Press the button."""
-        try:
-            await self.entity_description.press_fn(self.coordinator.device)
-        except ModbusError as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="modbus_error",
-                translation_placeholders={"error": str(err)},
-            ) from err
+        await self.entity_description.press_fn(self.coordinator.device)
         if self.entity_description.refresh_after:
             await self.coordinator.async_request_refresh()

--- a/homeassistant/components/sofar/icons.json
+++ b/homeassistant/components/sofar/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "button": {
+      "iv_curve_scan": {
+        "default": "mdi:chart-bell-curve"
+      },
+      "rtc_sync": {
+        "default": "mdi:home-clock"
+      }
+    },
     "sensor": {
       "bat_config_capacity": {
         "default": "mdi:battery-check-outline"

--- a/homeassistant/components/sofar/strings.json
+++ b/homeassistant/components/sofar/strings.json
@@ -32,6 +32,14 @@
     }
   },
   "entity": {
+    "button": {
+      "iv_curve_scan": {
+        "name": "IV curve scan"
+      },
+      "rtc_sync": {
+        "name": "RTC sync"
+      }
+    },
     "sensor": {
       "active_power_load_sys": {
         "name": "Active power load system"

--- a/tests/components/sofar/snapshots/test_button.ambr
+++ b/tests/components/sofar/snapshots/test_button.ambr
@@ -1,0 +1,151 @@
+# serializer version: 1
+# name: test_hybrid_entities[button.hydxxktl_3p_iv_curve_scan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.hydxxktl_3p_iv_curve_scan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IV curve scan',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IV curve scan',
+    'platform': 'sofar',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'iv_curve_scan',
+    'unique_id': 'SP1XXES100XX_iv_curve_scan',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_hybrid_entities[button.hydxxktl_3p_iv_curve_scan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HYDxxKTL-3P IV curve scan',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.hydxxktl_3p_iv_curve_scan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_hybrid_entities[button.hydxxktl_3p_rtc_sync-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.hydxxktl_3p_rtc_sync',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'RTC sync',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'RTC sync',
+    'platform': 'sofar',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'rtc_sync',
+    'unique_id': 'SP1XXES100XX_rtc_sync',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_hybrid_entities[button.hydxxktl_3p_rtc_sync-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HYDxxKTL-3P RTC sync',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.hydxxktl_3p_rtc_sync',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_pv_entities[button.4_4_ktlx_g3_rtc_sync-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.4_4_ktlx_g3_rtc_sync',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'RTC sync',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'RTC sync',
+    'platform': 'sofar',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'rtc_sync',
+    'unique_id': 'SS2ES104N5S445_rtc_sync',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_pv_entities[button.4_4_ktlx_g3_rtc_sync-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '4.4 KTLX-G3 RTC sync',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.4_4_ktlx_g3_rtc_sync',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/sofar/test_button.py
+++ b/tests/components/sofar/test_button.py
@@ -138,8 +138,6 @@ async def test_rtc_sync_reported_to_hass(
         blocking=True,
     )
 
-    # The write's trailing "execute" word and the result register are the
-    # same address (0x100A), so the press itself moves it to in-progress.
     assert (state := hass.states.get(result_id)) is not None
     assert state.state == "operation_in_progress"
 

--- a/tests/components/sofar/test_button.py
+++ b/tests/components/sofar/test_button.py
@@ -1,6 +1,6 @@
 """Test the Sofar Inverter Modbus button platform."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from unittest.mock import patch
 
 from modbus_connection import ModbusError
@@ -9,10 +9,10 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.sofar.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import (
@@ -33,8 +33,9 @@ async def _setup(
     serial: str,
     model: str,
     seed: Callable[[MockModbusUnit], None],
+    platforms: Sequence[Platform] = (Platform.BUTTON,),
 ) -> tuple[MockConfigEntry, MockModbusConnection]:
-    """Set up an inverter with only the button platform loaded."""
+    """Set up an inverter with the given platforms loaded."""
     connection = MockModbusConnection()
     seed(connection.for_unit(1))
     entry = MockConfigEntry(
@@ -42,7 +43,7 @@ async def _setup(
     )
     entry.add_to_hass(hass)
     with (
-        patch("homeassistant.components.sofar.PLATFORMS", [Platform.BUTTON]),
+        patch("homeassistant.components.sofar.PLATFORMS", list(platforms)),
         patch(
             "homeassistant.components.sofar.async_get_unit",
             side_effect=lambda hass, entry, params, unit_id: connection.for_unit(
@@ -79,35 +80,22 @@ async def test_hybrid_entities(
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
-async def test_rtc_sync_press(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+@pytest.mark.parametrize(
+    ("key", "register"),
+    [
+        pytest.param("rtc_sync", 0x100A, id="rtc_sync"),
+        pytest.param("iv_curve_scan", 0x1027, id="iv_curve_scan"),
+    ],
+)
+async def test_button_press(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, key: str, register: int
 ) -> None:
-    """Test pressing RTC sync writes the seven-register time block."""
-    _, connection = await _setup(hass, MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter)
-    entity_id = entity_registry.async_get_entity_id(
-        BUTTON_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_rtc_sync"
-    )
-    assert entity_id is not None
-
-    await hass.services.async_call(
-        BUTTON_DOMAIN,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
-
-    assert connection.for_unit(1).holding[0x100A] == 1
-
-
-async def test_iv_curve_scan_press(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test pressing IV curve scan writes the trigger register."""
+    """Test pressing a button writes its trigger register."""
     _, connection = await _setup(
         hass, MOCK_HYBRID_SERIAL, MOCK_HYBRID_MODEL, seed_hybrid_inverter
     )
     entity_id = entity_registry.async_get_entity_id(
-        BUTTON_DOMAIN, DOMAIN, f"{MOCK_HYBRID_SERIAL}_iv_curve_scan"
+        BUTTON_DOMAIN, DOMAIN, f"{MOCK_HYBRID_SERIAL}_{key}"
     )
     assert entity_id is not None
 
@@ -118,13 +106,48 @@ async def test_iv_curve_scan_press(
         blocking=True,
     )
 
-    assert connection.for_unit(1).holding[0x1027] == 1
+    assert connection.for_unit(1).holding[register] == 1
+
+
+async def test_rtc_sync_reported_to_hass(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the RTC sync result reaches its sensor after the refresh."""
+    await _setup(
+        hass,
+        MOCK_HYBRID_SERIAL,
+        MOCK_HYBRID_MODEL,
+        seed_hybrid_inverter,
+        platforms=(Platform.BUTTON, Platform.SENSOR),
+    )
+    button_id = entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, DOMAIN, f"{MOCK_HYBRID_SERIAL}_rtc_sync"
+    )
+    result_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{MOCK_HYBRID_SERIAL}_sync_rtc_result"
+    )
+    assert button_id is not None
+    assert result_id is not None
+    assert (state := hass.states.get(result_id)) is not None
+    assert state.state == "successful"
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: button_id},
+        blocking=True,
+    )
+
+    # The write's trailing "execute" word and the result register are the
+    # same address (0x100A), so the press itself moves it to in-progress.
+    assert (state := hass.states.get(result_id)) is not None
+    assert state.state == "operation_in_progress"
 
 
 async def test_press_modbus_error(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test a write failure surfaces as a HomeAssistantError."""
+    """Test a write failure propagates as-is."""
     _, connection = await _setup(hass, MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter)
     entity_id = entity_registry.async_get_entity_id(
         BUTTON_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_rtc_sync"
@@ -132,13 +155,10 @@ async def test_press_modbus_error(
     assert entity_id is not None
     connection.for_unit(1).fail_write(0x1004, ModbusError("busy"))
 
-    with pytest.raises(HomeAssistantError) as excinfo:
+    with pytest.raises(ModbusError, match="busy"):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
-
-    assert excinfo.value.translation_domain == DOMAIN
-    assert excinfo.value.translation_key == "modbus_error"

--- a/tests/components/sofar/test_button.py
+++ b/tests/components/sofar/test_button.py
@@ -1,0 +1,144 @@
+"""Test the Sofar Inverter Modbus button platform."""
+
+from collections.abc import Callable
+from unittest.mock import patch
+
+from modbus_connection import ModbusError
+from modbus_connection.mock import MockModbusConnection, MockModbusUnit
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.sofar.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import (
+    MOCK_HYBRID_MODEL,
+    MOCK_HYBRID_SERIAL,
+    MOCK_MODEL,
+    MOCK_SERIAL,
+    MOCK_USER_INPUT,
+    seed_hybrid_inverter,
+    seed_pv_inverter,
+)
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def _setup(
+    hass: HomeAssistant,
+    serial: str,
+    model: str,
+    seed: Callable[[MockModbusUnit], None],
+) -> tuple[MockConfigEntry, MockModbusConnection]:
+    """Set up an inverter with only the button platform loaded."""
+    connection = MockModbusConnection()
+    seed(connection.for_unit(1))
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=serial, data=MOCK_USER_INPUT, title=model
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch("homeassistant.components.sofar.PLATFORMS", [Platform.BUTTON]),
+        patch(
+            "homeassistant.components.sofar.async_get_unit",
+            side_effect=lambda hass, entry, params, unit_id: connection.for_unit(
+                unit_id
+            ),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+    return entry, connection
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_pv_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a PV-only inverter only gets the RTC sync button."""
+    entry, _ = await _setup(hass, MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter)
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_hybrid_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a hybrid inverter gets both buttons."""
+    entry, _ = await _setup(
+        hass, MOCK_HYBRID_SERIAL, MOCK_HYBRID_MODEL, seed_hybrid_inverter
+    )
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_rtc_sync_press(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test pressing RTC sync writes the seven-register time block."""
+    _, connection = await _setup(hass, MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter)
+    entity_id = entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_rtc_sync"
+    )
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert connection.for_unit(1).holding[0x100A] == 1
+
+
+async def test_iv_curve_scan_press(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test pressing IV curve scan writes the trigger register."""
+    _, connection = await _setup(
+        hass, MOCK_HYBRID_SERIAL, MOCK_HYBRID_MODEL, seed_hybrid_inverter
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, DOMAIN, f"{MOCK_HYBRID_SERIAL}_iv_curve_scan"
+    )
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert connection.for_unit(1).holding[0x1027] == 1
+
+
+async def test_press_modbus_error(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a write failure surfaces as a HomeAssistantError."""
+    _, connection = await _setup(hass, MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter)
+    entity_id = entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_rtc_sync"
+    )
+    assert entity_id is not None
+    connection.for_unit(1).fail_write(0x1004, ModbusError("busy"))
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "modbus_error"

--- a/tests/components/sofar/test_sensor.py
+++ b/tests/components/sofar/test_sensor.py
@@ -103,13 +103,13 @@ async def test_sensor_entities_created_and_state(
 @pytest.mark.parametrize(
     ("serial", "model", "seed", "created", "enabled"),
     [
-        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 73, 23, id="pv"),
+        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 72, 22, id="pv"),
         pytest.param(
             MOCK_HYBRID_SERIAL,
             MOCK_HYBRID_MODEL,
             seed_hybrid_inverter,
-            140,
-            47,
+            138,
+            45,
             id="hybrid",
         ),
     ],
@@ -137,7 +137,11 @@ async def test_enabled_by_default_partition(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    entries = [
+        e
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if e.domain == SENSOR_DOMAIN
+    ]
     # Literal counts: an accidental flip has to be acknowledged here.
     assert len(entries) == created
     assert len([e for e in entries if e.disabled_by is None]) == enabled

--- a/tests/components/sofar/test_sensor.py
+++ b/tests/components/sofar/test_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.components.sofar.sensor import (
     SofarSensorDescription,
     SofarTotalSensor,
 )
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -54,9 +54,14 @@ async def test_all_entities(
         title=MOCK_HYBRID_MODEL,
     )
     entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.sofar.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: connection.for_unit(unit_id),
+    with (
+        patch("homeassistant.components.sofar.PLATFORMS", [Platform.SENSOR]),
+        patch(
+            "homeassistant.components.sofar.async_get_unit",
+            side_effect=lambda hass, entry, params, unit_id: connection.for_unit(
+                unit_id
+            ),
+        ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -98,13 +103,13 @@ async def test_sensor_entities_created_and_state(
 @pytest.mark.parametrize(
     ("serial", "model", "seed", "created", "enabled"),
     [
-        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 72, 22, id="pv"),
+        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 73, 23, id="pv"),
         pytest.param(
             MOCK_HYBRID_SERIAL,
             MOCK_HYBRID_MODEL,
             seed_hybrid_inverter,
-            138,
-            45,
+            140,
+            47,
             id="hybrid",
         ),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds two `button` entities, both wired to methods the sofar-modbus
library already exposes on `SofarInverter`:
- **RTC sync** — writes the current time to the inverter's clock
  (`async_set_time()`). Applies to both PV and hybrid. The
  confirmation sensor for this (`sync_rtc_result`) only exists on
  hybrids, so a PV inverter gets a working button with no read-back —
  matching the vendor's own upstream behavior for this control.
- **IV curve scan** — triggers a sweep of the PV strings' I-V curves
  (`async_start_iv_curve_scan()`), hybrid only. No result register to
  read back, so it doesn't request a coordinator refresh afterward.
Both are `EntityCategory.CONFIG`: infrequent maintenance/calibration
actions, not day-to-day controls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47654
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
