### PR TITLE
Keep Proxmox VE snapshot names within the API limits

### DIFF
--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -32,10 +32,10 @@ PARALLEL_UPDATES = 1
 def _snapshot_name() -> str:
     """Return the name to give a newly created snapshot.
 
-    Proxmox caps snapshot names at 40 characters and only accepts
-    [A-Za-z0-9_], starting with a letter. The guest name is left out because
-    it is of variable length and routinely holds characters Proxmox rejects,
-    and the snapshot already lives under the guest it belongs to.
+    Proxmox validates this as a `pve-configid` of at most 40 characters, and
+    the prefix and timestamp already take up 37 of those. So the guest name is
+    left out: any name longer than two characters pushed the total over the
+    limit, and the snapshot already lives under the guest it belongs to.
     """
     return f"homeassistant_snapshot_{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
 

--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -29,6 +29,17 @@ from .helpers import is_granted
 PARALLEL_UPDATES = 1
 
 
+def _snapshot_name() -> str:
+    """Return the name to give a newly created snapshot.
+
+    Proxmox caps snapshot names at 40 characters and only accepts
+    [A-Za-z0-9_], starting with a letter. The guest name is left out because
+    it is of variable length and routinely holds characters Proxmox rejects,
+    and the snapshot already lives under the guest it belongs to.
+    """
+    return f"homeassistant_snapshot_{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
+
+
 @dataclass(frozen=True, kw_only=True)
 class ProxmoxNodeButtonNodeEntityDescription(ButtonEntityDescription):
     """Class to hold Proxmox node button description."""
@@ -176,13 +187,7 @@ VM_BUTTONS: tuple[ProxmoxVMButtonEntityDescription, ...] = (
         press_action=lambda coordinator, node, vmid: (
             coordinator.proxmox.nodes(node)
             .qemu(vmid)
-            .snapshot.post(
-                name=(
-                    "homeassistant_snapshot_"
-                    f"{coordinator.data[node].vms[vmid]['name']}_"
-                    f"{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
-                )
-            )
+            .snapshot.post(name=_snapshot_name())
         ),
         permission=ProxmoxPermission.SNAPSHOT,
         entity_category=EntityCategory.CONFIG,
@@ -220,13 +225,7 @@ CONTAINER_BUTTONS: tuple[ProxmoxContainerButtonEntityDescription, ...] = (
         press_action=lambda coordinator, node, vmid: (
             coordinator.proxmox.nodes(node)
             .lxc(vmid)
-            .snapshot.post(
-                name=(
-                    "homeassistant_snapshot_"
-                    f"{coordinator.data[node].containers[vmid]['name']}_"
-                    f"{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
-                )
-            )
+            .snapshot.post(name=_snapshot_name())
         ),
         permission=ProxmoxPermission.SNAPSHOT,
         entity_category=EntityCategory.CONFIG,

--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -29,17 +29,6 @@ from .helpers import is_granted
 PARALLEL_UPDATES = 1
 
 
-def _snapshot_name() -> str:
-    """Return the name to give a newly created snapshot.
-
-    Proxmox validates this as a `pve-configid` of at most 40 characters, and
-    the prefix and timestamp already take up 37 of those. So the guest name is
-    left out: any name longer than two characters pushed the total over the
-    limit, and the snapshot already lives under the guest it belongs to.
-    """
-    return f"homeassistant_snapshot_{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
-
-
 @dataclass(frozen=True, kw_only=True)
 class ProxmoxNodeButtonNodeEntityDescription(ButtonEntityDescription):
     """Class to hold Proxmox node button description."""
@@ -187,7 +176,9 @@ VM_BUTTONS: tuple[ProxmoxVMButtonEntityDescription, ...] = (
         press_action=lambda coordinator, node, vmid: (
             coordinator.proxmox.nodes(node)
             .qemu(vmid)
-            .snapshot.post(name=_snapshot_name())
+            .snapshot.post(
+                name=f"homeassistant_snapshot_{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
+            )
         ),
         permission=ProxmoxPermission.SNAPSHOT,
         entity_category=EntityCategory.CONFIG,
@@ -225,7 +216,9 @@ CONTAINER_BUTTONS: tuple[ProxmoxContainerButtonEntityDescription, ...] = (
         press_action=lambda coordinator, node, vmid: (
             coordinator.proxmox.nodes(node)
             .lxc(vmid)
-            .snapshot.post(name=_snapshot_name())
+            .snapshot.post(
+                name=f"homeassistant_snapshot_{dt_util.utcnow().strftime('%Y%m%d%H%M%S')}"
+            )
         ),
         permission=ProxmoxPermission.SNAPSHOT,
         entity_category=EntityCategory.CONFIG,

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -174,11 +174,11 @@ async def test_snapshot_button(
 
     assert len(method_mock.mock_calls) == pre_calls + 1
 
-    # Proxmox rejects anything longer than 40 characters or outside
-    # [A-Za-z0-9_], and the guest names it hands out hold neither guarantee
+    # Proxmox validates the name as a `pve-configid` of at most 40 characters:
+    # two or more, starting with a letter, then only [A-Za-z0-9_-]
     name = method_mock.call_args.kwargs["name"]
     assert len(name) <= 40
-    assert re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name)
+    assert re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]+", name)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -1,5 +1,6 @@
 """Tests for the ProxmoxVE button platform."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 from proxmoxer import AuthenticationError
@@ -142,48 +143,42 @@ async def test_vm_buttons(
     assert len(method_mock.mock_calls) == pre_calls + 1
 
 
-async def test_vm_snapshot_button(
+@pytest.mark.parametrize(
+    ("entity_id", "vmid", "guest_resource"),
+    [
+        pytest.param("button.vm_web_create_snapshot", 100, "qemu", id="vm"),
+        pytest.param("button.ct_nginx_create_snapshot", 200, "lxc", id="container"),
+    ],
+)
+async def test_snapshot_button(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    vmid: int,
+    guest_resource: str,
 ) -> None:
-    """Test pressing a ProxmoxVE VM snapshot button triggers the correct API call."""
+    """Test a ProxmoxVE snapshot button triggers the correct API call."""
     await setup_integration(hass, mock_config_entry)
 
-    mock_proxmox_client._node_mock.qemu(100)
-    method_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
+    node = mock_proxmox_client.nodes("pve1")
+    method_mock = getattr(node, guest_resource)(vmid).snapshot.post
     pre_calls = len(method_mock.mock_calls)
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.vm_web_create_snapshot"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
 
     assert len(method_mock.mock_calls) == pre_calls + 1
 
-
-async def test_container_snapshot_button(
-    hass: HomeAssistant,
-    mock_proxmox_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test ProxmoxVE container snapshot button API call."""
-    await setup_integration(hass, mock_config_entry)
-
-    mock_proxmox_client._node_mock.lxc(200)
-    method_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
-    pre_calls = len(method_mock.mock_calls)
-
-    await hass.services.async_call(
-        BUTTON_DOMAIN,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.ct_nginx_create_snapshot"},
-        blocking=True,
-    )
-
-    assert len(method_mock.mock_calls) == pre_calls + 1
+    # Proxmox rejects anything longer than 40 characters or outside
+    # [A-Za-z0-9_], and the guest names it hands out hold neither guarantee
+    name = method_mock.call_args.kwargs["name"]
+    assert len(name) <= 40
+    assert re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The snapshot buttons build the name as `homeassistant_snapshot_<guest name>_<14 digit timestamp>`, of which the fixed part alone is already 37 characters.

Proxmox validates `snapname` as a `pve-configid` and caps it at 40 characters. From `PVE::JSONSchema`:

```perl
my $CONFIGID_RE = qr/[a-z][a-z0-9_-]+/i;
...
'pve-snapshot-name' => {
    description => "The name of the snapshot.",
    type => 'string', format => 'pve-configid',
    maxLength => 40,
},
```

So any guest name longer than two characters pushes the total past 40, which is effectively every real VM or container. PVE answers with a 400 and the user sees "Communication not possible". The button has never worked for a realistically named guest.

This drops the guest name from the snapshot name. `homeassistant_snapshot_20260827183753` is 37 characters and within the limit by construction, and the guest name was redundant anyway, since the snapshot already lives under the guest it belongs to. Truncating it instead is not an option, as only two characters of it would fit.

The existing tests only asserted that `snapshot.post` was called once and never looked at what was passed to it, which is why this never showed up in CI. The two near identical snapshot button tests are merged into one parameterized test that now checks the generated name against the `pve-configid` rules above. Both halves of that check were confirmed to fail on their own: restoring the guest name trips `assert 44 <= 40`, and a guest named `web.lan` trips the pattern, since dots are outside `pve-configid` even though hyphens are fine.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179930, fixes #168555
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
