### PR TITLE
Report an uncalibrated Shelly roller by its last direction

### DIFF
--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -120,22 +120,38 @@ class BlockShellyCover(ShellyBlockAttributeEntity, CoverEntity):
         self.control_result: dict[str, Any] | None = None
         self._attr_name = None  # Main device entity
         self._attr_unique_id: str = f"{coordinator.mac}-{block.description}"
-        if self.coordinator.device.settings["rollers"][0]["positioning"]:
+        self._positioning: bool = self.coordinator.device.settings["rollers"][0][
+            "positioning"
+        ]
+        if self._positioning:
             self._attr_supported_features |= CoverEntityFeature.SET_POSITION
 
     @property
     @override
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """If cover is closed."""
         if self.control_result:
             return cast(bool, self.control_result["current_pos"] == 0)
+
+        if not self._positioning:
+            # An uncalibrated roller parks its position on 101, so the direction
+            # it last travelled in is all there is to go on
+            last_direction = self.coordinator.device.status["rollers"][0].get(
+                "last_direction"
+            )
+            if not last_direction:
+                return None
+            return cast(str, last_direction) == "close"
 
         return cast(int, self.block.rollerPos) == 0
 
     @property
     @override
-    def current_cover_position(self) -> int:
+    def current_cover_position(self) -> int | None:
         """Position of the cover."""
+        if not self._positioning:
+            return None
+
         if self.control_result:
             return cast(int, self.control_result["current_pos"])
 

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -130,18 +130,22 @@ class BlockShellyCover(ShellyBlockAttributeEntity, CoverEntity):
     @override
     def is_closed(self) -> bool | None:
         """If cover is closed."""
-        if self.control_result:
-            return cast(bool, self.control_result["current_pos"] == 0)
-
         if not self._positioning:
             # An uncalibrated roller parks its position on 101, so the direction
             # it last travelled in is all there is to go on
             last_direction = self.coordinator.device.status["rollers"][0].get(
                 "last_direction"
             )
+            if self.control_result:
+                last_direction = self.control_result.get(
+                    "last_direction", last_direction
+                )
             if not last_direction:
                 return None
             return cast(str, last_direction) == "close"
+
+        if self.control_result:
+            return cast(bool, self.control_result["current_pos"] == 0)
 
         return cast(int, self.block.rollerPos) == 0
 

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -123,6 +123,9 @@ class BlockShellyCover(ShellyBlockAttributeEntity, CoverEntity):
         self._positioning: bool = self.coordinator.device.settings["rollers"][0][
             "positioning"
         ]
+        # Without positioning the direction it last travelled in is all there is,
+        # and that says nothing about where it stopped
+        self._attr_assumed_state = not self._positioning
         if self._positioning:
             self._attr_supported_features |= CoverEntityFeature.SET_POSITION
 

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -23,7 +23,12 @@ from homeassistant.components.cover import (
     CoverState,
 )
 from homeassistant.components.shelly.const import RPC_COVER_UPDATE_TIME_SEC
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -111,6 +116,39 @@ async def test_block_device_update(
     state = hass.states.get("cover.test_name")
     assert state
     assert state.state == CoverState.OPEN
+
+
+@pytest.mark.parametrize(
+    ("last_direction", "expected_state"),
+    [
+        ("close", CoverState.CLOSED),
+        ("open", CoverState.OPEN),
+        # Nothing has moved since the device booted
+        (None, STATE_UNKNOWN),
+    ],
+)
+async def test_block_device_roller_without_positioning(
+    hass: HomeAssistant,
+    mock_block_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    last_direction: str | None,
+    expected_state: str,
+) -> None:
+    """Test an uncalibrated roller reports the direction it last travelled in."""
+    settings = deepcopy(mock_block_device.settings)
+    settings["rollers"][0]["positioning"] = False
+    monkeypatch.setattr(mock_block_device, "settings", settings)
+
+    status = deepcopy(mock_block_device.status)
+    # An uncalibrated roller parks its position on 101
+    status["rollers"] = [{"current_pos": 101, "last_direction": last_direction}]
+    monkeypatch.setattr(mock_block_device, "status", status)
+
+    await init_integration(hass, 1)
+
+    assert (state := hass.states.get("cover.test_name"))
+    assert state.state == expected_state
+    assert state.attributes.get(ATTR_CURRENT_POSITION) is None
 
 
 async def test_block_device_no_roller_blocks(

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -24,6 +24,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.shelly.const import RPC_COVER_UPDATE_TIME_SEC
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -116,6 +117,7 @@ async def test_block_device_update(
     state = hass.states.get("cover.test_name")
     assert state
     assert state.state == CoverState.OPEN
+    assert ATTR_ASSUMED_STATE not in state.attributes
 
 
 @pytest.mark.parametrize(
@@ -149,6 +151,9 @@ async def test_block_device_roller_without_positioning(
     assert (state := hass.states.get("cover.test_name"))
     assert state.state == expected_state
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+    # Stopping mid travel leaves the direction saying more than it knows, so
+    # both buttons stay available
+    assert state.attributes[ATTR_ASSUMED_STATE] is True
 
 
 async def test_block_device_roller_without_positioning_stopped(

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -1,7 +1,7 @@
 """Tests for Shelly cover platform."""
 
 from copy import deepcopy
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -149,6 +149,46 @@ async def test_block_device_roller_without_positioning(
     assert (state := hass.states.get("cover.test_name"))
     assert state.state == expected_state
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+async def test_block_device_roller_without_positioning_stopped(
+    hass: HomeAssistant,
+    mock_block_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test stopping an uncalibrated roller keeps it on its last direction."""
+    settings = deepcopy(mock_block_device.settings)
+    settings["rollers"][0]["positioning"] = False
+    monkeypatch.setattr(mock_block_device, "settings", settings)
+
+    status = deepcopy(mock_block_device.status)
+    status["rollers"] = [{"current_pos": 101, "last_direction": "close"}]
+    monkeypatch.setattr(mock_block_device, "status", status)
+
+    # An uncalibrated roller answers a command with position 101 as well
+    monkeypatch.setattr(
+        mock_block_device.blocks[ROLLER_BLOCK_ID],
+        "set_state",
+        AsyncMock(
+            side_effect=lambda go, roller_pos=0: {"current_pos": 101, "state": go}
+        ),
+    )
+
+    await init_integration(hass, 1)
+
+    entity_id = "cover.test_name"
+    assert (state := hass.states.get(entity_id))
+    assert state.state == CoverState.CLOSED
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == CoverState.CLOSED
 
 
 async def test_block_device_no_roller_blocks(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`BlockShellyCover.is_closed` is `rollerPos == 0`. On a Shelly 2 or 2.5 with positioning disabled there is no calibration, so the roller parks its position on 101 permanently. That comparison is never true and the cover reads open forever, closed or not.

The two captures in the issue are the proof, and they differ in exactly one field:

```
open:   "last_direction":"open",  "current_pos":101, "positioning":false
closed: "last_direction":"close", "current_pos":101, "positioning":false
```

There is a second defect from the same cause: `current_cover_position` publishes that 101 as `current_position`, which is outside the 0-100 range a cover attribute is allowed to be.

`positioning` is already read in `__init__` to decide on `SET_POSITION`, so it is simply kept. When it is off, `is_closed` comes from `last_direction` and `current_cover_position` returns `None` rather than a bogus 101. When it is on, nothing changes.

An absent `last_direction`, a roller that has not moved since it booted, gives `None`, so the cover reads unknown rather than guessing.

The new test is parameterized over `close`, `open` and absent. Against the old position-only logic all three fail:

```
assert 'open' == <CoverState.CLOSED: 'closed'>
assert <Mock name='mock.rollerPos'> is None
assert 'open' == 'unknown'
```

@thecode, `last_direction` is the only signal an uncalibrated Gen1 roller offers and it lines up with the reporter's captures, but shout if there is a wrinkle here I have missed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177560
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
