### PR TITLE
Honor the Modbus verify states for coils

### DIFF
--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -374,20 +374,21 @@ class ModbusToggleEntity(ModbusBaseEntity, ToggleEntity, RestoreEntity):
 
         self._attr_available = True
         if self._verify_type in (CALL_TYPE_COIL, CALL_TYPE_DISCRETE):
-            self._attr_is_on = bool(result.bits[0] & 1)
+            value = int(result.bits[0] & 1)
         else:
             value = int(result.registers[0])
-            if value in self._state_on:
-                self._attr_is_on = True
-            elif value in self._state_off:
-                self._attr_is_on = False
-            elif value is not None:
-                LOGGER.error(
-                    (
-                        "Unexpected response from modbus device slave %s register %s,"
-                        " got 0x%2x"
-                    ),
-                    self._device_address,
-                    self._verify_address,
-                    value,
-                )
+
+        if value in self._state_on:
+            self._attr_is_on = True
+        elif value in self._state_off:
+            self._attr_is_on = False
+        elif value is not None:
+            LOGGER.error(
+                (
+                    "Unexpected response from modbus device slave %s register %s,"
+                    " got 0x%2x"
+                ),
+                self._device_address,
+                self._verify_address,
+                value,
+            )

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -507,7 +507,7 @@ async def test_service_switch_update(hass: HomeAssistant, mock_modbus_ha) -> Non
 )
 async def test_switch_verify_coil_inverted(
     hass: HomeAssistant,
-    mock_modbus_ha,
+    mock_modbus_ha: mock.AsyncMock,
     coil_value: int,
     expected_state: str,
 ) -> None:

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -485,6 +485,50 @@ async def test_service_switch_update(hass: HomeAssistant, mock_modbus_ha) -> Non
             CONF_SWITCHES: [
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 1234,
+                    CONF_WRITE_TYPE: CALL_TYPE_COIL,
+                    CONF_COMMAND_ON: 0,
+                    CONF_COMMAND_OFF: 1,
+                    CONF_VERIFY: {
+                        CONF_STATE_ON: [0],
+                        CONF_STATE_OFF: [1],
+                    },
+                }
+            ]
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    ("coil_value", "expected_state"),
+    [
+        (0x00, STATE_ON),
+        (0x01, STATE_OFF),
+    ],
+)
+async def test_switch_verify_coil_inverted(
+    hass: HomeAssistant,
+    mock_modbus_ha,
+    coil_value: int,
+    expected_state: str,
+) -> None:
+    """Run test for an inverted coil switch, where state_on is 0."""
+    mock_modbus_ha.read_coils.return_value = ReadResult([coil_value])
+    await hass.services.async_call(
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    assert hass.states.get(ENTITY_ID).state == expected_state
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
                     CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ModbusToggleEntity._async_update` verifies coils and registers down two different paths:

```python
if self._verify_type in (CALL_TYPE_COIL, CALL_TYPE_DISCRETE):
    self._attr_is_on = bool(result.bits[0] & 1)     # state_on/state_off ignored
else:
    value = int(result.registers[0])
    if value in self._state_on: ...
```

The coil branch takes the raw bit and never consults `state_on` or `state_off`, so 0 is always off and 1 is always on. An inverted switch (`command_on: 0` with `verify: {state_on: 0}`) therefore reads backwards and is unusable.

It also breaks the documented default that the register branch honours. `_state_on` and `_state_off` fall back to `[command_on]` and `[command_off]`, so an inverted `command_on` should already invert the verify without the user writing `state_on` at all.

Both branches now produce a `value` and share a single comparison. The coil path contributes 0 or 1, and since `state_on` and `state_off` are `vol.All(cv.ensure_list, [cv.positive_int])` they are always lists of ints, so the comparison is exactly the one the register path was already doing.

Default behaviour is untouched: with `command_on: 1` and `command_off: 0`, `_state_on == [1]`, and `bool(bit)` and `bit in [1]` agree.

The new test drives an inverted coil switch: bit 0 has to read `on`, bit 1 has to read `off`. Against the old coil branch it fails with `assert 'off' == 'on'`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167968
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
