### PR TITLE
Report every SwitchBot Cloud lock state

### DIFF
--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -2,7 +2,14 @@
 
 from typing import Any, override
 
-from switchbot_api import Device, LockCommands, LockV2Commands, Remote, SwitchBotAPI
+from switchbot_api import (
+    Device,
+    LockCommands,
+    LockV2Commands,
+    Remote,
+    SwitchBotAPI,
+    SwitchbotCloudDeviceLockState,
+)
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
@@ -10,6 +17,20 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import SwitchbotCloudConfigEntry, SwitchBotCoordinator
 from .entity import SwitchBotCloudEntity
+
+# The cloud camel cases these when polled and upper cases them over the
+# webhook, so look them up by their lower cased value
+LOCK_STATES_BY_VALUE = {
+    state.value.lower(): state for state in SwitchbotCloudDeviceLockState
+}
+
+# A latch bolt or half locked door is secured, both are resting positions the
+# lock can be commanded into
+LOCKED_STATES = {
+    SwitchbotCloudDeviceLockState.LOCKED,
+    SwitchbotCloudDeviceLockState.LATCH_BOLT_LOCKED,
+    SwitchbotCloudDeviceLockState.HALF_LOCKED,
+}
 
 
 async def async_setup_entry(
@@ -44,7 +65,11 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
     def _set_attributes(self) -> None:
         """Set attributes from coordinator data."""
         if coord_data := self.coordinator.data:
-            self._attr_is_locked = coord_data["lockState"].lower() == "locked"
+            state = LOCK_STATES_BY_VALUE.get(coord_data["lockState"].lower())
+            self._attr_is_locked = state in LOCKED_STATES if state else None
+            self._attr_is_locking = state is SwitchbotCloudDeviceLockState.LOCKING
+            self._attr_is_unlocking = state is SwitchbotCloudDeviceLockState.UNLOCKING
+            self._attr_is_jammed = state is SwitchbotCloudDeviceLockState.JAMMED
         if self.__model not in [
             "Smart Lock Lite",
             "Smart Lock Vision",

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -12,7 +12,7 @@ from switchbot_api import (
 )
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import SwitchbotCloudConfigEntry, SwitchBotCoordinator
@@ -79,23 +79,34 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
         ]:
             self._attr_supported_features = LockEntityFeature.OPEN
 
+    @callback
+    def _write_optimistic_state(self, *, is_locked: bool) -> None:
+        """Write the state the command asked for, until the cloud reports back.
+
+        The transient states have to go with it: they outrank `is_locked` in
+        `LockEntity.state`, so a lock commanded out of a jam would keep
+        reading jammed until the next poll.
+        """
+        self._attr_is_locked = is_locked
+        self._attr_is_locking = False
+        self._attr_is_unlocking = False
+        self._attr_is_jammed = False
+        self.async_write_ha_state()
+
     @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         await self.send_api_command(LockCommands.LOCK)
-        self._attr_is_locked = True
-        self.async_write_ha_state()
+        self._write_optimistic_state(is_locked=True)
 
     @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         await self.send_api_command(LockCommands.UNLOCK)
-        self._attr_is_locked = False
-        self.async_write_ha_state()
+        self._write_optimistic_state(is_locked=False)
 
     @override
     async def async_open(self, **kwargs: Any) -> None:
         """Latch open the lock."""
         await self.send_api_command(LockV2Commands.DEADBOLT)
-        self._attr_is_locked = False
-        self.async_write_ha_state()
+        self._write_optimistic_state(is_locked=False)

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     SERVICE_LOCK,
     SERVICE_OPEN,
     SERVICE_UNLOCK,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 
@@ -104,3 +105,46 @@ async def test_lock_open(
             LOCK_DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: lock_id}, blocking=True
         )
     assert hass.states.get(lock_id).state == LockState.UNLOCKED
+
+
+@pytest.mark.parametrize(
+    ("lock_state", "expected_state"),
+    [
+        ("locked", LockState.LOCKED),
+        ("unlocked", LockState.UNLOCKED),
+        ("locking", LockState.LOCKING),
+        ("unlocking", LockState.UNLOCKING),
+        ("jammed", LockState.JAMMED),
+        ("latchBoltLocked", LockState.LOCKED),
+        ("halfLocked", LockState.LOCKED),
+        # The webhook reports the very same states upper cased
+        ("LOCKED", LockState.LOCKED),
+        ("JAMMED", LockState.JAMMED),
+        # Anything the cloud adds later is unknown rather than unlocked
+        ("somethingNew", STATE_UNKNOWN),
+    ],
+)
+async def test_lock_states(
+    hass: HomeAssistant,
+    mock_list_devices,
+    mock_get_status,
+    lock_state: str,
+    expected_state: str,
+) -> None:
+    """Test every lock state the cloud reports."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="lock-id-1",
+            deviceName="lock-1",
+            deviceType="Smart Lock Ultra",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+
+    mock_get_status.return_value = {"lockState": lock_state}
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get("lock.lock_1").state == expected_state

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -148,3 +148,45 @@ async def test_lock_states(
 
     assert entry.state is ConfigEntryState.LOADED
     assert hass.states.get("lock.lock_1").state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_state"),
+    [
+        (SERVICE_LOCK, LockState.LOCKED),
+        (SERVICE_UNLOCK, LockState.UNLOCKED),
+        (SERVICE_OPEN, LockState.UNLOCKED),
+    ],
+)
+async def test_command_replaces_a_jam(
+    hass: HomeAssistant,
+    mock_list_devices,
+    mock_get_status,
+    service: str,
+    expected_state: str,
+) -> None:
+    """Test a command clears the jam instead of leaving it standing."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="lock-id-1",
+            deviceName="lock-1",
+            deviceType="Smart Lock Ultra",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+
+    mock_get_status.return_value = {"lockState": "jammed"}
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    lock_id = "lock.lock_1"
+    assert hass.states.get(lock_id).state == LockState.JAMMED
+
+    with patch.object(SwitchBotAPI, "send_command"):
+        await hass.services.async_call(
+            LOCK_DOMAIN, service, {ATTR_ENTITY_ID: lock_id}, blocking=True
+        )
+    assert hass.states.get(lock_id).state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The lock entity derives everything from a single equality check:

```python
self._attr_is_locked = coord_data["lockState"].lower() == "locked"
```

`switchbot-api` models seven `lockState` values, and five of them come out as unlocked: `latchBoltLocked`, `halfLocked`, `locking`, `unlocking` and `jammed`.

Two consequences stand out. On European night latch doors `latchBoltLocked` is the normal resting secured state, so the entity reads unlocked essentially permanently while the door is locked. And `jammed` is silently swallowed: `LockEntity` has `is_jammed` for exactly this, so a jammed lock currently presents as a cleanly unlocked one.

The same integration's `sensor.<lock>_lock_state` already handles all seven values correctly, so two entities built from one coordinator payload disagree about the same door.

This maps the full enum onto `is_locked`, `is_locking`, `is_unlocking` and `is_jammed`.

Two judgement calls in here, both settled against existing precedent rather than a guess:

* **`halfLocked` counts as locked.** Core's local `switchbot` integration, same vendor and same hardware, does `is_locked = status in {LockStatus.LOCKED, LockStatus.HALF_LOCKED}`. `pyswitchbot` also exposes a deliberate `half_lock()` command with a calibration check for Lock Ultra EU, so it is a commanded resting position rather than a stuck in between state. `latchBoltLocked` follows the same reasoning.
* **The lookup stays case insensitive.** The polled REST payload camel cases these (`latchBoltLocked`) while the webhook upper cases them (`LOCKED`, per the debug payload in #179206). The old `.lower() == "locked"` happened to tolerate that, so a plain lookup by enum value would have regressed the webhook path that works today. A value the cloud adds later now reads as unknown rather than reporting the door open.

The new test walks all seven states plus both webhook casings and an unknown value. Run against the old one liner, `locking`, `unlocking`, `jammed`, `latchBoltLocked` and `halfLocked` all fail there and report `unlocked`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179589
- This PR is related to issue: #179206
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
