### PR TITLE
Use ESPHome project info for serial device manufacturer and model

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -27,6 +27,7 @@ from .manager import (
     DEVICE_CONFLICT_ISSUE_FORMAT,
     ESPHomeManager,
     async_create_api_client,
+    async_get_manufacturer_model,
     cleanup_instance,
 )
 from .websocket_api import async_setup as async_setup_websocket_api
@@ -52,14 +53,16 @@ def _async_scan_serial_ports(
         if device_info is None:
             continue
 
+        manufacturer, model = async_get_manufacturer_model(device_info)
+
         ports.extend(
             SerialDevice(
                 device=str(serial_proxy.build_url(entry.entry_id, proxy.name)),
                 serial_number=(
                     device_info.mac_address.replace(":", "") + "-" + slugify(proxy.name)
                 ),
-                manufacturer=device_info.manufacturer,
-                description=f"{device_info.model} ({proxy.name})",
+                manufacturer=manufacturer,
+                description=f"{model} ({proxy.name})",
             )
             for proxy in device_info.serial_proxies
         )

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -1191,6 +1191,15 @@ class ESPHomeManager:
 
 
 @callback
+def async_get_manufacturer_model(device_info: EsphomeDeviceInfo) -> tuple[str, str]:
+    """Return the manufacturer and model to use for a device."""
+    if device_info.project_name:
+        project_name = device_info.project_name.split(".")
+        return project_name[0], project_name[1]
+    return device_info.manufacturer or "espressif", device_info.model
+
+
+@callback
 def _async_setup_device_registry(
     hass: HomeAssistant, entry: ESPHomeConfigEntry, entry_data: RuntimeEntryData
 ) -> str:
@@ -1236,14 +1245,8 @@ def _async_setup_device_registry(
     ):
         configuration_url = f"homeassistant://app/{dashboard.addon_slug}"
 
-    manufacturer = "espressif"
-    if device_info.manufacturer:
-        manufacturer = device_info.manufacturer
-    model = device_info.model
+    manufacturer, model = async_get_manufacturer_model(device_info)
     if device_info.project_name:
-        project_name = device_info.project_name.split(".")
-        manufacturer = project_name[0]
-        model = project_name[1]
         sw_version = (
             f"{device_info.project_version} (ESPHome {device_info.esphome_version})"
         )

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -135,6 +135,65 @@ async def test_scan_serial_ports_happy_path(
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
+async def test_scan_serial_ports_uses_project_info(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Project information takes precedence over manufacturer and model."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "manufacturer": "Espressif",
+            "model": "ESP32",
+            "project_name": "vendor.gadget",
+            "serial_proxies": [
+                SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL)
+            ],
+        },
+    )
+
+    assert _async_scan_serial_ports(hass) == [
+        SerialDevice(
+            device=str(serial_proxy.build_url(device.entry.entry_id, "uart0")),
+            serial_number="AABBCCDDEEFF-uart0",
+            manufacturer="vendor",
+            description="gadget (uart0)",
+        )
+    ]
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_scan_serial_ports_defaults_manufacturer(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """A device without a manufacturer falls back to espressif."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "manufacturer": "",
+            "model": "ESP32",
+            "serial_proxies": [
+                SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL)
+            ],
+        },
+    )
+
+    assert _async_scan_serial_ports(hass) == [
+        SerialDevice(
+            device=str(serial_proxy.build_url(device.entry.entry_id, "uart0")),
+            serial_number="AABBCCDDEEFF-uart0",
+            manufacturer="espressif",
+            description="ESP32 (uart0)",
+        )
+    ]
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_scan_serial_ports_skips_unavailable(
     hass: HomeAssistant,
     mock_client: APIClient,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When ESPHome registers a device it prefers the project information over the raw manufacturer and model: a device configured with `project.name: vendor.gadget` shows up as manufacturer `vendor`, model `gadget`, rather than `espressif` / `esp32dev`. The serial ports a device exposes through the serial proxy were not doing this, so the same device appeared under two different names depending on where you looked at it.

The manufacturer/model resolution is pulled out of `_async_setup_device_registry` into `async_get_manufacturer_model`, and the serial port scanner now uses it too. The scanner also picks up the `espressif` fallback, so a device that reports no manufacturer no longer produces a serial port with an empty manufacturer field. The device registry behaviour is unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
