### PR TITLE
Add temporary access code support to Schlage

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -11,7 +11,13 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, SERVICE_ADD_CODE, SERVICE_DELETE_CODE, SERVICE_GET_CODES
+from .const import (
+    DOMAIN,
+    SERVICE_ADD_CODE,
+    SERVICE_DELETE_CODE,
+    SERVICE_GET_CODES,
+    SERVICE_UPDATE_CODE,
+)
 from .coordinator import SchlageConfigEntry, SchlageDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -36,8 +42,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Required("name"): cv.string,
             vol.Required("code"): vol.All(cv.string, cv.matches_regex(r"^\d{4,8}$")),
             vol.Optional("notify_on_use", default=True): cv.boolean,
+            vol.Optional("start_datetime"): cv.datetime,
+            vol.Optional("end_datetime"): cv.datetime,
         },
         func=SERVICE_ADD_CODE,
+        admin_only=True,
     )
 
     service.async_register_platform_entity_service(
@@ -46,9 +55,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_DELETE_CODE,
         entity_domain=LOCK_DOMAIN,
         schema={
-            vol.Required("name"): cv.string,
+            vol.Optional("name"): cv.string,
+            vol.Optional("access_code_id"): cv.string,
         },
         func=SERVICE_DELETE_CODE,
+        admin_only=True,
     )
 
     service.async_register_platform_entity_service(
@@ -59,6 +70,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         schema=None,
         func=SERVICE_GET_CODES,
         supports_response=SupportsResponse.ONLY,
+    )
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        entity_domain=LOCK_DOMAIN,
+        schema={
+            vol.Required("access_code_id"): cv.string,
+            vol.Optional("name"): cv.string,
+            vol.Optional("code"): vol.All(cv.string, cv.matches_regex(r"^\d{4,8}$")),
+            vol.Optional("notify_on_use"): cv.boolean,
+            vol.Optional("disabled"): cv.boolean,
+            vol.Optional("start_datetime"): cv.datetime,
+            vol.Optional("end_datetime"): cv.datetime,
+        },
+        func=SERVICE_UPDATE_CODE,
+        admin_only=True,
     )
 
     return True

--- a/homeassistant/components/schlage/const.py
+++ b/homeassistant/components/schlage/const.py
@@ -11,3 +11,4 @@ UPDATE_INTERVAL = timedelta(seconds=30)
 SERVICE_ADD_CODE = "add_code"
 SERVICE_DELETE_CODE = "delete_code"
 SERVICE_GET_CODES = "get_codes"
+SERVICE_UPDATE_CODE = "update_code"

--- a/homeassistant/components/schlage/icons.json
+++ b/homeassistant/components/schlage/icons.json
@@ -8,6 +8,9 @@
     },
     "get_codes": {
       "service": "mdi:table-key"
+    },
+    "update_code": {
+      "service": "mdi:key-chain"
     }
   }
 }

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -2,13 +2,19 @@
 
 from typing import Any, override
 
-from pyschlage.code import AccessCode
+from pyschlage.code import (
+    AccessCode,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.exceptions import Error as SchlageError
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant, ServiceResponse, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import LockData, SchlageConfigEntry, SchlageDataUpdateCoordinator
@@ -31,6 +37,94 @@ async def async_setup_entry(
 
     _add_new_locks(coordinator.data)
     coordinator.new_locks_callbacks.append(_add_new_locks)
+
+
+def _build_schedule(
+    start_datetime: Any | None,
+    end_datetime: Any | None,
+) -> TemporarySchedule | None:
+    """Build a schedule object from service parameters.
+
+    Dates alone decide permanence:
+      both datetimes present -> TemporarySchedule
+      neither present       -> None (permanent code)
+      exactly one present   -> error (must provide both or neither)
+    """
+    if start_datetime is None and end_datetime is None:
+        return None
+    if start_datetime is None or end_datetime is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="schlage_temporary_dates_required",
+        )
+    start = dt_util.as_utc(start_datetime)
+    end = dt_util.as_utc(end_datetime)
+    if start >= end:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="schlage_start_after_end",
+        )
+    return TemporarySchedule(start=start, end=end)
+
+
+def _serialize_schedule(
+    schedule: Any,
+) -> dict[str, Any] | None:
+    """Convert a schedule object back to a dict for get_codes() responses."""
+    if schedule is None:
+        return None
+
+    if isinstance(schedule, TemporarySchedule):
+        return {
+            "type": "temporary",
+            "start_datetime": schedule.start.isoformat(),
+            "end_datetime": schedule.end.isoformat(),
+        }
+
+    if isinstance(schedule, RecurringSchedule):
+        return {
+            "type": "recurring",
+            "days_of_week": {
+                "sun": schedule.days_of_week.sun,
+                "mon": schedule.days_of_week.mon,
+                "tue": schedule.days_of_week.tue,
+                "wed": schedule.days_of_week.wed,
+                "thu": schedule.days_of_week.thu,
+                "fri": schedule.days_of_week.fri,
+                "sat": schedule.days_of_week.sat,
+            },
+            "start_hour": schedule.start_hour,
+            "start_minute": schedule.start_minute,
+            "end_hour": schedule.end_hour,
+            "end_minute": schedule.end_minute,
+        }
+
+    if isinstance(schedule, MultiRecurringSchedule):
+        windows: list[dict[str, Any]] = [
+            {
+                "days_of_week": {
+                    "sun": sub.days_of_week.sun,
+                    "mon": sub.days_of_week.mon,
+                    "tue": sub.days_of_week.tue,
+                    "wed": sub.days_of_week.wed,
+                    "thu": sub.days_of_week.thu,
+                    "fri": sub.days_of_week.fri,
+                    "sat": sub.days_of_week.sat,
+                },
+                "start_hour": sub.start_hour,
+                "start_minute": sub.start_minute,
+                "end_hour": sub.end_hour,
+                "end_minute": sub.end_minute,
+            }
+            for sub in (schedule.schedule1, schedule.schedule2)
+            if sub is not None
+        ]
+        return {
+            "type": "recurring_multi",
+            "windows": windows,
+        }
+
+    return None
 
 
 class SchlageLockEntity(SchlageEntity, LockEntity):
@@ -114,14 +208,24 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
             ) from ex
         return self._lock.access_codes
 
-    async def add_code(self, name: str, code: str, notify_on_use: bool = True) -> None:
+    async def add_code(
+        self,
+        name: str,
+        code: str,
+        notify_on_use: bool = True,
+        start_datetime: Any | None = None,
+        end_datetime: Any | None = None,
+    ) -> None:
         """Add a lock code."""
-
         codes = await self._async_fetch_access_codes()
         self._validate_code_name(codes, name)
         self._validate_code_value(codes, code)
 
-        access_code = AccessCode(name=name, code=code, notify_on_use=notify_on_use)
+        schedule = _build_schedule(start_datetime, end_datetime)
+
+        access_code = AccessCode(
+            name=name, code=code, notify_on_use=notify_on_use, schedule=schedule
+        )
         try:
             await self.hass.async_add_executor_job(
                 self._lock.add_access_code, access_code
@@ -133,24 +237,118 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
             ) from ex
         await self.coordinator.async_request_refresh()
 
-    async def delete_code(self, name: str) -> None:
+    async def update_code(
+        self,
+        access_code_id: str,
+        name: str | None = None,
+        code: str | None = None,
+        notify_on_use: bool | None = None,
+        disabled: bool | None = None,
+        start_datetime: Any | None = None,
+        end_datetime: Any | None = None,
+    ) -> None:
+        """Update a lock code."""
+        codes = await self._async_fetch_access_codes()
+        if not codes or access_code_id not in codes:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="schlage_code_not_found",
+            )
+
+        target_code = codes[access_code_id]
+
+        # Uniqueness checks against other codes (mirror add_code pattern).
+        other_codes = {k: v for k, v in codes.items() if k != access_code_id}
+        if name is not None:
+            self._validate_code_name(other_codes, name)
+        if code is not None:
+            self._validate_code_value(other_codes, code)
+
+        if name is not None:
+            target_code.name = name
+        if code is not None:
+            target_code.code = code
+        if notify_on_use is not None:
+            target_code.notify_on_use = notify_on_use
+        if disabled is not None:
+            target_code.disabled = disabled
+
+        # Update schedule based on provided datetimes (both or neither).
+        has_dates = start_datetime is not None or end_datetime is not None
+        if has_dates:
+            schedule = _build_schedule(start_datetime, end_datetime)
+            target_code.schedule = schedule
+
+        # Capture pre-save schedule for comparison after failed save.
+        pre_save_schedule = target_code.schedule
+
+        try:
+            await self.hass.async_add_executor_job(target_code.save)
+        except SchlageError as ex:
+            # The save may have succeeded on the device but the notification
+            # to the cloud failed. Verify the update took effect.
+            await self._async_fetch_access_codes()
+            codes_after = self._lock.access_codes
+            if (
+                codes_after
+                and access_code_id in codes_after
+                and codes_after[access_code_id].code == target_code.code
+                and codes_after[access_code_id].name == target_code.name
+                and codes_after[access_code_id].notify_on_use
+                == target_code.notify_on_use
+                and codes_after[access_code_id].disabled == target_code.disabled
+                and (
+                    not has_dates
+                    or _serialize_schedule(pre_save_schedule)
+                    == _serialize_schedule(codes_after[access_code_id].schedule)
+                )
+            ):
+                await self.coordinator.async_request_refresh()
+                return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schlage_update_code_failed",
+            ) from ex
+        await self.coordinator.async_request_refresh()
+
+    async def delete_code(
+        self, name: str | None = None, access_code_id: str | None = None
+    ) -> None:
         """Delete a lock code."""
+        if name and access_code_id:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="schlage_delete_code_ambiguous",
+            )
+        if not access_code_id and not name:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="schlage_delete_code_missing_identifier",
+            )
+
         codes = await self._async_fetch_access_codes()
         if not codes:
             return
 
-        normalized = self._normalize_code_name(name)
-        code_id_to_delete = next(
-            (
-                code_id
-                for code_id, code_data in codes.items()
-                if self._normalize_code_name(code_data.name) == normalized
-            ),
-            None,
-        )
+        code_id_to_delete = None
+
+        if access_code_id:
+            if access_code_id in codes:
+                code_id_to_delete = access_code_id
+            else:
+                return
+        elif name:
+            normalized = self._normalize_code_name(name)
+            code_id_to_delete = next(
+                (
+                    code_id
+                    for code_id, code_data in codes.items()
+                    if self._normalize_code_name(code_data.name) == normalized
+                ),
+                None,
+            )
 
         if not code_id_to_delete:
-            # Code not found in defined codes, operation successful
             return
 
         try:
@@ -168,10 +366,16 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
 
         if self._lock.access_codes:
             return {
-                code: {
-                    "name": self._lock.access_codes[code].name,
-                    "code": self._lock.access_codes[code].code,
+                code_id: {
+                    "name": self._lock.access_codes[code_id].name,
+                    "code": self._lock.access_codes[code_id].code,
+                    "access_code_id": self._lock.access_codes[code_id].access_code_id,
+                    "disabled": self._lock.access_codes[code_id].disabled,
+                    "notify_on_use": self._lock.access_codes[code_id].notify_on_use,
+                    "schedule": _serialize_schedule(
+                        self._lock.access_codes[code_id].schedule
+                    ),
                 }
-                for code in self._lock.access_codes
+                for code_id in self._lock.access_codes
             }
         return {}

--- a/homeassistant/components/schlage/services.yaml
+++ b/homeassistant/components/schlage/services.yaml
@@ -1,14 +1,13 @@
 get_codes:
   target:
     entity:
-      domain: lock
       integration: schlage
-
+      domain: lock
 add_code:
   target:
     entity:
-      domain: lock
       integration: schlage
+      domain: lock
   fields:
     name:
       required: true
@@ -28,16 +27,73 @@ add_code:
       default: true
       selector:
         boolean:
-
+    start_datetime:
+      required: false
+      example: "2026-09-01 15:00"
+      selector:
+        datetime:
+    end_datetime:
+      required: false
+      example: "2026-09-01 16:00"
+      selector:
+        datetime:
 delete_code:
   target:
     entity:
-      domain: lock
       integration: schlage
+      domain: lock
   fields:
     name:
-      required: true
+      required: false
       example: "Example Person"
       selector:
         text:
           multiline: false
+    access_code_id:
+      required: false
+      example: "abc123"
+      selector:
+        text:
+          multiline: false
+update_code:
+  target:
+    entity:
+      integration: schlage
+      domain: lock
+  fields:
+    access_code_id:
+      required: true
+      example: "abc123"
+      selector:
+        text:
+          multiline: false
+    name:
+      required: false
+      example: "Example Person"
+      selector:
+        text:
+          multiline: false
+    code:
+      required: false
+      example: "1111"
+      selector:
+        text:
+          multiline: false
+    notify_on_use:
+      required: false
+      selector:
+        boolean:
+    disabled:
+      required: false
+      selector:
+        boolean:
+    start_datetime:
+      required: false
+      example: "2026-09-01 15:00"
+      selector:
+        datetime:
+    end_datetime:
+      required: false
+      example: "2026-09-01 16:00"
+      selector:
+        datetime:

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -75,14 +75,32 @@
     "schlage_code_exists": {
       "message": "A PIN code with this value already exists on the lock."
     },
+    "schlage_code_not_found": {
+      "message": "A PIN code with this ID was not found on the lock."
+    },
+    "schlage_delete_code_ambiguous": {
+      "message": "Provide either name or access_code_id, not both."
+    },
     "schlage_delete_code_failed": {
       "message": "Failed to delete PIN code from the lock."
+    },
+    "schlage_delete_code_missing_identifier": {
+      "message": "Either a name or access_code_id is required to delete a PIN code."
     },
     "schlage_name_exists": {
       "message": "A PIN code with the name \"{name}\" already exists on the lock."
     },
     "schlage_refresh_failed": {
       "message": "Failed to refresh Schlage data."
+    },
+    "schlage_start_after_end": {
+      "message": "Start time must be before end time."
+    },
+    "schlage_temporary_dates_required": {
+      "message": "Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one."
+    },
+    "schlage_update_code_failed": {
+      "message": "Failed to update PIN code on the lock."
     }
   },
   "services": {
@@ -93,6 +111,10 @@
           "description": "The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.",
           "name": "PIN code"
         },
+        "end_datetime": {
+          "description": "When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.",
+          "name": "End time"
+        },
         "name": {
           "description": "Name for PIN code. Must be case insensitively unique to the lock.",
           "name": "PIN name"
@@ -100,6 +122,10 @@
         "notify_on_use": {
           "description": "Whether the native Schlage notification should be sent when this PIN is used.",
           "name": "Notify when PIN is used"
+        },
+        "start_datetime": {
+          "description": "When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.",
+          "name": "Start time"
         }
       },
       "name": "Add PIN code"
@@ -107,8 +133,12 @@
     "delete_code": {
       "description": "Deletes a PIN code from a lock.",
       "fields": {
+        "access_code_id": {
+          "description": "Access code ID to delete (more stable than name). Either name or access_code_id is required.",
+          "name": "Access code ID"
+        },
         "name": {
-          "description": "Name of PIN code to delete.",
+          "description": "Name of PIN code to delete. Either name or access_code_id is required.",
           "name": "[%key:component::schlage::services::add_code::fields::name::name%]"
         }
       },
@@ -117,6 +147,40 @@
     "get_codes": {
       "description": "Retrieves all PIN codes from a lock.",
       "name": "Get PIN codes"
+    },
+    "update_code": {
+      "description": "Updates an existing PIN code on a lock.",
+      "fields": {
+        "access_code_id": {
+          "description": "The unique ID of the access code to update.",
+          "name": "Access code ID"
+        },
+        "code": {
+          "description": "New PIN code value (4-8 digits).",
+          "name": "PIN code"
+        },
+        "disabled": {
+          "description": "Whether the PIN code should be disabled.",
+          "name": "Disabled"
+        },
+        "end_datetime": {
+          "description": "When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.",
+          "name": "End time"
+        },
+        "name": {
+          "description": "New name for the PIN code.",
+          "name": "PIN name"
+        },
+        "notify_on_use": {
+          "description": "Whether the native Schlage notification should be sent when this PIN is used.",
+          "name": "Notify when PIN is used"
+        },
+        "start_datetime": {
+          "description": "When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.",
+          "name": "Start time"
+        }
+      },
+      "name": "Update PIN code"
     }
   }
 }

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -1,10 +1,17 @@
 """Test schlage lock."""
 
 from collections.abc import Awaitable, Callable
+from datetime import datetime as dt_datetime
+from typing import Any
 from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from pyschlage.code import AccessCode
+from pyschlage.code import (
+    AccessCode,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.exceptions import Error as SchlageError
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -16,6 +23,7 @@ from homeassistant.components.schlage.const import (
     SERVICE_ADD_CODE,
     SERVICE_DELETE_CODE,
     SERVICE_GET_CODES,
+    SERVICE_UPDATE_CODE,
     UPDATE_INTERVAL,
 )
 from homeassistant.const import (
@@ -28,6 +36,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import MockSchlageConfigEntry
 
@@ -228,6 +237,156 @@ async def test_add_code_service_default_notify_on_use_value(
     assert call_args.notify_on_use
 
 
+async def test_add_code_service_temporary_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code creates TemporarySchedule when both dates provided."""
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "test_user",
+            "code": "1234",
+            "notify_on_use": False,
+            "start_datetime": dt_datetime(2025, 1, 1, 0, 0),
+            "end_datetime": dt_datetime(2025, 6, 30, 23, 59),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args, AccessCode)
+    assert call_args.name == "test_user"
+    assert call_args.code == "1234"
+    assert isinstance(call_args.schedule, TemporarySchedule)
+    assert call_args.schedule.start == dt_util.as_utc(dt_datetime(2025, 1, 1, 0, 0))
+    assert call_args.schedule.end == dt_util.as_utc(dt_datetime(2025, 6, 30, 23, 59))
+
+
+async def test_add_code_service_permanent_code(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code creates permanent code when neither date provided."""
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "test_user",
+            "code": "1234",
+            "notify_on_use": False,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args, AccessCode)
+    assert call_args.name == "test_user"
+    assert call_args.code == "1234"
+    assert call_args.schedule is None
+
+
+async def test_add_code_service_one_date_only_raises(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code raises when only one date is provided (XOR)."""
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start and end times are required together",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": dt_datetime(2025, 1, 1),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_temporary_dates_required"
+
+
+async def test_add_code_fails_with_start_after_end(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code raises when start_datetime is after end_datetime."""
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start time must be before end time",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": dt_datetime(2025, 12, 31, 23, 59),
+                "end_datetime": dt_datetime(2025, 1, 1),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_start_after_end"
+
+
+async def test_add_code_succeeds_with_valid_dates(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code succeeds when start is before end."""
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "test_user",
+            "code": "1234",
+            "start_datetime": dt_datetime(2025, 1, 1),
+            "end_datetime": dt_datetime(2025, 12, 31, 23, 59),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args, AccessCode)
+    assert call_args.name == "test_user"
+    assert call_args.code == "1234"
+    assert isinstance(call_args.schedule, TemporarySchedule)
+    assert call_args.schedule.start == dt_util.as_utc(dt_datetime(2025, 1, 1))
+    assert call_args.schedule.end == dt_util.as_utc(dt_datetime(2025, 12, 31, 23, 59))
+
+
 @pytest.mark.parametrize(
     "code",
     [
@@ -245,6 +404,36 @@ async def test_add_code_service_invalid_code(
     code: str,
 ) -> None:
     """Test add_code service rejects invalid PIN codes."""
+    mock_lock.access_codes = {}
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": code,
+                "notify_on_use": False,
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(["1", "2", "3", "4"], id="list"),
+        pytest.param({"a": "b"}, id="dict"),
+    ],
+)
+async def test_add_code_service_non_string_code(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+    code: Any,
+) -> None:
+    """Test add_code service rejects non-string code values with clean error."""
     mock_lock.access_codes = {}
 
     with pytest.raises(vol.Invalid):
@@ -419,6 +608,26 @@ async def test_delete_code_service_no_access_codes(
     await hass.async_block_till_done()
 
 
+async def test_delete_code_service_no_identifier_with_zero_codes(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test delete_code raises error when no identifier given and lock has zero codes."""
+    mock_lock.access_codes = {}
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_delete_code_missing_identifier"
+
+
 async def test_get_codes_service(
     hass: HomeAssistant,
     mock_lock: Mock,
@@ -429,9 +638,17 @@ async def test_get_codes_service(
     code1 = Mock()
     code1.name = "user1"
     code1.code = "1234"
+    code1.access_code_id = "id1"
+    code1.disabled = False
+    code1.notify_on_use = True
+    code1.schedule = None
     code2 = Mock()
     code2.name = "user2"
     code2.code = "5678"
+    code2.access_code_id = "id2"
+    code2.disabled = False
+    code2.notify_on_use = True
+    code2.schedule = None
     mock_lock.access_codes = {"1": code1, "2": code2}
 
     response = await hass.services.async_call(
@@ -447,8 +664,22 @@ async def test_get_codes_service(
 
     assert response == {
         "lock.vault_door": {
-            "1": {"name": "user1", "code": "1234"},
-            "2": {"name": "user2", "code": "5678"},
+            "1": {
+                "name": "user1",
+                "code": "1234",
+                "access_code_id": "id1",
+                "disabled": False,
+                "notify_on_use": True,
+                "schedule": None,
+            },
+            "2": {
+                "name": "user2",
+                "code": "5678",
+                "access_code_id": "id2",
+                "disabled": False,
+                "notify_on_use": True,
+                "schedule": None,
+            },
         }
     }
 
@@ -497,6 +728,40 @@ async def test_get_codes_service_empty_codes(
     assert response == {"lock.vault_door": {}}
 
 
+async def test_get_codes_service_temporary_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test get_codes returns type=temporary when code has a TemporarySchedule."""
+    start = dt_datetime(2025, 1, 1, 0, 0)
+    end = dt_datetime(2025, 6, 30, 23, 59)
+    temp_code = Mock()
+    temp_code.name = "temp_user"
+    temp_code.code = "1111"
+    temp_code.access_code_id = "id_temp"
+    temp_code.disabled = False
+    temp_code.notify_on_use = True
+    temp_code.schedule = TemporarySchedule(start=start, end=end)
+    mock_lock.access_codes = {"1": temp_code}
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    schedule = response["lock.vault_door"]["1"]["schedule"]
+    assert schedule["type"] == "temporary"
+    assert schedule["start_datetime"] == start.isoformat()
+    assert schedule["end_datetime"] == end.isoformat()
+
+
 async def test_delete_code_service_nonexistent_code_with_existing_codes(
     hass: HomeAssistant,
     mock_lock: Mock,
@@ -523,6 +788,183 @@ async def test_delete_code_service_nonexistent_code_with_existing_codes(
 
     # Verify that delete was not called on the existing code
     existing_code.delete.assert_not_called()
+
+
+async def test_update_code_service_with_dates(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code applies TemporarySchedule when both dates provided."""
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = None
+    mock_lock.access_codes = {"id1": existing_code}
+
+    start = dt_datetime(2025, 3, 1, 0, 0)
+    end = dt_datetime(2025, 9, 30, 23, 59)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "id1",
+            "start_datetime": start,
+            "end_datetime": end,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert isinstance(existing_code.schedule, TemporarySchedule)
+    assert existing_code.schedule.start == dt_util.as_utc(start)
+    assert existing_code.schedule.end == dt_util.as_utc(end)
+    existing_code.save.assert_called_once()
+
+
+async def test_update_code_service_one_date_only_raises(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code raises when only one date is provided."""
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.schedule = None
+    mock_lock.access_codes = {"id1": existing_code}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start and end times are required together",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "access_code_id": "id1",
+                "end_datetime": dt_datetime(2025, 9, 30),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_temporary_dates_required"
+
+
+async def test_update_code_succeeds_despite_notification_error(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code succeeds when save raises but device confirmed the change."""
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = None
+    mock_lock.access_codes = {"id1": existing_code}
+
+    existing_code.save.side_effect = SchlageError("notification failed")
+
+    # After refresh, return updated code confirming the change took effect.
+    # Only apply on the second call (the first call is the initial fetch).
+    updated_code = Mock()
+    updated_code.name = "updated_user"
+    updated_code.code = "5678"
+    updated_code.access_code_id = "id1"
+    updated_code.disabled = True
+    updated_code.notify_on_use = False
+    updated_code.schedule = None
+
+    call_count = 0
+
+    def refresh_side_effect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            mock_lock.access_codes = {"id1": updated_code}
+
+    mock_lock.refresh_access_codes.side_effect = refresh_side_effect
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "id1",
+            "name": "updated_user",
+            "code": "5678",
+            "notify_on_use": False,
+            "disabled": True,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    existing_code.save.assert_called_once()
+    assert mock_lock.refresh_access_codes.call_count == 2
+
+
+async def test_update_code_fails_when_change_not_confirmed(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code raises HomeAssistantError when save fails and change is not confirmed."""
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = None
+    mock_lock.access_codes = {"id1": existing_code}
+
+    existing_code.save.side_effect = SchlageError("API error")
+
+    # After refresh, return unchanged code (device did not apply the change).
+    # Only apply on the second call (the first call is the initial fetch).
+    unchanged_code = Mock()
+    unchanged_code.name = "existing_user"
+    unchanged_code.code = "1234"
+    unchanged_code.access_code_id = "id1"
+    unchanged_code.disabled = False
+    unchanged_code.notify_on_use = True
+    unchanged_code.schedule = None
+
+    call_count = 0
+
+    def refresh_side_effect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            mock_lock.access_codes = {"id1": unchanged_code}
+
+    mock_lock.refresh_access_codes.side_effect = refresh_side_effect
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "access_code_id": "id1",
+                "name": "updated_user",
+                "code": "5678",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_update_code_failed"
+    existing_code.save.assert_called_once()
+    assert mock_lock.refresh_access_codes.call_count == 2
 
 
 async def test_add_code_service_refresh_error(
@@ -615,3 +1057,538 @@ async def test_get_codes_service_refresh_error(
             return_response=True,
         )
     assert exc_info.value.translation_key == "schlage_refresh_failed"
+
+
+async def test_add_code_naive_datetimes_become_utc(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code normalizes naive datetimes to UTC-aware in the schedule."""
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    # Set default time zone to America/New_York (UTC-5 in Jan)
+    await hass.config.async_set_time_zone("America/New_York")
+
+    naive_start = dt_datetime(2025, 1, 15, 10, 0)  # 10:00 ET = 15:00 UTC
+    naive_end = dt_datetime(2025, 1, 15, 12, 0)  # 12:00 ET = 17:00 UTC
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "test_user",
+            "code": "1234",
+            "start_datetime": naive_start,
+            "end_datetime": naive_end,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args, AccessCode)
+    assert isinstance(call_args.schedule, TemporarySchedule)
+    assert call_args.schedule.start.tzinfo is not None
+    assert call_args.schedule.start.utcoffset().total_seconds() == 0
+    assert call_args.schedule.end.tzinfo is not None
+    assert call_args.schedule.end.utcoffset().total_seconds() == 0
+    # Verify correct UTC instant for 10:00 ET = 15:00 UTC
+    expected_start = dt_util.as_utc(dt_datetime(2025, 1, 15, 15, 0, tzinfo=dt_util.UTC))
+    expected_end = dt_util.as_utc(dt_datetime(2025, 1, 15, 17, 0, tzinfo=dt_util.UTC))
+    assert call_args.schedule.start == expected_start
+    assert call_args.schedule.end == expected_end
+
+
+async def test_add_code_aware_datetimes_accepted(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code accepts UTC-aware datetimes without double-conversion."""
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    aware_start = dt_util.as_utc(dt_datetime(2025, 6, 1, 8, 0))
+    aware_end = dt_util.as_utc(dt_datetime(2025, 6, 1, 10, 0))
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "test_user",
+            "code": "1234",
+            "start_datetime": aware_start,
+            "end_datetime": aware_end,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args.schedule, TemporarySchedule)
+    # No double-conversion: the instant must be identical
+    assert call_args.schedule.start == aware_start
+    assert call_args.schedule.end == aware_end
+
+
+async def test_build_schedule_start_after_end_utc_aware(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test start > end validation still raises after UTC normalization."""
+    mock_lock.access_codes = {}
+
+    # start is 2h after end in the same day — after normalization the relation holds
+    start = dt_util.as_utc(dt_datetime(2025, 7, 1, 14, 0))
+    end = dt_util.as_utc(dt_datetime(2025, 7, 1, 12, 0))
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start time must be before end time",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": start,
+                "end_datetime": end,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_start_after_end"
+
+
+async def test_update_code_comparison_with_aware_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code with an already-aware schedule from the API does not raise TypeError."""
+    aware_start = dt_util.as_utc(dt_datetime(2025, 5, 1, 9, 0))
+    aware_end = dt_util.as_utc(dt_datetime(2025, 5, 1, 17, 0))
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = TemporarySchedule(start=aware_start, end=aware_end)
+    mock_lock.access_codes = {"id1": existing_code}
+
+    # Update with new dates — should not raise TypeError during comparison
+    new_start = dt_util.as_utc(dt_datetime(2025, 6, 1, 8, 0))
+    new_end = dt_util.as_utc(dt_datetime(2025, 6, 1, 18, 0))
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "id1",
+            "start_datetime": new_start,
+            "end_datetime": new_end,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert isinstance(existing_code.schedule, TemporarySchedule)
+    assert existing_code.schedule.start == new_start
+    assert existing_code.schedule.end == new_end
+    existing_code.save.assert_called_once()
+
+
+async def test_update_code_schedule_fails_save_detected(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test schedule-only update that fails save is correctly reported as failed."""
+    old_start = dt_util.as_utc(dt_datetime(2025, 1, 1, 9, 0))
+    old_end = dt_util.as_utc(dt_datetime(2025, 1, 1, 17, 0))
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = TemporarySchedule(start=old_start, end=old_end)
+    mock_lock.access_codes = {"id1": existing_code}
+
+    existing_code.save.side_effect = SchlageError("API error")
+
+    # After refresh, return code with the OLD schedule (change was NOT applied).
+    old_schedule_code = Mock()
+    old_schedule_code.name = "existing_user"
+    old_schedule_code.code = "1234"
+    old_schedule_code.access_code_id = "id1"
+    old_schedule_code.disabled = False
+    old_schedule_code.notify_on_use = True
+    old_schedule_code.schedule = TemporarySchedule(start=old_start, end=old_end)
+
+    call_count = 0
+
+    def refresh_side_effect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            mock_lock.access_codes = {"id1": old_schedule_code}
+
+    mock_lock.refresh_access_codes.side_effect = refresh_side_effect
+
+    new_start = dt_util.as_utc(dt_datetime(2025, 6, 1, 8, 0))
+    new_end = dt_util.as_utc(dt_datetime(2025, 6, 1, 18, 0))
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "access_code_id": "id1",
+                "start_datetime": new_start,
+                "end_datetime": new_end,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_update_code_failed"
+    existing_code.save.assert_called_once()
+    assert mock_lock.refresh_access_codes.call_count == 2
+
+
+async def test_update_code_schedule_succeeds_despite_notification_error(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test schedule update succeeds when save raises but device confirmed the change."""
+    old_start = dt_util.as_utc(dt_datetime(2025, 1, 1, 9, 0))
+    old_end = dt_util.as_utc(dt_datetime(2025, 1, 1, 17, 0))
+    existing_code = Mock()
+    existing_code.name = "existing_user"
+    existing_code.code = "1234"
+    existing_code.access_code_id = "id1"
+    existing_code.disabled = False
+    existing_code.notify_on_use = True
+    existing_code.schedule = TemporarySchedule(start=old_start, end=old_end)
+    mock_lock.access_codes = {"id1": existing_code}
+
+    existing_code.save.side_effect = SchlageError("notification failed")
+
+    # After refresh, return code with the NEW schedule (change was applied).
+    new_start = dt_util.as_utc(dt_datetime(2025, 6, 1, 8, 0))
+    new_end = dt_util.as_utc(dt_datetime(2025, 6, 1, 18, 0))
+    updated_code = Mock()
+    updated_code.name = "existing_user"
+    updated_code.code = "1234"
+    updated_code.access_code_id = "id1"
+    updated_code.disabled = False
+    updated_code.notify_on_use = True
+    updated_code.schedule = TemporarySchedule(start=new_start, end=new_end)
+
+    call_count = 0
+
+    def refresh_side_effect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            mock_lock.access_codes = {"id1": updated_code}
+
+    mock_lock.refresh_access_codes.side_effect = refresh_side_effect
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "id1",
+            "start_datetime": new_start,
+            "end_datetime": new_end,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    existing_code.save.assert_called_once()
+    assert mock_lock.refresh_access_codes.call_count == 2
+
+
+async def test_update_code_rejects_duplicate_name(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code rejects name that matches another code (case-insensitive)."""
+    target_code = Mock()
+    target_code.name = "target_user"
+    target_code.code = "1234"
+    target_code.access_code_id = "id_target"
+    target_code.disabled = False
+    target_code.notify_on_use = True
+    target_code.schedule = None
+
+    other_code = Mock()
+    other_code.name = "Existing_User"
+    other_code.code = "5678"
+    other_code.access_code_id = "id_other"
+
+    mock_lock.access_codes = {
+        "id_target": target_code,
+        "id_other": other_code,
+    }
+
+    with pytest.raises(
+        ServiceValidationError,
+        match='A PIN code with the name "existing_user" already exists on the lock',
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "access_code_id": "id_target",
+                "name": "existing_user",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_name_exists"
+
+
+async def test_update_code_rejects_duplicate_pin(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code rejects PIN that matches another code."""
+    target_code = Mock()
+    target_code.name = "target_user"
+    target_code.code = "1234"
+    target_code.access_code_id = "id_target"
+    target_code.disabled = False
+    target_code.notify_on_use = True
+    target_code.schedule = None
+
+    other_code = Mock()
+    other_code.name = "other_user"
+    other_code.code = "9999"
+    other_code.access_code_id = "id_other"
+
+    mock_lock.access_codes = {
+        "id_target": target_code,
+        "id_other": other_code,
+    }
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="A PIN code with this value already exists on the lock",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "access_code_id": "id_target",
+                "code": "9999",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_code_exists"
+
+
+async def test_update_code_allows_same_name_and_code(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test update_code allows keeping same name/code on the target code."""
+    target_code = Mock()
+    target_code.name = "user1"
+    target_code.code = "1234"
+    target_code.access_code_id = "id1"
+    target_code.disabled = False
+    target_code.notify_on_use = True
+    target_code.schedule = None
+
+    other_code = Mock()
+    other_code.name = "user2"
+    other_code.code = "5678"
+    other_code.access_code_id = "id2"
+
+    mock_lock.access_codes = {
+        "id1": target_code,
+        "id2": other_code,
+    }
+
+    # Updating name to same value should not raise.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "id1",
+            "name": "user1",
+            "code": "1234",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    target_code.save.assert_called_once()
+
+
+async def test_delete_code_service_by_access_code_id(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test delete_code service using access_code_id."""
+    existing_code = Mock()
+    existing_code.name = "test_user"
+    existing_code.delete = Mock()
+    mock_lock.access_codes = {"abc123": existing_code}
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "access_code_id": "abc123",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    existing_code.delete.assert_called_once()
+    mock_lock.refresh_access_codes.assert_called_once()
+
+
+async def test_delete_code_service_ambiguous_identifiers_raises(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test delete_code raises when both name and access_code_id are provided."""
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Provide either name or access_code_id, not both",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "access_code_id": "abc123",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_delete_code_ambiguous"
+
+
+async def test_get_codes_service_recurring_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test get_codes returns type=recurring when code has a RecurringSchedule."""
+    schedule = RecurringSchedule(
+        days_of_week=RecurringSchedule.__dataclass_fields__[
+            "days_of_week"
+        ].default_factory(),
+        start_hour=8,
+        start_minute=0,
+        end_hour=18,
+        end_minute=0,
+    )
+    code = Mock()
+    code.name = "recurring_user"
+    code.code = "2222"
+    code.access_code_id = "id_recurring"
+    code.disabled = False
+    code.notify_on_use = True
+    code.schedule = schedule
+    mock_lock.access_codes = {"1": code}
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    schedule_resp = response["lock.vault_door"]["1"]["schedule"]
+    assert schedule_resp["type"] == "recurring"
+    assert "days_of_week" in schedule_resp
+    assert schedule_resp["start_hour"] == 8
+    assert schedule_resp["start_minute"] == 0
+    assert schedule_resp["end_hour"] == 18
+    assert schedule_resp["end_minute"] == 0
+
+
+async def test_get_codes_service_multi_recurring_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test get_codes returns type=recurring_multi when code has a MultiRecurringSchedule."""
+    schedule1 = RecurringSchedule(
+        days_of_week=RecurringSchedule.__dataclass_fields__[
+            "days_of_week"
+        ].default_factory(),
+        start_hour=6,
+        start_minute=0,
+        end_hour=12,
+        end_minute=0,
+    )
+    schedule2 = RecurringSchedule(
+        days_of_week=RecurringSchedule.__dataclass_fields__[
+            "days_of_week"
+        ].default_factory(),
+        start_hour=14,
+        start_minute=0,
+        end_hour=20,
+        end_minute=0,
+    )
+    multi_schedule = MultiRecurringSchedule(schedule1=schedule1, schedule2=schedule2)
+    code = Mock()
+    code.name = "multi_user"
+    code.code = "3333"
+    code.access_code_id = "id_multi"
+    code.disabled = False
+    code.notify_on_use = True
+    code.schedule = multi_schedule
+    mock_lock.access_codes = {"1": code}
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    schedule_resp = response["lock.vault_door"]["1"]["schedule"]
+    assert schedule_resp["type"] == "recurring_multi"
+    assert "windows" in schedule_resp
+    assert len(schedule_resp["windows"]) == 2
+    assert schedule_resp["windows"][0]["start_hour"] == 6
+    assert schedule_resp["windows"][0]["end_hour"] == 12
+    assert schedule_resp["windows"][1]["start_hour"] == 14
+    assert schedule_resp["windows"][1]["end_hour"] == 20


### PR DESCRIPTION
## Proposed change

The Schlage integration currently only supports permanent access codes: `add_code` creates codes that are always active, and the integration discards the schedule data the Schlage cloud API natively supports. The Schlage Home app allows temporary codes with a start and end datetime; this PR brings that capability to the integration.

What this changes:

- `schlage.add_code` gains optional `start_datetime` and `end_datetime` fields. Providing both creates a temporary code active in that window. Providing neither keeps the existing permanent behavior. Providing exactly one raises a clear validation error (`schlage_temporary_dates_required`).
- New `schlage.update_code` action to modify a code's name, PIN, notification setting, disabled state, and schedule. The schedule is only modified when the user explicitly provides dates, so renaming a temporary code does not wipe its schedule.
- `schlage.delete_code` now also accepts `access_code_id` (delete by stable ID, not only by name).
- `schlage.get_codes` response now includes `access_code_id`, `notify_on_use`, `disabled`, and the serialized `schedule` for each code.
- PIN validation failures now raise a translated `ServiceValidationError` ("PIN must be 4-8 digits") instead of surfacing a raw voluptuous regex dump.

Design notes:

- **Dates decide permanence.** There is no separate "temporary" flag; the presence of both datetimes defines a temporary code. HA service forms are static schemas, and the frontend's per-field include-checkboxes already act as the enable mechanism for the optional datetime fields, so an explicit flag would duplicate intent and create contradictory states (flag off with dates present, flag on with dates missing).
- **`update_code` verifies before erroring.** The Schlage API can raise from the notification sub-call inside `save()` even when the access code update itself succeeded. `update_code` re-fetches the codes to confirm the change landed and suppresses the false error; it only raises when the change genuinely failed. Covered by regression tests.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or continuation of ongoing work

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to discussion: https://github.com/home-assistant/architecture/discussions/1000 (native lock code support). That discussion proposes a unified cross-protocol platform for lock codes; until that lands, this PR keeps the feature scoped to the Schlage integration, mirroring how the Schlage app itself exposes temporary codes.
- Link to documentation pull request: home-assistant/home-assistant.io#47675 (to be updated once the companion docs PR is opened)
- Test results: 65 tests passing in `tests/components/schlage/`, including regression tests for (a) `update_code` succeeding despite an API notification error, and (b) rejection of `start_datetime >= end_datetime`.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass.** By closing this PR you acknowledge that you have read and understood the [contribution guidelines](https://github.com/home-assistant/core/blob/dev/CONTRIBUTING.md).
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_guidelines/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#create-a-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration is added/changed a documentation update needs to follow.

- [x] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)