### PR TITLE
Route Gemini Interactions-API-only STT models through `interactions.create`

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/stt.py
+++ b/homeassistant/components/google_generative_ai_conversation/stt.py
@@ -1,9 +1,15 @@
 """Speech to text support for Google Generative AI."""
 
 from collections.abc import AsyncIterable
-from typing import override
+import io
+from typing import cast, override
 
 from google.genai.errors import APIError, ClientError
+from google.genai.interactions import (
+    AudioContentMimeType,
+    AudioContentParam,
+    TranscriptionConfigParam,
+)
 from google.genai.types import Part
 
 from homeassistant.components import stt
@@ -15,6 +21,17 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import CONF_CHAT_MODEL, DEFAULT_STT_PROMPT, LOGGER, RECOMMENDED_STT_MODEL
 from .entity import GoogleGenerativeAILLMBaseEntity
 from .helpers import convert_to_wav
+
+
+def _model_requires_interactions_api(model: str) -> bool:
+    """Return whether a model is only reachable through the Interactions API.
+
+    Neither the SDK nor Google's model listing API documents a way to
+    detect this from the model itself, so this is a name-based heuristic
+    matched as a substring (not just a suffix) so dated/preview variants
+    like "gemini-3.5-transcribe-preview" are covered too.
+    """
+    return "-transcribe" in model.rsplit("/", maxsplit=1)[-1]
 
 
 async def async_setup_entry(
@@ -238,6 +255,13 @@ class GoogleGenerativeAISttEntity(
                 f"audio/L{metadata.bit_rate.value};rate={metadata.sample_rate.value}",
             )
 
+        model = self.subentry.data.get(CONF_CHAT_MODEL, RECOMMENDED_STT_MODEL)
+
+        if _model_requires_interactions_api(model):
+            return await self._async_transcribe_via_interactions(
+                model, audio_data, metadata
+            )
+
         prompt = self.subentry.data.get(CONF_PROMPT, DEFAULT_STT_PROMPT)
         if metadata.language:
             prompt = (
@@ -248,7 +272,7 @@ class GoogleGenerativeAISttEntity(
 
         try:
             response = await self._genai_client.aio.models.generate_content(
-                model=self.subentry.data.get(CONF_CHAT_MODEL, RECOMMENDED_STT_MODEL),
+                model=model,
                 contents=[
                     prompt,
                     Part.from_bytes(
@@ -267,4 +291,51 @@ class GoogleGenerativeAISttEntity(
                     stt.SpeechResultState.SUCCESS,
                 )
 
+        return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+
+    async def _async_transcribe_via_interactions(
+        self,
+        model: str,
+        audio_data: bytes,
+        metadata: stt.SpeechMetadata,
+    ) -> stt.SpeechResult:
+        """Transcribe audio through the Interactions API.
+
+        Used for models only served this way (not generateContent), like
+        gemini-3.5-transcribe. This API doesn't accept a system prompt or
+        sampling/safety options, so those are skipped.
+        """
+        if self.subentry.data.get(CONF_PROMPT):
+            LOGGER.debug("Ignoring configured STT prompt: not supported by %s", model)
+
+        audio_content: AudioContentParam = {
+            "type": "audio",
+            "data": io.BytesIO(audio_data),
+            "mime_type": cast(AudioContentMimeType, f"audio/{metadata.format.value}"),
+        }
+        transcription_config: TranscriptionConfigParam = {}
+        if metadata.language:
+            transcription_config["language_codes"] = [metadata.language]
+
+        try:
+            interaction = await self._genai_client.aio.interactions.create(
+                model=model,
+                store=False,
+                stream=False,
+                input=[audio_content],
+                generation_config={"transcription_config": transcription_config},
+            )
+        except Exception as err:  # noqa: BLE001
+            # This API has no public exception type to catch narrowly.
+            LOGGER.error("Error during STT: %s", err)
+            return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+
+        # mypy can't narrow create()'s return type here (an SDK typing gap);
+        # the streaming variant can't happen since stream=False.
+        output_text = interaction.output_text  # type: ignore[union-attr]
+        if output_text:
+            return stt.SpeechResult(output_text, stt.SpeechResultState.SUCCESS)
+
+        status = interaction.status  # type: ignore[union-attr]
+        LOGGER.error("STT response contained no text (status=%s)", status)
         return stt.SpeechResult(None, stt.SpeechResultState.ERROR)

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -30,7 +30,7 @@ TEST_PROMPT = "Please transcribe the audio."
 
 
 def _interaction_with_text(text: str) -> interactions.Interaction:
-    """Build an Interaction whose output_text derives to the given text."""
+    """Build an Interaction whose output_text resolves to the given text."""
     return interactions.Interaction(
         status="completed",
         steps=[
@@ -82,9 +82,8 @@ async def setup_integration(
 ) -> None:
     """Set up the test environment.
 
-    The configured chat model defaults to TEST_CHAT_MODEL, but can be
-    overridden with indirect parametrization, e.g.
-    @pytest.mark.parametrize("setup_integration", [OTHER_MODEL], indirect=True)
+    The chat model defaults to TEST_CHAT_MODEL; override it by indirectly
+    parametrizing this fixture.
     """
     model = getattr(request, "param", TEST_CHAT_MODEL)
     config_entry = MockConfigEntry(

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -1,9 +1,9 @@
 """Tests for the Google Generative AI Conversation STT entity."""
 
 from collections.abc import AsyncIterable, Generator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
-from google.genai import types
+from google.genai import interactions, types
 import pytest
 
 from homeassistant.components import stt
@@ -12,6 +12,9 @@ from homeassistant.components.google_generative_ai_conversation.const import (
     DEFAULT_STT_PROMPT,
     DOMAIN,
     RECOMMENDED_STT_MODEL,
+)
+from homeassistant.components.google_generative_ai_conversation.stt import (
+    _model_requires_interactions_api,
 )
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_API_KEY, CONF_PROMPT
@@ -22,7 +25,21 @@ from . import API_ERROR_500, CLIENT_ERROR_BAD_REQUEST
 from tests.common import MockConfigEntry
 
 TEST_CHAT_MODEL = "models/gemini-3.1-flash-lite"
+TEST_INTERACTIONS_MODEL = "models/gemini-3.5-transcribe"
 TEST_PROMPT = "Please transcribe the audio."
+
+
+def _interaction_with_text(text: str) -> interactions.Interaction:
+    """Build an Interaction whose output_text derives to the given text."""
+    return interactions.Interaction(
+        status="completed",
+        steps=[
+            {
+                "type": "model_output",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    )
 
 
 async def _async_get_audio_stream(data: bytes) -> AsyncIterable[bytes]:
@@ -47,6 +64,9 @@ def mock_genai_client() -> Generator[AsyncMock]:
             ]
         )
     )
+    client.aio.interactions.create = AsyncMock(
+        return_value=_interaction_with_text("This is a test transcription.")
+    )
     with patch(
         "homeassistant.components.google_generative_ai_conversation.Client",
         return_value=client,
@@ -58,8 +78,15 @@ def mock_genai_client() -> Generator[AsyncMock]:
 async def setup_integration(
     hass: HomeAssistant,
     mock_genai_client: AsyncMock,
+    request: pytest.FixtureRequest,
 ) -> None:
-    """Set up the test environment."""
+    """Set up the test environment.
+
+    The configured chat model defaults to TEST_CHAT_MODEL, but can be
+    overridden with indirect parametrization, e.g.
+    @pytest.mark.parametrize("setup_integration", [OTHER_MODEL], indirect=True)
+    """
+    model = getattr(request, "param", TEST_CHAT_MODEL)
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_API_KEY: "bla"}, version=2, minor_version=1
     )
@@ -67,7 +94,7 @@ async def setup_integration(
 
     sub_entry = ConfigSubentry(
         data={
-            CONF_CHAT_MODEL: TEST_CHAT_MODEL,
+            CONF_CHAT_MODEL: model,
             CONF_PROMPT: TEST_PROMPT,
         },
         subentry_type="stt",
@@ -97,6 +124,24 @@ async def test_stt_entity_properties(hass: HomeAssistant) -> None:
     assert stt.AudioBitRates.BITRATE_16 in entity.supported_bit_rates
     assert stt.AudioSampleRates.SAMPLERATE_16000 in entity.supported_sample_rates
     assert stt.AudioChannels.CHANNEL_MONO in entity.supported_channels
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        pytest.param("models/gemini-3.5-transcribe", True, id="exact"),
+        pytest.param(
+            "models/gemini-3.5-transcribe-preview", True, id="preview_variant"
+        ),
+        pytest.param("models/gemini-3.5-transcribe-001", True, id="dated_variant"),
+        pytest.param("gemini-3.5-transcribe", True, id="no_models_prefix"),
+        pytest.param(TEST_CHAT_MODEL, False, id="regular_chat_model"),
+        pytest.param(RECOMMENDED_STT_MODEL, False, id="recommended_stt_model"),
+    ],
+)
+def test_model_requires_interactions_api(model: str, expected: bool) -> None:
+    """Test the Interactions-API-only model heuristic."""
+    assert _model_requires_interactions_api(model) is expected
 
 
 @pytest.mark.parametrize(
@@ -143,6 +188,7 @@ async def test_stt_process_audio_stream_success(
         mock_convert_to_wav.assert_not_called()
 
     mock_genai_client.aio.models.generate_content.assert_called_once()
+    mock_genai_client.aio.interactions.create.assert_not_called()
     call_args = mock_genai_client.aio.models.generate_content.call_args
     assert call_args.kwargs["model"] == TEST_CHAT_MODEL
 
@@ -216,6 +262,192 @@ async def test_stt_process_audio_stream_empty_response(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+
+
+@pytest.mark.parametrize(
+    ("setup_integration", "language", "expected_transcription_config"),
+    [
+        pytest.param(
+            TEST_INTERACTIONS_MODEL,
+            "en-US",
+            {"language_codes": ["en-US"]},
+            id="with_language",
+        ),
+        pytest.param(TEST_INTERACTIONS_MODEL, "", {}, id="without_language"),
+    ],
+    indirect=["setup_integration"],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_interactions_success(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    language: str,
+    expected_transcription_config: dict[str, list[str]],
+) -> None:
+    """Test Interactions-API-only models are routed through interactions.create."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+
+    metadata = stt.SpeechMetadata(
+        language=language,
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.text == "This is a test transcription."
+
+    mock_genai_client.aio.models.generate_content.assert_not_called()
+    mock_genai_client.aio.interactions.create.assert_called_once()
+    call_kwargs = mock_genai_client.aio.interactions.create.call_args.kwargs
+
+    assert call_kwargs["model"] == TEST_INTERACTIONS_MODEL
+    assert "system_instruction" not in call_kwargs
+    assert call_kwargs["store"] is False
+    assert call_kwargs["stream"] is False
+
+    [audio_content] = call_kwargs["input"]
+    assert audio_content["type"] == "audio"
+    assert audio_content["data"].read() == b"test_audio_bytes"
+    assert audio_content["mime_type"] == "audio/ogg"
+    assert "sample_rate" not in audio_content
+    assert "channels" not in audio_content
+
+    assert (
+        call_kwargs["generation_config"]["transcription_config"]
+        == expected_transcription_config
+    )
+
+
+@pytest.mark.parametrize(
+    ("audio_format", "expected_convert_calls", "expected_data"),
+    [
+        pytest.param(
+            stt.AudioFormats.WAV,
+            [call(b"test_audio_bytes", "audio/L16;rate=16000")],
+            b"converted_wav_bytes",
+            id="wav",
+        ),
+        pytest.param(
+            stt.AudioFormats.OGG,
+            [],
+            b"test_audio_bytes",
+            id="ogg",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "setup_integration",
+    [pytest.param(TEST_INTERACTIONS_MODEL, id="interactions_model")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_interactions_audio_format(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    audio_format: stt.AudioFormats,
+    expected_convert_calls: list[call],
+    expected_data: bytes,
+) -> None:
+    """Test Interactions-API audio content reflects WAV conversion like generateContent."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+
+    metadata = stt.SpeechMetadata(
+        language="en-US",
+        format=audio_format,
+        codec=stt.AudioCodecs.PCM,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    with patch(
+        "homeassistant.components.google_generative_ai_conversation.stt.convert_to_wav",
+        return_value=b"converted_wav_bytes",
+    ) as mock_convert_to_wav:
+        result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert mock_convert_to_wav.call_args_list == expected_convert_calls
+
+    call_kwargs = mock_genai_client.aio.interactions.create.call_args.kwargs
+    [audio_content] = call_kwargs["input"]
+    assert audio_content["mime_type"] == f"audio/{audio_format.value}"
+    assert audio_content["data"].read() == expected_data
+
+
+@pytest.mark.parametrize(
+    "setup_integration",
+    [pytest.param(TEST_INTERACTIONS_MODEL, id="interactions_model")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_interactions_error(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test STT logs and returns an error when interactions.create raises."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+    mock_genai_client.aio.interactions.create.side_effect = RuntimeError(
+        "Interactions API unavailable"
+    )
+
+    metadata = stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert "Error during STT" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "setup_integration",
+    [pytest.param(TEST_INTERACTIONS_MODEL, id="interactions_model")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_process_audio_stream_interactions_no_text(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test STT logs the interaction status when there is no output text."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+    mock_genai_client.aio.interactions.create.return_value = interactions.Interaction(
+        status="failed", steps=[]
+    )
+
+    metadata = stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    result = await entity.async_process_audio_stream(metadata, audio_stream)
+
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert "STT response contained no text (status=failed)" in caplog.text
 
 
 @pytest.mark.usefixtures("mock_genai_client")


### PR DESCRIPTION
## Proposed change

- `generateContent` silently fails for STT models only served through Google's newer Interactions API. This is namely `gemini-3.5-transcribe` (see #180386 for the related silent-failure logging gap)
- Models whose name contains `-transcribe` are now routed through `client.aio.interactions.create` instead of `generateContent`
- Transcription-only models reject both `system_instruction` and `sample_rate`/`channels` on a WAV/OGG `audio_content`, so neither is sent on this path; the configured STT prompt does not apply to these models (now logged at debug level when ignored)
- Verified end-to-end against the real Interactions API with a live Gemini API key (both WAV and OGG), and further verified live against my personal Home Assistant instance.

Possible follow-ups (not included here):
- `transcription_config.custom_vocabulary` (bias recognition toward specific terms, e.g. entity/brand names) could be exposed as a config option for these models or suggested for the user to add manually. See https://ai.google.dev/gemini-api/docs/transcribe#custom-vocabulary

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #180388
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
