### PR TITLE
Leave a SwitchBot air purifier without a preset it does not report

### DIFF
--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -137,6 +137,11 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         await self.coordinator.async_request_refresh()
 
 
+_AIR_PURIFIER_PRESET_MODES = {
+    mode.value: mode.name.lower() for mode in AirPurifierModeV2
+}
+
+
 class SwitchBotAirPurifierEntity(SwitchBotCloudEntity, FanEntity):
     """Representation of a Switchbot air purifier."""
 
@@ -164,9 +169,9 @@ class SwitchBotAirPurifierEntity(SwitchBotCloudEntity, FanEntity):
             return
 
         self._attr_is_on = self.coordinator.data.get("power") == STATE_ON.upper()
-        mode = self.coordinator.data.get("mode")
-        self._attr_preset_mode = (
-            AirPurifierModeV2(mode).name.lower() if mode is not None else None
+        # An unplugged purifier reports a mode of its own that is none of these
+        self._attr_preset_mode = _AIR_PURIFIER_PRESET_MODES.get(
+            self.coordinator.data.get("mode")
         )
 
     @override

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -308,6 +308,29 @@ async def test_air_purifier(
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
+async def test_air_purifier_unknown_mode(
+    hass: HomeAssistant,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
+) -> None:
+    """Test an air purifier reporting a mode that is not one of its presets.
+
+    An unplugged purifier reports mode 0, which no preset maps to.
+    """
+    mock_list_devices.return_value = [AIR_PURIFIER_INFO]
+    status = await async_load_json_object_fixture(
+        hass, "air_purifier_status.json", DOMAIN
+    )
+    mock_get_status.return_value = {**status, "power": "OFF", "mode": 0}
+
+    with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.FAN]):
+        await configure_integration(hass)
+
+    state = hass.states.get("fan.air_purifier_1")
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_PRESET_MODE] is None
+
+
 @pytest.mark.parametrize(
     ("service", "service_data", "expected_call_args"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


`AirPurifierModeV2` runs 1 to 4 (`NORMAL`, `AUTO`, `SLEEP`, `PET`), and the mode reached the enum whenever it was not `None`:

```python
mode = self.coordinator.data.get("mode")
self._attr_preset_mode = (
    AirPurifierModeV2(mode).name.lower() if mode is not None else None
)
```

An unplugged purifier reports `mode: 0`, which is not `None`, so it went straight into the constructor and raised `ValueError: 0 is not a valid AirPurifierModeV2` on every coordinator update. That takes the whole entity update with it, not just the preset.

A lookup built once from the enum replaces the construction, so a mode nothing maps to leaves the purifier without a preset instead of raising. `None` and `0` are handled by the same `.get()`, and `_attr_preset_modes` still comes from the enum, so the presets on offer are unchanged.

The test drives the reporter's own state, `power: OFF` with `mode: 0`. On `dev` the entity is missing altogether and the log carries the `ValueError`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/176841
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
