### PR TITLE
Don't attach a device to iotawatt entities without a unique ID

### DIFF
--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -164,9 +164,15 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
 
         self._key = key
         data = self._sensor_data
+        # An entity without a unique ID cannot be attached to a device.
         if data.getType() == "Input":
             self._attr_unique_id = (
                 f"{data.hub_mac_address}-input-{data.getChannel()}-{data.getUnit()}"
+            )
+            self._attr_device_info = dr.DeviceInfo(
+                connections={(dr.CONNECTION_NETWORK_MAC, data.hub_mac_address)},
+                manufacturer="IoTaWatt",
+                model="IoTaWatt",
             )
         self.entity_description = entity_description
 
@@ -180,18 +186,6 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
     def name(self) -> str | None:
         """Return name of the entity."""
         return self._sensor_data.getName()
-
-    @property
-    @override
-    def device_info(self) -> dr.DeviceInfo:
-        """Return device info."""
-        return dr.DeviceInfo(
-            connections={
-                (dr.CONNECTION_NETWORK_MAC, self._sensor_data.hub_mac_address)
-            },
-            manufacturer="IoTaWatt",
-            model="IoTaWatt",
-        )
 
     @callback
     @override

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.iotawatt.const import DOMAIN
 from homeassistant.components.sensor import (
@@ -19,11 +20,12 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import INPUT_SENSOR, OUTPUT_SENSOR
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_sensor_type_input(
@@ -88,3 +90,35 @@ async def test_sensor_type_output(
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.my_watthour_sensor") is None
+
+
+async def test_output_sensor_not_attached_to_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+    mock_iotawatt: MagicMock,
+    entry: MockConfigEntry,
+) -> None:
+    """Test only sensors with a unique ID are attached to the device."""
+    mock_iotawatt.getSensors.return_value["sensors"] = {
+        "my_sensor_key": INPUT_SENSOR,
+        "my_watthour_sensor_key": OUTPUT_SENSOR,
+    }
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "mock-mac"), entry.entry_id
+    )
+    assert device is not None
+
+    input_entry = entity_registry.async_get("sensor.test_device_my_sensor")
+    assert input_entry is not None
+    assert input_entry.device_id == device.id
+
+    # Outputs have no unique ID, hence no registry entry to attach a device to.
+    assert hass.states.get("sensor.my_watthour_sensor") is not None
+    assert entity_registry.async_get("sensor.my_watthour_sensor") is None
+
+    assert "attempts to attach a device to an entity" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since #177459 the following is logged on startup:

> Detected that integration 'iotawatt' attempts to attach a device to an entity without a unique ID. This will stop working in Home Assistant 2027.8.0

IoTaWatt "Output" sensors are user-defined calculations on the device (`Script`s, evaluated from the datalog) with no immutable identifier, so they intentionally get no unique ID — the `if data.getType() == "Input"` condition dates back to the initial integration in #55364. The `device_info` property however returned a `DeviceInfo` for *every* sensor, including those outputs.

That device info was never used: `entity_platform` only resolves `device_info` in the `entity.unique_id is not None` branch, so output entities have never been attached to the IoTaWatt device. This PR provides the device info only where the unique ID is set as well, making the existing behavior explicit.

**No functional change** — no entity gains or loses a device, and no entity registry entries are added or removed. Only the deprecation report goes away.

To be explicit, since this is a recurring topic (#86834, #158995, #176270): this PR does **not** add unique IDs to output sensors. It only stops claiming a device for entities that cannot have one. Assigning unique IDs to outputs still requires an immutable identifier from the device, which the firmware does not provide today (output identity is the user-chosen name; the configuration app even re-sorts outputs alphabetically by name on every save, so the position in the outputs array is not stable either).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177697
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
