### PR TITLE
Set up Denon receivers that report no serial number

### DIFF
--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -247,8 +247,6 @@ class DenonDevice(MediaPlayerEntity):
         self._attr_device_info = DeviceInfo(
             configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
             hw_version=config_entry.data[CONF_TYPE],
-            # A receiver that reports no serial number has no unique id, so all
-            # of its zones share the entry id instead
             identifiers={(DOMAIN, config_entry.unique_id or config_entry.entry_id)},
             manufacturer=config_entry.data[CONF_MANUFACTURER],
             model=config_entry.data[CONF_MODEL],

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -244,11 +244,12 @@ class DenonDevice(MediaPlayerEntity):
     ) -> None:
         """Initialize the device."""
         self._attr_unique_id = unique_id
-        assert config_entry.unique_id
         self._attr_device_info = DeviceInfo(
             configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
             hw_version=config_entry.data[CONF_TYPE],
-            identifiers={(DOMAIN, config_entry.unique_id)},
+            # A receiver that reports no serial number has no unique id, so all
+            # of its zones share the entry id instead
+            identifiers={(DOMAIN, config_entry.unique_id or config_entry.entry_id)},
             manufacturer=config_entry.data[CONF_MANUFACTURER],
             model=config_entry.data[CONF_MODEL],
             name=receiver.name,

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -95,8 +95,9 @@ async def setup_denonavr(
     return mock_entry
 
 
+@pytest.mark.usefixtures("client")
 async def test_setup_without_serial_number(
-    hass: HomeAssistant, client, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test a receiver reporting no serial number still gets its media player."""
     entry = await setup_denonavr(hass, serial_number=None)

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -23,6 +23,7 @@ from homeassistant.components.denonavr.services import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MODEL, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -63,19 +64,21 @@ def client_fixture():
         yield mock_client_class.return_value
 
 
-async def setup_denonavr(hass: HomeAssistant) -> None:
+async def setup_denonavr(
+    hass: HomeAssistant, serial_number: str | None = TEST_SERIALNUMBER
+) -> MockConfigEntry:
     """Initialize media_player for tests."""
     entry_data = {
         CONF_HOST: TEST_HOST,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
-        CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
+        CONF_SERIAL_NUMBER: serial_number,
     }
 
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=TEST_UNIQUE_ID,
+        unique_id=TEST_UNIQUE_ID if serial_number else None,
         data=entry_data,
     )
 
@@ -88,6 +91,19 @@ async def setup_denonavr(hass: HomeAssistant) -> None:
 
     assert state
     assert state.name == TEST_NAME
+
+    return mock_entry
+
+
+async def test_setup_without_serial_number(
+    hass: HomeAssistant, client, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test a receiver reporting no serial number still gets its media player."""
+    entry = await setup_denonavr(hass, serial_number=None)
+
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
 
 async def test_get_command(hass: HomeAssistant, client) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A receiver that reports no serial number ends up with no media player at all.

`async_setup_entry` already falls back to the entry id for the entity unique id:

```python
if config_entry.data[CONF_SERIAL_NUMBER] is not None:
    unique_id = f"{config_entry.unique_id}-{receiver_zone.zone}"
else:
    unique_id = f"{config_entry.entry_id}-{receiver_zone.zone}"
```

but `DenonDevice.__init__` then does `assert config_entry.unique_id` before building its `DeviceInfo`. With no serial the config flow leaves `unique_id` as `None`, the assert fires, and the whole `media_player` platform setup dies with the `AssertionError` from the traceback in the issue.

This is what the reporter proposed: drop the assert and use `config_entry.unique_id or config_entry.entry_id` for the device identifiers. Receivers that do report a serial are untouched, and serial-less ones get a single stable identifier shared by all their zones, matching the fallback already used for the entity unique id.

I deliberately left the `if config_entry.data[CONF_SERIAL_NUMBER] is not None` block above alone rather than unifying it with the same expression. The two agree in practice, but rewriting it could change an existing entity's unique id in an edge case where they disagree, which is not worth the risk in a bugfix.

`setup_denonavr` gains a `serial_number` argument so a serial-less entry can be set up, and the new test asserts the device lands in the registry under the entry id. Restoring the assert fails it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180489
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
