### PR TITLE
Only add a Lutron Caseta battery sensor where there is a battery

### DIFF
--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -4,17 +4,22 @@ import asyncio
 from datetime import timedelta
 from typing import Any, override
 
-from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, BridgeResponseError
+from pylutron_caseta import (
+    OCCUPANCY_GROUP_OCCUPIED,
+    BridgeDisconnectedError,
+    BridgeResponseError,
+)
 from pylutron_caseta.smartbridge import Smartbridge
 
 from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.const import ATTR_SUGGESTED_AREA, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -46,30 +51,40 @@ async def async_setup_entry(
         LutronOccupancySensor(hass, occupancy_group, data)
         for occupancy_group in occupancy_groups.values()
     )
-    covers = bridge.get_devices_by_domain(COVER_DOMAIN)
+    battery_sensors = [
+        LutronCasetaBatterySensor(hass, cover, data)
+        for cover in bridge.get_devices_by_domain(COVER_DOMAIN)
+    ]
     reports_battery = await asyncio.gather(
-        *(_async_reports_battery(bridge, cover["device_id"]) for cover in covers)
+        *(
+            _async_reports_battery(bridge, sensor.device_id)
+            for sensor in battery_sensors
+        )
     )
-    async_add_entities(
-        (
-            LutronCasetaBatterySensor(hass, cover, data)
-            for cover, has_battery in zip(covers, reports_battery, strict=True)
-            if has_battery
-        ),
-        update_before_add=True,
-    )
+    entity_registry = er.async_get(hass)
+    sensors_to_add: list[LutronCasetaBatterySensor] = []
+    for sensor, has_battery in zip(battery_sensors, reports_battery, strict=True):
+        if has_battery:
+            sensors_to_add.append(sensor)
+        elif entity_id := entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, sensor.unique_id
+        ):
+            # Earlier releases created this for every cover
+            entity_registry.async_remove(entity_id)
+
+    async_add_entities(sensors_to_add, update_before_add=True)
 
 
 async def _async_reports_battery(bridge: Smartbridge, device_id: str) -> bool:
     """Return whether the bridge reports a battery for the device.
 
     A shade wired for power answers without a battery status, and nothing in
-    the device data the bridge caches tells the two apart.
+    the device data the bridge caches tells the two apart. A cover the bridge
+    could not answer for keeps its sensor, so nothing is removed over a hiccup.
     """
     try:
         return await bridge.get_battery_status(device_id) is not None
-    except BridgeResponseError:
-        # Keep the sensor rather than drop it over a hiccup during setup
+    except BridgeResponseError, BridgeDisconnectedError, TimeoutError:
         return True
 
 
@@ -169,7 +184,7 @@ class LutronCasetaBatterySensor(LutronCasetaEntity, BinarySensorEntity):
         """Fetch the latest battery status from the bridge."""
         try:
             status = await self._smartbridge.get_battery_status(self.device_id)
-        except BridgeResponseError:
+        except BridgeResponseError, BridgeDisconnectedError, TimeoutError:
             self._attr_is_on = None
             return
         normalized_status = status.strip().casefold() if status else None

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -1,9 +1,11 @@
 """Support for Lutron Caseta Occupancy/Vacancy/Battery Sensors."""
 
+import asyncio
 from datetime import timedelta
 from typing import Any, override
 
 from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, BridgeResponseError
+from pylutron_caseta.smartbridge import Smartbridge
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -44,13 +46,31 @@ async def async_setup_entry(
         LutronOccupancySensor(hass, occupancy_group, data)
         for occupancy_group in occupancy_groups.values()
     )
+    covers = bridge.get_devices_by_domain(COVER_DOMAIN)
+    reports_battery = await asyncio.gather(
+        *(_async_reports_battery(bridge, cover["device_id"]) for cover in covers)
+    )
     async_add_entities(
         (
-            LutronCasetaBatterySensor(hass, device, data)
-            for device in bridge.get_devices_by_domain(COVER_DOMAIN)
+            LutronCasetaBatterySensor(hass, cover, data)
+            for cover, has_battery in zip(covers, reports_battery, strict=True)
+            if has_battery
         ),
         update_before_add=True,
     )
+
+
+async def _async_reports_battery(bridge: Smartbridge, device_id: str) -> bool:
+    """Return whether the bridge reports a battery for the device.
+
+    A shade wired for power answers without a battery status, and nothing in
+    the device data the bridge caches tells the two apart.
+    """
+    try:
+        return await bridge.get_battery_status(device_id) is not None
+    except BridgeResponseError:
+        # Keep the sensor rather than drop it over a hiccup during setup
+        return True
 
 
 class LutronOccupancySensor(LutronCasetaEntity, BinarySensorEntity):

--- a/tests/components/lutron_caseta/test_binary_sensor.py
+++ b/tests/components/lutron_caseta/test_binary_sensor.py
@@ -4,9 +4,14 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
-from pylutron_caseta import BridgeResponseError
+from pylutron_caseta import BridgeDisconnectedError, BridgeResponseError
+import pytest
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorDeviceClass,
+)
+from homeassistant.components.lutron_caseta import DOMAIN
 from homeassistant.components.lutron_caseta.binary_sensor import SCAN_INTERVAL
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -143,6 +148,63 @@ async def test_no_battery_sensor_for_a_shade_wired_for_power(
             "binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery"
         )
         is None
+    )
+
+
+async def test_battery_sensor_removed_when_the_shade_has_no_battery(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a battery sensor from an earlier release is removed."""
+    instance = MockBridge()
+    instance.battery_statuses = {}
+
+    def factory(*args: Any, **kwargs: Any) -> MockBridge:
+        """Return the mock bridge instance."""
+        return instance
+
+    entity_registry.async_get_or_create(
+        BINARY_SENSOR_DOMAIN,
+        DOMAIN,
+        "000004d2_802_battery",
+        suggested_object_id="basement_bedroom_basement_bedroom_left_shade_battery",
+    )
+
+    await async_setup_integration(hass, factory)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, "000004d2_802_battery"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [BridgeDisconnectedError(), TimeoutError],
+)
+async def test_battery_sensor_kept_when_the_bridge_cannot_answer(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """Test a cover keeps its battery sensor when the bridge cannot be asked."""
+    instance = MockBridge()
+    instance.get_battery_status = AsyncMock(side_effect=error)
+
+    def factory(*args: Any, **kwargs: Any) -> MockBridge:
+        """Return the mock bridge instance."""
+        return instance
+
+    await async_setup_integration(hass, factory)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(
+            "binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery"
+        )
+        is not None
     )
 
 

--- a/tests/components/lutron_caseta/test_binary_sensor.py
+++ b/tests/components/lutron_caseta/test_binary_sensor.py
@@ -88,6 +88,9 @@ async def test_battery_sensor_updates_on_schedule(
     await async_setup_integration(hass, factory)
     await hass.async_block_till_done()
 
+    # Setup asks once to find out whether the shade has a battery at all
+    instance.get_battery_status.reset_mock()
+
     binary_sensor_entity_id = (
         "binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery"
     )
@@ -107,7 +110,7 @@ async def test_battery_sensor_updates_on_schedule(
     updated_state = hass.states.get(binary_sensor_entity_id)
     assert updated_state is not None
     assert updated_state.state == STATE_ON
-    assert instance.get_battery_status.await_count == 2
+    assert instance.get_battery_status.await_count == 1
     instance.get_battery_status.assert_awaited_with("802")
 
     instance.battery_statuses["802"] = "Unknown"
@@ -118,7 +121,29 @@ async def test_battery_sensor_updates_on_schedule(
     unknown_state = hass.states.get(binary_sensor_entity_id)
     assert unknown_state is not None
     assert unknown_state.state == STATE_UNKNOWN
-    assert instance.get_battery_status.await_count == 3
+    assert instance.get_battery_status.await_count == 2
+
+
+async def test_no_battery_sensor_for_a_shade_wired_for_power(
+    hass: HomeAssistant,
+) -> None:
+    """Test a shade the bridge reports no battery for gets no battery sensor."""
+    instance = MockBridge()
+    instance.battery_statuses = {}
+
+    def factory(*args: Any, **kwargs: Any) -> MockBridge:
+        """Return the mock bridge instance."""
+        return instance
+
+    await async_setup_integration(hass, factory)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(
+            "binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery"
+        )
+        is None
+    )
 
 
 async def test_battery_sensor_handles_bridge_response_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


https://github.com/home-assistant/core/pull/165180 added a `LutronCasetaBatterySensor` for every device in the cover domain. Caseta shades can be hard wired for power, and those answer `get_battery_status` without a `BatteryStatus` at all, so the sensor sits at `unknown` forever.

I pulled the diagnostics from the issue to see whether the device data the bridge caches could tell the two apart. It cannot. Across 289 devices every shade looks like this:

```json
{
  "device_id": "4381",
  "type": "Shade",
  "model": null,
  "serial": null,
  "device_name": "Lounge - West"
}
```

No battery hint anywhere in it, so asking the bridge is the only way to know. Setup now asks once per cover and creates the sensor only where there is a battery to report.

A `BridgeResponseError` during that question keeps the sensor rather than dropping it, so a hiccup at startup cannot silently strip battery sensors from shades that do have one. That path already had a regression test from https://github.com/home-assistant/core/issues/169965 and it still passes.

One existing test needed adjusting. `test_battery_sensor_updates_on_schedule` counted every await of `get_battery_status`, which now includes the setup question, so it resets the mock after setup and counts the polls from there. Same intent, no longer sensitive to how setup gets its answer.

The fixture only ever had a shade with a battery, so the hard wired case was untested. The new test covers it: an `unknown` entity on `dev`, no entity at all with this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175900
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
