### PR TITLE
Report a sleeping Roborock Q7 job as paused

### DIFF
--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -75,6 +75,9 @@ Q7_STATE_CODE_TO_STATE = {
     WorkStatusMapping.SLEEPING: VacuumActivity.IDLE,
     WorkStatusMapping.WAITING_FOR_ORDERS: VacuumActivity.IDLE,
     WorkStatusMapping.PAUSED: VacuumActivity.PAUSED,
+    # An untouched pause falls asleep after ~10 minutes; the job is kept and
+    # resumes on the next start, so this is a pause rather than an idle state.
+    WorkStatusMapping.WORKING_SLEEP: VacuumActivity.PAUSED,
     WorkStatusMapping.DOCKING: VacuumActivity.RETURNING,
     WorkStatusMapping.CHARGING: VacuumActivity.DOCKED,
     WorkStatusMapping.SWEEP_MOPING: VacuumActivity.CLEANING,

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, call
 
 import pytest
 from roborock import RoborockException
+from roborock.data import WorkStatusMapping
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXFanLevel
 from roborock.roborock_typing import RoborockCommand
 from syrupy.assertion import SnapshotAssertion
@@ -888,6 +889,26 @@ async def test_q7_activity_none_status(
     vacuum = hass.states.get(Q7_ENTITY_ID)
     assert vacuum
     assert vacuum.state == "unknown"
+
+
+async def test_q7_working_sleep_is_paused(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_q7_vacuum: FakeDevice,
+) -> None:
+    """Test a cleaning job that fell asleep is reported as paused."""
+    assert fake_q7_vacuum.b01_q7_properties is not None
+    fake_q7_vacuum.b01_q7_properties._props_data.status = (
+        WorkStatusMapping.WORKING_SLEEP
+    )
+
+    coordinator = setup_entry.runtime_data.b01_q7[0]
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    vacuum = hass.states.get(Q7_ENTITY_ID)
+    assert vacuum
+    assert vacuum.state == "paused"
 
 
 @pytest.fixture(name="q10_vacuum_api", autouse=False)


### PR DESCRIPTION
The Q7 turns an untouched pause into WORKING_SLEEP after about ten minutes. The status had no entry in Q7_STATE_CODE_TO_STATE, so the vacuum entity fell back to an unknown state.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`WorkStatusMapping.WORKING_SLEEP` (code 11) had no entry in `Q7_STATE_CODE_TO_STATE`, so `activity` returned `None` and the vacuum entity fell back to `unknown` whenever the device reported it.

Code 11 is the dormant form of a paused job. Verified on a physical Q7 L5+:

* A pause that is left untouched turns into `working_sleep` after about ten minutes, twice reproduced, without docking and without the pause being cancelled.
* On the next `vacuum.start` the device goes `working_sleep` -> `paused` -> cleaning: it restores the paused state before resuming, and the robot continues where it stopped.
* The cleaning counters keep accumulating across the sleep (1 min at the first pause, 4 min at the second after ~3 min of resumed cleaning) rather than restarting, so the job survives.
* The Roborock app labels the state "Sleeping" but keeps showing the running job's timer and area, so it treats it as a suspended job too.

It is specific to an open job: a *finished* job parked outside the dock reported `waiting_for_orders` for ~16 minutes and then `sleeping`, never `working_sleep`. Mapping code 11 to `PAUSED` therefore never claims a job that is already done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177387
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The library half of #177387 is already released: python-roborock added `WORKING_SLEEP` in 7.1.1, which is the version pinned in the manifest, so the `ValueError` is gone. Without this mapping the entity still ends up `unknown` for the same status, which is what this PR fixes.

`WorkStatusMapping.UNKNOWN` (-1) is deliberately left unmapped: the library returns it as a sentinel for any status code it does not model, so `unknown` is the correct representation for it.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)