### PR TITLE
Validate the target of a service description registered in code

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -612,9 +612,7 @@ def async_set_service_schema(
     }
 
     if "target" in schema:
-        # The descriptions loaded from a services.yaml are validated, so validate
-        # the ones registered this way too, rather than let a target nothing can
-        # read reach everything that walks the descriptions
+        # Match validation applied to descriptions loaded from services.yaml.
         try:
             description["target"] = TargetSelector.CONFIG_SCHEMA(schema["target"])
         except vol.Invalid as err:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -612,7 +612,18 @@ def async_set_service_schema(
     }
 
     if "target" in schema:
-        description["target"] = schema["target"]
+        # The descriptions loaded from a services.yaml are validated, so validate
+        # the ones registered this way too, rather than let a target nothing can
+        # read reach everything that walks the descriptions
+        try:
+            description["target"] = TargetSelector.CONFIG_SCHEMA(schema["target"])
+        except vol.Invalid as err:
+            _LOGGER.warning(
+                "Invalid target in the description of service %s.%s, ignoring it: %s",
+                domain,
+                service,
+                err,
+            )
 
     if (
         response := hass.services.supports_response(domain, service)

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1512,6 +1512,57 @@ async def test_async_get_descriptions_with_placeholders(hass: HomeAssistant) -> 
     }
 
 
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        pytest.param(
+            {"entity": {"domain": "light"}},
+            {"entity": [{"domain": ["light"]}]},
+            id="normalized",
+        ),
+        pytest.param(
+            {"entity": [{"domain": "light"}]},
+            {"entity": [{"domain": ["light"]}]},
+            id="already_normalized",
+        ),
+    ],
+)
+async def test_set_service_schema_target(
+    hass: HomeAssistant,
+    target: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    """Test the target of a registered description is normalized."""
+    await async_setup_component(hass, LOGGER_DOMAIN, {LOGGER_DOMAIN: {}})
+    hass.services.async_register(LOGGER_DOMAIN, "new_service", lambda x: None, None)
+
+    service.async_set_service_schema(
+        hass, LOGGER_DOMAIN, "new_service", {"target": target}
+    )
+
+    descriptions = await service.async_get_all_descriptions(hass)
+    assert descriptions[LOGGER_DOMAIN]["new_service"]["target"] == expected
+
+
+async def test_set_service_schema_invalid_target(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a target nothing can read is left out of the description."""
+    await async_setup_component(hass, LOGGER_DOMAIN, {LOGGER_DOMAIN: {}})
+    hass.services.async_register(LOGGER_DOMAIN, "new_service", lambda x: None, None)
+
+    service.async_set_service_schema(
+        hass, LOGGER_DOMAIN, "new_service", {"target": {"entity": ["light"]}}
+    )
+
+    descriptions = await service.async_get_all_descriptions(hass)
+    assert "target" not in descriptions[LOGGER_DOMAIN]["new_service"]
+    assert (
+        "Invalid target in the description of service logger.new_service" in caplog.text
+    )
+
+
 async def test_register_with_mixed_case(hass: HomeAssistant) -> None:
     """Test registering a service with mixed case.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Opening "By target" in the automation editor fails for the reporter with:

```
File "homeassistant/components/websocket_api/automation.py", line 164, in _get_automation_component_domains
    filter_integration = entity_filter_config.get("integration")
AttributeError: 'str' object has no attribute 'get'
```

Descriptions reach the description cache two ways, and only one of them is validated.

`services.yaml` is loaded through `_SERVICES_SCHEMA`, which runs the target through `TargetSelector.CONFIG_SCHEMA`. That normalises `{"entity": {"domain": "light"}}` into `{"entity": [{"domain": ["light"]}]}` and rejects a bare string outright with `expected a mapping at 'entity[0]'`. The same applies to `triggers.yaml` and `conditions.yaml` through their own description schemas.

`async_set_service_schema()` copied `schema["target"]` verbatim, with no validation at all.

I scanned every `services.yaml`, `triggers.yaml` and `conditions.yaml` in core: none has a non-mapping entity filter. So this cannot come from a description of ours, it arrives through the unvalidated helper, which is what integrations outside core call.

Validating it there gives the cache one shape whichever way a description was registered, so a target the automation editor cannot read never gets in, and the warning names the service that supplied it rather than leaving a traceback that points at core.

The issue proposes an `isinstance` guard in `_get_automation_component_domains` instead. That silences this one crash while leaving the same unreadable target in the cache for every other consumer walking the descriptions, so it treats the symptom rather than the boundary that let it through.

Worth being explicit about the consequence: an integration passing a malformed target now loses that target from its description instead of taking the editor down with it. It keeps loading, and the warning says which one it is.

The tests cover both directions. On `dev` the normalising one fails with `{'entity': {'domain': 'light'}} != {'entity': [{'domain': ['light']}]}`, which is the verbatim passthrough.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/176543
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
