### PR TITLE
Bump simplisafe-python to 2026.06.0

### DIFF
--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["simplipy"],
-  "requirements": ["simplisafe-python==2024.01.0"]
+  "requirements": ["simplisafe-python==2026.06.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3081,7 +3081,7 @@ simplehound==0.3
 simplepush==2.2.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==2024.01.0
+simplisafe-python==2026.06.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.1.4


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `simplisafe-python` from 2024.01.0 to 2026.06.0.

The websocket listener crashes with `KeyError: 'playback/hls'` roughly every two hours, forcing a reconnect of the real time event channel:

```
ERROR (MainThread) [homeassistant.components.simplisafe] Unexpected error in websocket loop: 'playback/hls'
  File ".../simplipy/websocket.py", line 207, in __post_init__
KeyError: 'playback/hls'
```

The pinned release builds the media URLs by indexing the links directly, so an event that carries no HLS playback link raises. The new release reads them with `links.get("playback/hls") or {}` instead, which I confirmed in the installed build.

- PyPI: https://pypi.org/project/simplisafe-python/2026.6.0/
- Release notes: https://github.com/bachya/simplisafe-python/releases/tag/2026.06.0
- Diff: https://github.com/bachya/simplisafe-python/compare/2024.01.0...2026.06.0

This is a single release step. The library was dormant between the two, so there is nothing in between to work through.

What it contains:

- fix: handle missing `playback/hls` gracefully in `WebsocketEvent` (bachya/simplisafe-python#1145), the crash reported here
- fix: handle missing sensor fields gracefully, `KeyError: 'name'` (bachya/simplisafe-python#1155)
- new websocket event types for RF interference, successful base station updates and camera recordings, all additive
- dependency and tooling maintenance

No changes are needed on the Home Assistant side. The only signature change is `media_urls` widening from `dict[str, str] | None` to `dict[str, str | None] | None`, and this integration never reads `media_urls`. The existing tests pass against the new release.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179776
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
