### PR TITLE
Webostv screen switch capability

### DIFF
--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -83,6 +83,9 @@
     "notify_icon_not_found": {
       "message": "Icon {icon_path} not found when sending notification for device {name}"
     },
+    "screen_control_not_supported": {
+      "message": "{name} does not support turning the screen on or off."
+    },
     "source_not_found": {
       "message": "Source {source} not found in the sources list for {name}."
     },

--- a/homeassistant/components/webostv/switch.py
+++ b/homeassistant/components/webostv/switch.py
@@ -2,10 +2,14 @@
 
 from typing import Any, override
 
+from aiowebostv import WebOsTvServiceNotFoundError
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import WebOsTvConfigEntry
 from .entity import WebOsTvEntity, cmd
 
@@ -25,17 +29,21 @@ class LgWebOSScreenSwitchEntity(WebOsTvEntity, SwitchEntity):
     """Representation of a LG webOS TV Screen Switch."""
 
     _attr_translation_key = "screen"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, entry: WebOsTvConfigEntry) -> None:
         """Initialize the screen switch entity."""
         super().__init__(entry)
         self._attr_unique_id = f"{entry.unique_id}_screen"
+        self._unsupported = False
 
     @property
     @override
     def available(self) -> bool:
         """Return true if the entity is available."""
-        return super().available and self._client.tv_state.is_on
+        return (
+            super().available and self._client.tv_state.is_on and not self._unsupported
+        )
 
     @property
     @override
@@ -47,10 +55,23 @@ class LgWebOSScreenSwitchEntity(WebOsTvEntity, SwitchEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the screen on."""
-        await self._client.set_screen_state(True)
+        await self._async_set_screen_state(True)
 
     @cmd
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the screen off."""
-        await self._client.set_screen_state(False)
+        await self._async_set_screen_state(False)
+
+    async def _async_set_screen_state(self, state: bool) -> None:
+        """Set the screen state, marking the switch unsupported on a 404."""
+        try:
+            await self._client.set_screen_state(state)
+        except WebOsTvServiceNotFoundError as error:
+            self._unsupported = True
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="screen_control_not_supported",
+                translation_placeholders={"name": self.coordinator.name},
+            ) from error

--- a/tests/components/webostv/test_switch.py
+++ b/tests/components/webostv/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from aiowebostv import WebOsTvCommandError
+from aiowebostv import WebOsTvCommandError, WebOsTvServiceNotFoundError
 import pytest
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -25,29 +25,41 @@ from .const import FAKE_UUID
 SWITCH_ENTITY_ID = f"{SWITCH_DOMAIN}.lg_webos_tv_model_screen"
 
 
+async def _async_setup_and_enable_switch(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Set up webostv and enable the screen switch, disabled by default."""
+    await setup_webostv(hass)
+    entity_registry.async_update_entity(SWITCH_ENTITY_ID, disabled_by=None)
+    await hass.async_block_till_done()
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
 async def test_screen_switch_setup(
     hass: HomeAssistant,
     client: AsyncMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test setup of LG webOS TV screen switch."""
+    """Test the LG webOS TV screen switch is registered but disabled."""
     await setup_webostv(hass)
 
     entry = entity_registry.async_get(SWITCH_ENTITY_ID)
     assert entry is not None
     assert entry.unique_id == f"{FAKE_UUID}_screen"
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
-    state = hass.states.get(SWITCH_ENTITY_ID)
-    assert state is not None
-    assert state.state == STATE_OFF
+    assert hass.states.get(SWITCH_ENTITY_ID) is None
 
 
 async def test_screen_switch_state_updates(
     hass: HomeAssistant,
     client: AsyncMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test screen switch state updates from client."""
-    await setup_webostv(hass)
+    await _async_setup_and_enable_switch(hass, entity_registry)
 
     state = hass.states.get(SWITCH_ENTITY_ID)
     assert state is not None
@@ -81,11 +93,12 @@ async def test_screen_switch_state_updates(
 async def test_screen_switch_commands(
     hass: HomeAssistant,
     client: AsyncMock,
+    entity_registry: er.EntityRegistry,
     service: str,
     screen_state: bool,
 ) -> None:
     """Test the screen switch sets the screen state."""
-    await setup_webostv(hass)
+    await _async_setup_and_enable_switch(hass, entity_registry)
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -101,10 +114,11 @@ async def test_screen_switch_commands(
 async def test_screen_switch_command_error(
     hass: HomeAssistant,
     client: AsyncMock,
+    entity_registry: er.EntityRegistry,
     service: str,
 ) -> None:
     """Test a failing screen command raises a translated error."""
-    await setup_webostv(hass)
+    await _async_setup_and_enable_switch(hass, entity_registry)
     client.set_screen_state.side_effect = WebOsTvCommandError("Communication error")
 
     with pytest.raises(HomeAssistantError) as err:
@@ -117,3 +131,32 @@ async def test_screen_switch_command_error(
 
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == "communication_error"
+
+
+@pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
+async def test_screen_switch_not_supported(
+    hass: HomeAssistant,
+    client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    service: str,
+) -> None:
+    """Test a TV without screen control raises a translated error."""
+    await _async_setup_and_enable_switch(hass, entity_registry)
+    client.set_screen_state.side_effect = WebOsTvServiceNotFoundError(
+        "404 no such service or method"
+    )
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "screen_control_not_supported"
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/webostv/test_switch.py
+++ b/tests/components/webostv/test_switch.py
@@ -25,18 +25,6 @@ from .const import FAKE_UUID
 SWITCH_ENTITY_ID = f"{SWITCH_DOMAIN}.lg_webos_tv_model_screen"
 
 
-async def _async_setup_and_enable_switch(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Set up webostv and enable the screen switch, disabled by default."""
-    await setup_webostv(hass)
-    entity_registry.async_update_entity(SWITCH_ENTITY_ID, disabled_by=None)
-    await hass.async_block_till_done()
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-
 async def test_screen_switch_setup(
     hass: HomeAssistant,
     client: AsyncMock,
@@ -53,13 +41,13 @@ async def test_screen_switch_setup(
     assert hass.states.get(SWITCH_ENTITY_ID) is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_screen_switch_state_updates(
     hass: HomeAssistant,
     client: AsyncMock,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test screen switch state updates from client."""
-    await _async_setup_and_enable_switch(hass, entity_registry)
+    await setup_webostv(hass)
 
     state = hass.states.get(SWITCH_ENTITY_ID)
     assert state is not None
@@ -83,6 +71,7 @@ async def test_screen_switch_state_updates(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     ("service", "screen_state"),
     [
@@ -93,12 +82,11 @@ async def test_screen_switch_state_updates(
 async def test_screen_switch_commands(
     hass: HomeAssistant,
     client: AsyncMock,
-    entity_registry: er.EntityRegistry,
     service: str,
     screen_state: bool,
 ) -> None:
     """Test the screen switch sets the screen state."""
-    await _async_setup_and_enable_switch(hass, entity_registry)
+    await setup_webostv(hass)
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -110,15 +98,15 @@ async def test_screen_switch_commands(
     client.set_screen_state.assert_called_once_with(screen_state)
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
 async def test_screen_switch_command_error(
     hass: HomeAssistant,
     client: AsyncMock,
-    entity_registry: er.EntityRegistry,
     service: str,
 ) -> None:
     """Test a failing screen command raises a translated error."""
-    await _async_setup_and_enable_switch(hass, entity_registry)
+    await setup_webostv(hass)
     client.set_screen_state.side_effect = WebOsTvCommandError("Communication error")
 
     with pytest.raises(HomeAssistantError) as err:
@@ -133,15 +121,15 @@ async def test_screen_switch_command_error(
     assert err.value.translation_key == "communication_error"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
 async def test_screen_switch_not_supported(
     hass: HomeAssistant,
     client: AsyncMock,
-    entity_registry: er.EntityRegistry,
     service: str,
 ) -> None:
     """Test a TV without screen control raises a translated error."""
-    await _async_setup_and_enable_switch(hass, entity_registry)
+    await setup_webostv(hass)
     client.set_screen_state.side_effect = WebOsTvServiceNotFoundError(
         "404 no such service or method"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some LG TVs don't implement the turnOnScreen/turnOffScreen SSAP endpoints and 404 on every toggle ([home-assistant/core#180387](https://github.com/home-assistant/core/issues/180387)). There's no reliable way to detect this before a user actually tries the switch, so it's now disabled by default and opt-in instead of guessing.

If a user enables it on an unsupported TV, the first toggle raises a clear translated error instead of a generic communication error, and the switch goes unavailable afterward instead of failing the same way on every subsequent attempt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180387
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47677
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
