### PR TITLE
Retry Freebox setup when the router cannot be reached

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 import logging
 
+from aiohttp import ClientError
 from freebox_api.exceptions import HttpRequestError
 
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
@@ -81,15 +82,16 @@ async def async_migrate_entry(hass: HomeAssistant, entry: FreeboxConfigEntry) ->
 async def async_setup_entry(hass: HomeAssistant, entry: FreeboxConfigEntry) -> bool:
     """Set up Freebox entry."""
     api = await get_api(hass, entry.data[CONF_HOST])
+    # The library raises its own error only for a request the router refused,
+    # and leaves everything the transport can throw to aiohttp
     try:
         await api.open(entry.data[CONF_HOST], entry.data[CONF_PORT])
-    except HttpRequestError as err:
+        freebox_config = await api.system.get_config()
+        router = FreeboxRouter(hass, entry, api, freebox_config)
+        await router.update_all()
+    except (HttpRequestError, ClientError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
 
-    freebox_config = await api.system.get_config()
-
-    router = FreeboxRouter(hass, entry, api, freebox_config)
-    await router.update_all()
     entry.async_on_unload(
         async_track_time_interval(hass, router.update_all, SCAN_INTERVAL)
     )

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -1,8 +1,11 @@
 """Tests for the Freebox init."""
 
+from collections.abc import Callable
 from copy import deepcopy
 from unittest.mock import ANY, Mock
 
+from aiohttp import ClientError
+from freebox_api.exceptions import HttpRequestError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
@@ -43,6 +46,40 @@ async def test_setup(hass: HomeAssistant, router: Mock) -> None:
 
     assert router.call_count == 1
     assert router().open.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [HttpRequestError("Boom"), ClientError("Boom"), TimeoutError],
+)
+@pytest.mark.parametrize(
+    "failing_call",
+    [
+        pytest.param(lambda api: api.open, id="open"),
+        pytest.param(lambda api: api.system.get_config, id="get_config"),
+        pytest.param(lambda api: api.lan.get_interfaces, id="get_interfaces"),
+    ],
+)
+async def test_setup_retries_when_the_router_cannot_be_reached(
+    hass: HomeAssistant,
+    router: Mock,
+    error: Exception,
+    failing_call: Callable[[Mock], Mock],
+) -> None:
+    """Test that setup is retried when the router cannot be reached."""
+    failing_call(router()).side_effect = error
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+        unique_id=MOCK_HOST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_import(hass: HomeAssistant, router: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Two gaps, one cause:

```python
    try:
        await api.open(entry.data[CONF_HOST], entry.data[CONF_PORT])
    except HttpRequestError as err:
        raise ConfigEntryNotReady from err

    freebox_config = await api.system.get_config()
```

Reading the router configuration sits outside the handling entirely, and what covers opening the connection only catches `HttpRequestError`. In `freebox_api` that exception is raised in exactly one place, for an API response carrying `success: false`. Everything the transport can throw, timeouts and connection errors alike, comes straight out of aiohttp untouched.

That is the reporter's failure: `_perform_request` refreshes the session token before the call, the request for the challenge times out during startup, and the entry lands in "Setup failed". Selecting Reload immediately afterwards succeeds with no other change.

`update_all()` is now covered too. Leaving it out would fix the reported call and leave the very next one just as terminal, which is not much of a fix when the premise is a flaky network at startup.

The test parametrizes three calls against three errors. Eight of the nine leave the entry in `SETUP_ERROR` on `dev`; the one that already retried is `open` raising `HttpRequestError`, the single case the old handler covered.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/180498
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
