### PR TITLE
Give every Velbus module property its own unique ID

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -8,12 +8,17 @@ import shutil
 
 from velbusaio.controller import Velbus
 from velbusaio.exceptions import VelbusConnectionFailed
+from velbusaio.module import Module
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import ConfigType
 
@@ -58,7 +63,9 @@ async def velbus_scan_task(
         ) from ex
     # create all modules
     dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
     for module in controller.get_modules().values():
+        _migrate_property_unique_ids(ent_reg, module)
         dev_reg.async_get_or_create(
             config_entry_id=entry_id,
             identifiers={
@@ -71,6 +78,26 @@ async def velbus_scan_task(
             sw_version=module.get_sw_version(),
             serial_number=module.get_serial(),
         )
+
+
+def _migrate_property_unique_ids(ent_reg: er.EntityRegistry, module: Module) -> None:
+    """Move the properties of a module off the unique ID they all shared.
+
+    Every property reports channel number 0, so they were handed the same
+    unique ID and only the first of each platform ever got an entity. That
+    first one keeps its entity, now under the key of the property.
+    """
+    serial = module.get_serial() or str(module.get_addresses()[0])
+    migrated: set[str] = set()
+    for prop in module.get_properties().values():
+        for domain in prop.get_categories():
+            if domain in migrated:
+                continue
+            migrated.add(domain)
+            if entity_id := ent_reg.async_get_entity_id(domain, DOMAIN, f"{serial}-0"):
+                ent_reg.async_update_entity(
+                    entity_id, new_unique_id=f"{serial}-{prop.get_property_key()}"
+                )
 
 
 def _migrate_device_identifiers(hass: HomeAssistant, entry_id: str) -> None:

--- a/homeassistant/components/velbus/entity.py
+++ b/homeassistant/components/velbus/entity.py
@@ -33,7 +33,12 @@ class VelbusEntity(Entity):
         self._module_address = str(channel.get_module_address())
         self._attr_name = channel.get_name()
         serial = channel.get_module_serial() or self._module_address
-        self._attr_unique_id = f"{serial}-{channel.get_channel_number()}"
+        if isinstance(channel, VelbusProperty):
+            # Every property of a module reports channel number 0, so the key of
+            # the property is what tells one from another
+            self._attr_unique_id = f"{serial}-{channel.get_property_key()}"
+        else:
+            self._attr_unique_id = f"{serial}-{channel.get_channel_number()}"
 
     def _get_identifier(self) -> str:
         """Return the identifier of the entity."""

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -14,7 +14,7 @@ from velbusaio.channels import (
     Temperature,
 )
 from velbusaio.module import Module
-from velbusaio.properties import LightValue, SelectedProgram
+from velbusaio.properties import BusErrorRx, BusErrorTx, LightValue, SelectedProgram
 
 from homeassistant.components.velbus import VelbusConfigEntry
 from homeassistant.components.velbus.const import DOMAIN
@@ -35,6 +35,8 @@ def mock_controller(
     mock_buttoncounter: AsyncMock,
     mock_sensornumber: AsyncMock,
     mock_lightsensor: AsyncMock,
+    mock_bus_error_rx: AsyncMock,
+    mock_bus_error_tx: AsyncMock,
     mock_dimmer: AsyncMock,
     mock_module_no_subdevices: AsyncMock,
     mock_module_subdevices: AsyncMock,
@@ -60,6 +62,8 @@ def mock_controller(
             mock_temperature,
             mock_sensornumber,
             mock_lightsensor,
+            mock_bus_error_rx,
+            mock_bus_error_tx,
         ]
         cont.get_all_light.return_value = [mock_dimmer]
         cont.get_all_led.return_value = [mock_button]
@@ -78,6 +82,8 @@ def mock_controller(
 @pytest.fixture
 def mock_module_no_subdevices(
     mock_relay: AsyncMock,
+    mock_bus_error_rx: AsyncMock,
+    mock_bus_error_tx: AsyncMock,
 ) -> AsyncMock:
     """Mock a velbus module."""
     module = AsyncMock(spec=Module)
@@ -88,6 +94,10 @@ def mock_module_no_subdevices(
     module.get_sw_version.return_value = "1.0.0"
     module.is_loaded.return_value = True
     module.get_channels.return_value = {}
+    module.get_properties.return_value = {
+        "bus_error_rx": mock_bus_error_rx,
+        "bus_error_tx": mock_bus_error_tx,
+    }
     return module
 
 
@@ -103,6 +113,7 @@ def mock_module_subdevices() -> AsyncMock:
     module.get_sw_version.return_value = "2.0.0"
     module.is_loaded.return_value = True
     module.get_channels.return_value = {}
+    module.get_properties.return_value = {}
     return module
 
 
@@ -176,6 +187,7 @@ def mock_select() -> AsyncMock:
     """Mock a successful velbus channel."""
     channel = AsyncMock(spec=SelectedProgram)
     channel.get_categories.return_value = ["select"]
+    channel.get_property_key.return_value = "SelectedProgram"
     channel.get_name.return_value = "select"
     channel.get_module_address.return_value = 88
     channel.get_channel_number.return_value = 33
@@ -240,6 +252,7 @@ def mock_lightsensor() -> AsyncMock:
     """Mock a successful velbus channel."""
     channel = AsyncMock(spec=LightValue)
     channel.get_categories.return_value = ["sensor"]
+    channel.get_property_key.return_value = "LightValue"
     channel.get_name.return_value = "LightSensor"
     channel.get_module_address.return_value = 2
     channel.get_channel_number.return_value = 4
@@ -254,6 +267,40 @@ def mock_lightsensor() -> AsyncMock:
     channel.get_unit.return_value = "illuminance"
     channel.get_state.return_value = 250
     return channel
+
+
+def _mock_bus_error(spec: type, name: str, key: str) -> AsyncMock:
+    """Mock a bus error property of a module."""
+    prop = AsyncMock(spec=spec)
+    prop.get_categories.return_value = ["sensor"]
+    prop.get_name.return_value = name
+    prop.get_property_key.return_value = key
+    # Every property of a module reports channel number 0
+    prop.get_channel_number.return_value = 0
+    prop.get_module_address.return_value = 2
+    prop.get_module_type_name.return_value = "VMB7IN"
+    prop.get_module_type.return_value = 8
+    prop.get_full_name.return_value = "Input"
+    prop.get_module_sw_version.return_value = "1.0.0"
+    prop.get_module_serial.return_value = "a1b2c3d4e5f6"
+    prop.is_sub_device.return_value = False
+    prop.is_counter_channel.return_value = False
+    prop.is_temperature.return_value = False
+    prop.get_unit.return_value = None
+    prop.get_state.return_value = 0
+    return prop
+
+
+@pytest.fixture
+def mock_bus_error_rx() -> AsyncMock:
+    """Mock the bus error receive property of a module."""
+    return _mock_bus_error(BusErrorRx, "Bus Error Receive", "BusErrorRx")
+
+
+@pytest.fixture
+def mock_bus_error_tx() -> AsyncMock:
+    """Mock the bus error transmit property of a module."""
+    return _mock_bus_error(BusErrorTx, "Bus Error Transmit", "BusErrorTx")
 
 
 @pytest.fixture

--- a/tests/components/velbus/snapshots/test_select.ambr
+++ b/tests/components/velbus/snapshots/test_select.ambr
@@ -39,7 +39,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'select_program',
-    'unique_id': 'qwerty1234567-33-program_select',
+    'unique_id': 'qwerty1234567-SelectedProgram-program_select',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/velbus/snapshots/test_sensor.ambr
+++ b/tests/components/velbus/snapshots/test_sensor.ambr
@@ -1,4 +1,110 @@
 # serializer version: 1
+# name: test_entities[sensor.input_bus_error_receive-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_bus_error_receive',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bus Error Receive',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bus Error Receive',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-BusErrorRx',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.input_bus_error_receive-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input Bus Error Receive',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_bus_error_receive',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_entities[sensor.input_bus_error_transmit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_bus_error_transmit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bus Error Transmit',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bus Error Transmit',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-BusErrorTx',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.input_bus_error_transmit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input Bus Error Transmit',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_bus_error_transmit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_entities[sensor.input_buttoncounter-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -151,7 +257,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'a1b2c3d4e5f6-4',
+    'unique_id': 'a1b2c3d4e5f6-LightValue',
     'unit_of_measurement': 'illuminance',
   })
 # ---

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -6,6 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from velbusaio.exceptions import VelbusConnectionFailed
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.velbus import (
     VelbusConfigEntry,
@@ -308,3 +309,51 @@ async def test_remove_config_entry_device_detaches_subdevices(
         config_entry.entry_id not in sub_device_after.config_entries
         and sub_device_after.via_device_id is None
     )
+
+
+async def test_migrate_property_unique_id(
+    hass: HomeAssistant,
+    config_entry: VelbusConfigEntry,
+    controller: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the property that owned the shared unique ID keeps its entity."""
+    entity = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "a1b2c3d4e5f6-0",
+        config_entry=config_entry,
+        suggested_object_id="bus_error_receive",
+    )
+
+    await init_integration(hass, config_entry)
+
+    assert entity_registry.async_get(entity.entity_id).unique_id == (
+        "a1b2c3d4e5f6-BusErrorRx"
+    )
+    assert (
+        entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, "a1b2c3d4e5f6-0")
+        is None
+    )
+
+
+async def test_migrate_property_unique_id_without_properties(
+    hass: HomeAssistant,
+    config_entry: VelbusConfigEntry,
+    controller: MagicMock,
+    entity_registry: er.EntityRegistry,
+    mock_module_no_subdevices: AsyncMock,
+) -> None:
+    """Test a module without properties leaves the shared unique ID alone."""
+    mock_module_no_subdevices.get_properties.return_value = {}
+    entity = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "a1b2c3d4e5f6-0",
+        config_entry=config_entry,
+        suggested_object_id="bus_error_receive",
+    )
+
+    await init_integration(hass, config_entry)
+
+    assert entity_registry.async_get(entity.entity_id).unique_id == "a1b2c3d4e5f6-0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


`Property.get_channel_number()` in velbus-aio returns 0 for every property:

```python
class Property(BaseItem):
    def get_channel_number(self) -> int:
        """Return the channel number of this property (always 0)."""
        return 0
```

And `VelbusEntity` builds its unique ID as `f"{serial}-{channel.get_channel_number()}"`, so every module level property lands on `{serial}-0` and only the first one ever gets an entity.

This is wider than the issue describes. `module_spec/global.json` gives every module three sensor properties (`bus_error_off`, `bus_error_rx`, `bus_error_tx`), so it is not a VMB4RYLD quirk, it happens on every module of every installation. A VMBPIRO also carries `light_value`, making it four properties fighting over one ID.

The library already anticipated this. `Property.get_property_key()` exists, described as "Return a stable, type-unique key for use in unique_id generation", and Home Assistant simply never used it. Properties now build their ID from that key. Channels are untouched.

Reproducing it in the test suite gives the reporter's log line word for word:

```
Platform velbus does not generate unique IDs. ID a1b2c3d4e5f6-0 already exists - ignoring sensor.bus_error_receive
```

The existing fixtures hid this. `mock_lightsensor` is `spec=LightValue`, which is a property, but had `get_channel_number` mocked to 4, so the collision never appeared.

A migration comes with it, because the one property that does work today would otherwise be orphaned on every module. `velbus_scan_task` already walks the modules, so it moves the entity sitting on `{serial}-0` to its new ID, per category, using the first property of that category, which is exactly how that entity came by the ID in the first place. No module spec defines a channel 0, so `{serial}-0` can only ever have belonged to a property.

One gap worth stating plainly: `get_property_key()` returns the class name, and `VMBPSUMNGR-20` declares twelve properties across only four classes (`PSUCurrent`, `PSULoad`, `PSUPower` and `PSUVoltage`, three instances each). Those still collide three ways. Closing that needs velbus-aio to hand each property its spec key (`psu_current_1` and friends), which the object is never given. This takes that module from one sensor to four, and every other module from one to three, so it is a strict improvement, and I would rather raise the remainder upstream than let it look covered.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/170244
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
