### PR TITLE
Send the transition with the WLED segment change

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -297,9 +297,11 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
                 main_data[ATTR_BRIGHTNESS] = data[ATTR_BRIGHTNESS]
                 data[ATTR_BRIGHTNESS] = 255
 
+            # WLED reads tt per request, so the segment needs its own copy.
+            # Without it the color change in this call snaps to the device's
+            # own default transition while only the brightness fades.
             if ATTR_TRANSITION in data:
                 main_data[ATTR_TRANSITION] = data[ATTR_TRANSITION]
-                del data[ATTR_TRANSITION]
 
             await self.coordinator.wled.segment(**data)
             await self.coordinator.wled.master(**main_data)

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -297,9 +297,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
                 main_data[ATTR_BRIGHTNESS] = data[ATTR_BRIGHTNESS]
                 data[ATTR_BRIGHTNESS] = 255
 
-            # WLED reads tt per request, so the segment needs its own copy.
-            # Without it the color change in this call snaps to the device's
-            # own default transition while only the brightness fades.
             if ATTR_TRANSITION in data:
                 main_data[ATTR_TRANSITION] = data[ATTR_TRANSITION]
 

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -277,7 +277,9 @@ async def test_single_segment_behavior(
     )
     assert mock_wled.segment.call_count == 1
     assert mock_wled.master.call_count == 2
-    mock_wled.segment.assert_called_with(on=True, segment_id=0, brightness=255)
+    mock_wled.segment.assert_called_with(
+        on=True, segment_id=0, brightness=255, transition=50
+    )
     mock_wled.master.assert_called_with(on=True, transition=50, brightness=42)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On a WLED device with a single segment and no main light, `WLEDSegmentLight.async_turn_on` moves the transition over to the master call:

```python
if ATTR_TRANSITION in data:
    main_data[ATTR_TRANSITION] = data[ATTR_TRANSITION]
    del data[ATTR_TRANSITION]

await self.coordinator.wled.segment(**data)
await self.coordinator.wled.master(**main_data)
```

`tt` is a per request field in WLED's JSON API, and `python-wled` puts it at the top of the state object for `segment()` exactly like it does for `master()`. The segment call is the one carrying the color change and it goes out first, stripped of `tt`, so the color snaps at the device's own default transition and only the brightness fades after it.

That matches the packet capture in the issue byte for byte:

```json
{"seg":[{"bri":255,"on":true,"col":[[210,190,10,0]],"id":0}],"v":true}
```

`bri: 255`, the new color, no `tt`. The device then reports `"transition":7`, its own 0.7 second default, against the 126 seconds the service call asked for.

The `del` goes back to #36529 (June 2020), where the master and segment split was introduced. It made sense while the master owned brightness and power, but not once the segment call is the one carrying the color.

This keeps the transition on both requests, which is what WLED needs since each request transitions on its own.

`test_single_segment_behavior` already pinned the old behaviour, asserting `segment(on=True, segment_id=0, brightness=255)` with no transition right next to `master(on=True, transition=50, brightness=42)`. It now expects the transition on both, and restoring the `del` fails it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178655
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
