### PR TITLE
Accept a templated PIN for the Matter lock credential

### DIFF
--- a/homeassistant/components/matter/services.py
+++ b/homeassistant/components/matter/services.py
@@ -111,7 +111,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         entity_domain=LOCK_DOMAIN,
         schema={
             vol.Required(ATTR_CREDENTIAL_TYPE): vol.In(SERVICE_CREDENTIAL_TYPES),
-            vol.Required(ATTR_CREDENTIAL_DATA): str,
+            vol.Required(ATTR_CREDENTIAL_DATA): cv.string,
             vol.Optional(ATTR_CREDENTIAL_INDEX): vol.All(
                 vol.Coerce(int), vol.Range(min=0)
             ),

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1073,10 +1073,19 @@ async def test_matter_error_converted_to_home_assistant_error(
         }
     ],
 )
+@pytest.mark.parametrize(
+    "credential_data",
+    [
+        pytest.param("1234", id="string"),
+        # A template rendering a digit only PIN hands over an int
+        pytest.param(1234, id="int"),
+    ],
+)
 async def test_set_lock_credential_pin(
     hass: HomeAssistant,
     matter_client: MagicMock,
     matter_node: MatterNode,
+    credential_data: str | int,
 ) -> None:
     """Test set_lock_credential with PIN type."""
     matter_client.send_device_command = AsyncMock(
@@ -1094,7 +1103,7 @@ async def test_set_lock_credential_pin(
         {
             ATTR_ENTITY_ID: "lock.mock_door_lock",
             ATTR_CREDENTIAL_TYPE: "pin",
-            ATTR_CREDENTIAL_DATA: "1234",
+            ATTR_CREDENTIAL_DATA: credential_data,
             ATTR_CREDENTIAL_INDEX: 1,
         },
         blocking=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`matter.set_lock_credential` validates `credential_data` with a bare `str`. Home Assistant runs `literal_eval` over a rendered template result, so a digit only PIN arrives as an `int` and the schema rejects it:

```
expected str for dictionary value @ data['credential_data']
```

So every templated PIN fails, which makes the action unusable from any PIN rotation or code manager automation. The obvious escapes do not help either: `| string` and `~ ''` both run before the parse, and quote wrapping gets past the schema only to fail the integration's own `PIN must contain only digits` check.

It is also intermittent by luck. `literal_eval('0123456')` raises, so leading zero PINs survive as strings and work fine, which hides this from anyone generating zero padded PINs.

`cv.string` coerces the int back to `"1234"`. It matches the rest of this schema, where `ATTR_USER_NAME` already uses `vol.Any(str, None)` and `credential_data` was the only bare `str` left in the file. RFID hex is unaffected, since a hex string that is not all digits never gets parsed to an int in the first place.

The existing `test_set_lock_credential_pin` is parameterized over `"1234"` and `1234` rather than duplicated. With the bare `str` restored the int case fails with `probatio.error.MultipleInvalid: expected str at 'credential_data'` and no command is sent to the lock.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180480
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
