### PR TITLE
Add real-time updates for Roborock wet/dry vacuums

### DIFF
--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -278,7 +278,9 @@ class RoborockBinarySensorEntityA01(RoborockCoordinatedEntityA01, BinarySensorEn
 
     @property
     @override
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return the value reported by the sensor."""
+        if self.entity_description.data_protocol not in self.coordinator.data:
+            return None
         value = self.coordinator.data[self.entity_description.data_protocol]
         return self.entity_description.value_fn(value)

--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -280,7 +280,8 @@ class RoborockBinarySensorEntityA01(RoborockCoordinatedEntityA01, BinarySensorEn
     @override
     def is_on(self) -> bool | None:
         """Return the value reported by the sensor."""
-        if self.entity_description.data_protocol not in self.coordinator.data:
+        if (
+            value := self.coordinator.data.get(self.entity_description.data_protocol)
+        ) is None:
             return None
-        value = self.coordinator.data[self.entity_description.data_protocol]
         return self.entity_description.value_fn(value)

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -603,13 +603,19 @@ class RoborockWetDryVacUpdateCoordinator(
             data = await self.api.query_values(self.request_protocols)
         except RoborockException as ex:
             _LOGGER.debug("Failed to update wet dry vac data: %s", ex)
+            if pushed := self._take_pushed_during_poll():
+                return {**(self.data or {}), **pushed}
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_data_fail",
             ) from ex
-        finally:
-            pushed, self._pushed_during_poll = self._pushed_during_poll, None
-        return {**data, **pushed}
+        return {**data, **self._take_pushed_during_poll()}
+
+    @callback
+    def _take_pushed_during_poll(self) -> dict[RoborockDyadDataProtocol, StateType]:
+        """Return the values pushed while the poll was in flight, and stop recording."""
+        pushed, self._pushed_during_poll = self._pushed_during_poll, None
+        return pushed or {}
 
     @callback
     def _handle_push(self, values: dict[RoborockDyadDataProtocol, StateType]) -> None:

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -607,7 +607,15 @@ class RoborockWetDryVacUpdateCoordinator(
     @callback
     def _handle_push(self, values: dict[RoborockDyadDataProtocol, StateType]) -> None:
         """Apply an unsolicited state push from the device."""
-        self.async_set_updated_data({**(self.data or {}), **values})
+        data = {**(self.data or {}), **values}
+        if all(protocol in values for protocol in self.request_protocols):
+            self.async_set_updated_data(data)
+            return
+        # A partial push must not postpone the poll, or a protocol the device
+        # never pushes would stay stale for as long as pushes keep arriving.
+        self.data = data
+        self.last_update_success = True
+        self.async_update_listeners()
 
     @override
     async def async_shutdown(self) -> None:

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -574,11 +574,7 @@ class RoborockWetDryVacUpdateCoordinator(
         """Initialize."""
         super().__init__(hass, config_entry, device)
         self.api = api
-        self._setup_completed = False
-        self._unsub_push: Callable[[], None] | None = None
-        self._pushed_during_poll: dict[RoborockDyadDataProtocol, StateType] | None = (
-            None
-        )
+        self._unsub_update = api.add_update_listener(self._handle_update)
         supported_schema_ids = device.product.supported_schema_ids
         self.request_protocols = [
             protocol
@@ -587,57 +583,44 @@ class RoborockWetDryVacUpdateCoordinator(
         ]
 
     @override
-    async def _async_setup(self) -> None:
-        """Listen for state the device pushes on its own."""
-        self._unsub_push = await self.api.add_listener(self._handle_push)
-
-    @override
     async def _async_update_data(
         self,
     ) -> dict[RoborockDyadDataProtocol, StateType]:
-        if not self._setup_completed:
-            await self._async_setup()
-            self._setup_completed = True
-        self._pushed_during_poll = {}
         try:
-            data = await self.api.query_values(self.request_protocols)
+            await self.api.query_values(self.request_protocols)
         except RoborockException as ex:
             _LOGGER.debug("Failed to update wet dry vac data: %s", ex)
-            if pushed := self._take_pushed_during_poll():
-                return {**(self.data or {}), **pushed}
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_data_fail",
-            ) from ex
-        return {**data, **self._take_pushed_during_poll()}
+            if not self._should_suppress_update_failure():
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="update_data_fail",
+                ) from ex
+        return self.api.values
+
+    def _should_suppress_update_failure(self) -> bool:
+        """Determine if we should suppress update failure reporting.
+
+        The device leaves the network while it sleeps on its dock, so a poll can
+        fail while the device is still reporting its state on its own.
+        """
+        if (last_message_time := self.api.last_message_time) is None:
+            return False
+        failure_duration = dt_util.utcnow() - last_message_time
+        _LOGGER.debug("Update failure duration: %s", failure_duration)
+        return failure_duration < MIN_UNAVAILABLE_DURATION
 
     @callback
-    def _take_pushed_during_poll(self) -> dict[RoborockDyadDataProtocol, StateType]:
-        """Return the values pushed while the poll was in flight, and stop recording."""
-        pushed, self._pushed_during_poll = self._pushed_during_poll, None
-        return pushed or {}
-
-    @callback
-    def _handle_push(self, values: dict[RoborockDyadDataProtocol, StateType]) -> None:
-        """Apply an unsolicited state push from the device."""
-        if self._pushed_during_poll is not None:
-            self._pushed_during_poll.update(values)
-        data = {**(self.data or {}), **values}
-        if all(protocol in values for protocol in self.request_protocols):
-            self.async_set_updated_data(data)
-            return
-        # A partial push must not postpone the poll, or a protocol the device
-        # never pushes would stay stale for as long as pushes keep arriving.
-        self.data = data
+    def _handle_update(self) -> None:
+        """Apply the state the device reported on its own."""
+        _LOGGER.debug("Wet dry vac state updated, updating coordinator data")
+        self.data = self.api.values
         self.last_update_success = True
         self.async_update_listeners()
 
     @override
     async def async_shutdown(self) -> None:
-        """Unsubscribe the push listener on shutdown."""
-        if self._unsub_push is not None:
-            self._unsub_push()
-            self._unsub_push = None
+        """Stop following the device state on shutdown."""
+        self._unsub_update()
         await super().async_shutdown()
 
 

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -576,6 +576,9 @@ class RoborockWetDryVacUpdateCoordinator(
         self.api = api
         self._setup_completed = False
         self._unsub_push: Callable[[], None] | None = None
+        self._pushed_during_poll: dict[RoborockDyadDataProtocol, StateType] | None = (
+            None
+        )
         supported_schema_ids = device.product.supported_schema_ids
         self.request_protocols = [
             protocol
@@ -595,18 +598,24 @@ class RoborockWetDryVacUpdateCoordinator(
         if not self._setup_completed:
             await self._async_setup()
             self._setup_completed = True
+        self._pushed_during_poll = {}
         try:
-            return await self.api.query_values(self.request_protocols)
+            data = await self.api.query_values(self.request_protocols)
         except RoborockException as ex:
             _LOGGER.debug("Failed to update wet dry vac data: %s", ex)
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_data_fail",
             ) from ex
+        finally:
+            pushed, self._pushed_during_poll = self._pushed_during_poll, None
+        return {**data, **pushed}
 
     @callback
     def _handle_push(self, values: dict[RoborockDyadDataProtocol, StateType]) -> None:
         """Apply an unsolicited state push from the device."""
+        if self._pushed_during_poll is not None:
+            self._pushed_during_poll.update(values)
         data = {**(self.data or {}), **values}
         if all(protocol in values for protocol in self.request_protocols):
             self.async_set_updated_data(data)

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -574,6 +574,8 @@ class RoborockWetDryVacUpdateCoordinator(
         """Initialize."""
         super().__init__(hass, config_entry, device)
         self.api = api
+        self._setup_completed = False
+        self._unsub_push: Callable[[], None] | None = None
         supported_schema_ids = device.product.supported_schema_ids
         self.request_protocols = [
             protocol
@@ -582,9 +584,17 @@ class RoborockWetDryVacUpdateCoordinator(
         ]
 
     @override
+    async def _async_setup(self) -> None:
+        """Listen for state the device pushes on its own."""
+        self._unsub_push = await self.api.add_listener(self._handle_push)
+
+    @override
     async def _async_update_data(
         self,
     ) -> dict[RoborockDyadDataProtocol, StateType]:
+        if not self._setup_completed:
+            await self._async_setup()
+            self._setup_completed = True
         try:
             return await self.api.query_values(self.request_protocols)
         except RoborockException as ex:
@@ -593,6 +603,19 @@ class RoborockWetDryVacUpdateCoordinator(
                 translation_domain=DOMAIN,
                 translation_key="update_data_fail",
             ) from ex
+
+    @callback
+    def _handle_push(self, values: dict[RoborockDyadDataProtocol, StateType]) -> None:
+        """Apply an unsolicited state push from the device."""
+        self.async_set_updated_data({**(self.data or {}), **values})
+
+    @override
+    async def async_shutdown(self) -> None:
+        """Unsubscribe the push listener on shutdown."""
+        if self._unsub_push is not None:
+            self._unsub_push()
+            self._unsub_push = None
+        await super().async_shutdown()
 
 
 class RoborockDataUpdateCoordinatorB01(DataUpdateCoordinator[B01Props]):

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -698,7 +698,7 @@ class RoborockSensorEntityA01(RoborockCoordinatedEntityA01, SensorEntity):
     @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
-        return self.coordinator.data[self.entity_description.data_protocol]
+        return self.coordinator.data.get(self.entity_description.data_protocol)
 
 
 class RoborockSensorEntityB01Q7(RoborockCoordinatedEntityB01Q7, SensorEntity):

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -105,6 +105,7 @@ _LOGGER = logging.getLogger(__name__)
 def create_dyad_trait() -> Mock:
     """Create dyad trait for A01 devices."""
     dyad_trait = AsyncMock()
+    dyad_trait.add_listener.return_value = Mock()
     dyad_trait.query_values.return_value = {
         RoborockDyadDataProtocol.STATUS: RoborockDyadStateCode.drying.name,
         RoborockDyadDataProtocol.POWER: 100,

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -102,18 +102,22 @@ from tests.common import MockConfigEntry
 _LOGGER = logging.getLogger(__name__)
 
 
+DYAD_VALUES: dict[RoborockDyadDataProtocol, Any] = {
+    RoborockDyadDataProtocol.STATUS: RoborockDyadStateCode.drying.name,
+    RoborockDyadDataProtocol.POWER: 100,
+    RoborockDyadDataProtocol.MESH_LEFT: 111,
+    RoborockDyadDataProtocol.BRUSH_LEFT: 222,
+    RoborockDyadDataProtocol.ERROR: DyadError.none.name,
+    RoborockDyadDataProtocol.TOTAL_RUN_TIME: 213,
+}
+
+
 def create_dyad_trait() -> Mock:
     """Create dyad trait for A01 devices."""
     dyad_trait = AsyncMock()
-    dyad_trait.add_listener.return_value = Mock()
-    dyad_trait.query_values.return_value = {
-        RoborockDyadDataProtocol.STATUS: RoborockDyadStateCode.drying.name,
-        RoborockDyadDataProtocol.POWER: 100,
-        RoborockDyadDataProtocol.MESH_LEFT: 111,
-        RoborockDyadDataProtocol.BRUSH_LEFT: 222,
-        RoborockDyadDataProtocol.ERROR: DyadError.none.name,
-        RoborockDyadDataProtocol.TOTAL_RUN_TIME: 213,
-    }
+    dyad_trait.add_update_listener = Mock(return_value=Mock())
+    dyad_trait.values = dict(DYAD_VALUES)
+    dyad_trait.last_message_time = None
     return dyad_trait
 
 

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -7,11 +7,12 @@ import pytest
 from roborock.data import RoborockDockTypeCode
 from roborock.device_features import RoborockDockFeatures
 from roborock.exceptions import RoborockException
+from roborock.roborock_message import RoborockZeoProtocol
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.roborock.const import DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -127,6 +128,22 @@ async def test_zeo_request_protocols_filtered_by_schema(
     # Verify that the second Zeo device has detergent entities but NOT softener entities
     assert hass.states.get("binary_sensor.zeo_two_detergent") is not None
     assert hass.states.get("binary_sensor.zeo_two_softener") is None
+
+
+async def test_zeo_unreported_protocol_is_unknown(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test a protocol the device has not reported yet reads as unknown."""
+    zeo = next(device.zeo for device in fake_devices if device.zeo is not None)
+    del zeo.query_values.return_value[RoborockZeoProtocol.DETERGENT_EMPTY]
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.zeo_one_detergent").state == STATE_UNKNOWN
+    assert hass.states.get("binary_sensor.zeo_one_softener").state == "off"
 
 
 @pytest.fixture

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -10,7 +10,7 @@ from roborock.roborock_message import RoborockDyadDataProtocol
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.roborock.const import DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -190,3 +190,25 @@ async def test_dyad_push_unsubscribed_on_unload(
     await hass.async_block_till_done()
 
     unsub.assert_called_once()
+
+
+async def test_dyad_push_before_first_successful_poll(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test a partial push with no prior poll leaves protocols it does not carry unknown."""
+    setup_coordinator_side_effect(fake_devices, RoborockException("Simulated failure"))
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    assert hass.states.get("sensor.dyad_pro_battery").state == STATE_UNAVAILABLE
+
+    push_listener = dyad.add_listener.call_args[0][0]
+    push_listener({RoborockDyadDataProtocol.POWER: 50})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.dyad_pro_battery").state == "50"
+    assert hass.states.get("sensor.dyad_pro_status").state == STATE_UNKNOWN

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -167,12 +167,14 @@ async def test_dyad_push_updates_state(
     """Test an unsolicited device push updates state without waiting for a poll."""
     dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
     assert hass.states.get("sensor.dyad_pro_battery").state == "100"
+    assert hass.states.get("sensor.dyad_pro_status").state == "drying"
 
     push_listener = dyad.add_listener.call_args[0][0]
     push_listener({RoborockDyadDataProtocol.POWER: 50})
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.dyad_pro_battery").state == "50"
+    assert hass.states.get("sensor.dyad_pro_status").state == "drying"
 
 
 async def test_dyad_push_unsubscribed_on_unload(

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -241,3 +241,30 @@ async def test_dyad_partial_push_does_not_postpone_poll(
     await hass.async_block_till_done()
 
     assert dyad.query_values.call_count == 1
+
+
+async def test_dyad_push_during_poll_is_not_overwritten(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a push received while a poll is in flight survives the poll result."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    push_listener = dyad.add_listener.call_args[0][0]
+    polled = dyad.query_values.return_value
+    assert hass.states.get("sensor.dyad_pro_battery").state == "100"
+
+    async def push_while_polling(
+        protocols: list[RoborockDyadDataProtocol],
+    ) -> dict[RoborockDyadDataProtocol, Any]:
+        push_listener({RoborockDyadDataProtocol.POWER: 50})
+        return polled
+
+    dyad.query_values.side_effect = push_while_polling
+
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.dyad_pro_battery").state == "50"

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -6,6 +6,7 @@ import pytest
 from roborock.data.v1 import RoborockDockTypeCode
 from roborock.device_features import RoborockDockFeatures
 from roborock.exceptions import RoborockException
+from roborock.roborock_message import RoborockDyadDataProtocol
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.roborock.const import DOMAIN
@@ -156,3 +157,34 @@ async def test_dock_cleaning_brush_sensor_created_when_supported(
     state = hass.states.get("sensor.roborock_s7_maxv_dock_maintenance_brush_time_left")
     assert state is not None
     assert state.state == "235"
+
+
+async def test_dyad_push_updates_state(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test an unsolicited device push updates state without waiting for a poll."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    assert hass.states.get("sensor.dyad_pro_battery").state == "100"
+
+    push_listener = dyad.add_listener.call_args[0][0]
+    push_listener({RoborockDyadDataProtocol.POWER: 50})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.dyad_pro_battery").state == "50"
+
+
+async def test_dyad_push_unsubscribed_on_unload(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test the push listener is unsubscribed when the config entry unloads."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    unsub = dyad.add_listener.return_value
+
+    assert await hass.config_entries.async_unload(setup_entry.entry_id)
+    await hass.async_block_till_done()
+
+    unsub.assert_called_once()

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -1,7 +1,9 @@
 """Test Roborock Sensors."""
 
+from datetime import timedelta
 from typing import Any
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock.data.v1 import RoborockDockTypeCode
 from roborock.device_features import RoborockDockFeatures
@@ -16,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import FakeDevice
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.fixture
@@ -212,3 +214,30 @@ async def test_dyad_push_before_first_successful_poll(
 
     assert hass.states.get("sensor.dyad_pro_battery").state == "50"
     assert hass.states.get("sensor.dyad_pro_status").state == STATE_UNKNOWN
+
+
+async def test_dyad_partial_push_does_not_postpone_poll(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a partial push leaves the fallback poll schedule untouched."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    push_listener = dyad.add_listener.call_args[0][0]
+
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    dyad.query_values.reset_mock()
+
+    freezer.tick(timedelta(seconds=30))
+    push_listener({RoborockDyadDataProtocol.POWER: 50})
+    await hass.async_block_till_done()
+    assert dyad.query_values.call_count == 0
+
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert dyad.query_values.call_count == 1

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -268,3 +268,29 @@ async def test_dyad_push_during_poll_is_not_overwritten(
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.dyad_pro_battery").state == "50"
+
+
+async def test_dyad_push_survives_a_failed_poll(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a push received during a poll survives that poll failing."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    push_listener = dyad.add_listener.call_args[0][0]
+    assert hass.states.get("sensor.dyad_pro_battery").state == "100"
+
+    async def push_then_fail(
+        protocols: list[RoborockDyadDataProtocol],
+    ) -> dict[RoborockDyadDataProtocol, Any]:
+        push_listener({RoborockDyadDataProtocol.POWER: 50})
+        raise RoborockException("Simulated failure")
+
+    dyad.query_values.side_effect = push_then_fail
+
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.dyad_pro_battery").state == "50"

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -11,10 +11,12 @@ from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockDyadDataProtocol
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.roborock.const import DOMAIN
+from homeassistant.components.roborock.const import A01_UPDATE_INTERVAL, DOMAIN
+from homeassistant.components.roborock.coordinator import MIN_UNAVAILABLE_DURATION
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from .conftest import FakeDevice
 
@@ -161,32 +163,30 @@ async def test_dock_cleaning_brush_sensor_created_when_supported(
     assert state.state == "235"
 
 
-async def test_dyad_push_updates_state(
+async def test_dyad_follows_reported_state(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_devices: list[FakeDevice],
 ) -> None:
-    """Test an unsolicited device push updates state without waiting for a poll."""
+    """Test the device state is applied as the library reports it."""
     dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
     assert hass.states.get("sensor.dyad_pro_battery").state == "100"
-    assert hass.states.get("sensor.dyad_pro_status").state == "drying"
 
-    push_listener = dyad.add_listener.call_args[0][0]
-    push_listener({RoborockDyadDataProtocol.POWER: 50})
+    dyad.values = {**dyad.values, RoborockDyadDataProtocol.POWER: 50}
+    dyad.add_update_listener.call_args[0][0]()
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.dyad_pro_battery").state == "50"
-    assert hass.states.get("sensor.dyad_pro_status").state == "drying"
 
 
-async def test_dyad_push_unsubscribed_on_unload(
+async def test_dyad_unsubscribed_on_unload(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_devices: list[FakeDevice],
 ) -> None:
-    """Test the push listener is unsubscribed when the config entry unloads."""
+    """Test the update listener is removed when the config entry unloads."""
     dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
-    unsub = dyad.add_listener.return_value
+    unsub = dyad.add_update_listener.return_value
 
     assert await hass.config_entries.async_unload(setup_entry.entry_id)
     await hass.async_block_till_done()
@@ -194,103 +194,65 @@ async def test_dyad_push_unsubscribed_on_unload(
     unsub.assert_called_once()
 
 
-async def test_dyad_push_before_first_successful_poll(
+async def test_dyad_unreported_protocol_is_unknown(
     hass: HomeAssistant,
-    mock_roborock_entry: MockConfigEntry,
     fake_devices: list[FakeDevice],
+    mock_roborock_entry: MockConfigEntry,
 ) -> None:
-    """Test a partial push with no prior poll leaves protocols it does not carry unknown."""
-    setup_coordinator_side_effect(fake_devices, RoborockException("Simulated failure"))
+    """Test a protocol the device has not reported yet reads as unknown."""
+    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
+    dyad.values = {RoborockDyadDataProtocol.POWER: 50}
 
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
-    assert hass.states.get("sensor.dyad_pro_battery").state == STATE_UNAVAILABLE
-
-    push_listener = dyad.add_listener.call_args[0][0]
-    push_listener({RoborockDyadDataProtocol.POWER: 50})
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.dyad_pro_battery").state == "50"
     assert hass.states.get("sensor.dyad_pro_status").state == STATE_UNKNOWN
 
 
-async def test_dyad_partial_push_does_not_postpone_poll(
+async def test_dyad_update_does_not_postpone_poll(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_devices: list[FakeDevice],
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test a partial push leaves the fallback poll schedule untouched."""
+    """Test the fallback poll keeps its schedule while the device reports state."""
     dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
-    push_listener = dyad.add_listener.call_args[0][0]
-
-    freezer.tick(timedelta(seconds=60))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
     dyad.query_values.reset_mock()
 
-    freezer.tick(timedelta(seconds=30))
-    push_listener({RoborockDyadDataProtocol.POWER: 50})
+    freezer.tick(A01_UPDATE_INTERVAL / 2)
+    dyad.add_update_listener.call_args[0][0]()
     await hass.async_block_till_done()
-    assert dyad.query_values.call_count == 0
 
-    freezer.tick(timedelta(seconds=31))
+    freezer.tick(A01_UPDATE_INTERVAL / 2 + timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert dyad.query_values.call_count == 1
 
 
-async def test_dyad_push_during_poll_is_not_overwritten(
+@pytest.mark.parametrize(
+    ("last_message_age", "expected_state"),
+    [
+        pytest.param(timedelta(0), "100", id="still_talking"),
+        pytest.param(MIN_UNAVAILABLE_DURATION, STATE_UNAVAILABLE, id="gone_silent"),
+    ],
+)
+async def test_dyad_availability_follows_last_message(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_devices: list[FakeDevice],
     freezer: FrozenDateTimeFactory,
+    last_message_age: timedelta,
+    expected_state: str,
 ) -> None:
-    """Test a push received while a poll is in flight survives the poll result."""
+    """Test a failed poll only reports unavailable once the device stops talking."""
     dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
-    push_listener = dyad.add_listener.call_args[0][0]
-    polled = dyad.query_values.return_value
-    assert hass.states.get("sensor.dyad_pro_battery").state == "100"
+    dyad.query_values.side_effect = RoborockException("Simulated failure")
+    dyad.last_message_time = dt_util.utcnow() - last_message_age
 
-    async def push_while_polling(
-        protocols: list[RoborockDyadDataProtocol],
-    ) -> dict[RoborockDyadDataProtocol, Any]:
-        push_listener({RoborockDyadDataProtocol.POWER: 50})
-        return polled
-
-    dyad.query_values.side_effect = push_while_polling
-
-    freezer.tick(timedelta(seconds=60))
+    freezer.tick(A01_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.dyad_pro_battery").state == "50"
-
-
-async def test_dyad_push_survives_a_failed_poll(
-    hass: HomeAssistant,
-    setup_entry: MockConfigEntry,
-    fake_devices: list[FakeDevice],
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test a push received during a poll survives that poll failing."""
-    dyad = next(device.dyad for device in fake_devices if device.dyad is not None)
-    push_listener = dyad.add_listener.call_args[0][0]
-    assert hass.states.get("sensor.dyad_pro_battery").state == "100"
-
-    async def push_then_fail(
-        protocols: list[RoborockDyadDataProtocol],
-    ) -> dict[RoborockDyadDataProtocol, Any]:
-        push_listener({RoborockDyadDataProtocol.POWER: 50})
-        raise RoborockException("Simulated failure")
-
-    dyad.query_values.side_effect = push_then_fail
-
-    freezer.tick(timedelta(seconds=60))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("sensor.dyad_pro_battery").state == "50"
+    assert hass.states.get("sensor.dyad_pro_battery").state == expected_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Roborock wet/dry vacuums only reported their state on the one minute poll, so putting the device back on its dock or starting a clean could take up to a minute to show up in Home Assistant. The coordinator now follows the state the library tracks from the device's own MQTT updates, and keeps the poll as a fallback for the data points the device never reports by itself.

The device only reports the data points it has something to say about, so the A01 entities no longer assume every one is present and report unknown until it has been reported. A poll failing while the device is still sending updates no longer marks it unavailable either, which matters because these vacuums leave the network while they sleep on their dock.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

