### PR TITLE
Restore Plex recovery from a changed plex.direct certificate

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -191,8 +191,9 @@ class PlexServer:
                     error = error.__context__
                 if isinstance(error, ssl.SSLCertVerificationError):
                     domain = urlparse(self._url).netloc.split(":")[0]
-                    if domain.endswith("plex.direct") and error.args[0].startswith(
-                        f"hostname '{domain}' doesn't match"
+                    # OpenSSL's own wording for X509_V_ERR_HOSTNAME_MISMATCH
+                    if domain.endswith("plex.direct") and "Hostname mismatch" in str(
+                        error
                     ):
                         _LOGGER.warning(
                             "Plex SSL certificate's hostname changed, updating"

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -210,7 +210,7 @@ async def test_setup_when_certificate_changed(
         """Mock the exception showing a mismatched hostname."""
 
         def __init__(self) -> None:  # pylint: disable=super-init-not-called
-            # Shaped the way OpenSSL raises it: args are (verify_code, message)
+            # Shaped the way it is really raised: OSError args of (errno, message)
             self.__context__ = ssl.SSLCertVerificationError(
                 1,
                 "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:"

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -210,8 +210,11 @@ async def test_setup_when_certificate_changed(
         """Mock the exception showing a mismatched hostname."""
 
         def __init__(self) -> None:  # pylint: disable=super-init-not-called
+            # Shaped the way OpenSSL raises it: args are (verify_code, message)
             self.__context__ = ssl.SSLCertVerificationError(
-                f"hostname '{old_domain}' doesn't match"
+                1,
+                "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:"
+                f" Hostname mismatch, certificate is not valid for '{old_domain}'.",
             )
 
     old_domain = "1-2-3-4.1111111111ffffff1111111111ffffff.plex.direct"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Plex has self-healing for a rotated `plex.direct` certificate, and it has never been able to run. There are two defects in the guard that protects it, both confirmed against a real handshake failure staged with a mismatched self-signed certificate:

```
args:            (1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'old.plex.direct'. (_ssl.c:1081)")
args[0] type:    int
verify_code:     62
```

1. `error.args[0]` is the verify code, an `int`. Calling `.startswith()` on it raises `AttributeError`, which escapes `async_setup_entry`, aborts setup, and masks the SSL error in the log.
2. Even reaching for `args[1]`, the expected prefix `hostname '<domain>' doesn't match` no longer matches. That wording came from CPython's own `match_hostname()`, removed in 3.7 when hostname verification moved into OpenSSL.

So the recovery cannot fire at all, and since `supports_reconfigure` is `False` for this integration the only remedy left to the user is deleting and re-adding the config entry.

This matches on `"Hostname mismatch"` in `str(error)` instead. That text is OpenSSL's own for `X509_V_ERR_HOSTNAME_MISMATCH`, rather than CPython's, which is why the previous wording rotted out from under this code.

I deliberately did not reach for `error.verify_message` or `error.verify_code`. Both are only set by the handshake itself: an `SSLCertVerificationError` constructed from Python has no `verify_code` attribute at all, so reading it would reintroduce the same `AttributeError` failure mode for any synthesized error. `str(error)` is always there.

The reason this never showed up in CI is that the test fabricated `ssl.SSLCertVerificationError(f"hostname '{domain}' doesn't match")` with a single string argument. That shape makes `args[0]` a string, so the broken guard worked against it, and the test was validating a mock CPython does not produce. The mock is reshaped to the real `(verify_code, message)` form, and the corrected test was run against the old guard to confirm it fails there.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179256
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
