### PR TITLE
Restore a SwitchBot Cloud AC temperature in the unit it was published in

### DIFF
--- a/homeassistant/components/switchbot_cloud/climate.py
+++ b/homeassistant/components/switchbot_cloud/climate.py
@@ -138,10 +138,12 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
         ) is not None:
             # The attribute was published in the unit of the system, not the one
             # this entity reports in, so it converts back on the way in
-            temperature = TemperatureConverter.convert(
-                temperature,
-                self.hass.config.units.temperature_unit,
-                self.temperature_unit,
+            temperature = round(
+                TemperatureConverter.convert(
+                    temperature,
+                    self.hass.config.units.temperature_unit,
+                    self.temperature_unit,
+                )
             )
             # A state written before that conversion was made can hold anything
             if self.min_temp <= temperature <= self.max_temp:

--- a/homeassistant/components/switchbot_cloud/climate.py
+++ b/homeassistant/components/switchbot_cloud/climate.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import SwitchbotCloudConfigEntry, SwitchBotCoordinator
 from .const import (
@@ -108,7 +109,7 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
     ]
     _attr_hvac_mode = HVACMode.FAN_ONLY
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_target_temperature = 21
+    _attr_target_temperature = 21.0
     _attr_target_temperature_step = 1
     _attr_precision = 1
     _attr_name = None
@@ -130,10 +131,21 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
         self._attr_fan_mode = last_state.attributes.get(
             ClimateEntityStateAttribute.FAN_MODE, self._attr_fan_mode
         )
-        self._attr_target_temperature = last_state.attributes.get(
-            ClimateEntityStateAttribute.TARGET_TEMPERATURE,
-            self._attr_target_temperature,
-        )
+        if (
+            temperature := last_state.attributes.get(
+                ClimateEntityStateAttribute.TARGET_TEMPERATURE
+            )
+        ) is not None:
+            # The attribute was published in the unit of the system, not the one
+            # this entity reports in, so it converts back on the way in
+            temperature = TemperatureConverter.convert(
+                temperature,
+                self.hass.config.units.temperature_unit,
+                self.temperature_unit,
+            )
+            # A state written before that conversion was made can hold anything
+            if self.min_temp <= temperature <= self.max_temp:
+                self._attr_target_temperature = temperature
 
     def _get_mode(self, hvac_mode: HVACMode | None) -> int:
         new_hvac_mode = hvac_mode or self._attr_hvac_mode

--- a/tests/components/switchbot_cloud/test_climate.py
+++ b/tests/components/switchbot_cloud/test_climate.py
@@ -1,7 +1,8 @@
 """Test for the switchbot_cloud climate."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from switchbot_api import Device, Remote, SmartRadiatorThermostatCommands, SwitchBotAPI
 
 from homeassistant.components.climate import (
@@ -20,6 +21,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, State
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import configure_integration
 
@@ -160,6 +162,44 @@ async def test_air_conditioner_restore_state(
     assert state.state == "cool"
     assert state.attributes[ATTR_FAN_MODE] == "high"
     assert state.attributes[ATTR_TEMPERATURE] == 25
+
+
+@pytest.mark.parametrize(
+    ("restored_temperature", "expected_temperature"),
+    [
+        pytest.param(75, 75, id="restored_as_published"),
+        pytest.param(19381607032619749376, 70, id="corrupted_falls_back_to_default"),
+    ],
+)
+async def test_air_conditioner_restore_state_in_fahrenheit(
+    hass: HomeAssistant,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
+    restored_temperature: float,
+    expected_temperature: float,
+) -> None:
+    """Test the target temperature is restored in the unit it was published in."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    mock_list_devices.return_value = [
+        Remote(
+            deviceId="ac-device-id-1",
+            deviceName="climate-1",
+            remoteType="Air Conditioner",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+
+    entity_id = "climate.climate_1"
+    mock_restore_cache(
+        hass,
+        (State(entity_id, HVACMode.COOL, {ATTR_TEMPERATURE: restored_temperature}),),
+    )
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == expected_temperature
 
 
 async def test_air_conditioner_no_last_state(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The four samples in the issue give the mechanism away. Each one is exactly nine fifths of the previous:

```
3,323,320,821,779,792,000  ->  5,981,977,479,203,626,000
5,981,977,479,203,626,000  -> 10,767,559,462,566,527,000
10,767,559,462,566,527,000 -> 19,381,607,032,619,749,376
```

That is the Fahrenheit factor, applied over and over. The `+ 32` disappears into float precision at that size.

The entity reports in Celsius, so `state_attributes` publishes `temperature` through `display_temp()`, converted to the unit of the system. On a Fahrenheit instance 21 °C goes out as 70. `async_added_to_hass` then reads that published attribute straight back into `_attr_target_temperature`, which is declared Celsius, so the next publish turns 70 into 158, then 316, and onwards. One multiplication per restart, which is why it only reaches Fahrenheit instances and why it compounds instead of settling on a bad but stable value.

Once past 64 bits, anything serializing the state fails, so `GET /api/states/climate.*` returns a 500, every websocket state push breaks, and `restore_state` cannot save. A reload then fails halfway through removing the entity and the re-add is rejected as a duplicate unique ID, leaving it stuck.

The restored value converts back on the way in now. The range check alongside it is what lets an affected instance recover: converting a corrupted value only divides it by 1.8, so from 1.9e19 it would take about fifty restarts before it fit in a state again.

Both parametrized cases are red on `dev`, with the mechanism written on their face:

```
assert 167 == 75                        # 75 °F read as 75 °C, published as 167 °F
assert 34886892658715549696 == 70       # and the corrupted value grows once more
```

`_attr_target_temperature = 21` became `21.0` because mypy pins the class attribute to `int` otherwise, and the converted value is a float.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/177612
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
