### PR TITLE
Ensure gardena image goes back to unknown on render fails

### DIFF
--- a/homeassistant/components/gardena_bluetooth/image.py
+++ b/homeassistant/components/gardena_bluetooth/image.py
@@ -97,7 +97,7 @@ class GardenaBluetoothImage(GardenaBluetoothEntity, ImageEntity):
     def _handle_coordinator_update(self) -> None:
         if (image := self._render()) != self._image:
             self._image = image
-            self._attr_image_last_updated = dt_util.utcnow()
+            self._attr_image_last_updated = dt_util.utcnow() if image else None
         super()._handle_coordinator_update()
 
     @override

--- a/homeassistant/components/gardena_bluetooth/image.py
+++ b/homeassistant/components/gardena_bluetooth/image.py
@@ -100,6 +100,14 @@ class GardenaBluetoothImage(GardenaBluetoothEntity, ImageEntity):
             self._attr_image_last_updated = dt_util.utcnow() if image else None
         super()._handle_coordinator_update()
 
+    @property
+    @override
+    def entity_picture(self) -> str | None:
+        """Return a link to the image, or none while there is nothing to show."""
+        if self._image is None:
+            return None
+        return super().entity_picture
+
     @override
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""

--- a/tests/components/gardena_bluetooth/snapshots/test_image.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_image.ambr
@@ -254,7 +254,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_4?token=1',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 4',
     }),
     'context': <ANY>,
@@ -306,7 +305,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.mock_title_contour_5?token=1',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Contour 5',
     }),
     'context': <ANY>,

--- a/tests/components/gardena_bluetooth/test_image.py
+++ b/tests/components/gardena_bluetooth/test_image.py
@@ -154,6 +154,7 @@ async def test_image_without_contour(
     state = hass.states.get("image.mock_title_contour_4")
     assert state
     assert state.state == "unknown"
+    assert "entity_picture" not in state.attributes
 
     client = await hass_client()
     resp = await client.get("/api/image_proxy/image.mock_title_contour_4")
@@ -175,6 +176,7 @@ async def test_contour_cleared_after_being_present(
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.state != "unknown"
+    assert "entity_picture" in state.attributes
 
     client = await hass_client()
     resp = await client.get(f"/api/image_proxy/{ENTITY_ID}")
@@ -187,6 +189,7 @@ async def test_contour_cleared_after_being_present(
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.state == "unknown"
+    assert "entity_picture" not in state.attributes
 
     resp = await client.get(f"/api/image_proxy/{ENTITY_ID}")
     assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR

--- a/tests/components/gardena_bluetooth/test_image.py
+++ b/tests/components/gardena_bluetooth/test_image.py
@@ -160,6 +160,38 @@ async def test_image_without_contour(
     assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+@pytest.mark.usefixtures("mock_contours")
+async def test_contour_cleared_after_being_present(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_read_char_raw: dict[str, bytes | Exception],
+    scan_step: Callable[[], Awaitable[None]],
+) -> None:
+    """Test a contour that is taught and then cleared goes back to unknown."""
+    await setup_entry(
+        hass, platforms=[Platform.IMAGE], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state != "unknown"
+
+    client = await hass_client()
+    resp = await client.get(f"/api/image_proxy/{ENTITY_ID}")
+    assert resp.status == HTTPStatus.OK
+
+    mock_read_char_raw[AquaContourContours.contour_points_1.unique_id] = b""
+    for _ in range(SEGMENTED_SCAN_COUNT):
+        await scan_step()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == "unknown"
+
+    resp = await client.get(f"/api/image_proxy/{ENTITY_ID}")
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
 async def test_active_contour_follows_position(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure the image goes to unknown when when a render update fails and does not expose a broken entity picture.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
