### PR TITLE
cloudflare_r2: warmup loader caches to remove blocking listdir calls

### DIFF
--- a/homeassistant/components/cloudflare_r2/__init__.py
+++ b/homeassistant/components/cloudflare_r2/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import cast
 
 from aiobotocore.client import AioBaseClient as S3Client
+from aiobotocore.config import AioConfig
 from aiobotocore.session import AioSession
 from botocore.exceptions import (
     ClientError,
@@ -43,6 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: R2ConfigEntry) -> bool:
             endpoint_url=data.get(CONF_ENDPOINT_URL),
             aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
             aws_access_key_id=data[CONF_ACCESS_KEY_ID],
+            config=AioConfig(warm_up_loader_caches=True),
         ).__aenter__()
         await client.head_bucket(Bucket=data[CONF_BUCKET])
     except ClientError as err:

--- a/homeassistant/components/cloudflare_r2/config_flow.py
+++ b/homeassistant/components/cloudflare_r2/config_flow.py
@@ -3,6 +3,7 @@
 from typing import Any, override
 from urllib.parse import urlparse
 
+from aiobotocore.config import AioConfig
 from aiobotocore.session import AioSession
 from botocore.exceptions import (
     ClientError,
@@ -78,6 +79,7 @@ class R2ConfigFlow(ConfigFlow, domain=DOMAIN):
                         endpoint_url=user_input.get(CONF_ENDPOINT_URL),
                         aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
                         aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
+                        config=AioConfig(warm_up_loader_caches=True),
                     ) as client:
                         await client.head_bucket(Bucket=user_input[CONF_BUCKET])
                 except ClientError:

--- a/tests/components/cloudflare_r2/test_config_flow.py
+++ b/tests/components/cloudflare_r2/test_config_flow.py
@@ -44,7 +44,17 @@ async def _async_start_flow(
 
 async def test_flow(hass: HomeAssistant) -> None:
     """Test config flow."""
-    result = await _async_start_flow(hass)
+    create_client = AsyncMock(name="create_client")
+    create_client.__aenter__.return_value.head_bucket.return_value = {}
+
+    with patch(
+        "homeassistant.components.cloudflare_r2.config_flow.AioSession.create_client",
+        return_value=create_client,
+    ) as patched_create_client:
+        result = await _async_start_flow(hass)
+
+        assert patched_create_client.call_args.kwargs["config"].warm_up_loader_caches
+
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test"
     assert result["data"] == USER_INPUT

--- a/tests/components/cloudflare_r2/test_init.py
+++ b/tests/components/cloudflare_r2/test_init.py
@@ -73,3 +73,23 @@ async def test_setup_entry_head_bucket_error(
     )
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_warms_loader_caches(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that create_client passes warm_up_loader_caches config."""
+    with patch(
+        "homeassistant.components.cloudflare_r2.AioSession.create_client"
+    ) as create_client:
+        client_ctx = AsyncMock()
+        client = AsyncMock()
+        client_ctx.__aenter__.return_value = client
+        create_client.return_value = client_ctx
+
+        await setup_integration(hass, mock_config_entry)
+
+        create_client.assert_called_once()
+        _, kwargs = create_client.call_args
+        assert kwargs["config"].warm_up_loader_caches is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the merge of PR #170783 (`aiobotocore` 3,7.0) it is now possible to warmup the loader caches which prevents calls like `os.listdir` be called blocking. One SSL blocking call remains which is resolved in version 3.8.0 of `aiobotocore`.

This fix is already applied to `idrive_e2` `aiobotocore` backup integration (PR #177422). It also need to be applied to the `aws_s3` backup integration but that will be handled in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: 
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
