### PR TITLE
Add color temperature support for Modern Forms Gen4 light fixtures

### DIFF
--- a/homeassistant/components/modern_forms/const.py
+++ b/homeassistant/components/modern_forms/const.py
@@ -6,6 +6,7 @@ OPT_ON = "on"
 OPT_SPEED = "speed"
 OPT_BRIGHTNESS = "brightness"
 OPT_WIND = "wind"
+OPT_COLOR_TEMP_KELVIN = "color_temp_kelvin"
 
 # Services
 SERVICE_SET_LIGHT_SLEEP_TIMER = "set_light_sleep_timer"

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -97,30 +97,32 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
 
         if light_address is None:
             self._attr_unique_id = mac_address
+            self._attr_color_mode = ColorMode.BRIGHTNESS
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
         else:
             # Real Gen4 fixtures are named by the user, so the device-name
             # prefix strip below is per-device data rather than static.
             self._attr_unique_id = f"{mac_address}_{light_address}"
-            fixture_name = next(
-                light.name
+            fixture = next(
+                light
                 for light in coordinator.data.state.light_fixtures
                 if light.address == light_address
             )
             self._attr_name = strip_device_name_prefix(
-                self.coordinator.data.info.device_name, fixture_name
+                self.coordinator.data.info.device_name, fixture.name
             )
 
-        if (
-            self._light.min_color_temp_kelvin is not None
-            and self._light.max_color_temp_kelvin is not None
-        ):
-            self._attr_color_mode = ColorMode.COLOR_TEMP
-            self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
-            self._attr_min_color_temp_kelvin = self._light.min_color_temp_kelvin
-            self._attr_max_color_temp_kelvin = self._light.max_color_temp_kelvin
-        else:
-            self._attr_color_mode = ColorMode.BRIGHTNESS
-            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+            if (
+                fixture.min_color_temp_kelvin is not None
+                and fixture.max_color_temp_kelvin is not None
+            ):
+                self._attr_color_mode = ColorMode.COLOR_TEMP
+                self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+                self._attr_min_color_temp_kelvin = fixture.min_color_temp_kelvin
+                self._attr_max_color_temp_kelvin = fixture.max_color_temp_kelvin
+            else:
+                self._attr_color_mode = ColorMode.BRIGHTNESS
+                self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
     def _light(self) -> Light | None:
@@ -156,7 +158,7 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
     @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature of this light in Kelvin."""
-        return self._light.color_temp_kelvin
+        return self._light.color_temp_kelvin if self._light is not None else None
 
     @modernforms_exception_handler
     @override

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -6,7 +6,12 @@ from aiomodernforms.const import LIGHT_POWER_OFF, LIGHT_POWER_ON
 from aiomodernforms.models import Light
 import voluptuous as vol
 
-from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ColorMode,
+    LightEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
@@ -22,6 +27,7 @@ from .const import (
     CLEAR_TIMER,
     DOMAIN,
     OPT_BRIGHTNESS,
+    OPT_COLOR_TEMP_KELVIN,
     OPT_ON,
     SERVICE_CLEAR_LIGHT_SLEEP_TIMER,
     SERVICE_SET_LIGHT_SLEEP_TIMER,
@@ -76,8 +82,6 @@ async def async_setup_entry(
 class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
     """Defines a Modern Forms light."""
 
-    _attr_color_mode = ColorMode.BRIGHTNESS
-    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_translation_key = "light"
 
     def __init__(
@@ -105,6 +109,18 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
             self._attr_name = strip_device_name_prefix(
                 self.coordinator.data.info.device_name, fixture_name
             )
+
+        if (
+            self._light.min_color_temp_kelvin is not None
+            and self._light.max_color_temp_kelvin is not None
+        ):
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+            self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+            self._attr_min_color_temp_kelvin = self._light.min_color_temp_kelvin
+            self._attr_max_color_temp_kelvin = self._light.max_color_temp_kelvin
+        else:
+            self._attr_color_mode = ColorMode.BRIGHTNESS
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
     def _light(self) -> Light | None:
@@ -136,6 +152,12 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
         """Return the state of the light."""
         return self._light is not None and bool(self._light.on)
 
+    @property
+    @override
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature of this light in Kelvin."""
+        return self._light.color_temp_kelvin
+
     @modernforms_exception_handler
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -152,6 +174,8 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
             data[OPT_BRIGHTNESS] = ranged_value_to_percentage(
                 BRIGHTNESS_RANGE, kwargs[ATTR_BRIGHTNESS]
             )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            data[OPT_COLOR_TEMP_KELVIN] = kwargs[ATTR_COLOR_TEMP_KELVIN]
 
         await self._async_control_light(**data)
 

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -7,7 +7,15 @@ from aiomodernforms import ModernFormsConnectionError
 import pytest
 from yarl import URL
 
-from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
+    ATTR_SUPPORTED_COLOR_MODES,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
 from homeassistant.components.modern_forms.const import (
     ATTR_SLEEP_TIME,
     DOMAIN,
@@ -362,3 +370,43 @@ async def test_clear_light_sleep_timer_not_supported_gen4(
 
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "sleep_timer_not_supported"
+
+
+async def test_light_color_temp_gen4(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test Gen4 light fixtures advertise and control color temperature."""
+    await init_integration_gen4(hass, aioclient_mock)
+
+    state = hass.states.get("light.modernformsfan_uplight")
+    assert state
+    assert state.attributes.get(ATTR_COLOR_TEMP_KELVIN) == 3000
+    assert state.attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN) == 2700
+    assert state.attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN) == 5000
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.COLOR_TEMP]
+
+    with patch("aiomodernforms.ModernFormsDevice.light_fixture") as light_fixture_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "light.modernformsfan_uplight",
+                ATTR_COLOR_TEMP_KELVIN: 4000,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_fixture_mock.assert_called_once_with(2, on=True, color_temp_kelvin=4000)
+
+
+async def test_light_no_color_temp_on_legacy(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test Gen 1/2/3 lights never advertise color temperature."""
+    await init_integration(hass, aioclient_mock)
+
+    state = hass.states.get("light.modernformsfan_light")
+    assert state
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.BRIGHTNESS]

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -400,6 +400,33 @@ async def test_light_color_temp_gen4(
         light_fixture_mock.assert_called_once_with(2, on=True, color_temp_kelvin=4000)
 
 
+async def test_light_color_temp_missing_bounds_gen4(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test a Gen4 fixture missing color-temp bounds falls back to brightness."""
+
+    async def missing_bounds_mock(
+        hass: HomeAssistant, method: str, url: URL, data: dict[str, Any]
+    ) -> AiohttpClientMockResponse:
+        """Serve the normal Gen4 fixtures, minus the downlight's color-temp bounds."""
+        if not url.path.endswith("/fixture"):
+            return await modern_forms_gen4_call_mock(hass, method, url, data)
+        payload = json.loads(
+            await async_load_fixture(hass, "fixture_gen4.json", DOMAIN)
+        )
+        for fixture in payload["fixture"]:
+            if fixture["addr"] == 3:
+                fixture["detail"] = {}
+        return AiohttpClientMockResponse(method=method, url=url, json=payload)
+
+    await init_integration_gen4(hass, aioclient_mock, mock_type=missing_bounds_mock)
+
+    state = hass.states.get("light.modernformsfan_downlight")
+    assert state
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.BRIGHTNESS]
+    assert state.attributes.get(ATTR_COLOR_TEMP_KELVIN) is None
+
+
 async def test_light_no_color_temp_on_legacy(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -411,8 +411,8 @@ async def test_light_color_temp_missing_bounds_gen4(
         """Serve the normal Gen4 fixtures, minus the downlight's color-temp bounds."""
         if not url.path.endswith("/fixture"):
             return await modern_forms_gen4_call_mock(hass, method, url, data)
-        payload = json.loads(
-            await async_load_fixture(hass, "fixture_gen4.json", DOMAIN)
+        payload = await async_load_json_object_fixture(
+            hass, "fixture_gen4.json", DOMAIN
         )
         for fixture in payload["fixture"]:
             if fixture["addr"] == 3:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Stacked on #180525** (capability gating, itself stacked on #180524 and #180523) — this PR's diff currently includes all three of those PRs' commits too; it'll shrink to just its own commit as each merges.

Gen4 light fixtures report their supported color temperature range, and that range is settable. This PR advertises `ColorMode.COLOR_TEMP` when a fixture reports both bounds, and passes the requested temperature through to `light_fixture()`.

The values map straight across from the library's `Light` dataclass to the native Kelvin `LightEntity` attributes, so no conversion is involved. The bounds are fixed per fixture, so they're read once during construction.

Gen 1/2/3 fixtures never report these bounds, so they keep advertising `ColorMode.BRIGHTNESS` exactly as before.

Validated against real Gen4 hardware (a Radiant 56", including simultaneously holding two different color temperatures on its uplight and downlight) as part of a combined branch shared with fan owners in wonderslug/aiomodernforms#287.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #169247
- This PR is related to issue: wonderslug/aiomodernforms#287
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47693
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


