### PR TITLE
Mark Vistapool entities unavailable while the push connection is down

### DIFF
--- a/homeassistant/components/vistapool/coordinator.py
+++ b/homeassistant/components/vistapool/coordinator.py
@@ -10,7 +10,7 @@ from aioaquarite import (
     ResilientPoolSubscription,
 )
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -69,7 +69,25 @@ class VistapoolDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, data)
 
         self.subscription = await self.api.subscribe_pool_resilient(
-            self.pool_id, _on_data
+            self.pool_id, _on_data, on_health=self._async_on_subscription_health
+        )
+
+    @callback
+    def _async_on_subscription_health(self, healthy: bool) -> None:
+        """Mark entities unavailable while the push connection is down.
+
+        Without a polling interval the last snapshot would otherwise stay
+        on display as if it were current. Recovery needs no action here:
+        resubscribing delivers a fresh snapshot, which restores
+        availability through async_set_updated_data.
+        """
+        if healthy:
+            return
+        self.async_set_update_error(
+            UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+            )
         )
 
     @override

--- a/homeassistant/components/vistapool/coordinator.py
+++ b/homeassistant/components/vistapool/coordinator.py
@@ -41,6 +41,7 @@ class VistapoolDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.pool_id: str = pool_id
         self.pool_name: str = pool_name
         self.subscription: ResilientPoolSubscription | None = None
+        self._push_connected = True
 
         super().__init__(
             hass,
@@ -61,34 +62,48 @@ class VistapoolDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_key="update_failed",
             ) from err
 
+    @property
+    def push_connected(self) -> bool:
+        """Whether pool data is still flowing in from the subscription."""
+        return self._push_connected
+
     async def subscribe(self) -> None:
         """Subscribe to Firestore real-time updates via the library."""
 
         def _on_data(data: dict[str, Any]) -> None:
             """Callback from the Firestore thread; push data to the HA loop."""
-            self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, data)
+            self.hass.loop.call_soon_threadsafe(self._async_handle_push, data)
 
         self.subscription = await self.api.subscribe_pool_resilient(
             self.pool_id, _on_data, on_health=self._async_on_subscription_health
         )
 
     @callback
+    def _async_handle_push(self, data: dict[str, Any]) -> None:
+        """Apply a snapshot; its arrival is what proves the connection is up."""
+        if not self._push_connected:
+            self._push_connected = True
+            _LOGGER.info("Reconnected to %s, entities are available again", self.name)
+        self.async_set_updated_data(data)
+
+    @callback
     def _async_on_subscription_health(self, healthy: bool) -> None:
         """Mark entities unavailable while the push connection is down.
 
-        Without a polling interval the last snapshot would otherwise stay
-        on display as if it were current. Recovery needs no action here:
-        resubscribing delivers a fresh snapshot, which restores
-        availability through async_set_updated_data.
+        Tracked separately from last_update_success: an optimistic update
+        or a manual refresh sets that flag back to True while the
+        subscription is still down, and the health callback only fires on
+        transitions, so it would not correct it. Only an incoming snapshot
+        clears this.
         """
-        if healthy:
+        if healthy or not self._push_connected:
             return
-        self.async_set_update_error(
-            UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed",
-            )
+        self._push_connected = False
+        _LOGGER.warning(
+            "Lost the connection to %s, entities are unavailable until it recovers",
+            self.name,
         )
+        self.async_update_listeners()
 
     @override
     async def async_shutdown(self) -> None:

--- a/homeassistant/components/vistapool/entity.py
+++ b/homeassistant/components/vistapool/entity.py
@@ -1,5 +1,7 @@
 """Shared base entity helpers for Vistapool."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -23,6 +25,12 @@ class VistapoolEntity(CoordinatorEntity[VistapoolDataUpdateCoordinator]):
             model=MODEL,
             sw_version=str(sw_version) if sw_version is not None else None,
         )
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.push_connected
 
     @property
     def pool_id(self) -> str:

--- a/homeassistant/components/vistapool/quality_scale.yaml
+++ b/homeassistant/components/vistapool/quality_scale.yaml
@@ -39,7 +39,7 @@ rules:
   docs-troubleshooting: done
   entity-category: done
   entity-disabled-by-default: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done

--- a/tests/components/vistapool/test_init.py
+++ b/tests/components/vistapool/test_init.py
@@ -8,6 +8,7 @@ from aioaquarite import AquariteError, AuthenticationError
 
 from homeassistant.components.vistapool.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -18,6 +19,7 @@ from tests.common import MockConfigEntry
 _SECOND_POOL_ID = "ZYXWVU9876543210"
 _SECOND_POOL_NAME = "Spa"
 _THIRD_POOL_ID = "QQQQQQ1111111111"
+_TEMPERATURE_ENTITY = "sensor.my_pool_temperature"
 
 
 async def test_setup_entry(
@@ -310,6 +312,39 @@ async def test_apply_optimistic_creates_missing_intermediate_dicts(
 
     assert coordinator.data["filtration"]["intel"]["temp"] == 27
     assert coordinator.data["existing"] == {"nested": {"key": 1}}
+
+
+async def test_entities_unavailable_while_push_connection_is_down(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test entities go unavailable when the Firestore subscription drops.
+
+    The integration has no polling interval, so without this the last
+    snapshot would stay on display as if it were still current.
+    """
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_TEMPERATURE_ENTITY).state != STATE_UNAVAILABLE
+
+    call = mock_vistapool_client.subscribe_pool_resilient.call_args
+    on_data = call.args[1]
+    on_health = call.kwargs["on_health"]
+
+    on_health(False)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_TEMPERATURE_ENTITY).state == STATE_UNAVAILABLE
+
+    # Resubscribing delivers a fresh snapshot, which restores availability.
+    on_health(True)
+    on_data({"main": {"temperature": 25}})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_TEMPERATURE_ENTITY).state == "25.0"
 
 
 async def test_unload_entry(

--- a/tests/components/vistapool/test_init.py
+++ b/tests/components/vistapool/test_init.py
@@ -6,11 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 from aioaquarite import AquariteError, AuthenticationError
 
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.vistapool.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
 
 from .conftest import MOCK_POOL_ID, MOCK_POOL_NAME
 
@@ -20,6 +22,7 @@ _SECOND_POOL_ID = "ZYXWVU9876543210"
 _SECOND_POOL_NAME = "Spa"
 _THIRD_POOL_ID = "QQQQQQ1111111111"
 _TEMPERATURE_ENTITY = "sensor.my_pool_temperature"
+_LIGHT_ENTITY = "light.my_pool_light"
 
 
 async def test_setup_entry(
@@ -339,12 +342,55 @@ async def test_entities_unavailable_while_push_connection_is_down(
 
     assert hass.states.get(_TEMPERATURE_ENTITY).state == STATE_UNAVAILABLE
 
-    # Resubscribing delivers a fresh snapshot, which restores availability.
-    on_health(True)
+    # Only an incoming snapshot proves the connection is back.
     on_data({"main": {"temperature": 25}})
     await hass.async_block_till_done()
 
     assert hass.states.get(_TEMPERATURE_ENTITY).state == "25.0"
+
+
+async def test_entities_stay_unavailable_on_local_updates_during_outage(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test updates that are not push snapshots do not fake availability.
+
+    Both an optimistic write and a manual refresh set the coordinator's
+    success flag, so availability cannot ride on that flag alone.
+    """
+    mock_vistapool_client.fetch_pool_data.return_value = {"light": {"status": 0}}
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    on_health = mock_vistapool_client.subscribe_pool_resilient.call_args.kwargs[
+        "on_health"
+    ]
+    on_health(False)
+    await hass.async_block_till_done()
+    assert hass.states.get(_LIGHT_ENTITY).state == STATE_UNAVAILABLE
+
+    # An optimistic write updates coordinator data while the push is down.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: _LIGHT_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(_LIGHT_ENTITY).state == STATE_UNAVAILABLE
+
+    # So does a successful manual refresh.
+    await hass.services.async_call(
+        "homeassistant",
+        "update_entity",
+        {ATTR_ENTITY_ID: _LIGHT_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(_LIGHT_ENTITY).state == STATE_UNAVAILABLE
 
 
 async def test_unload_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mark Vistapool entities unavailable while the Firestore push connection is down, satisfying the `entity-unavailable` quality scale rule.

The integration is cloud push and runs with `update_interval=None`, so once the initial refresh succeeded `last_update_success` stayed `True` for the lifetime of the entry. If the subscription dropped, the resilient subscription reconnected in the background but the entities kept showing the last snapshot as if it were current, with no indication that data had stopped flowing.

The coordinator now passes an `on_health` callback to `subscribe_pool_resilient` (added in aioaquarite 0.9.0) and keeps its own `push_connected` state, which the base entity folds into `available`. Health is deliberately tracked separately from `last_update_success`: that flag is shared, and an optimistic write or a successful manual refresh sets it straight back to `True` while the subscription is still down — and since the health callback only fires on transitions, nothing would correct it. Losing the connection logs a warning and notifies listeners; only an incoming snapshot clears the flag, since data actually flowing is what proves the connection is back (a successful resubscribe alone is not enough).

Also flips the `entity-unavailable` rule to done. The manifest tier is unchanged: Silver additionally needs `docs-installation-parameters` and `stale-devices`, handled in #180550, so the tier bump comes once both have landed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr