### PR TITLE
Translate KNX device trigger configuration error

### DIFF
--- a/homeassistant/components/knx/device_trigger.py
+++ b/homeassistant/components/knx/device_trigger.py
@@ -115,8 +115,11 @@ async def async_attach_trigger(
     try:
         trigger_config = TRIGGER_TRIGGER_SCHEMA(trigger_config)
     except vol.Invalid as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
-        raise InvalidDeviceAutomationConfig(f"{err}") from err
+        raise InvalidDeviceAutomationConfig(
+            translation_domain=DOMAIN,
+            translation_key="device_trigger_invalid_config",
+            translation_placeholders={"error": str(err)},
+        ) from err
 
     return await trigger.async_attach_trigger(
         hass, config=trigger_config, action=action, trigger_info=trigger_info

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1279,6 +1279,9 @@
     }
   },
   "exceptions": {
+    "device_trigger_invalid_config": {
+      "message": "Invalid KNX telegram trigger configuration: {error}"
+    },
     "integration_not_loaded": {
       "message": "KNX integration is not loaded."
     },

--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -425,7 +425,13 @@ async def test_invalid_trigger_configuration(
     )
     # After changing the config in async_attach_trigger, the config is validated again
     # against the integration trigger. This test checks if this validation works.
-    with pytest.raises(InvalidDeviceAutomationConfig):
+    with pytest.raises(
+        InvalidDeviceAutomationConfig,
+        match=(
+            "Invalid KNX telegram trigger configuration: "
+            "invalid boolean value invalid at 'group_value_write'"
+        ),
+    ):
         await device_trigger.async_attach_trigger(
             hass,
             {


### PR DESCRIPTION
## Breaking change


## Proposed change

`knx` has `exception-translations: done` in its quality scale, but `device_trigger.async_attach_trigger` still raised `InvalidDeviceAutomationConfig` with a hardcoded English message (guarded by a `pylint: disable-next=home-assistant-exception-not-translated`).

The re-validation error is now raised with `translation_domain` / `translation_key` / `translation_placeholders` and a new `device_trigger_invalid_config` entry in `strings.json`.

The validation detail is kept as an `{error}` placeholder. It is not itself translatable, but it names the offending field and what was expected, and since validation runs on probatio the rendered message is a readable sentence with a dotted path:

> Invalid KNX telegram trigger configuration: invalid boolean value invalid at 'group_value_write'

where voluptuous used to produce `... for dictionary value @ data['group_value_write']`. This mirrors the existing `service_send_invalid_payload` key in this integration.

`test_invalid_trigger_configuration` now asserts the rendered message, so the translation lookup and the placeholder are covered.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171493
- This PR is related to issue: home-assistant/epics#71
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
