### PR TITLE
Remove stale xfail in hdmi_cec switch status test

### DIFF
--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -155,13 +155,6 @@ async def test_device_status_change(
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.hdmi_3")
-    if power_status in (POWER_ON, 4) and status is not None:
-        pytest.xfail(
-            reason=(
-                "`CecSwitchEntity.is_on` returns `False` here"
-                " instead of `true` as expected."
-            )
-        )
     assert state.state == expected_state
 
 


### PR DESCRIPTION
## Proposed change

`test_device_status_change` in the hdmi_cec switch tests guards six of its
sixteen parameter sets with the imperative `pytest.xfail()`:

```python
state = hass.states.get("switch.hdmi_3")
if power_status in (POWER_ON, 4) and status is not None:
    pytest.xfail(reason="`CecSwitchEntity.is_on` returns `False` here instead of `true` as expected.")
assert state.state == expected_state
```

The imperative form aborts the test on the spot, so the assertion below it
never runs. Unlike `pytest.mark.xfail` it cannot report XPASS, which means it
keeps reporting xfailed whether or not the bug is still there.

The bug is gone. It was fixed by the async migration in #168306, which turned
`CecSwitchEntity.update` into `async_update`. That same PR removed two
`pytest.mark.xfail` markers from `test_media_player.py` because they started
passing and showed up as XPASS. This one was left behind because it never
could.

Removing the guard lets all sixteen parameter sets assert, and they all pass.

Only one other imperative `pytest.xfail()` exists in the test suite,
in `tests/pylint/test_determinism.py`, where it is the intended behaviour of a
self-test. So this is the only stale one.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

`pytest tests/components/hdmi_cec/` before this change: 102 passed, 23 xfailed.
After: 108 passed, 17 xfailed, no failures. Stable across repeated randomised
runs.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
