### PR TITLE
Stop deriving PrusaLink job timestamps after the print ends

### DIFF
--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -48,6 +48,13 @@ class PrusaLinkSensorEntityDescription[
     value_fn: Callable[[T], datetime | StateType]
 
 
+# Both job timestamps are derived from the wall clock, so they only hold while
+# the job is actually progressing. Once it ends the printer keeps reporting the
+# job with a frozen printing time and nothing remaining, which would drift the
+# start forward and pin the finish to "now".
+JOB_IN_PROGRESS_STATES = {PrinterState.PRINTING.value, PrinterState.PAUSED.value}
+
+
 SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
     "status": (
         PrusaLinkSensorEntityDescription[PrinterStatus](
@@ -195,7 +202,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             ),
             available_fn=lambda data: (
                 data.get("time_printing") is not None
-                and data.get("state") != PrinterState.IDLE.value
+                and data.get("state") in JOB_IN_PROGRESS_STATES
             ),
         ),
         PrusaLinkSensorEntityDescription[JobInfo](
@@ -212,7 +219,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             ),
             available_fn=lambda data: (
                 data.get("time_remaining") is not None
-                and data.get("state") != PrinterState.IDLE.value
+                and data.get("state") in JOB_IN_PROGRESS_STATES
             ),
         ),
     ),

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
+    STATE_UNAVAILABLE,
     Platform,
     UnitOfLength,
     UnitOfTemperature,
@@ -365,3 +366,62 @@ async def test_min_extrusion_temp_not_created_when_absent(
         hass.states.get("sensor.workshop_mock_title_minimum_extrusion_temperature")
         is None
     )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_job_timestamps_not_derived_after_the_print(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    mock_get_status_printing,
+    mock_job_api_printing,
+    mock_job_api_attention,
+) -> None:
+    """Test the job timestamps stop being derived once the print has ended."""
+    # A finished print keeps reporting the job while the printer waits for the
+    # part to be removed, with the printing time frozen and nothing remaining.
+    mock_job_api_printing["time_remaining"] = 0
+
+    with patch(
+        "homeassistant.components.prusalink.sensor.utcnow",
+        return_value=datetime(2022, 8, 27, 14, 0, 0, tzinfo=UTC),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    state = hass.states.get("sensor.workshop_mock_title")
+    assert state is not None
+    assert state.state == "attention"
+
+    # Deriving these from the wall clock now only produces a drifting start and
+    # a finish that is forever "just now".
+    state = hass.states.get("sensor.workshop_mock_title_print_start")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    state = hass.states.get("sensor.workshop_mock_title_print_finish")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_job_timestamps_kept_while_paused(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    mock_get_status_printing,
+    mock_job_api_paused,
+) -> None:
+    """Test the job timestamps stay available while the job is paused."""
+    with patch(
+        "homeassistant.components.prusalink.sensor.utcnow",
+        return_value=datetime(2022, 8, 27, 14, 0, 0, tzinfo=UTC),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    state = hass.states.get("sensor.workshop_mock_title_print_start")
+    assert state is not None
+    assert state.state == "2022-08-27T01:46:53+00:00"
+
+    state = hass.states.get("sensor.workshop_mock_title_print_finish")
+    assert state is not None
+    assert state.state == "2022-08-28T10:17:00+00:00"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `print_start` and `print_finish` sensors keep moving once a print has finished and the printer sits in `attention` waiting for the part to be removed.

Both are derived from the wall clock:

```python
"job.start":  utcnow() - timedelta(seconds=data["time_printing"])
"job.finish": utcnow() + timedelta(seconds=data["time_remaining"])
```

That only holds while the job is running, because `time_printing` advances along with `utcnow()` and the difference stays put. It is what the `ignore_variance(2 minutes)` wrapper is there to absorb.

Once the print is done, PrusaLink goes on reporting the job with `time_printing` frozen and `time_remaining` at 0, and `available_fn` allowed every state except `IDLE`, so `attention`, `finished` and `stopped` all kept recalculating:

- `print_start` moves forward by one poll interval each update, losing the actual start of the print.
- `print_finish` is `utcnow()` on every update, so it reads "0 minutes ago", climbs to 2 minutes and drops back, forever.

They are now offered only while the job is actually progressing. The states are pulled out into a named constant since the reason these two sensors are special is not obvious from `available_fn` alone.

`PAUSED` is deliberately kept, and there is a test pinning that, since it is the boundary of this change and the easy thing to over-narrow later.

One nuance left alone on purpose: if `time_printing` also stops advancing while a job is paused, the start could drift slowly across a pause longer than the two minute variance. That is not what was reported and I have no printer to confirm the field's behaviour, so I have not guessed at it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180086
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
