### PR TITLE
Require admin for remaining Z-Wave lock services

### DIFF
--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -606,6 +606,7 @@ class ZWaveServices:
             self._hass,
             const.DOMAIN,
             const.SERVICE_GET_LOCK_USERCODE,
+            admin_only=True,
             entity_domain=LOCK_DOMAIN,
             schema={
                 vol.Optional(ATTR_CODE_SLOT): vol.Coerce(int),
@@ -618,6 +619,7 @@ class ZWaveServices:
             self._hass,
             const.DOMAIN,
             const.SERVICE_SET_LOCK_USERCODE,
+            admin_only=True,
             entity_domain=LOCK_DOMAIN,
             schema={
                 vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
@@ -630,6 +632,7 @@ class ZWaveServices:
             self._hass,
             const.DOMAIN,
             const.SERVICE_CLEAR_LOCK_USERCODE,
+            admin_only=True,
             entity_domain=LOCK_DOMAIN,
             schema={
                 vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -644,6 +644,7 @@ class ZWaveServices:
             self._hass,
             const.DOMAIN,
             const.SERVICE_SET_LOCK_CONFIGURATION,
+            admin_only=True,
             entity_domain=LOCK_DOMAIN,
             schema={
                 vol.Required(const.ATTR_OPERATION_TYPE): vol.All(

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -30,10 +30,12 @@ from homeassistant.components.zwave_js.const import (
 )
 from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 
 from .common import SCHLAGE_BE469_LOCK_ENTITY, replace_value_of_zwave_value
+
+from tests.common import MockConfigEntry, MockUser
 
 
 async def test_door_lock(
@@ -517,3 +519,49 @@ async def test_get_all_lock_usercodes(
                 "2": {"usercode": None, "in_use": False},
             }
         }
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "returns_response"),
+    [
+        pytest.param(
+            SERVICE_GET_LOCK_USERCODE,
+            {ATTR_CODE_SLOT: 1},
+            True,
+            id="get_lock_usercode",
+        ),
+        pytest.param(
+            SERVICE_SET_LOCK_USERCODE,
+            {ATTR_CODE_SLOT: 1, ATTR_USERCODE: "1234"},
+            False,
+            id="set_lock_usercode",
+        ),
+        pytest.param(
+            SERVICE_CLEAR_LOCK_USERCODE,
+            {ATTR_CODE_SLOT: 1},
+            False,
+            id="clear_lock_usercode",
+        ),
+    ],
+)
+async def test_lock_usercode_services_require_admin(
+    hass: HomeAssistant,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    hass_read_only_user: MockUser,
+    service: str,
+    service_data: dict[str, int | str],
+    returns_response: bool,
+) -> None:
+    """Every lock usercode service rejects non-admin users."""
+    hass_read_only_user.mock_policy({"entities": {"all": {"control": True}}})
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY, **service_data},
+            blocking=True,
+            return_response=returns_response,
+            context=Context(user_id=hass_read_only_user.id),
+        )

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -542,9 +542,15 @@ async def test_get_all_lock_usercodes(
             False,
             id="clear_lock_usercode",
         ),
+        pytest.param(
+            SERVICE_SET_LOCK_CONFIGURATION,
+            {ATTR_OPERATION_TYPE: "CONSTANT"},
+            False,
+            id="set_lock_configuration",
+        ),
     ],
 )
-async def test_lock_usercode_services_require_admin(
+async def test_lock_management_services_require_admin(
     hass: HomeAssistant,
     lock_schlage_be469: Node,
     integration: MockConfigEntry,
@@ -553,7 +559,7 @@ async def test_lock_usercode_services_require_admin(
     service_data: dict[str, int | str],
     returns_response: bool,
 ) -> None:
-    """Every lock usercode service rejects non-admin users."""
+    """Sensitive lock services reject non-admin users."""
     hass_read_only_user.mock_policy({"entities": {"all": {"control": True}}})
 
     with pytest.raises(Unauthorized):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Z-Wave JS actions `get_lock_usercode`, `set_lock_usercode`, `clear_lock_usercode`, and `set_lock_configuration` now require an admin user.
This is a followup to https://github.com/home-assistant/core/pull/177300, which missed these actions.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Prevent non-admin Home Assistant users with control access to a lock entity from reading or changing persistent Z-Wave lock usercodes and lock configuration.

This applies the existing `admin_only` platform entity service option to all four actions. A regression test verifies that a non-admin user with entity control is rejected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177300
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr