### PR TITLE
Remove cloud config entry on logout

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -407,10 +407,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
 
     async def _on_cloud_logout(event: CloudEvent) -> None:
-        """Forget a pending auto-login, hass_nabucasa cancels it on logout."""
+        """Clean up after a logout."""
+        nonlocal loaded
+
+        # Forget a pending auto-login, hass_nabucasa cancels it on logout.
         # No frontend event here, hass_nabucasa publishes LOGOUT before it clears
         # the tokens, so a client re-reading the status would still see a session.
         hass.data[DATA_PENDING_AUTO_LOGIN] = None
+        # Allow _on_start to create a new config entry on the next login.
+        loaded = False
+        await _async_remove_config_entry(hass)
 
     cloud.register_on_start(_on_start)
     cloud.iot.register_on_connect(_on_connect)
@@ -423,6 +429,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     cloud.events.subscribe(event_type=CloudEventType.LOGOUT, handler=_on_cloud_logout)
 
     await cloud.initialize()
+
+    if not cloud.is_logged_in:
+        # Remove leftover config entries if the user is not logged in.
+        await _async_remove_config_entry(hass)
+
     http_api.async_setup(hass)
 
     account_link.async_setup(hass)
@@ -448,6 +459,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     return True
+
+
+async def _async_remove_config_entry(hass: HomeAssistant) -> None:
+    """Remove the config entry, it's recreated when a user logs in again."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        await hass.config_entries.async_remove(entry.entry_id)
 
 
 @callback

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -463,8 +463,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_remove_config_entry(hass: HomeAssistant) -> None:
     """Remove the config entry, it's recreated when a user logs in again."""
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        await hass.config_entries.async_remove(entry.entry_id)
+    if entries := hass.config_entries.async_entries(DOMAIN):
+        # The manifest sets single_config_entry, so there is at most one entry.
+        await hass.config_entries.async_remove(entries[0].entry_id)
 
 
 @callback

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.cloud import (
     CloudConnectionState,
     CloudNotAvailable,
@@ -25,9 +26,12 @@ from homeassistant.components.cloud.prefs import STORAGE_KEY
 from homeassistant.const import CONF_MODE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockUser
+
+REMOTE_UI_UNIQUE_ID = "cloud-remote-ui-connectivity"
 
 
 async def test_constructor_loads_info_from_config(hass: HomeAssistant) -> None:
@@ -320,7 +324,7 @@ async def test_async_get_or_create_cloudhook(
         await async_get_or_create_cloudhook(hass, webhook_id)
 
 
-async def test_cloud_logout(
+async def test_setup_removes_stale_config_entry(
     hass: HomeAssistant,
     cloud: MagicMock,
 ) -> None:
@@ -333,6 +337,43 @@ async def test_cloud_logout(
     await hass.async_block_till_done()
 
     assert cloud.is_logged_in is False
+    assert not hass.config_entries.async_entries(DOMAIN)
+
+
+async def test_logout_removes_config_entry(
+    hass: HomeAssistant,
+    cloud: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the config entry is removed on logout and recreated on login."""
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
+    await hass.async_block_till_done()
+
+    assert not hass.config_entries.async_entries(DOMAIN)
+
+    await cloud.login("test-user", "test-pass")
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, REMOTE_UI_UNIQUE_ID
+    )
+
+    await cloud.logout()
+    await hass.async_block_till_done()
+
+    assert not hass.config_entries.async_entries(DOMAIN)
+    assert not entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, REMOTE_UI_UNIQUE_ID
+    )
+
+    await cloud.login("test-user", "test-pass")
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, REMOTE_UI_UNIQUE_ID
+    )
 
 
 async def test_async_listen_cloudhook_change(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The config entry is created after login but was never removed again, so the integration and its entities stayed behind after logging out. Also clean up an entry left behind by a logout in an older version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136341
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
