### PR TITLE
Bump lyngdorf to 1.11.0

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.10.0"],
+  "requirements": ["lyngdorf==1.11.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -298,10 +298,9 @@ class LyngdorfMainDevice(LyngdorfDevice):
         """Return the state of the device."""
         if not self._receiver.power_on:
             return MediaPlayerState.OFF
-        if (now_playing := self._now_playing) is not None:
-            if (state := PLAYBACK_STATES.get(now_playing.state)) is not None:
-                return state
-        return MediaPlayerState.ON
+        if (now_playing := self._now_playing) is None or now_playing.state is None:
+            return MediaPlayerState.ON
+        return PLAYBACK_STATES.get(now_playing.state, MediaPlayerState.ON)
 
     @override
     @property
@@ -349,9 +348,12 @@ class LyngdorfMainDevice(LyngdorfDevice):
     @property
     def media_position(self) -> int | None:
         """Return the position of the current track, in seconds."""
-        if not self._has_streamer or not self._receiver.has_position:
+        if (
+            not self._has_streamer
+            or (position_ms := self._receiver.position_ms) is None
+        ):
             return None
-        return round(self._receiver.position_ms / 1000)
+        return round(position_ms / 1000)
 
     @override
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1556,7 +1556,7 @@ lw12==0.9.2
 lxml==6.1.2
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.10.0
+lyngdorf==1.11.0
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0


### PR DESCRIPTION
## Proposed change

Bump lyngdorf from 1.10.0 to 1.11.0. Manifest only.

Depends on #180530, which fixes two `media_player.py` bugs that 1.11.0 makes
mypy fail on — it is the first release to ship `py.typed`, so this is the
first time our code is checked against real library types instead of `Any`.
This branch is stacked on it, so that commit shows here until it merges.

1.11.0 adds the 2.0 API alongside the existing one and leaves every 1.x
signature unchanged, so nothing else needed to move.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Release notes: https://github.com/fishloa/lyngdorf/releases/tag/v1.11.0
Diff: https://github.com/fishloa/lyngdorf/compare/v1.10.0...v1.11.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
