### PR TITLE
Keep an LG soundbar on when it never reports a power status

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -126,7 +126,8 @@ class LGDevice(MediaPlayerEntity):
         self._treble = 0
         self._device = None
         self._support_play_control = False
-        self._device_on = False
+        # Starts out matching the ON default of _attr_state, for the same reason
+        self._device_on = True
         self._stream_type = 0
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)}, name=host

--- a/tests/components/lg_soundbar/test_media_player.py
+++ b/tests/components/lg_soundbar/test_media_player.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 import temescal
 
 from homeassistant.components.media_player import (
@@ -12,6 +13,7 @@ from homeassistant.components.media_player import (
     DOMAIN as MEDIA_PLAYER_DOMAIN,
     SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
+    MediaPlayerState,
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -247,3 +249,56 @@ async def test_selecting_a_source_the_device_does_not_offer(
     mock_temescal.return_value.set_func.assert_called_once_with(
         temescal.functions.index("E-ARC")
     )
+
+
+def send_play_info(callback: MagicMock, stream_type: int) -> None:
+    """Report the given stream type via the callback."""
+    callback({"msg": "PLAY_INFO", "data": {"i_stream_type": stream_type}})
+
+
+def send_power_status(callback: MagicMock, powered_on: bool) -> None:
+    """Report the given power status via the callback."""
+    callback({"msg": "SPK_LIST_VIEW_INFO", "data": {"b_powerstatus": powered_on}})
+
+
+async def test_state_stays_on_without_a_reported_power_status(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a soundbar that never reports a power status stays on.
+
+    Being used as a soundbar is the ordinary case for such a model, so the
+    stream type it reports for that must not be read as powered off.
+    """
+    await setup_integration(hass, mock_config_entry)
+
+    send_play_info(find_update_callback(mock_temescal), 0)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).state == MediaPlayerState.ON
+
+
+@pytest.mark.parametrize(
+    ("powered_on", "expected_state"),
+    [
+        pytest.param(True, MediaPlayerState.ON, id="on"),
+        pytest.param(False, MediaPlayerState.OFF, id="off"),
+    ],
+)
+async def test_state_follows_a_reported_power_status(
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    powered_on: bool,
+    expected_state: MediaPlayerState,
+) -> None:
+    """Test that a reported power status decides the state of a soundbar."""
+    await setup_integration(hass, mock_config_entry)
+
+    callback = find_update_callback(mock_temescal)
+    send_power_status(callback, powered_on)
+    send_play_info(callback, 0)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The entity defaults its state to on:

```python
    # Default to ON to ensure compatibility with models
    # that don't send a powerstatus message
    _attr_state = MediaPlayerState.ON
```

But `self._device_on` starts out `False`, and the only thing that ever writes it is a message carrying `b_powerstatus`. The `i_stream_type == 0` branch, the one for "the soundbar is used as an actual soundbar", then decides between on and off from that flag.

So the default and the branch were written for the same models and contradict each other. On a DSP9YA the default holds right up until the first `PLAY_INFO` arrives, and then a flag that has never been populated forces the state to off, in the same second, at every startup, and it never recovers. Being used as a soundbar is the ordinary case for such a model, so the default protects it only until it does the thing it is for.

That is also why the entity stops exposing what it had just read correctly: a media player reporting off withholds `source`, `volume_level` and `sound_mode`, so anything automating on `source` sees `None`.

From the recorder, the same four steps at three separate restarts:

```
on   volume
on   volume, sound_mode
on   volume, sound_mode, source     <- complete and correct
off  (attributes withheld)          <- same second
```

The flag now starts out agreeing with the state it feeds. That fixes the `i_play_ctrl` branch along with it, since it is gated on the same flag, so a model that never reports a power status can report playing and paused too.

The window where this could report on for a soundbar that is genuinely off is the window in which `_attr_state = MediaPlayerState.ON` already claims exactly that, and `update()` asks for `get_info`, which carries `b_powerstatus`, before it asks for `get_play`.

The new test fails on `dev` with `assert 'off' == 'on'`. The parametrized pair alongside it proves a reported power status still decides the state in both directions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/179772
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
