### PR TITLE
Add serial number to Roborock devices

### DIFF
--- a/homeassistant/components/roborock/models.py
+++ b/homeassistant/components/roborock/models.py
@@ -33,6 +33,7 @@ def get_device_info(device: RoborockDevice) -> DeviceInfo:
         model=device.product.model,
         model_id=device.product.model,
         sw_version=device.device_info.fv,
+        serial_number=device.device_info.sn,
     )
 
 

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -109,6 +109,35 @@ async def test_stale_device(
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_device_serial_number(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test the serial number is taken from home data, where the cloud reports one.
+
+    The docks are separate devices without their own home data entry, and the
+    Dyad Pro is a shared device whose home data carries no serial number.
+    """
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    await asyncio.gather(*mock_roborock_entry._background_tasks)
+    devices = dr.async_entries_for_config_entry(
+        device_registry, mock_roborock_entry.entry_id
+    )
+    assert {device.name: device.serial_number for device in devices} == {
+        "Roborock S7 MaxV": "abc123",
+        "Roborock S7 MaxV Dock": None,
+        "Roborock S7 2": "abc123",
+        "Roborock S7 2 Dock": None,
+        "Dyad Pro": None,
+        "Zeo One": "zeo_sn",
+        "Roborock Q7": "q7_sn",
+        "Roborock Q10 S5+": "9FFC112EQAD843",
+    }
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_no_stale_device(
     hass: HomeAssistant,
     mock_roborock_entry: MockConfigEntry,

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -120,8 +120,7 @@ async def test_device_serial_number(
     Dyad Pro is a shared device whose home data carries no serial number.
     """
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    await hass.async_block_till_done()
-    await asyncio.gather(*mock_roborock_entry._background_tasks)
+    await hass.async_block_till_done(wait_background_tasks=True)
     devices = dr.async_entries_for_config_entry(
         device_registry, mock_roborock_entry.entry_id
     )


### PR DESCRIPTION
The Roborock cloud already reports a serial number per device. Pass it on to the device registry so it shows up on the device page.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`get_device_info()` builds the `DeviceInfo` for every Roborock device (V1 robots, A01 Dyad and Zeo, B01 Q7 and Q10), but never set `serial_number`, even though `HomeDataDevice.sn` is part of the home data the integration already fetches. This adds it, so the serial number shows up on the device page and can be used to identify a device against the Roborock app or a support case.

`sn` is `str | None` in the library and is not always present (a shared device may come without one), which `DeviceInfo.serial_number` accepts as-is. The docks are registered as separate devices from `dock_device_info` and have no home data entry of their own, so they keep no serial number.

The added test asserts the serial number of every device the fixtures set up, including the two docks and the shared Dyad Pro that legitimately have none.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
