### PR TITLE
Report a color mode for WiZ bulbs that send no color values

### DIFF
--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -116,6 +116,13 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         elif ColorMode.RGBW in color_modes and (rgbw := state.get_rgbw()) is not None:
             self._attr_color_mode = ColorMode.RGBW
             self._attr_rgbw_color = rgbw
+        elif len(color_modes) == 1:
+            self._attr_color_mode = next(iter(color_modes))
+        else:
+            # The bulb reports none of the values a color mode is picked from,
+            # so with more than one to choose from it cannot be told which is
+            # active.
+            self._attr_color_mode = ColorMode.UNKNOWN
 
         self._attr_effect = effect = state.get_scene()
         if effect is not None:

--- a/tests/components/wiz/test_light.py
+++ b/tests/components/wiz/test_light.py
@@ -1,6 +1,6 @@
 """Tests for light platform."""
 
-from pywizlight import PilotBuilder
+from pywizlight import PilotBuilder, PilotParser
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -10,6 +10,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -27,6 +28,7 @@ from . import (
     FAKE_RGBW_BULB,
     FAKE_RGBWW_BULB,
     FAKE_TURNABLE_BULB,
+    _mocked_wizlight,
     async_push_update,
     async_setup_integration,
 )
@@ -234,3 +236,17 @@ async def test_old_firmware_dimmable_light(hass: HomeAssistant) -> None:
     )
     pilot: PilotBuilder = bulb.turn_on.mock_calls[0][1][0]
     assert pilot.pilot_params == {"dimming": 100}
+
+
+async def test_light_without_any_color_state(hass: HomeAssistant) -> None:
+    """Test a light reporting no color values still reports a color mode."""
+    bulb = _mocked_wizlight(None, None, FAKE_RGBWW_BULB)
+    # A bulb can report being on without any of the values the color mode is
+    # otherwise picked from, and there is no color mode to fall back on for a
+    # bulb that supports more than one.
+    bulb.state = PilotParser({"mac": FAKE_MAC, "state": True, "dimming": 100})
+    await async_setup_integration(hass, wizlight=bulb, bulb_type=FAKE_RGBWW_BULB)
+
+    state = hass.states.get("light.mock_title")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.UNKNOWN


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A WiZ bulb can end up without a color mode, which the light platform refuses while the light is on:

```
homeassistant.exceptions.HomeAssistantError: light.wiz_ambilight
(<class 'homeassistant.components.wiz.light.WizBulbEntity'>) does not report a color mode
```

`_async_update_attrs` only assigns `_attr_color_mode` inside its branches, from a state carrying a color temp, an RGBWW value or an RGBW value, or from an active scene. `__init__` pre-sets one only when the bulb supports a single color mode. A bulb supporting several that reports a state with none of those values is therefore left without one.

It is worse than the reported update error. Hitting this on the first state means the entity is never added at all:

```
ERROR (MainThread) [homeassistant.components.light] Error adding entity light.mock_title for domain light with platform wiz
homeassistant.exceptions.HomeAssistantError: ... does not report a color mode
```

The fallback is `ColorMode.UNKNOWN`, documented as "Ambiguous color mode", which is exactly the situation: the state does not say which mode is active. `state_attributes` rejects only `None`, and `__validate_color_mode` returns early for `UNKNOWN`, so it is a mode the platform accepts by design. `zwave_js` already handles the same situation the same way, single supported mode where there is one and `UNKNOWN` otherwise, so this mirrors it rather than inventing a preference between the modes a bulb happens to support.

Two things I ruled out on the way, in case they come up in review:

Falling back to `BRIGHTNESS` or `ONOFF` does not work. `filter_supported_color_modes` drops those once richer modes are present, so a color bulb supports only `{RGBWW, COLOR_TEMP}` and setting either raises `set to unsupported color mode`.

The existing scene branch, which does set `BRIGHTNESS` or `ONOFF`, is not affected by that. `__validate_color_mode` takes the active effect into account and allows those two on top of the supported modes while an effect is running.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178295
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
