### PR TITLE
Add a regression test for the Lyngdorf media player position

### DIFF
--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -486,6 +486,20 @@ async def test_no_streaming_features_on_model_without_streamer(
 
 
 @pytest.mark.usefixtures("init_integration")
+async def test_no_position_before_the_streamer_reports_one(
+    hass: HomeAssistant,
+    playing_receiver: MagicMock,
+) -> None:
+    """Test an attached player that has not yet reported a position."""
+    playing_receiver.position_ms = None
+    notify_receiver_update(playing_receiver)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(MAIN_ZONE)
+    assert state.attributes.get(ATTR_MEDIA_POSITION) is None
+
+
+@pytest.mark.usefixtures("init_integration")
 async def test_position_jump_updates_state(
     hass: HomeAssistant,
     playing_receiver: MagicMock,


### PR DESCRIPTION
## Proposed change

The fix merged in #180528. This is the regression test for it, which was asked
for in review after that PR had already gone in.

The fixtures covered `has_position=False` with `position_ms=None`, and `True`
with an integer, but not the `True`/`None` pair that raised. Without the fix
the test fails with `TypeError: unsupported operand type(s) for /: 'NoneType'
and 'int'`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Release notes: https://github.com/fishloa/lyngdorf/releases/tag/v1.11.0
Diff: https://github.com/fishloa/lyngdorf/compare/v1.10.0...v1.11.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
