### PR TITLE
Fix moon phase calculations to use current time

### DIFF
--- a/homeassistant/components/moon/helpers.py
+++ b/homeassistant/components/moon/helpers.py
@@ -1,6 +1,7 @@
 """Helpers for moon phases."""
 
-from astral import moon
+import math
+from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -26,9 +27,85 @@ MOON_PHASES: tuple[str, ...] = (
     STATE_WANING_CRESCENT,
 )
 
-# astral.moon.phase returns 0-27.99; illumination increases up to the full moon
+# Phase calculation returns 0-27.99; illumination increases up to the full moon
 # (value 14) and decreases afterwards.
 _FULL_MOON_PHASE_VALUE = 14
+
+
+class _Moon:
+    """Moon calculation helper."""
+
+    @staticmethod
+    def phase(
+        target_date: Any = None,
+    ) -> float:
+        """Calculate the phase of the moon (0..27.99) for a given date/datetime."""
+        if target_date is None:
+            target_date = dt_util.utcnow()
+
+        if hasattr(target_date, "hour"):
+            target_date = dt_util.as_utc(target_date)
+            day_fraction = (
+                target_date.hour * 3600
+                + target_date.minute * 60
+                + target_date.second
+                + target_date.microsecond / 1_000_000
+            ) / 86400.0
+        else:
+            day_fraction = 0.0
+
+        year = target_date.year
+        month = target_date.month
+        day = target_date.day
+
+        if month <= 2:
+            year -= 1
+            month += 12
+
+        century = year // 100
+        greg_corr = 2 - century + (century // 4)
+        julian_day = (
+            int(365.25 * (year + 4716))
+            + int(30.6001 * (month + 1))
+            + day
+            + day_fraction
+            + greg_corr
+            - 1524.5
+        )
+
+        delta_t = pow((julian_day - 2382148), 2) / (41048480 * 86400)
+        centuries = (julian_day + delta_t - 2451545.0) / 36525
+        cent_sq = pow(centuries, 2)
+        cent_cube = pow(centuries, 3)
+
+        mean_elong = math.radians(
+            (
+                297.85
+                + 445267.1115 * centuries
+                - 0.0016300 * cent_sq
+                + cent_cube / 545868
+            )
+            % 360.0
+        )
+        sun_anomaly = math.radians((357.53 + 35999.0503 * centuries) % 360.0)
+        moon_anomaly = math.radians(
+            (134.96 + 477198.8676 * centuries + 0.0089970 * cent_sq + cent_cube / 69699)
+            % 360.0
+        )
+
+        elongation = math.degrees(mean_elong) + 6.29 * math.sin(moon_anomaly)
+        elongation -= 2.10 * math.sin(sun_anomaly)
+        elongation += 1.27 * math.sin(2 * mean_elong - moon_anomaly)
+        elongation += 0.66 * math.sin(2 * mean_elong)
+        elong_deg = int(elongation % 360.0)
+
+        phase_val = ((elong_deg + 6.43) / 360.0) * 28.0
+        if phase_val >= 28.0:
+            phase_val -= 28.0
+        return phase_val
+
+
+moon = _Moon()
 
 
 @callback

--- a/homeassistant/components/moon/helpers.py
+++ b/homeassistant/components/moon/helpers.py
@@ -34,7 +34,7 @@ _FULL_MOON_PHASE_VALUE = 14
 @callback
 def moon_phase() -> str:
     """Return the current moon phase."""
-    value: float = moon.phase(dt_util.now().date())
+    value: float = moon.phase(dt_util.now())
     if value < 0.5 or value > 27.5:
         return STATE_NEW_MOON
     if value < 6.5:
@@ -55,5 +55,5 @@ def moon_phase() -> str:
 @callback
 def is_waxing() -> bool:
     """Return whether the moon is currently waxing (illumination increasing)."""
-    value: float = moon.phase(dt_util.now().date())
+    value: float = moon.phase(dt_util.now())
     return value < _FULL_MOON_PHASE_VALUE

--- a/homeassistant/components/moon/helpers.py
+++ b/homeassistant/components/moon/helpers.py
@@ -1,7 +1,6 @@
 """Helpers for moon phases."""
 
-import math
-from typing import Any
+from astral import moon
 
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -27,91 +26,15 @@ MOON_PHASES: tuple[str, ...] = (
     STATE_WANING_CRESCENT,
 )
 
-# Phase calculation returns 0-27.99; illumination increases up to the full moon
+# astral.moon.phase returns 0-27.99; illumination increases up to the full moon
 # (value 14) and decreases afterwards.
 _FULL_MOON_PHASE_VALUE = 14
-
-
-class _Moon:
-    """Moon calculation helper."""
-
-    @staticmethod
-    def phase(
-        target_date: Any = None,
-    ) -> float:
-        """Calculate the phase of the moon (0..27.99) for a given date/datetime."""
-        if target_date is None:
-            target_date = dt_util.utcnow()
-
-        if hasattr(target_date, "hour"):
-            target_date = dt_util.as_utc(target_date)
-            day_fraction = (
-                target_date.hour * 3600
-                + target_date.minute * 60
-                + target_date.second
-                + target_date.microsecond / 1_000_000
-            ) / 86400.0
-        else:
-            day_fraction = 0.0
-
-        year = target_date.year
-        month = target_date.month
-        day = target_date.day
-
-        if month <= 2:
-            year -= 1
-            month += 12
-
-        century = year // 100
-        greg_corr = 2 - century + (century // 4)
-        julian_day = (
-            int(365.25 * (year + 4716))
-            + int(30.6001 * (month + 1))
-            + day
-            + day_fraction
-            + greg_corr
-            - 1524.5
-        )
-
-        delta_t = pow((julian_day - 2382148), 2) / (41048480 * 86400)
-        centuries = (julian_day + delta_t - 2451545.0) / 36525
-        cent_sq = pow(centuries, 2)
-        cent_cube = pow(centuries, 3)
-
-        mean_elong = math.radians(
-            (
-                297.85
-                + 445267.1115 * centuries
-                - 0.0016300 * cent_sq
-                + cent_cube / 545868
-            )
-            % 360.0
-        )
-        sun_anomaly = math.radians((357.53 + 35999.0503 * centuries) % 360.0)
-        moon_anomaly = math.radians(
-            (134.96 + 477198.8676 * centuries + 0.0089970 * cent_sq + cent_cube / 69699)
-            % 360.0
-        )
-
-        elongation = math.degrees(mean_elong) + 6.29 * math.sin(moon_anomaly)
-        elongation -= 2.10 * math.sin(sun_anomaly)
-        elongation += 1.27 * math.sin(2 * mean_elong - moon_anomaly)
-        elongation += 0.66 * math.sin(2 * mean_elong)
-        elong_deg = int(elongation % 360.0)
-
-        phase_val = ((elong_deg + 6.43) / 360.0) * 28.0
-        if phase_val >= 28.0:
-            phase_val -= 28.0
-        return phase_val
-
-
-moon = _Moon()
 
 
 @callback
 def moon_phase() -> str:
     """Return the current moon phase."""
-    value: float = moon.phase(dt_util.now())
+    value: float = moon.phase(dt_util.utcnow())
     if value < 0.5 or value > 27.5:
         return STATE_NEW_MOON
     if value < 6.5:
@@ -132,5 +55,5 @@ def moon_phase() -> str:
 @callback
 def is_waxing() -> bool:
     """Return whether the moon is currently waxing (illumination increasing)."""
-    value: float = moon.phase(dt_util.now())
+    value: float = moon.phase(dt_util.utcnow())
     return value < _FULL_MOON_PHASE_VALUE

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -13,13 +13,11 @@ from homeassistant.components.moon.helpers import (
     STATE_WANING_GIBBOUS,
     STATE_WAXING_CRESCENT,
     STATE_WAXING_GIBBOUS,
-    moon,
 )
 from homeassistant.components.sensor import ATTR_OPTIONS, SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -80,53 +78,3 @@ async def test_moon_day(
     assert device_entry
     assert device_entry.name == "Moon"
     assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
-
-
-@pytest.mark.parametrize(
-    ("target_str", "expected_phase"),
-    [
-        pytest.param(
-            "2026-08-27",
-            13.411222222222223,
-            id="date-midnight",
-        ),
-        pytest.param(
-            "2026-08-27 22:56:00+00:00",
-            14.26677777777778,
-            id="datetime-utc",
-        ),
-        pytest.param(
-            "2026-08-27 22:56:00",
-            14.26677777777778,
-            id="datetime-naive",
-        ),
-    ],
-)
-def test_moon_phase_calculation(target_str: str, expected_phase: float) -> None:
-    """Test moon phase calculation across date and datetime inputs."""
-    target = dt_util.parse_date(target_str) or dt_util.parse_datetime(target_str)
-    assert target is not None
-    assert moon.phase(target) == pytest.approx(expected_phase)
-
-
-def test_moon_phase_default_now() -> None:
-    """Test moon phase defaults to current time."""
-    now = dt_util.parse_datetime("2026-08-27 22:56:00+00:00")
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        assert moon.phase() == pytest.approx(14.26677777777778)
-
-
-async def test_moon_sensor_unmocked(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test the Moon sensor without mocking moon.phase."""
-    now = dt_util.parse_datetime("2026-08-27 22:56:00+00:00")
-    with patch("homeassistant.util.dt.now", return_value=now):
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.moon_phase")
-    assert state
-    assert state.state == STATE_FULL_MOON

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -13,11 +13,13 @@ from homeassistant.components.moon.helpers import (
     STATE_WANING_GIBBOUS,
     STATE_WAXING_CRESCENT,
     STATE_WAXING_GIBBOUS,
+    moon,
 )
 from homeassistant.components.sensor import ATTR_OPTIONS, SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -78,3 +80,53 @@ async def test_moon_day(
     assert device_entry
     assert device_entry.name == "Moon"
     assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
+
+
+@pytest.mark.parametrize(
+    ("target_str", "expected_phase"),
+    [
+        pytest.param(
+            "2026-08-27",
+            13.411222222222223,
+            id="date-midnight",
+        ),
+        pytest.param(
+            "2026-08-27 22:56:00+00:00",
+            14.26677777777778,
+            id="datetime-utc",
+        ),
+        pytest.param(
+            "2026-08-27 22:56:00",
+            14.26677777777778,
+            id="datetime-naive",
+        ),
+    ],
+)
+def test_moon_phase_calculation(target_str: str, expected_phase: float) -> None:
+    """Test moon phase calculation across date and datetime inputs."""
+    target = dt_util.parse_date(target_str) or dt_util.parse_datetime(target_str)
+    assert target is not None
+    assert moon.phase(target) == pytest.approx(expected_phase)
+
+
+def test_moon_phase_default_now() -> None:
+    """Test moon phase defaults to current time."""
+    now = dt_util.parse_datetime("2026-08-27 22:56:00+00:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        assert moon.phase() == pytest.approx(14.26677777777778)
+
+
+async def test_moon_sensor_unmocked(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Moon sensor without mocking moon.phase."""
+    now = dt_util.parse_datetime("2026-08-27 22:56:00+00:00")
+    with patch("homeassistant.util.dt.now", return_value=now):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.moon_phase")
+    assert state
+    assert state.state == STATE_FULL_MOON


### PR DESCRIPTION
Updated moon_phase and is_waxing functions to use current time instead of date.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the state change is done on midnight, so when it gets dark, it's not possible to see the current state of the moon as it shows the one from last night.
For example today (27/8/2026 22:00), it's currently full moon and this integration shows as Waxing gibbous, but it should show Full moon. At midnight this will change to Full moon, but this won't be visible on the integration until then.

This was calculating the start of the day using the date only:
```python
>>> datetime.datetime.now().date()
datetime.date(2026, 8, 27)
>>> moon.phase(datetime.datetime.now().date())
13.411222222222223
```
With this fix, it calculates the current datetime:
```python
>>> datetime.datetime.now()
datetime.datetime(2026, 8, 27, 22, 19, 43, 317351)
>>> moon.phase(datetime.datetime.now())
14.26677777777778
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #53434
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
