### PR TITLE
Fix Portainer tests hanging on real event listener

### DIFF
--- a/tests/components/portainer/conftest.py
+++ b/tests/components/portainer/conftest.py
@@ -139,9 +139,13 @@ def mock_portainer_client(mock_portainer_watcher: MagicMock) -> Generator[AsyncM
         yield client
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_portainer_event_listeners() -> Generator[dict[int, MagicMock]]:
-    """Mock PortainerEventListener; one MagicMock instance per endpoint_id."""
+    """Mock PortainerEventListener; one MagicMock instance per endpoint_id.
+
+    Autouse because the real listener reconnects in a tight loop when its
+    event stream ends immediately, as the mocked client's does.
+    """
     instances: dict[int, MagicMock] = {}
 
     def _factory(


### PR DESCRIPTION
## Proposed change

This PR fixes Portainer tests hanging after:
- showed up after: https://github.com/home-assistant/core/pull/180405
- underlying issue introduced here: https://github.com/home-assistant/core/pull/180384

Hang and fix confirmed locally. Also tested CI [partial run](https://github.com/home-assistant/core/actions/runs/33126394688/job/98712169873?pr=180464) and [full run](https://github.com/TheJulianJES/core/actions/runs/33128787656) (Codecov failure there is expected because it's run from a fork – tests did not hang though).

### AI-generated PR description

dev is currently red — the group 8 test job (Run tests Python 3.14.5 (8)) stalls and is SIGTERM'd after ~25 minutes, so every full-suite CI run since inherits the failure: requirements- or core-touching PRs, and every dev push. This fixes that.

The `mock_portainer_event_listeners` fixture was not `autouse`, and only `test_event.py` and `test_init.py` requested it, so every other module that sets up the integration ran the real `PortainerEventListener` against the `autospec`'d Portainer mock.

`PortainerEventListener._listen()` iterates `self._portainer.get_events()`; on a `MagicMock` that async iterator is exhausted immediately, so `_listen()` returns without ever awaiting anything real and `_listen_with_reconnect()`'s while loop re-enters it without yielding to the event loop. The result is a busy loop that pins a CPU and grows the mock's recorded calls until the test process is killed.

Make the fixture `autouse`. `tests/components/portainer` goes from hanging to 116 passed in ~26s, with no individual test over 1s.

### Root cause is upstream, in pyportainer 1.0.45

Recording this so the trigger is not mis-attributed: #180405 exposed the hang, it did not cause it.

In pyportainer 1.0.44, `_listen_with_reconnect()` ended every iteration with an unconditional `await asyncio.sleep(self._reconnect_interval.total_seconds())` outside the try/except, so a clean stream end slept before reconnecting. The 1.0.45 backoff refactor moved that sleep into `_backoff()`, which only runs on the exception branches, leaving the clean-end path with no delay at all. Core picked up 1.0.45 in #180384, one portainer commit before #180405.

This matters in production too, not just under mocks: a graceful server-side close of the event stream currently produces an unthrottled reconnect loop. This test change stays correct either way.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
