### PR TITLE
Move Tado child lock switch to physical device

### DIFF
--- a/homeassistant/components/tado/switch.py
+++ b/homeassistant/components/tado/switch.py
@@ -9,8 +9,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import TadoConfigEntry
-from .entity import TadoDataUpdateCoordinator, TadoDeviceEntity
+from .coordinator import TadoConfigEntry, TadoDataUpdateCoordinator
+from .entity import TadoDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tado/switch.py
+++ b/homeassistant/components/tado/switch.py
@@ -3,12 +3,14 @@
 import logging
 from typing import Any, override
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import TadoConfigEntry
-from .entity import TadoDataUpdateCoordinator, TadoZoneEntity
+from .entity import TadoDataUpdateCoordinator, TadoDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,24 +23,48 @@ async def async_setup_entry(
     """Set up the Tado switch platform."""
 
     tado = entry.runtime_data
-    entities: list[TadoChildLockSwitchEntity] = []
-    for zone in tado.zones:
-        zone_child_lock_supported = (
-            len(zone["devices"]) > 0 and "childLockEnabled" in zone["devices"][0]
-        )
+    entity_registry = er.async_get(hass)
 
-        if not zone_child_lock_supported:
+    # Child lock used to be represented as a zone entity, even though the Tado API
+    # exposes and controls it per device. Migrate existing entities to device-based
+    # unique IDs so users keep their existing entity IDs and customizations.
+    for zone in tado.zones:
+        if not zone["devices"]:
             continue
 
-        entities.append(
-            TadoChildLockSwitchEntity(
-                tado, zone["name"], zone["id"], zone["devices"][0]
-            )
+        device = zone["devices"][0]
+        if "childLockEnabled" not in device:
+            continue
+
+        old_unique_id = f"{zone['id']} {tado.home_id} child-lock"
+        new_unique_id = f"{device['shortSerialNo']} {tado.home_id} child-lock"
+        entity_id = entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN, DOMAIN, old_unique_id
         )
-    async_add_entities(entities, True)
+        if entity_id is not None and entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN, DOMAIN, new_unique_id
+        ) is None:
+            _LOGGER.debug(
+                "Migrating Tado child lock entity %s from zone %s to device %s",
+                entity_id,
+                zone["id"],
+                device["shortSerialNo"],
+            )
+            entity_registry.async_update_entity(
+                entity_id, new_unique_id=new_unique_id
+            )
+
+    async_add_entities(
+        [
+            TadoChildLockSwitchEntity(tado, device)
+            for device in tado.devices
+            if "childLockEnabled" in device
+        ],
+        True,
+    )
 
 
-class TadoChildLockSwitchEntity(TadoZoneEntity, SwitchEntity):
+class TadoChildLockSwitchEntity(TadoDeviceEntity, SwitchEntity):
     """Representation of a Tado child lock switch entity."""
 
     _attr_translation_key = "child_lock"
@@ -46,27 +72,23 @@ class TadoChildLockSwitchEntity(TadoZoneEntity, SwitchEntity):
     def __init__(
         self,
         coordinator: TadoDataUpdateCoordinator,
-        zone_name: str,
-        zone_id: int,
         device_info: dict[str, Any],
     ) -> None:
         """Initialize the Tado child lock switch entity."""
-        super().__init__(zone_name, coordinator.home_id, zone_id, coordinator)
+        super().__init__(device_info, coordinator)
 
-        self._device_info = device_info
-        self._device_id = self._device_info["shortSerialNo"]
-        self._attr_unique_id = f"{zone_id} {coordinator.home_id} child-lock"
+        self._attr_unique_id = f"{self.device_id} {coordinator.home_id} child-lock"
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self.coordinator.set_child_lock(self._device_id, True)
+        await self.coordinator.set_child_lock(self.device_id, True)
         await self.coordinator.async_request_refresh()
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.coordinator.set_child_lock(self._device_id, False)
+        await self.coordinator.set_child_lock(self.device_id, False)
         await self.coordinator.async_request_refresh()
 
     @callback
@@ -80,12 +102,10 @@ class TadoChildLockSwitchEntity(TadoZoneEntity, SwitchEntity):
     def _async_update_callback(self) -> None:
         """Handle update callbacks."""
         try:
-            self._device_info = self.coordinator.data["device"][self._device_id]
+            self._device_info = self.coordinator.data["device"][self.device_id]
         except KeyError:
             _LOGGER.error(
-                "Could not update child lock info for device %s in zone %s",
-                self._device_id,
-                self.zone_name,
+                "Could not update child lock info for device %s", self.device_id
             )
         else:
             self._attr_is_on = self._device_info.get("childLockEnabled", False) is True

--- a/tests/components/tado/snapshots/test_switch.ambr
+++ b/tests/components/tado/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_entities[switch.baseboard_heater_baseboard_heater_child_lock-entry]
+# name: test_entities[switch.wr4_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.baseboard_heater_baseboard_heater_child_lock',
+    'entity_id': 'switch.wr4_child_lock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -32,17 +32,17 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': '1 1 child-lock',
+    'unique_id': 'WR4 1 child-lock',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[switch.baseboard_heater_baseboard_heater_child_lock-state]
+# name: test_entities[switch.wr4_child_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Baseboard Heater Child lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WR4 Child lock',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.baseboard_heater_baseboard_heater_child_lock',
+    'entity_id': 'switch.wr4_child_lock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tado/test_switch.py
+++ b/tests/components/tado/test_switch.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch import (
 from homeassistant.components.tado import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -30,13 +30,23 @@ def setup_platforms() -> Generator[None]:
 
 @pytest.mark.usefixtures("init_integration")
 async def test_entities(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test creation of switch entities."""
 
     config_entry: MockConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+    entity_entry = entity_registry.async_get(CHILD_LOCK_SWITCH_ENTITY)
+    assert entity_entry is not None
+    assert entity_entry.device_id is not None
+    device_entry = device_registry.async_get(entity_entry.device_id)
+    assert device_entry is not None
+    assert (DOMAIN, "WR4") in device_entry.identifiers
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tado/test_switch.py
+++ b/tests/components/tado/test_switch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
-CHILD_LOCK_SWITCH_ENTITY = "switch.baseboard_heater_baseboard_heater_child_lock"
+CHILD_LOCK_SWITCH_ENTITY = "switch.wr4_child_lock"
 
 
 @pytest.fixture(autouse=True)
@@ -56,5 +56,4 @@ async def test_set_child_lock(hass: HomeAssistant, method, expected) -> None:
             blocking=True,
         )
 
-    mock_set_state.assert_called_once()
-    assert mock_set_state.call_args[0][1] is expected
+    mock_set_state.assert_called_once_with("WR4", expected)


### PR DESCRIPTION
## Proposed change

Represent Tado child lock switches as device entities instead of zone entities. The Tado API exposes child lock per device, and the Tado app presents the setting on the physical thermostat rather than the room/zone.

This change:

- creates child lock switches for each child-lock-capable Tado device;
- associates the switch with the physical Tado device in Home Assistant;
- uses a device-based unique ID;
- migrates the previous zone-based unique ID so existing users keep their entity ID and customizations; and
- adds a test that explicitly verifies the physical device association and that child-lock commands target the correct device serial.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
