### PR TITLE
Keep a SwitchBot Cloud entry loading when the cloud goes away

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -1,6 +1,6 @@
 """SwitchBot via API integration."""
 
-from asyncio import gather
+from asyncio import Lock, gather
 from collections.abc import Awaitable, Callable
 import contextlib
 from dataclasses import dataclass, field
@@ -310,11 +310,13 @@ async def async_setup_entry(
     )
     entry.runtime_data = SwitchbotCloudData(api=api, devices=switchbot_devices)
 
-    await _initialize_webhook(hass, entry, api, coordinators_by_id)
+    # One at a time, so the cloud connecting cannot register a webhook next to
+    # the one being registered here
+    webhook_lock = Lock()
 
-    # Forwarded last, so a failure above cannot leave the platforms set up for a
-    # retry to set up a second time
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    async def _async_initialize_webhook() -> None:
+        async with webhook_lock:
+            await _initialize_webhook(hass, entry, api, coordinators_by_id)
 
     async def _handle_cloud_connection_change(
         state: cloud.CloudConnectionState,
@@ -326,11 +328,19 @@ async def async_setup_entry(
         and re-register it with SwitchBot's cloud so push devices work.
         """
         if state is cloud.CloudConnectionState.CLOUD_CONNECTED:
-            await _initialize_webhook(hass, entry, api, coordinators_by_id)
+            await _async_initialize_webhook()
 
+    # Listening before the first attempt, so a cloud that connects while the
+    # entry is still setting up is not missed
     entry.async_on_unload(
         cloud.async_listen_connection_change(hass, _handle_cloud_connection_change)
     )
+
+    await _async_initialize_webhook()
+
+    # Forwarded last, so a failure above cannot leave the platforms set up for a
+    # retry to set up a second time
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -310,9 +310,11 @@ async def async_setup_entry(
     )
     entry.runtime_data = SwitchbotCloudData(api=api, devices=switchbot_devices)
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     await _initialize_webhook(hass, entry, api, coordinators_by_id)
+
+    # Forwarded last, so a failure above cannot leave the platforms set up for a
+    # retry to set up a second time
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _handle_cloud_connection_change(
         state: cloud.CloudConnectionState,
@@ -445,12 +447,16 @@ async def _async_get_webhook_url(
             return str(entry.data[CONF_CLOUDHOOK_URL])
         if cloud.async_is_connected(hass):
             webhook_id = entry.data[CONF_WEBHOOK_ID]
-            cloudhook_url = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_CLOUDHOOK_URL: cloudhook_url}
-            )
-            _LOGGER.debug("Created SwitchBot Cloud cloudhook: %s", cloudhook_url)
-            return cloudhook_url
+            # The cloud can go away between being asked and being used
+            with contextlib.suppress(cloud.CloudNotAvailable):
+                cloudhook_url = await cloud.async_get_or_create_cloudhook(
+                    hass, webhook_id
+                )
+                hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, CONF_CLOUDHOOK_URL: cloudhook_url}
+                )
+                _LOGGER.debug("Created SwitchBot Cloud cloudhook: %s", cloudhook_url)
+                return cloudhook_url
 
     return webhook.async_generate_url(
         hass,

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -425,6 +425,45 @@ async def test_setup_creates_cloudhook_when_cloud_active(
         mock_setup_webhook.assert_called_once_with(CLOUDHOOK_URL)
 
 
+async def test_setup_survives_the_cloud_going_away(
+    hass: HomeAssistant,
+    mock_list_devices,
+    mock_get_status,
+    mock_get_webook_configuration,
+    mock_delete_webhook,
+    mock_setup_webhook,
+) -> None:
+    """Test the entry still loads when the cloud goes away mid-setup.
+
+    The connection is checked before the cloudhook is created, so it can be
+    gone by the time it is used. The local URL carries it until the
+    connection change listener creates the cloudhook.
+    """
+    await mock_cloud(hass)
+    await hass.async_block_till_done()
+
+    mock_get_webook_configuration.return_value = {"urls": []}
+    mock_list_devices.return_value = [_water_detector()]
+    mock_get_status.return_value = {"battery": 100}
+    mock_delete_webhook.return_value = {}
+    mock_setup_webhook.return_value = {}
+
+    with (
+        patch("homeassistant.components.cloud.async_is_logged_in", return_value=True),
+        patch("homeassistant.components.cloud.async_is_connected", return_value=True),
+        patch.object(cloud, "async_active_subscription", return_value=True),
+        patch(
+            "homeassistant.components.cloud.async_get_or_create_cloudhook",
+            side_effect=CloudNotAvailable,
+        ),
+        patch("homeassistant.components.cloud.async_delete_cloudhook"),
+    ):
+        entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_CLOUDHOOK_URL not in entry.data
+
+
 async def test_setup_reuses_persisted_cloudhook(
     hass: HomeAssistant,
     mock_list_devices,

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -427,11 +427,11 @@ async def test_setup_creates_cloudhook_when_cloud_active(
 
 async def test_setup_survives_the_cloud_going_away(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
-    mock_get_webook_configuration,
-    mock_delete_webhook,
-    mock_setup_webhook,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
+    mock_get_webook_configuration: AsyncMock,
+    mock_delete_webhook: AsyncMock,
+    mock_setup_webhook: AsyncMock,
 ) -> None:
     """Test the entry still loads when the cloud goes away mid-setup.
 
@@ -439,6 +439,10 @@ async def test_setup_survives_the_cloud_going_away(
     gone by the time it is used. The local URL carries it until the
     connection change listener creates the cloudhook.
     """
+    await async_process_ha_core_config(
+        hass,
+        {"external_url": "https://example.com"},
+    )
     await mock_cloud(hass)
     await hass.async_block_till_done()
 
@@ -462,6 +466,11 @@ async def test_setup_survives_the_cloud_going_away(
 
     assert entry.state is ConfigEntryState.LOADED
     assert CONF_CLOUDHOOK_URL not in entry.data
+    # SwitchBot was given the local URL to push to in the meantime
+    mock_setup_webhook.assert_called_once()
+    assert mock_setup_webhook.call_args[0][0].startswith(
+        "https://example.com/api/webhook/"
+    )
 
 
 async def test_setup_reuses_persisted_cloudhook(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Two things, one story.

**The cascade.** `async_forward_entry_setups` ran before `_initialize_webhook`, so a failure while setting up the webhook fails the entry with the platforms already forwarded, and the retry forwards them a second time. That is where the "already been setup" errors come from. Forwarding last is the usual ordering, and it means a failure anywhere above cannot cascade in future either.

**A way it actually fails.** `_async_get_webhook_url` checks `cloud.async_is_connected(hass)` and then calls `cloud.async_get_or_create_cloudhook()`, which raises `CloudNotAvailable`. Nothing caught it, so a cloud that goes away between the check and the call takes the whole entry down with it. The same module already suppresses that exception in `async_remove_entry`, so it is a known raise.

The fix is what the docstring of that function already promises:

> when a subscription is active but not yet connected, we fall back to the local URL and let the connection-change listener create the cloudhook once connected.

That listener is registered a few lines further down in setup, so the recovery was already built. The code simply never reached it.

The test patches `async_get_or_create_cloudhook` to raise. On `dev` the entry lands in `SETUP_ERROR`; with this it loads on the local URL and persists no cloudhook, leaving the listener to create one when the cloud comes back.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175614
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
