### PR TITLE
Normalize the Proxmox VE guest id to an int

### DIFF
--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -378,7 +378,7 @@ class ProxmoxVMButtonEntity(ProxmoxVMEntity, ProxmoxBaseButton):
             self.entity_description.press_action,
             self.coordinator,
             self._node_name,
-            self.vm_data["vmid"],
+            self.device_id,
         )
 
 
@@ -394,5 +394,5 @@ class ProxmoxContainerButtonEntity(ProxmoxContainerEntity, ProxmoxBaseButton):
             self.entity_description.press_action,
             self.coordinator,
             self._node_name,
-            self.container_data["vmid"],
+            self.device_id,
         )

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -161,8 +161,8 @@ def _get_nodes_data(data: dict[str, Any]) -> list[dict[str, Any]]:
         nodes_data.append(
             {
                 CONF_NODE: node["node"],
-                CONF_VMS: [vm["vmid"] for vm in vms],
-                CONF_CONTAINERS: [container["vmid"] for container in containers],
+                CONF_VMS: [int(vm["vmid"]) for vm in vms],
+                CONF_CONTAINERS: [int(container["vmid"]) for container in containers],
             }
         )
 

--- a/homeassistant/components/proxmoxve/entity.py
+++ b/homeassistant/components/proxmoxve/entity.py
@@ -129,7 +129,7 @@ class ProxmoxVMEntity(ProxmoxCoordinatorEntity):
         self.entity_description = entity_description
         self._vm_data = vm_data
         self._node_name = node_data.node["node"]
-        self.device_id = vm_data["vmid"]
+        self.device_id = int(vm_data["vmid"])
         self.device_name = vm_data["name"]
 
         self._attr_device_info = DeviceInfo(
@@ -187,7 +187,8 @@ class ProxmoxContainerEntity(ProxmoxCoordinatorEntity):
         self.entity_description = entity_description
         self._container_data = container_data
         self._node_name = node_data.node["node"]
-        self.device_id = container_data["vmid"]
+        # Proxmox hands out a container vmid as a string, a VM one as an int
+        self.device_id = int(container_data["vmid"])
         self.device_name = container_data["name"]
 
         self._attr_device_info = DeviceInfo(

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -133,8 +133,8 @@ def mock_proxmox_client():
             else load_json_array_fixture("nodes/tasks.json", DOMAIN)
         )
 
-        qemu_by_vmid = {vm["vmid"]: vm for vm in qemu_list}
-        lxc_by_vmid = {vm["vmid"]: vm for vm in lxc_list}
+        qemu_by_vmid = {int(vm["vmid"]): vm for vm in qemu_list}
+        lxc_by_vmid = {int(vm["vmid"]): vm for vm in lxc_list}
 
         # Cache resource mocks by vmid so callers (e.g. button tests) can
         # inspect specific call counts after pressing a button.

--- a/tests/components/proxmoxve/fixtures/nodes/lxc.json
+++ b/tests/components/proxmoxve/fixtures/nodes/lxc.json
@@ -1,6 +1,6 @@
 [
   {
-    "vmid": 200,
+    "vmid": "200",
     "name": "ct-nginx",
     "status": "running",
     "maxmem": 1073741824,
@@ -14,7 +14,7 @@
     "netout": 524288
   },
   {
-    "vmid": 201,
+    "vmid": "201",
     "name": "ct-backup",
     "status": "stopped",
     "maxmem": 1073741824,

--- a/tests/components/proxmoxve/snapshots/test_diagnostics.ambr
+++ b/tests/components/proxmoxve/snapshots/test_diagnostics.ambr
@@ -71,7 +71,7 @@
             'netout': 524288,
             'status': 'running',
             'uptime': 43200,
-            'vmid': 200,
+            'vmid': '200',
           }),
           '201': dict({
             'cpu': 0.05,
@@ -85,7 +85,7 @@
             'netout': 524288,
             'status': 'stopped',
             'uptime': 43200,
-            'vmid': 201,
+            'vmid': '201',
           }),
         }),
         'node': dict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Every LXC container entity reads `unavailable` while VMs on the same node work fine. The reporter guessed a string/int key mismatch, and their diagnostics prove it:

```
vms:        vmid=114   (int)
containers: vmid='104' (str)
```

Proxmox VE returns the `vmid` as an int for `/nodes/{node}/qemu` and as a string for `/nodes/{node}/lxc`.

The integration already normalizes that when the coordinator builds its lookup:

```python
containers={int(container["vmid"]): container for container in resources.containers}
```

but the entity does not:

```python
self.device_id = container_data["vmid"]
```

So `available` ends up evaluating `'104' in {104: ...}`, which is False, forever, for every container. The integration builds an int keyed dict and then looks it up with a string.

This normalizes at every point the vmid enters, matching what the coordinator was already doing:

* `entity.py` is the actual fix. Both entity classes cast, VMs included, so the two stop depending on which type Proxmox happened to send for that endpoint.
* `button.py` re-read `self.container_data["vmid"]` raw rather than using the already normalized `device_id`. Not user visible, since it ends up as a URL segment either way, but it is the same trap.
* `config_flow.py` stored the raw values in `CONF_VMS` and `CONF_CONTAINERS`, so a server sending string vmids wrote strings into the config entry. Nothing reads them at runtime so no migration is needed, but it keeps the stored data type stable.

`_attr_unique_id` and the device identifiers interpolate `device_id` into an f-string, where `100` and `'100'` render identically, so no entity or device identity changes.

One note on the tests: `lxc.json` carried int vmids, which no real Proxmox sends for containers. It now carries strings, which is why the diagnostics snapshot shows `'200'`, and it is what makes the test meaningful: reverting the cast in `entity.py` turns the container sensors into `'state': 'unavailable'` in the snapshot.

Worth saying why this is not a library fix: `proxmoxer` is a generic REST wrapper that returns `response.json()["data"]` straight through, with no models, no schema and no coercion. It has no concept of a container, so it has no opinion on what a vmid is. The inconsistency is in the Proxmox VE API itself, and the consumer normalizes at its boundary.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178283
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
