### PR TITLE
Poll the myStrom motion sensor readings

### DIFF
--- a/homeassistant/components/mystrom/sensor.py
+++ b/homeassistant/components/mystrom/sensor.py
@@ -1,10 +1,12 @@
 """Support for myStrom sensors of switches/plugs."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+import logging
 from typing import Any, override
 
+from pymystrom.exceptions import MyStromConnectionError
 from pymystrom.pir import MyStromPir
 from pymystrom.switch import MyStromSwitch
 
@@ -29,12 +31,17 @@ from homeassistant.util.dt import utcnow
 from .const import DOMAIN, MANUFACTURER
 from .models import MyStromConfigEntry
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True)
 class MyStromSensorEntityDescription[_DeviceT](SensorEntityDescription):
     """Class describing mystrom sensor entities."""
 
     value_fn: Callable[[_DeviceT], float | None]
+    # Only needed where nothing else on the device polls; a switch is kept
+    # fresh by its own entity refreshing the shared device.
+    update_fn: Callable[[_DeviceT], Coroutine[Any, Any, None]] | None = None
 
 
 SENSOR_TYPES_PIR: tuple[MyStromSensorEntityDescription[MyStromPir], ...] = (
@@ -50,6 +57,7 @@ SENSOR_TYPES_PIR: tuple[MyStromSensorEntityDescription[MyStromPir], ...] = (
                 else None
             )
         ),
+        update_fn=lambda device: device.get_temperatures(),
     ),
     MyStromSensorEntityDescription(
         key="illuminance",
@@ -61,6 +69,7 @@ SENSOR_TYPES_PIR: tuple[MyStromSensorEntityDescription[MyStromPir], ...] = (
                 float(device.intensity) if device.intensity is not None else None
             )
         ),
+        update_fn=lambda device: device.get_light(),
     ),
 )
 
@@ -179,6 +188,20 @@ class MyStromSensor[_DeviceT](MyStromSensorBase):
     def native_value(self) -> float | None:
         """Return the value of the sensor."""
         return self.entity_description.value_fn(self.device)
+
+    async def async_update(self) -> None:
+        """Get the latest reading from the device."""
+        if (update_fn := self.entity_description.update_fn) is None:
+            return
+
+        try:
+            await update_fn(self.device)
+        except MyStromConnectionError:
+            if self.available:
+                self._attr_available = False
+                _LOGGER.error("No route to myStrom device")
+        else:
+            self._attr_available = True
 
 
 class MyStromSwitchUptimeSensor(MyStromSensorBase):

--- a/tests/components/mystrom/test_sensor.py
+++ b/tests/components/mystrom/test_sensor.py
@@ -1,0 +1,39 @@
+"""Test the myStrom sensors."""
+
+from datetime import timedelta
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.core import HomeAssistant
+
+from .test_init import init_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_pir_sensors_are_polled(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the motion sensor readings are refreshed while polling."""
+    await init_integration(hass, config_entry, 110)
+
+    device = config_entry.runtime_data.device
+    assert hass.states.get("sensor.mystrom_device_temperature").state == "24.87"
+    assert hass.states.get("sensor.mystrom_device_illuminance").state == "16.0"
+
+    # The mock only reports readings once they have been fetched, and nothing
+    # else talks to a motion sensor, so this stays cleared unless the sensors
+    # fetch them themselves.
+    device._requested_state = False
+    device._state["temperature_compensated"] = 21.5
+    device._state["intensity"] = 42
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert device._requested_state is True
+    assert hass.states.get("sensor.mystrom_device_temperature").state == "21.5"
+    assert hass.states.get("sensor.mystrom_device_illuminance").state == "42.0"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The myStrom motion sensor's temperature and illuminance readings only ever come from the fetch done during setup. They then stay put until the entry is reloaded, and `homeassistant.update_entity` does nothing for them.

`MyStromSensor` has no `async_update`; `native_value` just reads an attribute off the device object through `value_fn`. That goes unnoticed on a switch, because `switch.py` polls `get_state()` on the same shared device object and refreshes those attributes along the way. A motion sensor sets up `PLATFORMS_MOTION_SENSOR = [Platform.SENSOR]` and nothing else, so nothing ever talks to it again. It also explains why `homeassistant.update_entity` has no effect: the default polling calls an `async_update` that does not exist.

The two readings come from different endpoints in the library, `get_light()` for the intensity and `get_temperatures()` for the compensated temperature, so the fetch is attached to the entity description. Each sensor makes exactly one request per poll, and the switch descriptions leave `update_fn` unset so nothing changes for them.

A connection error marks the sensor unavailable and logs once, matching what the switch entity already does.

Note on the test. The obvious version, changing the mocked reading and asserting the sensor follows it, passes without this change, because the mock's properties read its state dict live, so it only tests the mock. It asserts the device is actually refreshed instead, which the mock exposes, and that version does fail without the change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180123
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
