### PR TITLE
Stop a template render warning about an invalid decimal literal

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -13,6 +13,7 @@ import re
 import sys
 from types import CodeType
 from typing import TYPE_CHECKING, Any, Literal, Self, overload, override
+import warnings
 import weakref
 
 import jinja2
@@ -271,7 +272,12 @@ def _cached_parse_result(render_result: str) -> Any:
     # every render. Catching here caches that outcome (return the original
     # render) so the recompile only happens once per distinct result.
     try:
-        result = literal_eval(render_result)
+        with warnings.catch_warnings():
+            # A render such as "7.0in" is not a literal, but it does make the
+            # tokenizer warn about an invalid decimal literal on its way to
+            # raising, which would otherwise reach the log.
+            warnings.simplefilter("ignore", SyntaxWarning)
+            result = literal_eval(render_result)
     except ValueError, TypeError, SyntaxError, MemoryError:
         return render_result
     if type(result) in RESULT_WRAPPERS:

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import gc
 from unittest.mock import patch
+import warnings
 
 from freezegun import freeze_time
 import pytest
@@ -989,3 +990,14 @@ def test_template_output_exceeds_maximum_size(hass: HomeAssistant) -> None:
     """Test template output exceeds maximum size."""
     with pytest.raises(TemplateError):
         render(hass, "{{ 'a' * 1024 * 257 }}")
+
+
+async def test_parse_result_does_not_warn(hass: HomeAssistant) -> None:
+    """Test a render that is not a literal does not warn while being parsed."""
+    # Appending a unit straight onto a number reads as an invalid decimal
+    # literal to the tokenizer, which warns on its way to refusing it.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert template.Template("{{ 7.0 }}in", hass).async_render() == "7.0in"
+
+    assert [str(warning.message) for warning in caught] == []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Appending a unit straight onto a number in a template logs a warning, even though the template renders exactly as intended:

```yaml
message: >
  {{ AMOUNT }}in
```

```
<unknown>:1: SyntaxWarning: invalid decimal literal
```

A render is passed through `literal_eval` so that numeric results come back as numbers. `"7.0in"` is not a Python literal, but the tokenizer warns about an invalid decimal literal on its way to raising `SyntaxError`. The raise is caught and the original render is returned, which is correct, but the warning is not caught and reaches `py.warnings`. Leaving a space before the unit avoids it, which is not much of an answer for a template that already works.

The warning is ignored while parsing.

Since this is `_cached_parse_result`, I measured the cost rather than assuming it:

| case | plain | wrapped |
|---|---|---|
| `literal_eval` that warns and raises | 9.37 us | 6.75 us |
| `literal_eval` that succeeds | 2.91 us | 4.70 us |

Suppressing is faster where the warning would be emitted, because emitting one costs more than copying the filters. The remaining cost lands only on `lru_cache` misses, so it is once per distinct render result rather than once per render; the common plain states are parsed once ever.

One tradeoff worth stating: `warnings.catch_warnings()` changes global filter state and is not thread safe, so a warning raised by another thread inside that window could be missed. There is precedent for it in core, and templates render on the event loop, but this is the hottest place it would be used. The alternative is to check the render more strictly before attempting `literal_eval` at all, which avoids the global state at the cost of more code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179754
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
