### PR TITLE
Fix Govee H5055 Bluetooth discovery

### DIFF
--- a/homeassistant/components/govee_ble/manifest.json
+++ b/homeassistant/components/govee_ble/manifest.json
@@ -70,7 +70,6 @@
     },
     {
       "connectable": false,
-      "manufacturer_id": 23562,
       "service_uuid": "00005550-0000-1000-8000-00805f9b34fb"
     },
     {

--- a/homeassistant/components/govee_ble/manifest.json
+++ b/homeassistant/components/govee_ble/manifest.json
@@ -70,6 +70,11 @@
     },
     {
       "connectable": false,
+      "manufacturer_id": 23562,
+      "service_uuid": "00005550-0000-1000-8000-00805f9b34fb"
+    },
+    {
+      "connectable": false,
       "manufacturer_id": 63391,
       "service_uuid": "00008351-0000-1000-8000-00805f9b34fb"
     },

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -259,7 +259,6 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
     {
         "connectable": False,
         "domain": "govee_ble",
-        "manufacturer_id": 23562,
         "service_uuid": "00005550-0000-1000-8000-00805f9b34fb",
     },
     {

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -259,6 +259,12 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
     {
         "connectable": False,
         "domain": "govee_ble",
+        "manufacturer_id": 23562,
+        "service_uuid": "00005550-0000-1000-8000-00805f9b34fb",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
         "manufacturer_id": 63391,
         "service_uuid": "00008351-0000-1000-8000-00805f9b34fb",
     },

--- a/tests/components/govee_ble/__init__.py
+++ b/tests/components/govee_ble/__init__.py
@@ -24,6 +24,18 @@ GVH5075_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+GVH5055_SERVICE_INFO = BluetoothServiceInfo(
+    name="",
+    address="C0:A3:C7:0A:5C:77",
+    rssi=-63,
+    manufacturer_data={
+        23562: b"\x77\x41\x00\x01\x01\xe4\x81\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+    },
+    service_uuids=["00005550-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
 GVH5184_SERVICE_INFO = BluetoothServiceInfo(
     name="GVH5184_XXXX",
     address="4125DDBA-2774-4851-9889-6AADDD4CAC3D",

--- a/tests/components/govee_ble/test_config_flow.py
+++ b/tests/components/govee_ble/test_config_flow.py
@@ -65,6 +65,16 @@ async def test_async_step_bluetooth_h5055(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
 
+    with patch(
+        "homeassistant.components.govee_ble.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {CONF_DEVICE_TYPE: "H5055"}
+
 
 async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""

--- a/tests/components/govee_ble/test_config_flow.py
+++ b/tests/components/govee_ble/test_config_flow.py
@@ -1,11 +1,18 @@
 """Test the Govee config flow."""
 
+from typing import cast
 from unittest.mock import patch
 
 from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.bluetooth.match import (
+    BluetoothMatcher,
+    IntegrationMatcher,
+)
 from homeassistant.components.govee_ble.const import CONF_DEVICE_TYPE, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.generated.bluetooth import BLUETOOTH
 
 from . import (
     GVH5055_SERVICE_INFO,
@@ -15,10 +22,40 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 
 async def test_async_step_bluetooth_h5055(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with an H5055."""
+    bleak_service_info = BluetoothServiceInfoBleak(
+        name=GVH5055_SERVICE_INFO.name,
+        address=GVH5055_SERVICE_INFO.address,
+        rssi=GVH5055_SERVICE_INFO.rssi,
+        manufacturer_data=GVH5055_SERVICE_INFO.manufacturer_data,
+        service_uuids=GVH5055_SERVICE_INFO.service_uuids,
+        service_data=GVH5055_SERVICE_INFO.service_data,
+        source=GVH5055_SERVICE_INFO.source,
+        device=generate_ble_device(
+            address=GVH5055_SERVICE_INFO.address,
+            name=GVH5055_SERVICE_INFO.name,
+        ),
+        advertisement=generate_advertisement_data(
+            local_name=GVH5055_SERVICE_INFO.name,
+            manufacturer_data=GVH5055_SERVICE_INFO.manufacturer_data,
+            service_data=GVH5055_SERVICE_INFO.service_data,
+            service_uuids=GVH5055_SERVICE_INFO.service_uuids,
+            rssi=GVH5055_SERVICE_INFO.rssi,
+        ),
+        time=0,
+        connectable=False,
+        tx_power=None,
+    )
+
+    matcher = IntegrationMatcher(cast(list[BluetoothMatcher], BLUETOOTH))
+    matcher.async_setup()
+
+    assert DOMAIN in matcher.match_domains(bleak_service_info)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},

--- a/tests/components/govee_ble/test_config_flow.py
+++ b/tests/components/govee_ble/test_config_flow.py
@@ -1,18 +1,11 @@
 """Test the Govee config flow."""
 
-from typing import cast
 from unittest.mock import patch
 
 from homeassistant import config_entries
-from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.components.bluetooth.match import (
-    BluetoothMatcher,
-    IntegrationMatcher,
-)
 from homeassistant.components.govee_ble.const import CONF_DEVICE_TYPE, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.generated.bluetooth import BLUETOOTH
 
 from . import (
     GVH5055_SERVICE_INFO,
@@ -22,47 +15,18 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_async_step_bluetooth_h5055(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with an H5055."""
-    bleak_service_info = BluetoothServiceInfoBleak(
-        name=GVH5055_SERVICE_INFO.name,
-        address=GVH5055_SERVICE_INFO.address,
-        rssi=GVH5055_SERVICE_INFO.rssi,
-        manufacturer_data=GVH5055_SERVICE_INFO.manufacturer_data,
-        service_uuids=GVH5055_SERVICE_INFO.service_uuids,
-        service_data=GVH5055_SERVICE_INFO.service_data,
-        source=GVH5055_SERVICE_INFO.source,
-        device=generate_ble_device(
-            address=GVH5055_SERVICE_INFO.address,
-            name=GVH5055_SERVICE_INFO.name,
-        ),
-        advertisement=generate_advertisement_data(
-            local_name=GVH5055_SERVICE_INFO.name,
-            manufacturer_data=GVH5055_SERVICE_INFO.manufacturer_data,
-            service_data=GVH5055_SERVICE_INFO.service_data,
-            service_uuids=GVH5055_SERVICE_INFO.service_uuids,
-            rssi=GVH5055_SERVICE_INFO.rssi,
-        ),
-        time=0,
-        connectable=False,
-        tx_power=None,
-    )
+    inject_bluetooth_service_info(hass, GVH5055_SERVICE_INFO)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    matcher = IntegrationMatcher(cast(list[BluetoothMatcher], BLUETOOTH))
-    matcher.async_setup()
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
 
-    assert DOMAIN in matcher.match_domains(bleak_service_info)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=GVH5055_SERVICE_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
+    result = flows[0]
     assert result["step_id"] == "bluetooth_confirm"
 
     with patch(

--- a/tests/components/govee_ble/test_config_flow.py
+++ b/tests/components/govee_ble/test_config_flow.py
@@ -7,9 +7,26 @@ from homeassistant.components.govee_ble.const import CONF_DEVICE_TYPE, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import GVH5075_SERVICE_INFO, GVH5177_SERVICE_INFO, NOT_GOVEE_SERVICE_INFO
+from . import (
+    GVH5055_SERVICE_INFO,
+    GVH5075_SERVICE_INFO,
+    GVH5177_SERVICE_INFO,
+    NOT_GOVEE_SERVICE_INFO,
+)
 
 from tests.common import MockConfigEntry
+
+
+async def test_async_step_bluetooth_h5055(hass: HomeAssistant) -> None:
+    """Test discovery via bluetooth with an H5055."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=GVH5055_SERVICE_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
 
 
 async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->



Add Bluetooth discovery support for the Govee H5055 meat thermometer.

The H5055 is already supported by the bundled `govee-ble` parser, but Home
Assistant Core was not matching its Bluetooth advertisements because the
integration manifest did not include the H5055 service UUID.

This adds the missing Bluetooth discovery matcher and a regression test using
a real H5055 advertisement.

Testing completed locally:

- `uv run --no-sync pytest tests/components/govee_ble/test_config_flow.py`
- `uv run --no-sync pytest tests/components/govee_ble`
- Ruff checks passed
- hassfest passed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180165
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr