### PR TITLE
Wait for the EHEIM Digital main device data before setting up

### DIFF
--- a/homeassistant/components/eheimdigital/coordinator.py
+++ b/homeassistant/components/eheimdigital/coordinator.py
@@ -23,6 +23,8 @@ type AsyncSetupDeviceEntitiesCallback = Callable[[dict[str, EheimDigitalDevice]]
 
 type EheimDigitalConfigEntry = ConfigEntry[EheimDigitalUpdateCoordinator]
 
+MAIN_DEVICE_TIMEOUT = 2
+
 
 class EheimDigitalUpdateCoordinator(
     DataUpdateCoordinator[dict[str, EheimDigitalDevice]]
@@ -43,6 +45,7 @@ class EheimDigitalUpdateCoordinator(
             update_interval=DEFAULT_SCAN_INTERVAL,
         )
         self.main_device_added_event = asyncio.Event()
+        self.main_device_complete_event = asyncio.Event()
         self.hub = EheimDigitalHub(
             host=self.config_entry.data[CONF_HOST],
             session=async_get_clientsession(hass),
@@ -83,7 +86,13 @@ class EheimDigitalUpdateCoordinator(
             if device_address in self.incomplete_devices:
                 self.incomplete_devices.remove(device_address)
 
+    def _async_check_main_device_complete(self) -> None:
+        """Flag the main device as ready once the rest of its data arrived."""
+        if (main := self.hub.main) is not None and not main.is_missing_data:
+            self.main_device_complete_event.set()
+
     async def _async_receive_callback(self) -> None:
+        self._async_check_main_device_complete()
         if any(self.incomplete_devices):
             for device_address in self.incomplete_devices.copy():
                 if not self.hub.devices[device_address].is_missing_data:
@@ -96,13 +105,19 @@ class EheimDigitalUpdateCoordinator(
     async def _async_setup(self) -> None:
         try:
             await self.hub.connect()
-            async with asyncio.timeout(2):
+            async with asyncio.timeout(MAIN_DEVICE_TIMEOUT):
                 # This event gets triggered when the first message is received from
                 # the device, it contains the data necessary to create the main device.
                 # This removes the race condition where the main device is accessed
                 # before the response from the device is parsed.
                 await self.main_device_added_event.wait()
             await self.hub.update()
+            async with asyncio.timeout(MAIN_DEVICE_TIMEOUT):
+                # A device is announced as soon as it is seen, but the packet
+                # carrying the values its device entry is built from can arrive
+                # after that, so wait for the rest of the main device as well.
+                self._async_check_main_device_complete()
+                await self.main_device_complete_event.wait()
         except (TimeoutError, EheimDigitalClientError) as err:
             raise ConfigEntryNotReady from err
 

--- a/tests/components/eheimdigital/test_init.py
+++ b/tests/components/eheimdigital/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the init module."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from eheimdigital.types import EheimDeviceType, EheimDigitalClientError
@@ -142,3 +143,32 @@ async def test_child_device_via_device(
     )
     assert child_device is not None
     assert child_device.via_device_id == main_device.id
+
+
+async def test_entry_setup_retries_on_incomplete_main_device(
+    hass: HomeAssistant,
+    eheimdigital_hub_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    filter_mock: MagicMock,
+) -> None:
+    """Test setup is retried while the main device is still missing data."""
+    # A filter announces itself before its data packet arrives, and the device
+    # entry cannot be built until it has, so setting up has to wait for it.
+    filter_mock.filter_data = None
+    eheimdigital_hub_mock.return_value.main = filter_mock
+
+    def _announce_main_device(*args: Any, **kwargs: Any) -> None:
+        """Report the main device the way the library does on connect."""
+        eheimdigital_hub_mock.call_args.kwargs["main_device_added_event"].set()
+
+    eheimdigital_hub_mock.return_value.connect.side_effect = _announce_main_device
+
+    # The real events are needed here, since the point is that one of them is
+    # never set while the data is still missing.
+    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.eheimdigital.coordinator.MAIN_DEVICE_TIMEOUT", 0
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since 2026.8 the config entry can fail to set up with `EheimDigitalDataMissingError`, and it lands in `setup_error` rather than `setup_retry`, so Home Assistant never retries it on its own. The reporter's entry stayed dead across four manual reloads and a power cycle of the filter.

`_async_setup` waits for `main_device_added_event`, which the library sets once the first packet has been parsed. For a filter that packet is `USRDTA`, and the model the device entry is built from only comes with the later `FILTER_DATA` packet. From the reported debug log:

```
23:45:39.466 Received usrdta packet
23:45:39.471 Finished fetching eheimdigital data     <-- first refresh done, setup continues
23:45:39.486 Received packet FILTER_DATA             <-- 15 ms too late
```

`async_setup_entry` then registers the main device, `async_device_info` reads `device.model_name`, and `filter_model_name` raises because `filter_data` is still `None`. That exception is not a `ConfigEntryNotReady`, so the entry is marked as failed for good.

Setting up now waits for the rest of the main device as well, using the integration's own `is_missing_data`. For a filter that is exactly `filter_data is None`, the same condition that makes `model_name` raise, and the coordinator already relies on it to defer incomplete devices in `_async_device_found`. It is driven off the existing receive callback, with an inline check first so a device that already has everything never waits.

Two notes for review:

The wait is placed after `hub.update()` on purpose. If that call is what prompts the device to send the remaining data, waiting before it would deadlock every setup. Should the placement still be wrong in some setup, the existing `TimeoutError` handler turns it into `ConfigEntryNotReady`, so the worst case is a retry rather than the current permanent failure.

I have no EHEIM hardware, so I cannot reproduce the timing itself. What the test covers is the part that matters: a main device whose data has not arrived leaves the entry in `setup_retry` instead of `setup_error`. It needs real `asyncio.Event` objects, since the shared test helper replaces them with `AsyncMock` and no wait would block.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180350
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
