### PR TITLE
Translate the Peblar setup exceptions

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -59,14 +59,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
         system_information = await peblar.system_information()
         api = await peblar.rest_api(enable=True, access_mode=AccessMode.READ_WRITE)
     except PeblarConnectionError as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
-        raise ConfigEntryNotReady("Could not connect to Peblar charger") from err
-    except PeblarAuthenticationError as err:
-        raise ConfigEntryAuthFailed from err
-    except PeblarError as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
         raise ConfigEntryNotReady(
-            "Unknown error occurred while connecting to Peblar charger"
+            translation_domain=DOMAIN,
+            translation_key="communication_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
+    except PeblarAuthenticationError as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="authentication_error",
+        ) from err
+    except PeblarError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="unknown_error",
+            translation_placeholders={"error": str(err)},
         ) from err
 
     # Setup the data coordinators

--- a/tests/components/peblar/test_init.py
+++ b/tests/components/peblar/test_init.py
@@ -35,16 +35,35 @@ async def test_load_unload_config_entry(
 
 
 @pytest.mark.parametrize(
-    "exception",
-    [PeblarConnectionError, PeblarError],
+    ("exception", "translation_key", "reason"),
+    [
+        (
+            PeblarConnectionError("Could not connect"),
+            "communication_error",
+            "An error occurred while communicating with the Peblar EV charger: "
+            "Could not connect",
+        ),
+        (
+            PeblarError("Unknown error"),
+            "unknown_error",
+            "An unknown error occurred while communicating with the Peblar EV "
+            "charger: Unknown error",
+        ),
+    ],
 )
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_peblar: MagicMock,
     exception: Exception,
+    translation_key: str,
+    reason: str,
 ) -> None:
-    """Test the Peblar configuration entry not ready."""
+    """Test the Peblar configuration entry not ready.
+
+    The reason reaches the user, so it comes from strings.json rather than
+    from a sentence typed into the raise.
+    """
     mock_peblar.login.side_effect = exception
 
     mock_config_entry.add_to_hass(hass)
@@ -53,6 +72,8 @@ async def test_config_entry_not_ready(
 
     assert len(mock_peblar.login.mock_calls) == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.error_reason_translation_key == translation_key
+    assert mock_config_entry.reason == reason
 
 
 async def test_config_entry_authentication_failed(
@@ -69,6 +90,7 @@ async def test_config_entry_authentication_failed(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.error_reason_translation_key == "authentication_error"
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the two hardcoded exception strings the issue points at, plus one it does not mention.

The integration has `exception-translations: done` in its quality scale, but setup still raised `ConfigEntryNotReady` with English sentences typed into the raise, each behind a `# pylint: disable-next=home-assistant-exception-not-translated` suppression. Both now use `communication_error` and `unknown_error`, the keys the coordinator already uses for the same two library exceptions, so no new strings were needed and both suppressions are gone.

While in there: `raise ConfigEntryAuthFailed from err` carried no message at all, while the coordinator reports `authentication_error` for exactly the same failure. Those are lined up now, so the user gets the same wording whether the charger rejects the password during setup or later during a refresh.

The tests were the reason this could happen unnoticed. `test_config_entry_not_ready` only asserted the resulting config entry state, never the message the user ends up reading, so replacing a translated message with a hardcoded sentence broke nothing. It now asserts the translation key and the rendered reason for both paths, and the authentication test asserts its key too.

Verified with a mutation check: putting one of the hardcoded strings back makes both the test fail and pylint report `W7417 ConfigEntryNotReady should use translation_domain and translation_key`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171501
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
