### PR TITLE
Address review feedback on Matter fan PercentSetting fix

### DIFF
--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -43,7 +43,7 @@ PRESET_SLEEP_WIND = "sleep_wind"
 # while FanMode is Auto. This is not part of the Matter spec (which says the
 # device should keep reporting its real current speed, see spec 4.4.6.1.2 and
 # 4.4.6.4), but we need to work around it regardless.
-PERCENT_CURRENT_AUTO_QUIRK_VALUE = 255
+PERCENT_CURRENT_AUTO_QUIRK = 255
 
 
 async def async_setup_entry(
@@ -214,9 +214,7 @@ class MatterFan(MatterEntity, FanEntity):
             clusters.FanControl.Attributes.PercentCurrent
         )
         self._attr_percentage = (
-            None
-            if current_percent == PERCENT_CURRENT_AUTO_QUIRK_VALUE
-            else current_percent
+            None if current_percent == PERCENT_CURRENT_AUTO_QUIRK else current_percent
         )
 
         # get preset mode from fan mode (and wind feature if available)
@@ -250,7 +248,7 @@ class MatterFan(MatterEntity, FanEntity):
         # keep track of the last known mode for turn_on commands without preset
         if self._attr_preset_mode is not None:
             self._last_known_preset_mode = self._attr_preset_mode
-        if current_percent and current_percent != PERCENT_CURRENT_AUTO_QUIRK_VALUE:
+        if current_percent and current_percent != PERCENT_CURRENT_AUTO_QUIRK:
             self._last_known_percentage = current_percent
 
     @callback

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -39,6 +39,12 @@ FAN_MODE_MAP_REVERSE = {v: k for k, v in FAN_MODE_MAP.items()}
 PRESET_NATURAL_WIND = "natural_wind"
 PRESET_SLEEP_WIND = "sleep_wind"
 
+# Some devices report 255 for PercentCurrent instead of their actual speed
+# while FanMode is Auto. This is not part of the Matter spec (which says the
+# device should keep reporting its real current speed, see spec 4.4.6.1.2 and
+# 4.4.6.4), but we need to work around it regardless.
+PERCENT_CURRENT_AUTO_QUIRK_VALUE = 255
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -207,9 +213,11 @@ class MatterFan(MatterEntity, FanEntity):
         current_percent = self.get_matter_attribute_value(
             clusters.FanControl.Attributes.PercentCurrent
         )
-        # NOTE that a device may give back 255 as a special value to indicate that
-        # the speed is under automatic control and not set to a specific value.
-        self._attr_percentage = None if current_percent == 255 else current_percent
+        self._attr_percentage = (
+            None
+            if current_percent == PERCENT_CURRENT_AUTO_QUIRK_VALUE
+            else current_percent
+        )
 
         # get preset mode from fan mode (and wind feature if available)
         wind_setting = self.get_matter_attribute_value(
@@ -242,7 +250,7 @@ class MatterFan(MatterEntity, FanEntity):
         # keep track of the last known mode for turn_on commands without preset
         if self._attr_preset_mode is not None:
             self._last_known_preset_mode = self._attr_preset_mode
-        if current_percent and current_percent != 255:
+        if current_percent and current_percent != PERCENT_CURRENT_AUTO_QUIRK_VALUE:
             self._last_known_percentage = current_percent
 
     @callback

--- a/tests/components/matter/test_fan.py
+++ b/tests/components/matter/test_fan.py
@@ -134,10 +134,11 @@ async def test_fan_turn_on_with_percentage(
         attribute_path="1/514/2",
         value=50,
     )
-    # test again where percentage is omitted in the service call
-    # PercentCurrent is 255 (auto) on this fixture, which is not a valid
-    # value to write back, so it should fall back to the last known preset
-    # mode instead of blindly replaying the sentinel value.
+    # test again where percentage is omitted in the service call.
+    # This fixture's PercentCurrent is 255, a device-specific quirk value
+    # (not part of the Matter spec) that is not valid to write back, so it
+    # should fall back to the last known preset mode instead of blindly
+    # replaying that sentinel value.
     matter_client.write_attribute.reset_mock()
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -150,6 +151,33 @@ async def test_fan_turn_on_with_percentage(
         node_id=matter_node.node_id,
         attribute_path="1/514/0",
         value=clusters.FanControl.Enums.FanModeEnum.kAuto,
+    )
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("node_fixture", ["mock_air_purifier"])
+async def test_fan_turn_on_replays_last_known_percentage(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test that a bare turn_on replays a real last known percentage."""
+    entity_id = "fan.mock_air_purifier"
+    # simulate the device confirming a real (non-quirk) speed
+    set_node_attribute(matter_node, 1, 514, 3, 70)
+    await trigger_subscription_callback(hass, matter_client)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    assert matter_client.write_attribute.call_count == 1
+    assert matter_client.write_attribute.call_args == call(
+        node_id=matter_node.node_id,
+        attribute_path="1/514/2",
+        value=70,
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #180541, addressing review feedback from @TheJulianJES that came
in after that PR was merged:

- Extract the device-specific `255` sentinel value (reported by some devices for `PercentCurrent` while `FanMode` is `Auto`, instead of the real current speed as required by Matter spec §4.4.6.4) into a named constant
  (`PERCENT_CURRENT_AUTO_QUIRK_VALUE`), reused in both places it is checked, with a comment clarifying this is a device quirk and not spec-defined behavior.
- Fix a test comment that incorrectly implied `255` was part of the spec.
- Add test coverage for replaying a real (non-quirk) last known percentage
  via a bare `fan.turn_on`, which was previously untested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180537
- This PR is related to issue: #180541
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

