### PR TITLE
Stop exposing sleep timers and adaptive learning on Modern Forms Gen4 fans

### DIFF
--- a/homeassistant/components/modern_forms/binary_sensor.py
+++ b/homeassistant/components/modern_forms/binary_sensor.py
@@ -20,15 +20,18 @@ async def async_setup_entry(
     """Set up Modern Forms binary sensors."""
     coordinator = entry.runtime_data
 
-    binary_sensors: list[ModernFormsBinarySensor] = [
-        ModernFormsFanSleepTimerActive(entry.entry_id, coordinator),
-    ]
+    binary_sensors: list[ModernFormsBinarySensor] = []
 
-    # Only setup light sleep timer sensor if light unit installed
-    if coordinator.data.info.light_type:
+    if coordinator.data.has_sleep_timer():
         binary_sensors.append(
-            ModernFormsLightSleepTimerActive(entry.entry_id, coordinator)
+            ModernFormsFanSleepTimerActive(entry.entry_id, coordinator)
         )
+
+        # Only setup light sleep timer sensor if light unit installed
+        if coordinator.data.info.light_type:
+            binary_sensors.append(
+                ModernFormsLightSleepTimerActive(entry.entry_id, coordinator)
+            )
 
     async_add_entities(binary_sensors)
 

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.percentage import (
@@ -19,6 +20,7 @@ from . import modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
+    DOMAIN,
     OPT_ON,
     OPT_SPEED,
     OPT_WIND,
@@ -186,6 +188,11 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         sleep_time: int,
     ) -> None:
         """Set a Modern Forms light sleep timer."""
+        if not self.coordinator.data.has_sleep_timer():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sleep_timer_not_supported",
+            )
         await self.coordinator.modern_forms.fan(sleep=sleep_time * 60)
 
     @modernforms_exception_handler
@@ -193,4 +200,9 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         self,
     ) -> None:
         """Clear a Modern Forms fan sleep timer."""
+        if not self.coordinator.data.has_sleep_timer():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sleep_timer_not_supported",
+            )
         await self.coordinator.modern_forms.fan(sleep=CLEAR_TIMER)

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.percentage import (
@@ -19,6 +20,7 @@ from . import modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
+    DOMAIN,
     OPT_BRIGHTNESS,
     OPT_ON,
     SERVICE_CLEAR_LIGHT_SLEEP_TIMER,
@@ -159,6 +161,11 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
         sleep_time: int,
     ) -> None:
         """Set a Modern Forms light sleep timer."""
+        if not self.coordinator.data.has_sleep_timer():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sleep_timer_not_supported",
+            )
         await self._async_control_light(sleep=sleep_time * 60)
 
     @modernforms_exception_handler
@@ -166,6 +173,11 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
         self,
     ) -> None:
         """Clear a Modern Forms light sleep timer."""
+        if not self.coordinator.data.has_sleep_timer():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sleep_timer_not_supported",
+            )
         await self._async_control_light(sleep=CLEAR_TIMER)
 
     async def _async_control_light(self, **kwargs: Any) -> None:

--- a/homeassistant/components/modern_forms/sensor.py
+++ b/homeassistant/components/modern_forms/sensor.py
@@ -22,15 +22,18 @@ async def async_setup_entry(
     """Set up Modern Forms sensor based on a config entry."""
     coordinator = entry.runtime_data
 
-    sensors: list[ModernFormsSensor] = [
-        ModernFormsFanTimerRemainingTimeSensor(entry.entry_id, coordinator),
-    ]
+    sensors: list[ModernFormsSensor] = []
 
-    # Only setup light sleep timer sensor if light unit installed
-    if coordinator.data.info.light_type:
+    if coordinator.data.has_sleep_timer():
         sensors.append(
-            ModernFormsLightTimerRemainingTimeSensor(entry.entry_id, coordinator)
+            ModernFormsFanTimerRemainingTimeSensor(entry.entry_id, coordinator)
         )
+
+        # Only setup light sleep timer sensor if light unit installed
+        if coordinator.data.info.light_type:
+            sensors.append(
+                ModernFormsLightTimerRemainingTimeSensor(entry.entry_id, coordinator)
+            )
 
     async_add_entities(sensors)
 

--- a/homeassistant/components/modern_forms/strings.json
+++ b/homeassistant/components/modern_forms/strings.json
@@ -71,6 +71,9 @@
     },
     "invalid_response": {
       "message": "Invalid response from the Modern Forms device"
+    },
+    "sleep_timer_not_supported": {
+      "message": "This fan does not support sleep timers"
     }
   },
   "services": {

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -19,10 +19,13 @@ async def async_setup_entry(
     """Set up Modern Forms switch based on a config entry."""
     coordinator = entry.runtime_data
 
-    switches = [
+    switches: list[ModernFormsSwitch] = [
         ModernFormsAwaySwitch(entry.entry_id, coordinator),
-        ModernFormsAdaptiveLearningSwitch(entry.entry_id, coordinator),
     ]
+
+    if coordinator.data.has_adaptive_learning():
+        switches.append(ModernFormsAdaptiveLearningSwitch(entry.entry_id, coordinator))
+
     async_add_entities(switches)
 
 

--- a/tests/components/modern_forms/test_binary_sensor.py
+++ b/tests/components/modern_forms/test_binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
+from . import init_integration, init_integration_gen4
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -43,3 +43,18 @@ async def test_binary_sensors(
     state = hass.states.get("binary_sensor.modernformsfan_fan_sleep_timer_active")
     assert state
     assert state.state == "off"
+
+
+async def test_no_sleep_timer_binary_sensors_on_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the sleep-timer binary sensors aren't created for Gen4 fans."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    assert (
+        hass.states.get("binary_sensor.modernformsfan_fan_sleep_timer_active") is None
+    )
+    assert (
+        hass.states.get("binary_sensor.modernformsfan_light_sleep_timer_active") is None
+    )

--- a/tests/components/modern_forms/test_binary_sensor.py
+++ b/tests/components/modern_forms/test_binary_sensor.py
@@ -47,14 +47,22 @@ async def test_binary_sensors(
 
 async def test_no_sleep_timer_binary_sensors_on_gen4(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the sleep-timer binary sensors aren't created for Gen4 fans."""
     await init_integration_gen4(hass, aioclient_mock)
 
+    # Both entities are disabled by default, so checking hass.states here
+    # wouldn't distinguish "not created" from "created but disabled" --
+    # check the entity registry instead.
     assert (
-        hass.states.get("binary_sensor.modernformsfan_fan_sleep_timer_active") is None
+        entity_registry.async_get("binary_sensor.modernformsfan_fan_sleep_timer_active")
+        is None
     )
     assert (
-        hass.states.get("binary_sensor.modernformsfan_light_sleep_timer_active") is None
+        entity_registry.async_get(
+            "binary_sensor.modernformsfan_light_sleep_timer_active"
+        )
+        is None
     )

--- a/tests/components/modern_forms/test_fan.py
+++ b/tests/components/modern_forms/test_fan.py
@@ -43,6 +43,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import (
     init_integration,
+    init_integration_gen4,
     modern_forms_breeze_active_call_mock,
     modern_forms_breeze_call_mock,
 )
@@ -395,3 +396,41 @@ async def test_turn_off_does_not_touch_wind(
         )
         await hass.async_block_till_done()
         fan_mock.assert_called_once_with(on=False)
+
+
+async def test_fan_sleep_timer_not_supported_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test setting a sleep timer on a Gen4 fan raises an error."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_FAN_SLEEP_TIMER,
+            {ATTR_ENTITY_ID: "fan.modernformsfan_fan", ATTR_SLEEP_TIME: 1},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "sleep_timer_not_supported"
+
+
+async def test_clear_fan_sleep_timer_not_supported_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test clearing a sleep timer on a Gen4 fan raises an error."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_FAN_SLEEP_TIMER,
+            {ATTR_ENTITY_ID: "fan.modernformsfan_fan"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "sleep_timer_not_supported"

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -326,28 +326,39 @@ async def test_light_change_state_gen4(
         light_mock.assert_not_called()
 
 
-async def test_sleep_timer_services_gen4(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+async def test_light_sleep_timer_not_supported_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test Gen4 sleep timer services pass sleep through light_fixture()."""
+    """Test setting a sleep timer on a Gen4 light fixture raises an error."""
     await init_integration_gen4(hass, aioclient_mock)
 
-    with patch("aiomodernforms.ModernFormsDevice.light_fixture") as light_fixture_mock:
+    with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_LIGHT_SLEEP_TIMER,
             {ATTR_ENTITY_ID: "light.modernformsfan_uplight", ATTR_SLEEP_TIME: 1},
             blocking=True,
         )
-        await hass.async_block_till_done()
-        light_fixture_mock.assert_called_once_with(2, sleep=60)
 
-    with patch("aiomodernforms.ModernFormsDevice.light_fixture") as light_fixture_mock:
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "sleep_timer_not_supported"
+
+
+async def test_clear_light_sleep_timer_not_supported_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test clearing a sleep timer on a Gen4 light fixture raises an error."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_CLEAR_LIGHT_SLEEP_TIMER,
             {ATTR_ENTITY_ID: "light.modernformsfan_uplight"},
             blocking=True,
         )
-        await hass.async_block_till_done()
-        light_fixture_mock.assert_called_once_with(2, sleep=0)
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "sleep_timer_not_supported"

--- a/tests/components/modern_forms/test_sensor.py
+++ b/tests/components/modern_forms/test_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant
 
-from . import init_integration, modern_forms_timers_set_mock
+from . import init_integration, init_integration_gen4, modern_forms_timers_set_mock
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -51,3 +51,14 @@ async def test_active_sensors(
     assert state
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     datetime.fromisoformat(state.state)
+
+
+async def test_no_sleep_timer_sensors_on_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the sleep-timer sensors aren't created for Gen4 fans."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    assert hass.states.get("sensor.modernformsfan_fan_sleep_time") is None
+    assert hass.states.get("sensor.modernformsfan_light_sleep_time") is None

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration
+from . import init_integration, init_integration_gen4
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -156,3 +156,14 @@ async def test_switch_connection_error(
 
     state = hass.states.get("switch.modernformsfan_away_mode")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_no_adaptive_learning_switch_on_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the adaptive learning switch isn't created for Gen4 fans."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    assert hass.states.get("switch.modernformsfan_adaptive_learning") is None
+    assert hass.states.get("switch.modernformsfan_away_mode") is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Stacked on #180524** (per-fixture lights, itself stacked on #180523) — this PR's diff currently includes both of those PRs' commits too; it'll shrink to just its own commit as each merges.

Gen4 fans have no sleep timer and no adaptive learning, but the integration created those entities unconditionally because until now every supported generation had them. On a Gen4 fan they were permanently inert.

This PR gates them on the capability flags `aiomodernforms` exposes, matching the existing `has_wind()` gate in the number platform:

- The adaptive learning switch is now gated on `has_adaptive_learning()`.
- The fan and light sleep timer sensors and binary sensors are now gated on `has_sleep_timer()`. The light ones keep their existing `light_type` check in addition to it.

The sleep timer actions had the same problem in a quieter form: `aiomodernforms` drops the `sleep` argument for Gen4, so `set_fan_sleep_timer` and friends returned success while doing nothing. They now raise a translated `HomeAssistantError` instead. This covers the fan platform as well as the light platform — the fan actions were unreachable before, because Gen4 fans could not be added at all until the `aiomodernforms` 0.3.0/0.3.1 bump in #180523.

Validated against real Gen4 hardware (a Radiant 56") as part of a combined branch shared with fan owners in wonderslug/aiomodernforms#287.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: wonderslug/aiomodernforms#287
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47692
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

