### PR TITLE
Report Overkiz Uno awnings as closed when retracted

### DIFF
--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -77,6 +77,8 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         invert_position=False,
         is_closed_state=OverkizState.CORE_OPEN_CLOSED,
     ),
+    # Uno receivers need to omit is_closed_state, since OpenClosedState is
+    # unreliable on them and stays open however far the awning is retracted
     OverkizCoverDescription(
         key=UIWidget.PERGOLA_HORIZONTAL_AWNING_UNO,
         device_class=CoverDeviceClass.AWNING,
@@ -86,7 +88,17 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         close_command=OverkizCommand.UNDEPLOY,
         stop_command=OverkizCommand.STOP,
         invert_position=False,
-        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
+    ),
+    # uiClass is Awning
+    OverkizCoverDescription(
+        key=UIWidget.POSITIONABLE_HORIZONTAL_AWNING_UNO,
+        device_class=CoverDeviceClass.AWNING,
+        current_position_state=OverkizState.CORE_DEPLOYMENT,
+        set_position_command=OverkizCommand.SET_DEPLOYMENT,
+        open_command=OverkizCommand.DEPLOY,
+        close_command=OverkizCommand.UNDEPLOY,
+        stop_command=OverkizCommand.STOP,
+        invert_position=False,
     ),
     # Needs override to omit is_closed_state, since OpenClosedState is unreliable
     # uiClass is RollerShutter

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -77,8 +77,6 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         invert_position=False,
         is_closed_state=OverkizState.CORE_OPEN_CLOSED,
     ),
-    # Uno receivers need to omit is_closed_state, since OpenClosedState is
-    # unreliable on them and stays open however far the awning is retracted
     OverkizCoverDescription(
         key=UIWidget.PERGOLA_HORIZONTAL_AWNING_UNO,
         device_class=CoverDeviceClass.AWNING,
@@ -88,7 +86,9 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         close_command=OverkizCommand.UNDEPLOY,
         stop_command=OverkizCommand.STOP,
         invert_position=False,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
     ),
+    # Needs override to omit is_closed_state, since OpenClosedState is unreliable
     # uiClass is Awning
     OverkizCoverDescription(
         key=UIWidget.POSITIONABLE_HORIZONTAL_AWNING_UNO,

--- a/tests/components/overkiz/fixtures/setup/local_somfy_connexoon_europe.json
+++ b/tests/components/overkiz/fixtures/setup/local_somfy_connexoon_europe.json
@@ -376,6 +376,260 @@
       }
     },
     {
+      "deviceURL": "io://1234-1234-1234/5928358",
+      "available": true,
+      "synced": true,
+      "type": 1,
+      "states": [
+        {
+          "type": 3,
+          "name": "core:StatusState",
+          "value": "available"
+        },
+        {
+          "type": 3,
+          "name": "core:DiscreteRSSILevelState",
+          "value": "good"
+        },
+        {
+          "type": 1,
+          "name": "core:RSSILevelState",
+          "value": 88
+        },
+        {
+          "type": 1,
+          "name": "core:DeploymentState",
+          "value": 0
+        },
+        {
+          "type": 11,
+          "name": "core:ManufacturerSettingsState",
+          "value": {
+            "currentPosition": 0
+          }
+        },
+        {
+          "type": 3,
+          "name": "core:OpenClosedState",
+          "value": "open"
+        },
+        {
+          "type": 1,
+          "name": "core:TargetClosureState",
+          "value": 0
+        },
+        {
+          "type": 6,
+          "name": "core:MovingState",
+          "value": false
+        },
+        {
+          "type": 3,
+          "name": "core:NameState",
+          "value": "Pergola Awning"
+        },
+        {
+          "type": 1,
+          "name": "core:Memorized1PositionState",
+          "value": 105
+        }
+      ],
+      "label": "Pergola Awning",
+      "subsystemId": 0,
+      "attributes": [
+        {
+          "type": 3,
+          "name": "core:Manufacturer",
+          "value": "Somfy"
+        },
+        {
+          "type": 3,
+          "name": "core:FirmwareRevision",
+          "value": "5071665X10\u0003"
+        }
+      ],
+      "enabled": true,
+      "controllableName": "io:HorizontalAwningIOComponent",
+      "definition": {
+        "states": [
+          {
+            "name": "core:AdditionalStatusState"
+          },
+          {
+            "name": "core:DeploymentState"
+          },
+          {
+            "name": "core:DiscreteRSSILevelState"
+          },
+          {
+            "name": "core:ManufacturerSettingsState"
+          },
+          {
+            "name": "core:Memorized1PositionState"
+          },
+          {
+            "name": "core:MovingState"
+          },
+          {
+            "name": "core:NameState"
+          },
+          {
+            "name": "core:OpenClosedState"
+          },
+          {
+            "name": "core:RSSILevelState"
+          },
+          {
+            "name": "core:SecuredPositionState"
+          },
+          {
+            "name": "core:StatusState"
+          },
+          {
+            "name": "core:TargetClosureState"
+          }
+        ],
+        "widgetName": "PositionableHorizontalAwningUno",
+        "type": "ACTUATOR",
+        "commands": [
+          {
+            "nparams": 1,
+            "commandName": "advancedRefresh",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "close",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "delayedStopIdentify",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "deploy",
+            "nparams": 0
+          },
+          {
+            "commandName": "down",
+            "nparams": 0
+          },
+          {
+            "commandName": "getName",
+            "nparams": 0
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "keepOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "commandName": "my",
+            "nparams": 0
+          },
+          {
+            "commandName": "open",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "pairOneWayController",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "commandName": "refreshMemorized1Position",
+            "nparams": 0
+          },
+          {
+            "nparams": 2,
+            "commandName": "runManufacturerSettingsCommand",
+            "paramsSig": "p1,p2"
+          },
+          {
+            "commandName": "sendIOKey",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "setClosure",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setConfigState",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setDeployment",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setMemorized1Position",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setName",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setPosition",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setSecuredPosition",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "startIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "stop",
+            "nparams": 0
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "undeploy",
+            "nparams": 0
+          },
+          {
+            "commandName": "unpairAllOneWayControllers",
+            "nparams": 0
+          },
+          {
+            "commandName": "unpairAllOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "unpairOneWayController",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "commandName": "up",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "wink",
+            "paramsSig": "p1"
+          }
+        ],
+        "uiClass": "Awning"
+      }
+    },
+    {
       "deviceURL": "io://1234-1234-1234/16516299",
       "available": true,
       "synced": true,

--- a/tests/components/overkiz/snapshots/test_cover.ambr
+++ b/tests/components/overkiz/snapshots/test_cover.ambr
@@ -2638,6 +2638,60 @@
     'state': 'closed',
   })
 # ---
+# name: test_cover_entities_snapshot[local_somfy_connexoon_europe.json][cover.pergola_awning-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.pergola_awning',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <CoverEntityFeature: 15>,
+    'translation_key': None,
+    'unique_id': 'io://1234-1234-1234/5928358',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_entities_snapshot[local_somfy_connexoon_europe.json][cover.pergola_awning-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'awning',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Pergola Awning',
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <CoverEntityFeature: 15>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.pergola_awning',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
 # name: test_cover_entities_snapshot[local_somfy_connexoon_europe.json][cover.terrace_awning-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Somfy awnings behind an Uno io receiver never report `closed`. `PositionableHorizontalAwningUno` has no description of its own, so it falls back to the generic `UIClass.AWNING` entry, which carries `is_closed_state=CORE_OPEN_CLOSED`. `OverkizCover.is_closed` returns from that state as soon as it is set, so the `position == 0` fallback below it is never reached. On Uno receivers `core:OpenClosedState` is stuck on `open`, so the awning reads open however far it is retracted, while `current_position` correctly reports 0.

This is the awning half of a bug that was already fixed for shutters: #171703 fixed by #172506, then #173349 fixed by #175837, which added a `POSITIONABLE_ROLLER_SHUTTER_UNO` override omitting `is_closed_state` with the comment that OpenClosedState is unreliable. The other Uno widgets were left behind.

The practical cost is real: awning wind and rain automations guard on `state != closed` before retracting, and with the state stuck on open that guard never filters.

`POSITIONABLE_HORIZONTAL_AWNING_UNO` gets a description that omits `is_closed_state`, mirroring what #175837 did for `POSITIONABLE_ROLLER_SHUTTER_UNO`.

`PERGOLA_HORIZONTAL_AWNING_UNO` is deliberately left alone. It belongs to the same Uno family and the reporter flagged it as likely affected, but neither of us has the hardware and there is no fixture for it, so changing it would be an untested behaviour change. It can follow once someone reports it with evidence.

On the fixture: no awning with an Uno widget existed anywhere in the fixtures, and `Terrace Awning` in `local_somfy_connexoon_europe.json` was in fact the only awning at all. It uses the plain widget, so flipping it would have cost the generic `UIClass.AWNING` coverage. A second device is added alongside it instead, retracted (`core:Deployment: 0`) while the receiver still insists on `core:OpenClosedState: open`, which is exactly the failure the issue describes. That device is the bulk of the diff.

The generated snapshot reports `is_closed: True` and `state: closed` at position 0. Removing the new description so the device falls back to the generic awning entry flips it to `is_closed: False`, which is the reported bug verbatim.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178766
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
