### PR TITLE
Fix swallowed exceptions in dlna_dmr action handlers

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -9,7 +9,11 @@ from typing import Any, Concatenate, override
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
 from async_upnp_client.const import NotificationSubType
-from async_upnp_client.exceptions import UpnpError, UpnpResponseError
+from async_upnp_client.exceptions import (
+    UpnpConnectionError,
+    UpnpError,
+    UpnpResponseError,
+)
 from async_upnp_client.profiles.dlna import DmrDevice, PlayMode, TransportState
 from async_upnp_client.utils import async_get_local_ip
 from didl_lite import didl_lite
@@ -29,6 +33,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_MAC, CONF_TYPE, CONF_URL
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
@@ -79,10 +84,24 @@ def catch_request_errors[_DlnaDmrEntityT: DlnaDmrEntity, **_P, _R](
             return None
         try:
             return await func(self, *args, **kwargs)
+        except UpnpConnectionError as err:
+            # Inform user explicitly of connection issues (like device turned off)
+            self.check_available = True
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="request_connection_error",
+                translation_placeholders={"action": func.__name__},
+            ) from err
         except UpnpError as err:
             self.check_available = True
-            _LOGGER.error("Error during call %s: %r", func.__name__, err)
-        return None
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="request_error",
+                translation_placeholders={
+                    "action": func.__name__,
+                    "upnperror": str(err),
+                },
+            ) from err
 
     return wrapper
 
@@ -612,7 +631,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
             return None
         return self._device.volume_level
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_set_volume_level(self, volume: float) -> None:
@@ -628,7 +646,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
             return None
         return self._device.is_volume_muted
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_mute_volume(self, mute: bool) -> None:
@@ -637,7 +654,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         desired_mute = bool(mute)
         await self._device.async_mute_volume(desired_mute)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_pause(self) -> None:
@@ -645,7 +661,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         assert self._device is not None
         await self._device.async_pause()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_play(self) -> None:
@@ -653,7 +668,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         assert self._device is not None
         await self._device.async_play()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_stop(self) -> None:
@@ -661,7 +675,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         assert self._device is not None
         await self._device.async_stop()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_seek(self, position: float) -> None:
@@ -670,7 +683,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         time = timedelta(seconds=position)
         await self._device.async_seek_rel_time(time)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_play_media(
@@ -740,7 +752,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         await self._device.async_wait_for_can_play()
         await self.async_media_play()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_previous_track(self) -> None:
@@ -748,7 +759,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         assert self._device is not None
         await self._device.async_previous()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_media_next_track(self) -> None:
@@ -771,7 +781,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
         return play_mode in (PlayMode.SHUFFLE, PlayMode.RANDOM)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_set_shuffle(self, shuffle: bool) -> None:
@@ -813,7 +822,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
         return RepeatMode.OFF
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
@@ -842,7 +850,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
             return None
         return self._device.preset_names
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors
     @override
     async def async_select_sound_mode(self, sound_mode: str) -> None:

--- a/homeassistant/components/dlna_dmr/strings.json
+++ b/homeassistant/components/dlna_dmr/strings.json
@@ -36,6 +36,14 @@
       }
     }
   },
+  "exceptions": {
+    "request_connection_error": {
+      "message": "Could not connect to device when calling service for action {action}"
+    },
+    "request_error": {
+      "message": "Error when calling device service for action {action}: {upnperror}"
+    }
+  },
   "options": {
     "error": {
       "invalid_url": "Invalid URL"

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -2055,9 +2055,10 @@ async def test_generic_error(
 
     # With a working connection, device should remain available on the next,
     # update, and any thereafter.
-    for _ in range(2):
+    for do_ping in (True, False):
+        dmr_device_mock.async_update.reset_mock()
         await async_update_entity(hass, mock_entity_id)
-        dmr_device_mock.async_update.assert_any_call(do_ping=True)
+        dmr_device_mock.async_update.assert_called_with(do_ping=do_ping)
         mock_state = hass.states.get(mock_entity_id)
         assert mock_state is not None
         assert mock_state.state == MediaPlayerState.IDLE

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, DEFAULT, Mock, patch
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
 from async_upnp_client.exceptions import (
+    UpnpActionResponseError,
     UpnpConnectionError,
     UpnpError,
     UpnpResponseError,
@@ -43,6 +44,7 @@ from homeassistant.const import (
     CONF_URL,
 )
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
@@ -1963,7 +1965,7 @@ async def test_become_unavailable(
     mock_entity_id: str,
     dmr_device_mock: Mock,
 ) -> None:
-    """Test a device becoming unavailable."""
+    """Test a device becoming unavailable due to a connection error."""
     # Check async_update currently works
     await async_update_entity(hass, mock_entity_id)
     dmr_device_mock.async_update.assert_called_with(do_ping=False)
@@ -1973,13 +1975,17 @@ async def test_become_unavailable(
     dmr_device_mock.async_update.reset_mock()
 
     # Interface service calls should flag that the device is unavailable, but
-    # not disconnect it immediately
-    await hass.services.async_call(
-        mp.DOMAIN,
-        ha_const.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
-        blocking=True,
-    )
+    # not disconnect it immediately.
+    # An exception should also be raised to inform the user or automation.
+    with pytest.raises(
+        HomeAssistantError, match="Could not connect .* async_set_volume_level"
+    ):
+        await hass.services.async_call(
+            mp.DOMAIN,
+            ha_const.SERVICE_VOLUME_SET,
+            {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
+            blocking=True,
+        )
 
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
@@ -1997,17 +2003,64 @@ async def test_become_unavailable(
     dmr_device_mock.async_update.reset_mock()
     dmr_device_mock.async_update.side_effect = UpnpConnectionError
 
-    await hass.services.async_call(
-        mp.DOMAIN,
-        ha_const.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
-        blocking=True,
-    )
+    with pytest.raises(
+        HomeAssistantError, match="Could not connect .* async_set_volume_level"
+    ):
+        await hass.services.async_call(
+            mp.DOMAIN,
+            ha_const.SERVICE_VOLUME_SET,
+            {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
+            blocking=True,
+        )
+
     await async_update_entity(hass, mock_entity_id)
     dmr_device_mock.async_update.assert_called_with(do_ping=True)
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
     assert mock_state.state == ha_const.STATE_UNAVAILABLE
+
+
+async def test_generic_error(
+    hass: HomeAssistant,
+    mock_entity_id: str,
+    dmr_device_mock: Mock,
+) -> None:
+    """Test when a UpnpError occurs during an action, it is bubbled up to the user.
+
+    The behaviour should be the same as for a UpnpConnectionError.
+    """
+    # Generate a service-specific UpnpError on the next service call. This particular
+    # error simulates trying to play a file that the device does not support.
+    dmr_device_mock.async_play.side_effect = UpnpActionResponseError(
+        status=500, error_code=714, error_desc="Illegal MIME-type"
+    )
+
+    # Interface service calls should flag that the device may be unavailable,
+    # but not disconnect it immediately.
+    # An exception should also be raised to inform the user or automation.
+    with pytest.raises(
+        HomeAssistantError,
+        match="Error when calling device service for action async_media_play: .*Illegal MIME-type",
+    ):
+        await hass.services.async_call(
+            mp.DOMAIN,
+            ha_const.SERVICE_MEDIA_PLAY,
+            {ATTR_ENTITY_ID: mock_entity_id},
+            blocking=True,
+        )
+
+    mock_state = hass.states.get(mock_entity_id)
+    assert mock_state is not None
+    assert mock_state.state == MediaPlayerState.IDLE
+
+    # With a working connection, device should remain available on the next,
+    # update, and any thereafter.
+    for _ in range(2):
+        await async_update_entity(hass, mock_entity_id)
+        dmr_device_mock.async_update.assert_any_call(do_ping=True)
+        mock_state = hass.states.get(mock_entity_id)
+        assert mock_state is not None
+        assert mock_state.state == MediaPlayerState.IDLE
 
 
 async def test_poll_availability(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `dlna_dmr` integration now raises `HomeAssistantError` exceptions when it catches an exception from the underlying device library (`async_upnp_client`) during an action call. This is instead of the previous behaviour of logging the exception and continuing on.

The raised exception provides user (or script) feedback when something goes wrong.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170610

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] ~~Any generated code has been carefully reviewed for correctness and compliance with project standards.~~ No generated code.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
