### PR TITLE
Fix the Peblar charge limit maximum

### DIFF
--- a/homeassistant/components/peblar/number.py
+++ b/homeassistant/components/peblar/number.py
@@ -70,8 +70,16 @@ class PeblarChargeCurrentLimitNumberEntity(
             coordinator=coordinator,
             description=NumberEntityDescription(key="charge_current_limit"),
         )
+        # Not the user's own charge limit: that is the value being set here,
+        # so using it as the ceiling would ratchet the slider down and never
+        # let it back up. The charger accepts up to its hardware rating, and
+        # reduces anything above the installation limit configured during
+        # commissioning, so the lower of the two is what can actually be set.
         configuration = entry.runtime_data.user_configuration_coordinator.data
-        self._attr_native_max_value = configuration.user_defined_charge_limit_current
+        self._attr_native_max_value = min(
+            entry.runtime_data.system_information.hardware_max_current,
+            configuration.current_control_fixed_charge_current_limit,
+        )
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -47,14 +47,22 @@ def mock_setup_entry() -> Generator[None]:
 def mock_peblar(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Peblar client.
 
-    Parametrize indirectly with a dict to override single system
-    information fields, so a test that cares about one hardware flag does
-    not need a full copy of the fixture.
+    Parametrize indirectly with a dict to override single fixture fields,
+    so a test that cares about one flag or one limit does not need a full
+    copy of the fixture. Keys are looked up in both the system information
+    and the user configuration.
     """
-    system_information = {
-        **json.loads(load_fixture("system_information.json", DOMAIN)),
-        **getattr(request, "param", {}),
-    }
+    overrides = getattr(request, "param", {})
+    system_information = json.loads(load_fixture("system_information.json", DOMAIN))
+    user_configuration = json.loads(load_fixture("user_configuration.json", DOMAIN))
+    for key, value in overrides.items():
+        if key in system_information:
+            system_information[key] = value
+        elif key in user_configuration:
+            user_configuration[key] = value
+        else:
+            msg = f"Unknown fixture field: {key}"
+            raise ValueError(msg)
     with (
         patch("homeassistant.components.peblar.Peblar", autospec=True) as peblar_mock,
         patch("homeassistant.components.peblar.config_flow.Peblar", new=peblar_mock),
@@ -66,8 +74,8 @@ def mock_peblar(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         peblar.current_versions.return_value = PeblarVersions.from_json(
             load_fixture("current_versions.json", DOMAIN)
         )
-        peblar.user_configuration.return_value = PeblarUserConfiguration.from_json(
-            load_fixture("user_configuration.json", DOMAIN)
+        peblar.user_configuration.return_value = PeblarUserConfiguration.from_dict(
+            user_configuration
         )
         peblar.system_information.return_value = PeblarSystemInformation.from_dict(
             system_information

--- a/tests/components/peblar/test_number.py
+++ b/tests/components/peblar/test_number.py
@@ -7,6 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.number import (
+    ATTR_MAX,
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
@@ -265,3 +266,55 @@ async def test_restore_state(
     # Check if state is restored and value is set correctly
     assert (state := hass.states.get("number.peblar_ev_charger_charge_limit"))
     assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("mock_peblar", "expected_max"),
+    [
+        ({"UserDefinedChargeLimitCurrent": 10}, 16),
+        ({"CurrentCtrlFixedChargeCurrentLimit": 10}, 10),
+        ({"HwMaxCurrent": 10}, 10),
+    ],
+    ids=["user limit is not a ceiling", "installation limit", "hardware rating"],
+    indirect=["mock_peblar"],
+)
+@pytest.mark.parametrize("init_integration", [Platform.NUMBER], indirect=True)
+@pytest.mark.usefixtures("init_integration", "entity_registry_enabled_by_default")
+async def test_charge_limit_maximum(
+    hass: HomeAssistant,
+    expected_max: int,
+) -> None:
+    """Test the ceiling on the charge limit.
+
+    The charger accepts up to its hardware rating and reduces anything
+    above the installation limit. The user's own charge limit is the value
+    being set here, so it must not narrow the range it is chosen from.
+    """
+    state = hass.states.get("number.peblar_ev_charger_charge_limit")
+    assert state
+    assert state.attributes[ATTR_MAX] == expected_max
+
+
+@pytest.mark.parametrize(
+    "mock_peblar",
+    [{"UserDefinedChargeLimitCurrent": 10}],
+    indirect=True,
+)
+@pytest.mark.parametrize("init_integration", [Platform.NUMBER], indirect=True)
+@pytest.mark.usefixtures("init_integration", "entity_registry_enabled_by_default")
+async def test_charge_limit_can_be_raised_again(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+) -> None:
+    """A charger left on a low limit can still be turned back up."""
+    mocked_method = mock_peblar.rest_api.return_value.ev_interface
+    mocked_method.reset_mock()
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.peblar_ev_charger_charge_limit", ATTR_VALUE: 16},
+        blocking=True,
+    )
+
+    mocked_method.assert_any_call(charge_current_limit=16000)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The charge limit slider took its maximum from the user's own charge limit:

```python
configuration = entry.runtime_data.user_configuration_coordinator.data
self._attr_native_max_value = configuration.user_defined_charge_limit_current
```

That is the value this entity sets, so it cannot also be the ceiling it is chosen from. Lower it once and the ceiling follows it down, and there is no way back up. That is exactly what the reporter describes: a charger rated 16A stuck at a maximum of 10A after one change.

The ceiling is now the lower of two real limits. The [local REST API documentation](https://developer.peblar.com/local-rest-api) says this endpoint accepts "between 6000mA and 16000mA (including) for 11kW Peblars, or 6000mA and 32000mA (including) for 22kW Peblars", which is `HwMaxCurrent`. It also lists "Installation limit: The maximum installation current configured during commissioning" as one of the sources that reduce the delivered current, which is `CurrentCtrlFixedChargeCurrentLimit`. Peblar's own web interface calls that one `installationCurrentLimit` and caps every other current field with `Math.min(..., installationCurrentLimit)`.

All three candidate fields are 16 in the test fixtures, which is why no test failed on this. `mock_peblar` can now override user configuration fields as well as system information ones, and the new tests lower each of the three in turn and pin the resulting maximum, plus one that a charger sitting on a low limit can still be set back up.

Not included: `UserDefinedChargeLimitCurrentAllowed`. That flag gates the slider in the web interface, which writes `UserDefinedChargeLimitCurrent` through the web API. This entity writes `ChargeCurrentLimit` on the local REST API, which is a different field, so the flag does not apply here.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180447
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
