### PR TITLE
Apply the hygrostat minimum cycle duration to keep-alive calls

### DIFF
--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -514,25 +514,6 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             if not self._active or not self._state:
                 return
 
-            if not force and time is None:
-                # If the `force` argument is True, we
-                # ignore `min_cycle_duration`.
-                # If the `time` argument is not none, we were invoked for
-                # keep-alive purposes, and `min_cycle_duration` is irrelevant.
-                if self._min_cycle_duration:
-                    if self._is_device_active:
-                        current_state = STATE_ON
-                    else:
-                        current_state = STATE_OFF
-                    long_enough = condition.state(
-                        self.hass,
-                        self._switch_entity_id,
-                        current_state,
-                        self._min_cycle_duration,
-                    )
-                    if not long_enough:
-                        return
-
             if force:
                 # Ignore the tolerance when switched on manually
                 dry_tolerance: float = 0
@@ -552,19 +533,35 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
                 ) or (
                     self._device_class == HumidifierDeviceClass.DEHUMIDIFIER and too_dry
                 ):
-                    _LOGGER.debug("Turning off humidifier %s", self._switch_entity_id)
-                    await self._async_device_turn_off()
+                    if self._min_cycle_duration_elapsed(force):
+                        _LOGGER.debug(
+                            "Turning off humidifier %s", self._switch_entity_id
+                        )
+                        await self._async_device_turn_off()
                 elif time is not None:
                     # The time argument is passed only in keep-alive case
                     await self._async_device_turn_on()
             elif (
                 self._device_class == HumidifierDeviceClass.HUMIDIFIER and too_dry
             ) or (self._device_class == HumidifierDeviceClass.DEHUMIDIFIER and too_wet):
-                _LOGGER.debug("Turning on humidifier %s", self._switch_entity_id)
-                await self._async_device_turn_on()
+                if self._min_cycle_duration_elapsed(force):
+                    _LOGGER.debug("Turning on humidifier %s", self._switch_entity_id)
+                    await self._async_device_turn_on()
             elif time is not None:
                 # The time argument is passed only in keep-alive case
                 await self._async_device_turn_off()
+
+    def _min_cycle_duration_elapsed(self, force: bool) -> bool:
+        """Return if the device has held its state long enough to toggle."""
+        if force or not self._min_cycle_duration:
+            return True
+
+        return condition.state(
+            self.hass,
+            self._switch_entity_id,
+            STATE_ON if self._is_device_active else STATE_OFF,
+            self._min_cycle_duration,
+        )
 
     @property
     def _is_device_active(self) -> bool:

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -1272,6 +1272,27 @@ async def test_humidity_change_dry_trigger_off_long_enough_3(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_7")
+async def test_humidity_change_dry_trigger_off_not_long_enough_keep_alive(
+    hass: HomeAssistant,
+) -> None:
+    """Test a keep-alive interval does not bypass the minimum cycle duration."""
+    calls = await _setup_switch(hass, True)
+    # Settle on a humidity that asks for no change, so the device is left running
+    _setup_sensor(hass, 45)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    # Dry enough to want the dehumidifier off, but it only just came on
+    _setup_sensor(hass, 30)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(minutes=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
 @pytest.fixture
 async def setup_comp_8(hass: HomeAssistant) -> None:
     """Initialize components."""

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -1293,6 +1293,27 @@ async def test_humidity_change_dry_trigger_off_not_long_enough_keep_alive(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_7")
+async def test_humidity_change_dry_trigger_on_not_long_enough_keep_alive(
+    hass: HomeAssistant,
+) -> None:
+    """Test a keep-alive interval does not bypass the minimum cycle duration."""
+    calls = await _setup_switch(hass, False)
+    # Settle on a humidity that asks for no change, so the device is left stopped
+    _setup_sensor(hass, 35)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    # Wet enough to want the dehumidifier on, but it only just went off
+    _setup_sensor(hass, 45)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(minutes=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
 @pytest.fixture
 async def setup_comp_8(hass: HomeAssistant) -> None:
     """Initialize components."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The issue links `generic_thermostat` code but is labelled `generic_hygrostat`, and that turns out to matter. The thermostat was fixed in 2026.4.0 by #136298, which removed exactly this bypass. The hygrostat was left behind and still carries it verbatim, comment and all:

```python
if not force and time is None:
    # If the `force` argument is True, we
    # ignore `min_cycle_duration`.
    # If the `time` argument is not none, we were invoked for
    # keep-alive purposes, and `min_cycle_duration` is irrelevant.
    if self._min_cycle_duration:
        ...
        if not long_enough:
            return
```

So with `keep_alive` configured, every keep-alive tick skips the minimum cycle check entirely and can short cycle the humidifier.

This takes the same shape the thermostat now uses: the check moves out of the early return and into the two toggle branches, behind a small `_min_cycle_duration_elapsed()` helper.

That placement is deliberate rather than cosmetic. A blanket early return would also kill the keep-alive re-assert paths (`elif time is not None: turn_on` / `turn_off`), which exist so a flaky switch gets its command repeated. Those have to keep firing; only the toggles need gating.

The new test uses the existing `setup_comp_7` fixture (dehumidifier, `min_cycle_duration: 15m`, `keep_alive: 10m`): settle at 45% so the device is left running, drop to 30% so it wants to switch off, then fire the keep-alive. Restoring the bypass fails it with `assert 1 == 0` and a `homeassistant.turn_off` call 10 minutes into a 15 minute cycle.

Worth noting that the two existing keep-alive tests (`..._trigger_on_long_enough_3` and `..._off_long_enough_3`) only cover the re-assert paths, which is why this went unnoticed. They still pass.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160967
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
