### PR TITLE
Keep the current hour in the SMHI hourly forecast

### DIFF
--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -159,7 +159,13 @@ class SmhiWeather(SmhiWeatherEntity, SingleCoordinatorWeatherEntity):
 
         data: list[Forecast] = []
 
-        for forecast in forecast_data[1:]:
+        # The library repeats the current conditions as the first entry of the
+        # daily and twice daily forecasts, so those start one entry in. It does
+        # not do that for the hourly forecast, where the first entry is the
+        # forecast for the current hour.
+        forecasts = forecast_data if forecast_type == "hourly" else forecast_data[1:]
+
+        for forecast in forecasts:
             condition = CONDITION_MAP.get(forecast["symbol"])
             if condition == ATTR_CONDITION_SUNNY and not sun.is_up(
                 self.hass, forecast["valid_time"]

--- a/tests/components/smhi/snapshots/test_weather.ambr
+++ b/tests/components/smhi/snapshots/test_weather.ambr
@@ -6,6 +6,19 @@
         dict({
           'cloud_coverage': 100,
           'condition': 'clear-night',
+          'datetime': '2026-04-03T00:00:00+00:00',
+          'humidity': 97,
+          'precipitation': 0.2,
+          'pressure': 1008.2,
+          'temperature': 5.3,
+          'templow': 5.3,
+          'wind_bearing': 138,
+          'wind_gust_speed': 4.32,
+          'wind_speed': 1.8,
+        }),
+        dict({
+          'cloud_coverage': 100,
+          'condition': 'clear-night',
           'datetime': '2026-04-03T01:00:00+00:00',
           'humidity': 97,
           'precipitation': 0.2,
@@ -811,30 +824,30 @@
   dict({
     'cloud_coverage': 100,
     'condition': 'cloudy',
-    'datetime': '2026-04-02T12:00:00+00:00',
-    'humidity': 79,
+    'datetime': '2026-04-02T11:00:00+00:00',
+    'humidity': 80,
     'precipitation': 0.0,
-    'pressure': 1011.3,
+    'pressure': 1011.5,
     'temperature': 10.4,
     'templow': 10.4,
-    'wind_bearing': 245,
-    'wind_gust_speed': 24.12,
-    'wind_speed': 11.16,
+    'wind_bearing': 255,
+    'wind_gust_speed': 24.48,
+    'wind_speed': 12.24,
   })
 # ---
 # name: test_forecast_services[load_platforms0].3
   dict({
     'cloud_coverage': 100,
     'condition': 'cloudy',
-    'datetime': '2026-04-02T18:00:00+00:00',
-    'humidity': 98,
+    'datetime': '2026-04-02T17:00:00+00:00',
+    'humidity': 94,
     'precipitation': 0.0,
     'pressure': 1009.7,
-    'temperature': 7.2,
-    'templow': 7.2,
-    'wind_bearing': 180,
-    'wind_gust_speed': 6.48,
-    'wind_speed': 3.24,
+    'temperature': 8.3,
+    'templow': 8.3,
+    'wind_bearing': 223,
+    'wind_gust_speed': 8.28,
+    'wind_speed': 3.6,
   })
 # ---
 # name: test_setup_hass[load_platforms0]

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -421,7 +421,10 @@ async def test_forecast_services(
     assert msg["type"] == "event"
     forecast1 = msg["event"]["forecast"]
 
-    assert len(forecast1) == 59
+    assert len(forecast1) == 60
+    # The hourly forecast covers the current hour, the first entry the API
+    # returned, rather than starting an hour later
+    assert forecast1[0]["datetime"] == "2026-04-02T11:00:00+00:00"
     assert forecast1[0] == snapshot
     assert forecast1[6] == snapshot
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SmhiWeather._get_forecast_data` iterates `forecast_data[1:]` for all three forecast types, but that slice is only correct for two of them.

In `pysmhi`, both `get_daily_forecast` and `get_twice_daily_forecast` start with `forecasts["current"] = sorted_forecasts[0]` before building their per-period entries, so their first element is a repeat of the current conditions and skipping it is right. `get_hourly_forecast` does not do that: it starts from `sorted_forecasts[0]` and walks the consecutive hours from there. So for the hourly forecast the slice silently drops a real forecast hour, and the hourly forecast starts an hour later than the data the API returned.

This now skips the repeated entry only where the library actually adds one.

The slice comes from #97275 (2023), which predates the split into separate daily, twice daily and hourly calls. It was carried into the hourly path unchanged.

The test fixture's first `timeSeries` entry is `2026-04-02T11:00:00Z`, and the hourly forecast used to start at 12:00. It now starts at 11:00 and the entry count goes from 59 to 60. Only the two hourly snapshots shift; the daily and twice daily snapshots are untouched, which confirms those still drop the repeated entry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179958
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
