### PR TITLE
Tell Telegram which updates the bot wants

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -123,6 +123,20 @@ from .helpers import signal
 _FILE_TYPES = ("animation", "document", "photo", "sticker", "video", "voice")
 _LOGGER = logging.getLogger(__name__)
 
+# Telegram keeps this per bot, server side, and keeps whatever it was told last
+# when the setting is omitted, so a bot narrowed by an earlier consumer of the
+# token silently drops the rest. Ask for what `handle_update` turns into events:
+# a callback query, and the updates `Update.effective_message` is drawn from.
+ALLOWED_UPDATES = [
+    Update.CALLBACK_QUERY,
+    Update.MESSAGE,
+    Update.EDITED_MESSAGE,
+    Update.CHANNEL_POST,
+    Update.EDITED_CHANNEL_POST,
+    Update.BUSINESS_MESSAGE,
+    Update.EDITED_BUSINESS_MESSAGE,
+]
+
 type TelegramBotConfigEntry = ConfigEntry[TelegramNotificationService]
 
 _RETRY_DELAY = 1  # 1 second delay between retries

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -9,7 +9,7 @@ from telegram.ext import ApplicationBuilder, CallbackContext, TypeHandler
 
 from homeassistant.core import HomeAssistant
 
-from .bot import BaseTelegramBot, TelegramBotConfigEntry
+from .bot import ALLOWED_UPDATES, BaseTelegramBot, TelegramBotConfigEntry
 from .helpers import get_base_url
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,7 +82,8 @@ class PollBot(BaseTelegramBot):
         await self.application.initialize()
         if self.application.updater:
             await self.application.updater.start_polling(
-                error_callback=lambda error: error_callback(self.bot, error, None)
+                allowed_updates=ALLOWED_UPDATES,
+                error_callback=lambda error: error_callback(self.bot, error, None),
             )
         await self.application.start()
         _LOGGER.info(

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import get_url
 
-from .bot import BaseTelegramBot, TelegramBotConfigEntry
+from .bot import ALLOWED_UPDATES, BaseTelegramBot, TelegramBotConfigEntry
 from .const import CONF_TRUSTED_NETWORKS
 from .helpers import get_base_url
 
@@ -107,6 +107,7 @@ class PushBot(BaseTelegramBot):
             try:
                 return await self.bot.set_webhook(
                     self.webhook_url,
+                    allowed_updates=ALLOWED_UPDATES,
                     api_kwargs={"secret_token": self.secret_token},
                     connect_timeout=5,
                 )

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -27,6 +27,7 @@ from telegram.error import (
 )
 
 from homeassistant.components.telegram_bot import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.components.telegram_bot.bot import ALLOWED_UPDATES
 from homeassistant.components.telegram_bot.const import (
     ATTR_AUTHENTICATION,
     ATTR_CALLBACK_QUERY_ID,
@@ -808,6 +809,39 @@ async def test_webhook_endpoint_generates_telegram_attachment_event(
 
     assert events[0].data["file_id"] == expected_file_id
     assert isinstance(events[0].context, Context)
+
+
+async def test_polling_platform_allowed_updates(
+    hass: HomeAssistant,
+    mock_polling_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+) -> None:
+    """Test polling asks for the updates the integration handles.
+
+    Telegram keeps the setting per bot and reuses the last one it was given
+    when it is omitted, so it has to be sent on every start.
+    """
+    with patch(
+        "homeassistant.components.telegram_bot.polling.ApplicationBuilder"
+    ) as application_builder_class:
+        application = (
+            application_builder_class.return_value.bot.return_value.build.return_value
+        )
+        application.updater.start_polling = AsyncMock()
+        application.updater.stop = AsyncMock()
+        application.initialize = AsyncMock()
+        application.start = AsyncMock()
+        application.stop = AsyncMock()
+        application.shutdown = AsyncMock()
+
+        mock_polling_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        application.updater.start_polling.call_args.kwargs["allowed_updates"]
+        == ALLOWED_UPDATES
+    )
 
 
 async def test_polling_platform_message_text_update(

--- a/tests/components/telegram_bot/test_webhooks.py
+++ b/tests/components/telegram_bot/test_webhooks.py
@@ -93,7 +93,7 @@ async def test_set_webhooks_allowed_updates(
     mock_webhooks_config_entry: MockConfigEntry,
     mock_external_calls: None,
     mock_register_webhook: None,
-    mock_generate_secret_token,
+    mock_generate_secret_token: str,
 ) -> None:
     """Test the webhook is registered for the updates the integration handles.
 

--- a/tests/components/telegram_bot/test_webhooks.py
+++ b/tests/components/telegram_bot/test_webhooks.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from telegram.error import TimedOut
 
+from homeassistant.components.telegram_bot.bot import ALLOWED_UPDATES
 from homeassistant.components.telegram_bot.const import DOMAIN
 from homeassistant.components.telegram_bot.webhooks import TELEGRAM_WEBHOOK_URL
 from homeassistant.config_entries import ConfigEntryState
@@ -85,6 +86,37 @@ async def test_set_webhooks(
 
     assert mock_webhooks_config_entry.state is ConfigEntryState.LOADED
     mock_start.assert_called_once()
+
+
+async def test_set_webhooks_allowed_updates(
+    hass: HomeAssistant,
+    mock_webhooks_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+    mock_register_webhook: None,
+    mock_generate_secret_token,
+) -> None:
+    """Test the webhook is registered for the updates the integration handles.
+
+    Telegram keeps the setting per bot and reuses the last one it was given
+    when it is omitted, so it has to be sent on every registration.
+    """
+    mock_webhooks_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.telegram_bot.webhooks.Application.start",
+            AsyncMock(),
+        ),
+        patch(
+            "homeassistant.components.telegram_bot.webhooks.Bot.set_webhook",
+            return_value=True,
+        ) as mock_set_webhook,
+    ):
+        await hass.config_entries.async_setup(mock_webhooks_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_webhooks_config_entry.state is ConfigEntryState.LOADED
+    assert mock_set_webhook.call_args.kwargs["allowed_updates"] == ALLOWED_UPDATES
 
 
 async def test_webhooks_update_invalid_json(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Telegram stores `allowed_updates` per bot, on its own side. Omitting it on `getUpdates` or `setWebhook` means "keep the previous setting", not "send me everything". Neither transport ever sent it:

```console
$ grep -rn --include=*.py -e allowed_updates homeassistant/components/telegram_bot/
(no matches)
```

So a token narrowed by any earlier consumer stays narrowed, and Home Assistant inherits that silently. It survives restarts, upgrades, and removing and re-adding the integration, because the setting never lived here at all. On the reporter's bot it was `["message"]`, so every inline keyboard press was discarded by Telegram before Home Assistant could see it: no `telegram_callback` event, no log line at any level, and `getWebhookInfo` reporting `pending_update_count: 0`, because filtered updates are dropped rather than queued. Outbound `send_message` kept working perfectly, since that is a different API call, so the prompts arrived complete with their keyboards and only the button presses vanished.

Both transports now ask for exactly what `handle_update` turns into events: a callback query, and the six updates `Update.effective_message` is drawn from. That list comes from reading `effective_message` in python-telegram-bot 22.7 rather than from guesswork.

`Update.ALL_TYPES` was the other option, and it is the wrong one here. It adds the opt-in types Telegram does not send by default (`chat_member`, `message_reaction`, and friends), all of which land in the `Unhandled update` warning branch, so it would trade a silent bug for log spam.

Worth calling out: this narrows the setting to those seven types for every bot. Anyone whose bot was previously receiving, say, `poll` or `inline_query` updates stops receiving them, but those only ever reached that same `Unhandled update` warning, so nothing that worked before stops working.

The tests assert the argument on both `start_polling` and `set_webhook`. Run against `dev` with the constant inlined, both fail with `KeyError: 'allowed_updates'`, since nothing passes it today.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/179896
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
