### PR TITLE
Drop ecobee thermostats from the action list on unload

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     STATE_ON,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
@@ -168,7 +168,18 @@ async def async_setup_entry(
         entities.append(Thermostat(data, index, thermostat, hass))
 
     async_add_entities(entities, True)
-    _async_get_thermostats(hass).extend(entities)
+
+    # The ecobee actions act on whatever is in this list, so the entities have
+    # to be taken back out again when the entry goes away.
+    thermostats = _async_get_thermostats(hass)
+    thermostats.extend(entities)
+
+    @callback
+    def _remove_thermostats() -> None:
+        for entity in entities:
+            thermostats.remove(entity)
+
+    config_entry.async_on_unload(_remove_thermostats)
 
     platform = entity_platform.async_get_current_platform()
 

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -2,6 +2,7 @@
 
 from http import HTTPStatus
 from unittest import mock
+from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -15,6 +16,7 @@ from homeassistant.components.ecobee.climate import (
     Thermostat,
 )
 from homeassistant.components.ecobee.const import DOMAIN
+from homeassistant.components.ecobee.services import _async_get_thermostats
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -700,3 +702,33 @@ async def test_set_sensors_used_in_climate(hass: HomeAssistant) -> None:
         )
     assert execinfo.value.translation_domain == "ecobee"
     assert execinfo.value.translation_key == "sensor_lookup_failed"
+
+
+async def test_thermostats_removed_from_services_on_unload(
+    hass: HomeAssistant,
+) -> None:
+    """Test unloading drops the entities the ecobee actions iterate over."""
+    entry = await setup_platform(hass, [const.Platform.CLIMATE])
+
+    assert _async_get_thermostats(hass)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The actions call methods on whatever is in this list, so entities that
+    # are gone must not be left behind for them to find.
+    assert not _async_get_thermostats(hass)
+
+
+async def test_thermostats_not_duplicated_on_reload(hass: HomeAssistant) -> None:
+    """Test reloading does not leave a second copy of every entity behind."""
+    entry = await setup_platform(hass, [const.Platform.CLIMATE])
+
+    before = len(_async_get_thermostats(hass))
+    assert before
+
+    with patch("homeassistant.components.ecobee.PLATFORMS", [const.Platform.CLIMATE]):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(_async_get_thermostats(hass)) == before


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ecobee.resume_program` resumes the program on the thermostat and still reports "Error running action", with an `IndexError: list index out of range` raised from `pyecobee`.

The climate platform appends its entities to a list held in `hass.data`, which every ecobee action iterates over:

```python
async_add_entities(entities, True)
_async_get_thermostats(hass).extend(entities)
```

`async_unload_entry` only unloads the platforms, so nothing ever takes those entities back out. Each reload of the config entry adds a fresh set while the previous ones stay behind, and the actions go on calling methods on entities that no longer exist.

A single reload is enough to show it. The list holds six entries where it should hold three, and the three left over have no entity ID any more:

```
assert 6 == 3
  where 6 = len([<entity unknown.unknown=unknown>, <entity unknown.unknown=unknown>,
                 <entity unknown.unknown=unknown>, <entity climate.ecobee=heat_cool>,
                 <entity climate.ecobee2=heat_cool>, <entity climate.unknownecobeename=heat_cool>])
```

`_resume_program_set_service` then calls `resume_program` on all six. The live entities reach the thermostat, which is why the program does resume, while a stale entity indexes into the `Ecobee` object its own entry left behind and raises. That is the partial success with an error on top.

The entities are removed again when the entry unloads. This covers all four ecobee actions, since they all walk the same list, and it stops the list growing on every reload.

One caveat worth stating: this fixes the leak and shows that removed entities do receive the action calls, but reproducing the reporter's exact `IndexError` needs the stale `Ecobee` object to hold fewer thermostats than the index it is asked for, which depends on their setup. The leak is the precondition for it either way.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180163
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
