### PR TITLE
Keep a finished template render out of work scheduled during it

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -523,7 +523,7 @@ class Template:
         if not self.hass:
             raise RuntimeError(f"hass not set while rendering {self}")
 
-        if render_info_cv.get() is not None:
+        if (in_flight := render_info_cv.get()) is not None and in_flight.collecting:
             raise RuntimeError(
                 f"RenderInfo already set while rendering {self}, "
                 "this usually indicates the template is being rendered "
@@ -543,6 +543,7 @@ class Template:
         except TemplateError as ex:
             render_info.exception = ex
         finally:
+            render_info.collecting = False
             render_info_cv.reset(token)
 
         render_info._freeze()  # noqa: SLF001

--- a/homeassistant/helpers/template/extensions/datetime.py
+++ b/homeassistant/helpers/template/extensions/datetime.py
@@ -226,21 +226,21 @@ class DateTimeExtension(BaseTemplateExtension):
 
     def now(self) -> datetime:
         """Record fetching now."""
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.has_time = True
 
         return dt_util.now()
 
     def utcnow(self) -> datetime:
         """Record fetching utcnow."""
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.has_time = True
 
         return dt_util.utcnow()
 
     def today_at(self, time_str: str = "") -> datetime:
         """Record fetching now where the time has been replaced with value."""
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.has_time = True
 
         today = dt_util.start_of_local_day()
@@ -263,7 +263,7 @@ class DateTimeExtension(BaseTemplateExtension):
         wrong direction are returned as-is, except naive datetimes are first
         converted to local time.
         """
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.has_time = True
 
         if not isinstance(value, datetime):

--- a/homeassistant/helpers/template/render_info.py
+++ b/homeassistant/helpers/template/render_info.py
@@ -40,6 +40,7 @@ class RenderInfo:
         "_result",
         "all_states",
         "all_states_lifecycle",
+        "collecting",
         "domains",
         "domains_lifecycle",
         "entities",
@@ -55,6 +56,10 @@ class RenderInfo:
     def __init__(self, template: Template) -> None:
         """Initialise."""
         self.template = template
+        # Work scheduled during a render inherits a copy of its context, so the
+        # render info in that copy outlives the render. Cleared when the render
+        # ends, so the copy neither collects nor looks like a render in flight.
+        self.collecting = True
         # Will be set sensibly once frozen.
         self.filter_lifecycle: Callable[[str], bool] = _true
         self.filter: Callable[[str], bool] = _true

--- a/homeassistant/helpers/template/states.py
+++ b/homeassistant/helpers/template/states.py
@@ -127,11 +127,11 @@ class AllStates:
     __getitem__ = __getattr__
 
     def _collect_all(self) -> None:
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.all_states = True
 
     def _collect_all_lifecycle(self) -> None:
-        if (render_info := render_info_cv.get()) is not None:
+        if (render_info := render_info_cv.get()) is not None and render_info.collecting:
             render_info.all_states_lifecycle = True
 
     def __iter__(self) -> Generator[TemplateState]:
@@ -262,11 +262,15 @@ class DomainStates:
     __getitem__ = __getattr__
 
     def _collect_domain(self) -> None:
-        if (entity_collect := render_info_cv.get()) is not None:
+        if (
+            entity_collect := render_info_cv.get()
+        ) is not None and entity_collect.collecting:
             entity_collect.domains.add(self._domain)  # type: ignore[attr-defined]
 
     def _collect_domain_lifecycle(self) -> None:
-        if (entity_collect := render_info_cv.get()) is not None:
+        if (
+            entity_collect := render_info_cv.get()
+        ) is not None and entity_collect.collecting:
             entity_collect.domains_lifecycle.add(self._domain)  # type: ignore[attr-defined]
 
     def __iter__(self) -> Generator[TemplateState]:
@@ -305,7 +309,11 @@ class TemplateStateBase(State):
         self._cache: dict[str, Any] = {}
 
     def _collect_state(self) -> None:
-        if self._collect and (render_info := render_info_cv.get()):
+        if (
+            self._collect
+            and (render_info := render_info_cv.get())
+            and render_info.collecting
+        ):
             render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
 
     # Jinja will try __getitem__ first and it avoids the need
@@ -314,7 +322,11 @@ class TemplateStateBase(State):
         """Return a property as an attribute for jinja."""
         if item in _COLLECTABLE_STATE_ATTRIBUTES:
             # _collect_state inlined here for performance
-            if self._collect and (render_info := render_info_cv.get()):
+            if (
+                self._collect
+                and (render_info := render_info_cv.get())
+                and render_info.collecting
+            ):
                 render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
             return getattr(self._state, item)
         if item == "entity_id":
@@ -472,7 +484,9 @@ _create_template_state_no_collect = partial(TemplateState, collect=False)
 
 
 def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
-    if (entity_collect := render_info_cv.get()) is not None:
+    if (
+        entity_collect := render_info_cv.get()
+    ) is not None and entity_collect.collecting:
         entity_collect.entities.add(entity_id)  # type: ignore[attr-defined]
 
 

--- a/tests/helpers/template/test_render_info.py
+++ b/tests/helpers/template/test_render_info.py
@@ -1,8 +1,11 @@
 """Test template render information tracking for Home Assistant."""
 
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 from homeassistant.helpers.template.render_info import (
@@ -13,6 +16,7 @@ from homeassistant.helpers.template.render_info import (
     _true,
     render_info_cv,
 )
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
@@ -26,6 +30,7 @@ def test_render_info_initialization(template_obj: template.Template) -> None:
     info = RenderInfo(template_obj)
 
     assert info.template is template_obj
+    assert info.collecting is True
     assert info._result is None
     assert info.is_static is False
     assert info.exception is None
@@ -190,3 +195,49 @@ def test_render_info_context_var(template_obj: template.Template) -> None:
     # Reset for other tests
     render_info_cv.set(None)
     assert render_info_cv.get() is None
+
+
+@pytest.mark.parametrize(
+    "render",
+    [
+        pytest.param(
+            lambda tpl: tpl.async_render_to_info().result(), id="render_to_info"
+        ),
+        pytest.param(lambda tpl: tpl.async_render(), id="render"),
+    ],
+)
+async def test_render_info_does_not_escape_into_scheduled_work(
+    hass: HomeAssistant,
+    render: Callable[[template.Template], Any],
+) -> None:
+    """Test the render in flight does not escape into work scheduled during it.
+
+    An error logged while a template renders makes `system_log` fire an event,
+    and firing hands the dispatch to the event loop together with a copy of the
+    context of the render. Renders made from that copy used to collect into the
+    render that had already finished, or raise "RenderInfo already set", and the
+    error logged for that fired another event carrying the same copy, so the
+    loop sustained itself.
+    """
+    assert await async_setup_component(
+        hass, "system_log", {"system_log": {"fire_event": True}}
+    )
+    hass.states.async_set("sensor.test", "ok")
+
+    renders: list[str] = []
+
+    @callback
+    def _render_on_event(event: Event) -> None:
+        renders.append(render(template.Template("{{ states('sensor.test') }}", hass)))
+
+    hass.bus.async_listen("system_log_event", _render_on_event)
+
+    # Calling an undefined variable logs an error from inside the render
+    with pytest.raises(TemplateError):
+        template.Template(
+            "{{ nope.startswith('x') }}", hass
+        ).async_render_to_info().result()
+
+    await hass.async_block_till_done()
+
+    assert renders == ["ok"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


A template render puts its `RenderInfo` in a `ContextVar` for the duration of the render. Anything that copies the context while the render is in flight keeps that render info long after the render is over, and `hass.bus.fire` does exactly that: it hands the dispatch to the event loop with `loop.call_soon_threadsafe`, which snapshots the current context.

The seed sits in the template helper itself. `LoggingUndefined._fail_with_undefined_error` logs at ERROR level from inside the render. With `system_log` configured with `fire_event: true`, that fires a `system_log_event` while the render is still running, so the dispatch of that event inherits the render.

From there it sustains itself. Every render made from the inherited context either raises `RenderInfo already set` or collects into a render info that was already frozen, an error is logged for it, that error fires another `system_log_event` carrying the same context, and around it goes. In the reported case it ran at roughly 100 iterations per second for 15 hours, pinned a core and wrote about 10 GB of tracebacks into the recorder. It survives `automation.reload`, because the poison lives in the recycled context and not in the `Template` object.

Two distinct failures come out of it, both reproduced in the tests:

```
RuntimeError: RenderInfo already set while rendering Template<...>
AttributeError: 'frozenset' object has no attribute 'add'
```

The second one is the same leak reaching a plain `async_render`, where the collectors write into a render info whose sets were already frozen.

A `RenderInfo` now knows when its render has ended, and every read of the context variable takes that into account. The flag is cleared in the `finally` rather than at freeze time on purpose: a render that raises something other than a `TemplateError` never reaches `_freeze()`, so the copy would keep looking like a render in flight.

The alternative was moving the render in flight to a thread-local, which removes the escape outright since a render is synchronous. It measures around 57 ns per read against around 20 ns for `ContextVar.get()`, and these are the hottest paths in template rendering, so the flag won on cost.

Tests render from inside an event listener, through both `async_render_to_info` and `async_render`, using nothing but public API. Both fail on `dev` and pass here.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175741
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
