### PR TITLE
Skip Bluesound players whose config entry is not loaded

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -538,8 +538,9 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
         if self.sync_status.leader is None and self.sync_status.followers is None:
             return []
 
+        # An entry that is not loaded has no runtime data to read a status from
         config_entries: list[BluesoundConfigEntry] = (
-            self.hass.config_entries.async_entries(DOMAIN)
+            self.hass.config_entries.async_loaded_entries(DOMAIN)
         )
         sync_status_list = [
             x.runtime_data.coordinator.data.sync_status for x in config_entries
@@ -609,8 +610,9 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
 
         entity_registry = er.async_get(self.hass)
 
+        # An entry that is not loaded has no runtime data to read a status from
         config_entries: list[BluesoundConfigEntry] = (
-            self.hass.config_entries.async_entries(DOMAIN)
+            self.hass.config_entries.async_loaded_entries(DOMAIN)
         )
         for config_entry in config_entries:
             entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -28,11 +28,14 @@ from homeassistant.components.media_player import (
     SERVICE_VOLUME_UP,
     MediaPlayerState,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
 from .conftest import PlayerMocks
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
@@ -360,6 +363,34 @@ async def test_attr_bluesound_group(
     ).attributes.get("bluesound_group")
 
     assert attr_bluesound_group == ["player-name1111", "player-name2222"]
+
+
+async def test_attr_bluesound_group_skips_an_entry_that_is_not_loaded(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    config_entry_secondary: MockConfigEntry,
+    player_mocks: PlayerMocks,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test grouping passes over a player whose entry never loaded.
+
+    Such an entry carries no runtime data to read a sync status from.
+    """
+    config_entry_secondary.add_to_hass(hass)
+    assert config_entry_secondary.state is ConfigEntryState.NOT_LOADED
+
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data.sync_status_long_polling_mock.get(),
+        followers=[PairedPlayer("2.2.2.2", 11000)],
+    )
+    player_mocks.player_data.sync_status_long_polling_mock.set(updated_sync_status)
+
+    # give the long polling loop a chance to update the
+    # state; this could be any async call
+    await hass.async_block_till_done()
+
+    assert "runtime_data" not in caplog.text
+    assert hass.states.get("media_player.player_name1111") is not None
 
 
 async def test_attr_bluesound_group_for_follower(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Two places walk every Bluesound config entry and read the runtime data straight off each one:

```python
config_entries = self.hass.config_entries.async_entries(DOMAIN)
sync_status_list = [x.runtime_data.coordinator.data.sync_status for x in config_entries]
```

`runtime_data` only exists on an entry that is loaded. Anyone running more than one player where one of them is offline, disabled or still retrying has an entry without it, and rebuilding a speaker group raises. Grouping is recomputed on every status poll, which is where the flood of `AttributeError: 'ConfigEntry' object has no attribute 'runtime_data'` comes from.

Both now use `async_loaded_entries(DOMAIN)`, which is what the rest of core reaches for in this situation (`jellyfin`, `lcn`, `homeworks` and `backblaze_b2` among others), and it leaves out ignored and disabled entries as well.

The test adds a second entry to hass without setting it up, so it sits at `NOT_LOADED`, then drives a status update. On `dev` it fails with the attribute right there in the traceback:

```
assert 'runtime_data' not in "...
    x.runtime_data.coordinator.data.sync_status for x in config_entries
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/178082
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
