### PR TITLE
Add endpoint device tree benchmark snapshots for multi-endpoint Z-Wave devices

### DIFF
--- a/tests/components/zwave_js/snapshots/test_endpoint_benchmarks.ambr
+++ b/tests/components/zwave_js/snapshots/test_endpoint_benchmarks.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_fibaro_fgr223_device_tree
+# name: test_device_tree[fibaro_fgr223]
   dict({
     'child_devices': list([
     ]),
@@ -354,7 +354,7 @@
     }),
   })
 # ---
-# name: test_heatit_z_trm2fx_device_tree
+# name: test_device_tree[heatit_z_trm2fx]
   dict({
     'child_devices': list([
     ]),
@@ -579,7 +579,7 @@
     }),
   })
 # ---
-# name: test_heatit_z_trm3_device_tree
+# name: test_device_tree[heatit_z_trm3]
   dict({
     'child_devices': list([
     ]),
@@ -764,7 +764,7 @@
     }),
   })
 # ---
-# name: test_heatit_z_trm6_device_tree
+# name: test_device_tree[heatit_z_trm6]
   dict({
     'child_devices': list([
     ]),
@@ -1059,7 +1059,7 @@
     }),
   })
 # ---
-# name: test_inovelli_lzw36_device_tree
+# name: test_device_tree[inovelli_lzw36]
   dict({
     'child_devices': list([
     ]),
@@ -1349,7 +1349,7 @@
     }),
   })
 # ---
-# name: test_merten_507801_device_tree
+# name: test_device_tree[merten_507801]
   dict({
     'child_devices': list([
     ]),
@@ -1469,7 +1469,7 @@
     }),
   })
 # ---
-# name: test_shelly_qnsh_001p10_device_tree
+# name: test_device_tree[shelly_qnsh_001p10]
   dict({
     'child_devices': list([
     ]),
@@ -1784,7 +1784,7 @@
     }),
   })
 # ---
-# name: test_vision_zl7432_device_tree
+# name: test_device_tree[vision_zl7432]
   dict({
     'child_devices': list([
     ]),

--- a/tests/components/zwave_js/snapshots/test_endpoint_benchmarks.ambr
+++ b/tests/components/zwave_js/snapshots/test_endpoint_benchmarks.ambr
@@ -1,0 +1,1871 @@
+# serializer version: 1
+# name: test_fibaro_fgr223_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.test_location_fgr_223_test_cover_over_current_detected',
+          'original_name': 'Over-current detected',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.test_location_fgr_223_test_cover_system_hardware_failure_with_failure_code',
+          'original_name': 'System hardware failure (with failure code)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.test_location_fgr_223_test_cover_idle_power_management_over_current_status',
+          'original_name': 'Idle Power Management Over-current status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.test_location_fgr_223_test_cover_idle_system_hardware_status',
+          'original_name': 'Idle System Hardware status',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.test_location_fgr_223_test_cover_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.test_location_fgr_223_test_cover_reset_accumulated_values',
+          'original_name': 'Reset accumulated values',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'cover.test_location_fgr_223_test_cover',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'cover.test_location_fgr_223_test_cover_2',
+          'original_name': '(2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_1_event_state_parameters',
+          'original_name': 'Alarm #1: Event/State Parameters',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_1_notification_status',
+          'original_name': 'Alarm #1: Notification Status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_1_notification_type',
+          'original_name': 'Alarm #1: Notification Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_2_event_state_parameters',
+          'original_name': 'Alarm #2: Event/State Parameters',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_2_notification_status',
+          'original_name': 'Alarm #2: Notification Status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_2_notification_type',
+          'original_name': 'Alarm #2: Notification Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_3_event_state_parameters',
+          'original_name': 'Alarm #3: Event/State Parameters',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_3_notification_status',
+          'original_name': 'Alarm #3: Notification Status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_3_notification_type',
+          'original_name': 'Alarm #3: Notification Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_4_event_state_parameters',
+          'original_name': 'Alarm #4: Event/State Parameters',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_4_notification_status',
+          'original_name': 'Alarm #4: Notification Status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_4_notification_type',
+          'original_name': 'Alarm #4: Notification Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_5_event_state_parameters',
+          'original_name': 'Alarm #5: Event/State Parameters',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_5_notification_status',
+          'original_name': 'Alarm #5: Notification Status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_alarm_5_notification_type',
+          'original_name': 'Alarm #5: Notification Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_delay_motor_stop',
+          'original_name': 'Delay motor stop',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_energy_reports_on_change',
+          'original_name': 'Energy reports - on change',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_energy_reports_periodic',
+          'original_name': 'Energy reports - periodic',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_motor_operation_detection',
+          'original_name': 'Motor operation detection',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_power_reports_on_change',
+          'original_name': 'Power reports - on change',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_power_reports_periodic',
+          'original_name': 'Power reports - periodic',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_time_of_down_movement',
+          'original_name': 'Time of down movement',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_time_of_up_movement',
+          'original_name': 'Time of up movement',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.test_location_fgr_223_test_cover_venetian_blind_time_of_full_turn_of_the_slats',
+          'original_name': 'Venetian blind - time of full turn of the slats',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_alarm_1_action',
+          'original_name': 'Alarm #1: Action',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_alarm_2_action',
+          'original_name': 'Alarm #2: Action',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_alarm_3_action',
+          'original_name': 'Alarm #3: Action',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_alarm_4_action',
+          'original_name': 'Alarm #4: Action',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_alarm_5_action',
+          'original_name': 'Alarm #5: Action',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_force_calibration',
+          'original_name': 'Force calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_inputs_orientation',
+          'original_name': 'Inputs orientation',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.test_location_fgr_223_test_cover_local_protection_state',
+          'original_name': 'Local protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_measuring_power_consumed_by_the_device_itself',
+          'original_name': 'Measuring power consumed by the device itself',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_operating_mode',
+          'original_name': 'Operating mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_outputs_orientation',
+          'original_name': 'Outputs orientation',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.test_location_fgr_223_test_cover_rf_protection_state',
+          'original_name': 'RF protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_set_slats_back_to_previous_position',
+          'original_name': 'Set slats back to previous position',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.test_location_fgr_223_test_cover_switch_type',
+          'original_name': 'Switch type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_alarm_level',
+          'original_name': 'Alarm Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_alarm_type',
+          'original_name': 'Alarm Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_electric_consumption_kwh',
+          'original_name': 'Electric Consumption [kWh]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_electric_consumption_w',
+          'original_name': 'Electric Consumption [W]',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.test_location_fgr_223_test_cover_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s1_scenes_hold_down_release',
+          'original_name': 'S1 scenes: Hold down / Release',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s1_scenes_pressed_1_time',
+          'original_name': 'S1 scenes: Pressed 1 time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s1_scenes_pressed_2_times',
+          'original_name': 'S1 scenes: Pressed 2 times',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s1_scenes_pressed_3_time',
+          'original_name': 'S1 scenes: Pressed 3 time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s2_scenes_hold_down_release',
+          'original_name': 'S2 scenes: Hold down / Release',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s2_scenes_pressed_1_time',
+          'original_name': 'S2 scenes: Pressed 1 time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s2_scenes_pressed_2_times',
+          'original_name': 'S2 scenes: Pressed 2 times',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'switch.test_location_fgr_223_test_cover_s2_scenes_pressed_3_time',
+          'original_name': 'S2 scenes: Pressed 3 time',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'update.test_location_fgr_223_test_cover_firmware',
+          'original_name': 'Firmware',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-10',
+        'zwave_js:3245146787-10-271:771:4096',
+      ]),
+      'name': 'fgr 223 test cover',
+    }),
+  })
+# ---
+# name: test_heatit_z_trm2fx_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.floor_thermostat_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'climate.floor_thermostat',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'light.floor_thermostat_basic',
+          'original_name': 'Basic',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'light.floor_thermostat_basic_3',
+          'original_name': 'Basic (3)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_air_a2_maximum_temperature_limit_ahi',
+          'original_name': 'Air (A2) maximum temperature limit (AHi)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_air_a2_minimum_temperature_limit_alo',
+          'original_name': 'Air (A2) minimum temperature limit (ALo)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_button_brightness_active_state',
+          'original_name': 'Button brightness - active state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_button_brightness_dimmed_state',
+          'original_name': 'Button brightness - dimmed state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_cooling_setpoint_cool',
+          'original_name': 'Cooling setpoint (COOL)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_display_brightness_active_state',
+          'original_name': 'Display brightness - active state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_display_brightness_dimmed_state',
+          'original_name': 'Display brightness - dimmed state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_energy_saving_mode_setpoint_eco',
+          'original_name': 'Energy saving mode setpoint (ECO)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_external_sensor_calibration',
+          'original_name': 'External sensor calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_maximum_temperature_fhi',
+          'original_name': 'Floor maximum temperature (FHi)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_minimum_temperature_limit_flo',
+          'original_name': 'Floor minimum temperature limit (FLo)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_sensor_calibration',
+          'original_name': 'Floor sensor calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_heating_mode_setpoint_co',
+          'original_name': 'Heating mode setpoint (CO)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_meter_report_delta_value',
+          'original_name': 'Meter report delta value',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_meter_report_interval',
+          'original_name': 'Meter report interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_control_hysteresis_diff_i',
+          'original_name': 'Temperature control hysteresis (DIFF I)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_hysteresis',
+          'original_name': 'Temperature report hysteresis',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_interval',
+          'original_name': 'Temperature report interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_floor_sensor_type',
+          'original_name': 'Floor sensor type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_operation_mode',
+          'original_name': 'Operation mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_sensor_mode',
+          'original_name': 'Sensor mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_temperature_display',
+          'original_name': 'Temperature display',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature',
+          'original_name': 'Air temperature',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature_3',
+          'original_name': 'Air temperature (3)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_electric_consumed_kwh',
+          'original_name': 'Electric Consumed [kWh]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_electric_consumed_v',
+          'original_name': 'Electric Consumed [V]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_electric_consumed_w',
+          'original_name': 'Electric Consumed [W]',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'switch.floor_thermostat',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'update.floor_thermostat_firmware',
+          'original_name': 'Firmware',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-26',
+        'zwave_js:3245146787-26-411:3:514',
+      ]),
+      'name': 'Floor thermostat',
+    }),
+  })
+# ---
+# name: test_heatit_z_trm3_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.floor_thermostat_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'climate.floor_thermostat',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_air_maximum_temperature_limit_ahi',
+          'original_name': 'Air maximum temperature limit (AHi)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_air_minimum_temperature_limit_alo',
+          'original_name': 'Air minimum temperature limit (ALo)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_button_brightness_active_state',
+          'original_name': 'Button brightness - active state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_button_brightness_dimmed_state',
+          'original_name': 'Button brightness - dimmed state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_display_brightness_active_state',
+          'original_name': 'Display brightness - active state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_display_brightness_dimmed_state',
+          'original_name': 'Display brightness - dimmed state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_external_sensor_calibration',
+          'original_name': 'External sensor calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_maximum_temperature_fhi',
+          'original_name': 'Floor maximum temperature (FHi)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_minimum_temperature_limit_flo',
+          'original_name': 'Floor minimum temperature limit (FLo)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_sensor_calibration',
+          'original_name': 'Floor sensor calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_meter_report_delta_value',
+          'original_name': 'Meter report delta value',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_meter_report_interval',
+          'original_name': 'Meter report interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_room_sensor_calibration',
+          'original_name': 'Room sensor calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_control_hysteresis_diff_i',
+          'original_name': 'Temperature control hysteresis (DIFF I)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_hysteresis',
+          'original_name': 'Temperature report hysteresis',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_interval',
+          'original_name': 'Temperature report interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_floor_sensor_type',
+          'original_name': 'Floor sensor type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_sensor_mode',
+          'original_name': 'Sensor mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_temperature_display',
+          'original_name': 'Temperature display',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature',
+          'original_name': 'Air temperature',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature_3',
+          'original_name': 'Air temperature (3)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature_4',
+          'original_name': 'Air temperature (4)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_value_electric_consumed',
+          'original_name': 'Value (Electric, Consumed)',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-24',
+        'zwave_js:3245146787-24-411:3:515',
+      ]),
+      'name': 'Floor thermostat',
+    }),
+  })
+# ---
+# name: test_heatit_z_trm6_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.floor_thermostat_over_load_detected',
+          'original_name': 'Over-load detected',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.floor_thermostat_overheat_detected',
+          'original_name': 'Overheat detected',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.floor_thermostat_identify',
+          'original_name': 'Identify',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.floor_thermostat_idle_heat_alarm_heat_sensor_status',
+          'original_name': 'Idle Heat Alarm Heat sensor status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.floor_thermostat_idle_power_management_over_load_status',
+          'original_name': 'Idle Power Management Over-load status',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.floor_thermostat_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.floor_thermostat_reset_accumulated_values',
+          'original_name': 'Reset accumulated values',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'climate.floor_thermostat',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_active_display_brightness',
+          'original_name': 'Active Display Brightness',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_cooling_setpoint',
+          'original_name': 'Cooling Setpoint',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_eco_setpoint',
+          'original_name': 'Eco Setpoint',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_external_sensor_calibration',
+          'original_name': 'External Sensor Calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_external_sensor_max_temp_limit',
+          'original_name': 'External Sensor Max Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_external_sensor_min_temp_limit',
+          'original_name': 'External Sensor Min Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_sensor_calibration',
+          'original_name': 'Floor Sensor Calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_sensor_max_temp_limit',
+          'original_name': 'Floor Sensor Max Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_floor_sensor_min_temp_limit',
+          'original_name': 'Floor Sensor Min Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_heating_setpoint',
+          'original_name': 'Heating Setpoint',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_indicator_value',
+          'original_name': 'Indicator value',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_internal_sensor_calibration',
+          'original_name': 'Internal Sensor Calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_internal_sensor_max_temp_limit',
+          'original_name': 'Internal Sensor Max Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_internal_sensor_min_temp_limit',
+          'original_name': 'Internal Sensor Min Temp Limit',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_load_power',
+          'original_name': 'Load Power',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_meter_report_interval',
+          'original_name': 'Meter Report Interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_power_regulator_active_time',
+          'original_name': 'Power Regulator Active Time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_standby_display_brightness',
+          'original_name': 'Standby Display Brightness',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_control_hysteresis',
+          'original_name': 'Temperature Control Hysteresis',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_hysteresis',
+          'original_name': 'Temperature Report Hysteresis',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_temperature_report_interval',
+          'original_name': 'Temperature Report Interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_thermostat_state_report_interval',
+          'original_name': 'Thermostat State Report Interval',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.floor_thermostat_turn_on_delay_after_error',
+          'original_name': 'Turn On Delay After Error',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_external_sensor_resistance',
+          'original_name': 'External Sensor Resistance',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_local_control',
+          'original_name': 'Local Control',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.floor_thermostat_local_protection_state',
+          'original_name': 'Local protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_open_window_detection',
+          'original_name': 'Open Window Detection',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_operating_mode',
+          'original_name': 'Operating Mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_regulation_mode',
+          'original_name': 'Regulation Mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_sensor_mode',
+          'original_name': 'Sensor Mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.floor_thermostat_temperature_display',
+          'original_name': 'Temperature Display',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature',
+          'original_name': 'Air temperature',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature_3',
+          'original_name': 'Air temperature (3)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_air_temperature_4',
+          'original_name': 'Air temperature (4)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_alarm_level',
+          'original_name': 'Alarm Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_alarm_type',
+          'original_name': 'Alarm Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_electric_consumption_kwh',
+          'original_name': 'Electric Consumption [kWh]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_electric_consumption_w',
+          'original_name': 'Electric Consumption [W]',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.floor_thermostat_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.floor_thermostat_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'update.floor_thermostat_firmware',
+          'original_name': 'Firmware',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-101',
+        'zwave_js:3245146787-101-411:48:12289',
+      ]),
+      'name': 'Floor Thermostat',
+    }),
+  })
+# ---
+# name: test_inovelli_lzw36_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.family_room_combo_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.family_room_combo_reset_accumulated_values',
+          'original_name': 'Reset accumulated values',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'fan.family_room_combo_2',
+          'original_name': '(2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'light.family_room_combo',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_active_power_reports',
+          'original_name': 'Active Power Reports',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_auto_off_fan_timer',
+          'original_name': 'Auto Off Fan Timer',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_auto_off_light_timer',
+          'original_name': 'Auto Off Light Timer',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_default_light_level_local',
+          'original_name': 'Default Light Level (Local)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_default_light_level_z_wave',
+          'original_name': 'Default Light Level (Z-Wave)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_energy_reports',
+          'original_name': 'Energy Reports',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_indicator_color',
+          'original_name': 'Fan LED Indicator Color',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_effect_color',
+          'original_name': 'Fan LED Strip Effect Color',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_effect_duration',
+          'original_name': 'Fan LED Strip Effect Duration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_effect_intensity',
+          'original_name': 'Fan LED Strip Effect Intensity',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_intensity',
+          'original_name': 'Fan LED Strip Intensity',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_intensity_when_off',
+          'original_name': 'Fan LED Strip Intensity (When OFF)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_led_strip_timeout',
+          'original_name': 'Fan LED Strip Timeout',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_fan_state_after_power_restored',
+          'original_name': 'Fan State After Power Restored',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_dimming_speed',
+          'original_name': 'Light Dimming Speed',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_dimming_speed_from_switch',
+          'original_name': 'Light Dimming Speed (From Switch)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_indicator_color',
+          'original_name': 'Light LED Indicator Color',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_effect_color',
+          'original_name': 'Light LED Strip Effect Color',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_effect_duration',
+          'original_name': 'Light LED Strip Effect Duration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_effect_intensity',
+          'original_name': 'Light LED Strip Effect Intensity',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_intensity',
+          'original_name': 'Light LED Strip Intensity',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_intensity_when_off',
+          'original_name': 'Light LED Strip Intensity (When OFF)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_led_strip_timeout',
+          'original_name': 'Light LED Strip Timeout',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_ramp_rate',
+          'original_name': 'Light Ramp Rate',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_ramp_rate_from_switch',
+          'original_name': 'Light Ramp Rate (From Switch)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_light_state_after_power_restored',
+          'original_name': 'Light State After Power Restored',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_maximum_fan_level',
+          'original_name': 'Maximum Fan Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_maximum_light_level',
+          'original_name': 'Maximum Light Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_minimum_fan_level',
+          'original_name': 'Minimum Fan Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_minimum_light_level',
+          'original_name': 'Minimum Light Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.family_room_combo_periodic_power_energy_reports',
+          'original_name': 'Periodic Power & Energy Reports',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_default_fan_level_local',
+          'original_name': 'Default Fan Level (Local)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_default_fan_level_z_wave',
+          'original_name': 'Default Fan Level (Z-Wave)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_fan_led_strip_effect',
+          'original_name': 'Fan LED Strip Effect',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_instant_on',
+          'original_name': 'Instant On',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_light_led_strip_effect',
+          'original_name': 'Light LED Strip Effect',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.family_room_combo_local_protection',
+          'original_name': 'Local Protection',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.family_room_combo_local_protection_state',
+          'original_name': 'Local protection state',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.family_room_combo_rf_protection_state',
+          'original_name': 'RF protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.family_room_combo_electric_consumed_kwh',
+          'original_name': 'Electric Consumed [kWh]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.family_room_combo_electric_consumed_w',
+          'original_name': 'Electric Consumed [W]',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.family_room_combo_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.family_room_combo_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'update.family_room_combo_firmware',
+          'original_name': 'Firmware',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-19',
+        'zwave_js:3245146787-19-798:14:1',
+      ]),
+      'name': 'family_room_combo',
+    }),
+  })
+# ---
+# name: test_merten_507801_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.connect_roller_shutter_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'cover.connect_roller_shutter',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'cover.connect_roller_shutter_2',
+          'original_name': '(2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.connect_roller_shutter_changeover_delay',
+          'original_name': 'Changeover Delay',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.connect_roller_shutter_travel_time_down_byte_1',
+          'original_name': 'Travel Time Down, Byte 1',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.connect_roller_shutter_travel_time_down_byte_2',
+          'original_name': 'Travel Time Down, Byte 2',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.connect_roller_shutter_travel_time_up_byte_1',
+          'original_name': 'Travel Time Up, Byte 1',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.connect_roller_shutter_travel_time_up_byte_2',
+          'original_name': 'Travel Time Up, Byte 2',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.connect_roller_shutter_local_protection_state',
+          'original_name': 'Local protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.connect_roller_shutter_local_protection_state_2',
+          'original_name': 'Local protection state (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'select.connect_roller_shutter_rf_protection_state',
+          'original_name': 'RF protection state',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.connect_roller_shutter_rf_protection_state_2',
+          'original_name': 'RF protection state (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.connect_roller_shutter_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.connect_roller_shutter_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-41',
+        'zwave_js:3245146787-41-122:32771:1',
+      ]),
+      'name': 'Connect Roller Shutter',
+    }),
+  })
+# ---
+# name: test_shelly_qnsh_001p10_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_over_current_detected',
+          'original_name': 'Over-current detected',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_over_current_detected_2',
+          'original_name': 'Over-current detected (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_overheat_detected',
+          'original_name': 'Overheat detected',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_overheat_detected_2',
+          'original_name': 'Overheat detected (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_system_hardware_failure',
+          'original_name': 'System hardware failure',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'binary_sensor.wave_shutter_system_hardware_failure_2',
+          'original_name': 'System hardware failure (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_identify',
+          'original_name': 'Identify',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_heat_alarm_heat_sensor_status',
+          'original_name': 'Idle Heat Alarm Heat sensor status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_heat_alarm_heat_sensor_status_2',
+          'original_name': 'Idle Heat Alarm Heat sensor status (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_power_management_over_current_status',
+          'original_name': 'Idle Power Management Over-current status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_power_management_over_current_status_2',
+          'original_name': 'Idle Power Management Over-current status (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_system_hardware_status',
+          'original_name': 'Idle System Hardware status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'button.wave_shutter_idle_system_hardware_status_2',
+          'original_name': 'Idle System Hardware status (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_reset_accumulated_values',
+          'original_name': 'Reset accumulated values',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_reset_accumulated_values_2',
+          'original_name': 'Reset accumulated values (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_reset_electric',
+          'original_name': 'Reset (Electric)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.wave_shutter_reset_electric_2',
+          'original_name': 'Reset (Electric) (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'cover.wave_shutter',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'cover.wave_shutter_2',
+          'original_name': '(2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_alarm_conf_co',
+          'original_name': 'Alarm conf. - CO',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_alarm_conf_heat',
+          'original_name': 'Alarm conf. - Heat',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_alarm_conf_smoke',
+          'original_name': 'Alarm conf. - Smoke',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_alarm_conf_water',
+          'original_name': 'Alarm conf. - Water',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_delay_motor_stop',
+          'original_name': 'Delay Motor Stop',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_down_time',
+          'original_name': 'Down time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_factory_reset',
+          'original_name': 'Factory reset',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_indicator_value',
+          'original_name': 'Indicator value',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_motor_moving_time',
+          'original_name': 'Motor Moving Time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_motor_operation_detection',
+          'original_name': 'Motor Operation Detection',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_next_move_delay',
+          'original_name': 'Next move delay',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_power_change_report_threshold',
+          'original_name': 'Power Change Report Threshold',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_power_consumption_measurement_delay',
+          'original_name': 'Power Consumption Measurement Delay',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_slats_turning_time_offset',
+          'original_name': 'Slats turning time offset',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_up_time',
+          'original_name': 'Up time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'number.wave_shutter_venetian_mode_turning_time',
+          'original_name': 'Venetian Mode: Turning Time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_operating_mode',
+          'original_name': 'Operating Mode',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_shutter_calibration',
+          'original_name': 'Shutter Calibration',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_sw1_switch_type',
+          'original_name': 'SW1 Switch Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_swap_inputs',
+          'original_name': 'Swap Inputs',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_swap_outputs',
+          'original_name': 'Swap Outputs',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'select.wave_shutter_venetian_mode_restore_slats_position_after_moving',
+          'original_name': 'Venetian Mode: Restore Slats Position After Moving',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_alarm_level',
+          'original_name': 'Alarm Level',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_alarm_level_2',
+          'original_name': 'Alarm Level (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_alarm_type',
+          'original_name': 'Alarm Type',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_alarm_type_2',
+          'original_name': 'Alarm Type (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.wave_shutter_electric_consumption_kwh',
+          'original_name': 'Electric Consumption [kWh]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.wave_shutter_electric_consumption_kwh_2',
+          'original_name': 'Electric Consumption [kWh] (2)',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.wave_shutter_electric_consumption_w',
+          'original_name': 'Electric Consumption [W]',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.wave_shutter_electric_consumption_w_2',
+          'original_name': 'Electric Consumption [W] (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.wave_shutter_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.wave_shutter_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'update.wave_shutter_firmware',
+          'original_name': 'Firmware',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-5',
+        'zwave_js:3245146787-5-1120:3:130',
+      ]),
+      'name': 'Wave Shutter',
+    }),
+  })
+# ---
+# name: test_vision_zl7432_device_tree
+  dict({
+    'child_devices': list([
+    ]),
+    'node_device': dict({
+      'entities': list([
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'button.in_wall_dual_relay_switch_ping',
+          'original_name': 'Ping',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'light.in_wall_dual_relay_switch_basic',
+          'original_name': 'Basic',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'light.in_wall_dual_relay_switch_basic_2',
+          'original_name': 'Basic (2)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_commands_dropped_rx',
+          'original_name': 'Commands dropped (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_commands_dropped_tx',
+          'original_name': 'Commands dropped (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_last_seen',
+          'original_name': 'Last seen',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_node_status',
+          'original_name': 'Node status',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_round_trip_time',
+          'original_name': 'Round trip time',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_signal_strength',
+          'original_name': 'Signal strength',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_successful_commands_rx',
+          'original_name': 'Successful commands (RX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_successful_commands_tx',
+          'original_name': 'Successful commands (TX)',
+        }),
+        dict({
+          'disabled_by': 'integration',
+          'entity_id': 'sensor.in_wall_dual_relay_switch_timed_out_responses',
+          'original_name': 'Timed out responses',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'switch.in_wall_dual_relay_switch',
+          'original_name': '',
+        }),
+        dict({
+          'disabled_by': 'None',
+          'entity_id': 'switch.in_wall_dual_relay_switch_2',
+          'original_name': '(2)',
+        }),
+      ]),
+      'identifiers': list([
+        'zwave_js:3245146787-7',
+        'zwave_js:3245146787-7-265:8215:5911',
+      ]),
+      'name': 'In Wall Dual Relay Switch',
+    }),
+  })
+# ---

--- a/tests/components/zwave_js/test_endpoint_benchmarks.py
+++ b/tests/components/zwave_js/test_endpoint_benchmarks.py
@@ -7,6 +7,7 @@ integration groups endpoints into devices and entities.
 
 from unittest.mock import MagicMock
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from zwave_js_server.model.node import Node
 
@@ -74,212 +75,75 @@ def _snapshot_device_tree(
     }
 
 
-async def test_vision_zl7432_device_tree(
+@pytest.fixture
+def node(request: pytest.FixtureRequest) -> Node:
+    """Resolve the parametrized node fixture before integration setup."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        # Vision ZL7432 In Wall Dual Relay Switch: two independent relay outputs:
+        # endpoint 1 controls load 1 and endpoint 2 controls load 2. Both expose
+        # SWITCH_BINARY currentValue, so they are two separate physical switch
+        # outputs on the same in-wall module.
+        pytest.param("vision_security_zl7432", id="vision_zl7432"),
+        # Fibaro FGR-223 Roller Shutter 3: single motor output controlling a roller
+        # or venetian shutter. Endpoint 1 is the primary shutter control
+        # (SWITCH_MULTILEVEL for position). Endpoint 2 exposes slat/tilt control for
+        # venetian mode; it produces a secondary cover entity disabled by the
+        # integration by default (disabled_by: integration), so a registry entry
+        # exists but the entity is off unless the user enables it.
+        pytest.param("fibaro_fgr223_shutter", id="fibaro_fgr223"),
+        # Shelly/Qubino QNSH-001P10 Wave Shutter: two genuine motor outputs sharing
+        # one device. Endpoint 1 is the primary shutter (SWITCH_MULTILEVEL for
+        # position). Endpoint 2 is a second independent output and produces its own
+        # full set of entities: cover, binary sensors, power sensors, and buttons,
+        # most of which are enabled by default. The secondary cover entity itself is
+        # disabled by the integration, but the endpoint-2 monitoring entities are not.
+        pytest.param("shelly_qnsh_001P10_shutter", id="shelly_qnsh_001p10"),
+        # Merten 507801 Connect Roller Shutter: single motor output controlling a
+        # roller shutter. Endpoint 1 is the primary shutter control
+        # (SWITCH_MULTILEVEL). Endpoint 2 exposes an additional control mode (e.g.
+        # slat/scene control) and is created as a disabled-by-integration entity by
+        # default; it is not suppressed, so it still produces a registry entry.
+        pytest.param("merten_507801", id="merten_507801"),
+        # Inovelli LZW36 Light/Fan Combo: two independent outputs on a single
+        # ceiling-fan canopy module: endpoint 1 controls the light kit
+        # (SWITCH_MULTILEVEL for dimming) and endpoint 2 controls the fan motor
+        # (SWITCH_MULTILEVEL for speed). The two outputs are physically separate
+        # and are meant to be controlled independently.
+        pytest.param("inovelli_lzw36", id="inovelli_lzw36"),
+        # Heatit Z-TRM6 floor thermostat: thermostat input on endpoint 0/1. Three
+        # separate temperature sensor probes report via SENSOR_MULTILEVEL Air
+        # temperature: endpoint 2 is the internal (room) air sensor, endpoint 3 is
+        # an external air sensor, and endpoint 4 is the floor sensor. Each probe is
+        # a physically distinct input.
+        pytest.param("climate_heatit_z_trm6", id="heatit_z_trm6"),
+        # Heatit Z-TRM3 floor thermostat: same multi-sensor topology as the Z-TRM6:
+        # thermostat input on endpoint 0/1, three separate temperature sensor probes
+        # reporting Air temperature on endpoints 2 (internal), 3 (external), and 4
+        # (floor).
+        pytest.param("climate_heatit_z_trm3", id="heatit_z_trm3"),
+        # Heatit Z-TRM2fx floor thermostat: thermostat control on endpoint 0/1.
+        # Endpoints 2 and 3 each expose an Air temperature sensor and a BASIC class
+        # entity. Unlike the Z-TRM3 and Z-TRM6, this device has only two temperature
+        # probes (endpoints 2 and 3) and no endpoint-4 floor sensor.
+        pytest.param("climate_heatit_z_trm2fx", id="heatit_z_trm2fx"),
+    ],
+    indirect=True,
+)
+async def test_device_tree(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     client: MagicMock,
-    vision_security_zl7432: Node,
+    node: Node,
     integration: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Snapshot the device tree for Vision ZL7432 In Wall Dual Relay Switch.
-
-    Two independent relay outputs: endpoint 1 controls load 1 and endpoint 2
-    controls load 2.  Both expose SWITCH_BINARY currentValue, so they are two
-    separate physical switch outputs on the same in-wall module.
-    """
-    node = vision_security_zl7432
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_fibaro_fgr223_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    fibaro_fgr223_shutter: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Fibaro FGR-223 Roller Shutter 3.
-
-    Single motor output controlling a roller or venetian shutter.  Endpoint 1
-    is the primary shutter control (SWITCH_MULTILEVEL for position).  Endpoint 2
-    exposes slat/tilt control for venetian mode but duplicates endpoint 1's motor
-    in roller-shutter mode; its discovery schema suppresses it so no redundant
-    entity is created.
-    """
-    node = fibaro_fgr223_shutter
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_shelly_qnsh_001p10_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    shelly_qnsh_001P10_shutter: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Shelly/Qubino QNSH-001P10 Wave Shutter.
-
-    Single motor output controlling a roller or venetian shutter.  Endpoint 1
-    is the primary shutter control (SWITCH_MULTILEVEL for position).  Endpoint 2
-    exposes slat/tilt control for venetian mode but duplicates endpoint 1's motor
-    in roller-shutter mode; its discovery schema suppresses it so no redundant
-    entity is created.
-    """
-    node = shelly_qnsh_001P10_shutter
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_merten_507801_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    merten_507801: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Merten 507801 Connect Roller Shutter.
-
-    Single motor output controlling a roller shutter.  Endpoint 1 is the primary
-    shutter control (SWITCH_MULTILEVEL).  Endpoint 2 exposes an additional
-    control mode (e.g. slat/scene control) and is created as a disabled entity
-    by default; it is not suppressed, so it still produces a registry entry.
-    """
-    node = merten_507801
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_inovelli_lzw36_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    inovelli_lzw36: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Inovelli LZW36 Light/Fan Combo.
-
-    Two independent outputs on a single ceiling-fan canopy module: endpoint 1
-    controls the light kit (SWITCH_MULTILEVEL for dimming) and endpoint 2
-    controls the fan motor (SWITCH_MULTILEVEL for speed).  The two outputs are
-    physically separate and are meant to be controlled independently.
-    """
-    node = inovelli_lzw36
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_heatit_z_trm6_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    climate_heatit_z_trm6: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Heatit Z-TRM6 floor thermostat.
-
-    The thermostat input is on endpoint 0/1.  Three separate temperature sensor
-    probes report via SENSOR_MULTILEVEL Air temperature: endpoint 2 is the
-    internal (room) air sensor, endpoint 3 is an external air sensor, and
-    endpoint 4 is the floor sensor.  Each probe is a physically distinct input.
-    """
-    node = climate_heatit_z_trm6
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_heatit_z_trm3_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    climate_heatit_z_trm3: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Heatit Z-TRM3 floor thermostat.
-
-    Same multi-sensor topology as the Z-TRM6: the thermostat input is on
-    endpoint 0/1, and three separate temperature sensor probes report via
-    SENSOR_MULTILEVEL Air temperature on endpoints 2 (internal), 3 (external),
-    and 4 (floor).
-    """
-    node = climate_heatit_z_trm3
-    node_device = device_registry.async_get_device_by_identifier(
-        get_device_id(client.driver, node), integration.entry_id
-    )
-    assert node_device
-    assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
-    )
-
-
-async def test_heatit_z_trm2fx_device_tree(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    climate_heatit_z_trm2fx: Node,
-    integration: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the device tree for Heatit Z-TRM2fx floor thermostat.
-
-    Similar multi-sensor topology to the Z-TRM3: thermostat input on endpoint
-    0/1, with multiple temperature sensor probes reporting SENSOR_MULTILEVEL
-    Air temperature on separate endpoints.
-    """
-    node = climate_heatit_z_trm2fx
+    """Snapshot the device tree for a multi-endpoint Z-Wave device."""
     node_device = device_registry.async_get_device_by_identifier(
         get_device_id(client.driver, node), integration.entry_id
     )

--- a/tests/components/zwave_js/test_endpoint_benchmarks.py
+++ b/tests/components/zwave_js/test_endpoint_benchmarks.py
@@ -1,0 +1,290 @@
+"""Snapshot benchmarks for multi-endpoint Z-Wave devices.
+
+These tests snapshot the full device-and-entity tree produced by the zwave_js
+integration for devices that expose multiple endpoints, documenting how the
+integration groups endpoints into devices and entities.
+"""
+
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+from zwave_js_server.model.node import Node
+
+from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+def _snapshot_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    node_device: dr.DeviceEntry,
+) -> dict:
+    """Build a stable, snapshot-friendly representation of a node's device tree.
+
+    Returns a dict with the node device name, its identifier suffixes, all
+    entities on the node device, and a list of child devices (if any), each
+    with their name, identifiers, and entities.  The snapshot is stable across
+    runs because raw device UUIDs are not included.
+    """
+
+    def _stable_identifiers(device: dr.DeviceEntry) -> list[str]:
+        return sorted(
+            f"{domain}:{identifier}" for domain, identifier in device.identifiers
+        )
+
+    def _entities_for_device(device_id: str) -> list[dict]:
+        entries = er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=True
+        )
+        return sorted(
+            [
+                {
+                    "entity_id": entry.entity_id,
+                    "original_name": entry.original_name,
+                    "disabled_by": str(entry.disabled_by),
+                }
+                for entry in entries
+            ],
+            key=lambda e: e["entity_id"],
+        )
+
+    child_devices = sorted(
+        dr.async_entries_for_parent_device(device_registry, node_device.id),
+        key=_stable_identifiers,
+    )
+
+    return {
+        "node_device": {
+            "name": node_device.name,
+            "identifiers": _stable_identifiers(node_device),
+            "entities": _entities_for_device(node_device.id),
+        },
+        "child_devices": [
+            {
+                "name": child.name,
+                "identifiers": _stable_identifiers(child),
+                "entities": _entities_for_device(child.id),
+            }
+            for child in child_devices
+        ],
+    }
+
+
+async def test_vision_zl7432_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    vision_security_zl7432: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Vision ZL7432 In Wall Dual Relay Switch.
+
+    Two independent relay outputs: endpoint 1 controls load 1 and endpoint 2
+    controls load 2.  Both expose SWITCH_BINARY currentValue, so they are two
+    separate physical switch outputs on the same in-wall module.
+    """
+    node = vision_security_zl7432
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_fibaro_fgr223_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    fibaro_fgr223_shutter: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Fibaro FGR-223 Roller Shutter 3.
+
+    Single motor output controlling a roller or venetian shutter.  Endpoint 1
+    is the primary shutter control (SWITCH_MULTILEVEL for position).  Endpoint 2
+    exposes slat/tilt control for venetian mode but duplicates endpoint 1's motor
+    in roller-shutter mode; its discovery schema suppresses it so no redundant
+    entity is created.
+    """
+    node = fibaro_fgr223_shutter
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_shelly_qnsh_001p10_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    shelly_qnsh_001P10_shutter: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Shelly/Qubino QNSH-001P10 Wave Shutter.
+
+    Single motor output controlling a roller or venetian shutter.  Endpoint 1
+    is the primary shutter control (SWITCH_MULTILEVEL for position).  Endpoint 2
+    exposes slat/tilt control for venetian mode but duplicates endpoint 1's motor
+    in roller-shutter mode; its discovery schema suppresses it so no redundant
+    entity is created.
+    """
+    node = shelly_qnsh_001P10_shutter
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_merten_507801_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    merten_507801: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Merten 507801 Connect Roller Shutter.
+
+    Single motor output controlling a roller shutter.  Endpoint 1 is the primary
+    shutter control (SWITCH_MULTILEVEL).  Endpoint 2 exposes an additional
+    control mode (e.g. slat/scene control) and is created as a disabled entity
+    by default; it is not suppressed, so it still produces a registry entry.
+    """
+    node = merten_507801
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_inovelli_lzw36_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    inovelli_lzw36: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Inovelli LZW36 Light/Fan Combo.
+
+    Two independent outputs on a single ceiling-fan canopy module: endpoint 1
+    controls the light kit (SWITCH_MULTILEVEL for dimming) and endpoint 2
+    controls the fan motor (SWITCH_MULTILEVEL for speed).  The two outputs are
+    physically separate and are meant to be controlled independently.
+    """
+    node = inovelli_lzw36
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_heatit_z_trm6_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    climate_heatit_z_trm6: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Heatit Z-TRM6 floor thermostat.
+
+    The thermostat input is on endpoint 0/1.  Three separate temperature sensor
+    probes report via SENSOR_MULTILEVEL Air temperature: endpoint 2 is the
+    internal (room) air sensor, endpoint 3 is an external air sensor, and
+    endpoint 4 is the floor sensor.  Each probe is a physically distinct input.
+    """
+    node = climate_heatit_z_trm6
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_heatit_z_trm3_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    climate_heatit_z_trm3: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Heatit Z-TRM3 floor thermostat.
+
+    Same multi-sensor topology as the Z-TRM6: the thermostat input is on
+    endpoint 0/1, and three separate temperature sensor probes report via
+    SENSOR_MULTILEVEL Air temperature on endpoints 2 (internal), 3 (external),
+    and 4 (floor).
+    """
+    node = climate_heatit_z_trm3
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )
+
+
+async def test_heatit_z_trm2fx_device_tree(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    climate_heatit_z_trm2fx: Node,
+    integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the device tree for Heatit Z-TRM2fx floor thermostat.
+
+    Similar multi-sensor topology to the Z-TRM3: thermostat input on endpoint
+    0/1, with multiple temperature sensor probes reporting SENSOR_MULTILEVEL
+    Air temperature on separate endpoints.
+    """
+    node = climate_heatit_z_trm2fx
+    node_device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, node), integration.entry_id
+    )
+    assert node_device
+    assert (
+        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
+        == snapshot
+    )

--- a/tests/components/zwave_js/test_endpoint_benchmarks.py
+++ b/tests/components/zwave_js/test_endpoint_benchmarks.py
@@ -12,14 +12,12 @@ from syrupy.assertion import SnapshotAssertion
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js.helpers import get_device_id
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
 
 def _snapshot_device_tree(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     node_device: dr.DeviceEntry,
@@ -138,7 +136,6 @@ def node(request: pytest.FixtureRequest) -> Node:
     indirect=True,
 )
 async def test_device_tree(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     client: MagicMock,
@@ -152,6 +149,5 @@ async def test_device_tree(
     )
     assert node_device
     assert (
-        _snapshot_device_tree(hass, device_registry, entity_registry, node_device)
-        == snapshot
+        _snapshot_device_tree(device_registry, entity_registry, node_device) == snapshot
     )

--- a/tests/components/zwave_js/test_endpoint_benchmarks.py
+++ b/tests/components/zwave_js/test_endpoint_benchmarks.py
@@ -84,10 +84,10 @@ def node(request: pytest.FixtureRequest) -> Node:
 @pytest.mark.parametrize(
     "node",
     [
-        # Vision ZL7432 In Wall Dual Relay Switch: two independent relay outputs:
-        # endpoint 1 controls load 1 and endpoint 2 controls load 2. Both expose
-        # SWITCH_BINARY currentValue, so they are two separate physical switch
-        # outputs on the same in-wall module.
+        # Vision ZL7432 In Wall Dual Relay Switch: two independently controllable
+        # relay outputs on one in-wall module. Endpoints 1 and 2 each expose
+        # SWITCH_BINARY currentValue, one per relay output; the manual does not
+        # state which endpoint maps to which physical load.
         pytest.param("vision_security_zl7432", id="vision_zl7432"),
         # Fibaro FGR-223 Roller Shutter 3: single motor output controlling a roller
         # or venetian shutter. Endpoint 1 is the primary shutter control
@@ -96,24 +96,25 @@ def node(request: pytest.FixtureRequest) -> Node:
         # integration by default (disabled_by: integration), so a registry entry
         # exists but the entity is off unless the user enables it.
         pytest.param("fibaro_fgr223_shutter", id="fibaro_fgr223"),
-        # Shelly/Qubino QNSH-001P10 Wave Shutter: two genuine motor outputs sharing
-        # one device. Endpoint 1 is the primary shutter (SWITCH_MULTILEVEL for
-        # position). Endpoint 2 is a second independent output and produces its own
-        # full set of entities: cover, binary sensors, power sensors, and buttons,
-        # most of which are enabled by default. The secondary cover entity itself is
-        # disabled by the integration, but the endpoint-2 monitoring entities are not.
+        # Shelly/Qubino QNSH-001P10 Wave Shutter: one bi-directional motor (O1 up,
+        # O2 down), same topology as the FGR-223. Endpoint 1 is shutter position;
+        # endpoint 2 is the venetian slat tilt, present only when operating mode
+        # (param 71) is Venetian. The endpoint-2 cover is disabled by the
+        # integration, but unlike the FGR-223 this endpoint also mirrors the Meter
+        # and Notification CCs, yielding a duplicate set of enabled sensor, binary
+        # sensor and button entities.
         pytest.param("shelly_qnsh_001P10_shutter", id="shelly_qnsh_001p10"),
-        # Merten 507801 Connect Roller Shutter: single motor output controlling a
-        # roller shutter. Endpoint 1 is the primary shutter control
-        # (SWITCH_MULTILEVEL). Endpoint 2 exposes an additional control mode (e.g.
-        # slat/scene control) and is created as a disabled-by-integration entity by
-        # default; it is not suppressed, so it still produces a registry entry.
+        # Merten 507801 Connect Roller Shutter: a 1-gang receiver with a single
+        # motor output (two interlocked make contacts for up/down). Endpoints 1
+        # and 2 have identical capabilities (SWITCH_MULTILEVEL + PROTECTION); the
+        # manufacturer documents no endpoint semantics at all, and the integration
+        # discovers endpoint 2 disabled.
         pytest.param("merten_507801", id="merten_507801"),
-        # Inovelli LZW36 Light/Fan Combo: two independent outputs on a single
-        # ceiling-fan canopy module: endpoint 1 controls the light kit
-        # (SWITCH_MULTILEVEL for dimming) and endpoint 2 controls the fan motor
-        # (SWITCH_MULTILEVEL for speed). The two outputs are physically separate
-        # and are meant to be controlled independently.
+        # Inovelli LZW36 Light/Fan Combo: an in-wall switch paired with a canopy
+        # module in the fan; only the switch is the Z-Wave node, driving the module
+        # over proprietary RF. Endpoint 1 is the light (SWITCH_MULTILEVEL dimming),
+        # endpoint 2 the fan motor (SWITCH_MULTILEVEL speed). The two loads are
+        # physically separate and independently controllable.
         pytest.param("inovelli_lzw36", id="inovelli_lzw36"),
         # Heatit Z-TRM6 floor thermostat: thermostat input on endpoint 0/1. Three
         # separate temperature sensor probes report via SENSOR_MULTILEVEL Air
@@ -126,10 +127,12 @@ def node(request: pytest.FixtureRequest) -> Node:
         # reporting Air temperature on endpoints 2 (internal), 3 (external), and 4
         # (floor).
         pytest.param("climate_heatit_z_trm3", id="heatit_z_trm3"),
-        # Heatit Z-TRM2fx floor thermostat: thermostat control on endpoint 0/1.
-        # Endpoints 2 and 3 each expose an Air temperature sensor and a BASIC class
-        # entity. Unlike the Z-TRM3 and Z-TRM6, this device has only two temperature
-        # probes (endpoints 2 and 3) and no endpoint-4 floor sensor.
+        # Heatit Z-TRM2fx floor thermostat: thermostat on endpoint 1. Unlike the
+        # Z-TRM3 and Z-TRM6, the endpoint order differs and there is no internal
+        # room sensor: endpoint 2 is the external room sensor and endpoint 3 is the
+        # floor sensor (it still reports sensor type "Air temperature"). Endpoint 4
+        # is the internal relay (Binary Switch + Meter), not a sensor. The BASIC
+        # currentValue/targetValue on endpoints 2 and 3 are undocumented.
         pytest.param("climate_heatit_z_trm2fx", id="heatit_z_trm2fx"),
     ],
     indirect=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a snapshot test file that captures the full device-and-entity tree for each Z-Wave device that exposes multiple endpoints. The snapshots serve as a baseline showing the pre-child-device state, where all entities live on the main node device.

Devices covered:
- Vision ZL7432 (two-relay dual switch)
- Fibaro FGR-223 (roller shutter)
- Shelly/Qubino QNSH-001P10 (wave shutter, same as FGR-223)
- Merten 507801 (roller shutter with disabled endpoint 2)
- Inovelli LZW36 (light/fan combo with fan on endpoint 2)
- Heatit Z-TRM6 / Z-TRM3 / Z-TRM2fx (thermostats with temperature sensor endpoints)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/179623
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
