### PR TITLE
Only offer smart charging modes the Peblar accepts

### DIFF
--- a/homeassistant/components/peblar/select.py
+++ b/homeassistant/components/peblar/select.py
@@ -33,8 +33,30 @@ class PeblarSelectEntityDescription(SelectEntityDescription):
     """Class describing Peblar select entities."""
 
     has_fn: Callable[[PeblarRuntimeData], bool] = lambda _: True
+    options_fn: Callable[[PeblarUserConfiguration], list[str]] | None = None
     current_fn: Callable[[PeblarUserConfiguration], str | None]
     select_fn: Callable[[Peblar, str], Awaitable[Any]]
+
+
+def _smart_charging_options(configuration: PeblarUserConfiguration) -> list[str]:
+    """Return the smart charging modes this charger will accept.
+
+    A charger without a power meter configured rejects solar charging, and
+    scheduled charging can be switched off during commissioning. Offering
+    those anyway lands the user on a mode the charger quietly ignores.
+    """
+    solar = configuration.solar_charging_allowed
+    return [
+        option
+        for option, allowed in (
+            ("default", True),
+            ("fast_solar", solar),
+            ("pure_solar", solar),
+            ("scheduled", configuration.scheduled_charging_allowed),
+            ("smart_solar", solar),
+        )
+        if allowed
+    ]
 
 
 DESCRIPTIONS = [
@@ -42,13 +64,7 @@ DESCRIPTIONS = [
         key="smart_charging",
         translation_key="smart_charging",
         entity_category=EntityCategory.CONFIG,
-        options=[
-            "default",
-            "fast_solar",
-            "pure_solar",
-            "scheduled",
-            "smart_solar",
-        ],
+        options_fn=_smart_charging_options,
         current_fn=lambda x: x.smart_charging.value if x.smart_charging else None,
         select_fn=lambda x, mode: x.smart_charging(SmartChargingMode(mode)),
     ),
@@ -117,6 +133,14 @@ class PeblarSelectEntity(
     """Defines a Peblar select entity."""
 
     entity_description: PeblarSelectEntityDescription
+
+    @property
+    @override
+    def options(self) -> list[str]:
+        """Return the options this charger currently accepts."""
+        if (options_fn := self.entity_description.options_fn) is not None:
+            return options_fn(self.coordinator.data)
+        return super().options
 
     @property
     @override

--- a/tests/components/peblar/test_select.py
+++ b/tests/components/peblar/test_select.py
@@ -17,6 +17,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.peblar.const import DOMAIN
 from homeassistant.components.select import (
     ATTR_OPTION,
+    ATTR_OPTIONS,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
@@ -250,3 +251,38 @@ async def test_hw_entity_absent_when_hw_flag_false(
         )
         is None
     )
+
+
+@pytest.mark.parametrize(
+    ("mock_peblar", "expected_options"),
+    [
+        (
+            {"SolarChargingAllowed": False},
+            ["default", "scheduled"],
+        ),
+        (
+            {"ScheduledChargingAllowed": False},
+            ["default", "fast_solar", "pure_solar", "smart_solar"],
+        ),
+        (
+            {"SolarChargingAllowed": False, "ScheduledChargingAllowed": False},
+            ["default"],
+        ),
+    ],
+    ids=["no solar", "no scheduled", "neither"],
+    indirect=["mock_peblar"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_smart_charging_options_follow_the_charger(
+    hass: HomeAssistant,
+    expected_options: list[str],
+) -> None:
+    """Only offer the smart charging modes the charger accepts.
+
+    A charger without a power meter rejects solar charging, and the web
+    interface hides those modes. Offering them anyway lets the user pick
+    something the charger quietly ignores.
+    """
+    state = hass.states.get("select.peblar_ev_charger_smart_charging")
+    assert state
+    assert state.attributes[ATTR_OPTIONS] == expected_options


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> [!NOTE]
> Stacked on #180564, which this needs for the `mock_peblar` fixture override. Review the second commit only, or merge #180564 first.

The smart charging select offered a fixed list of five modes regardless of what the charger supports. On a charger with no power meter configured, Peblar's own web interface hides the solar modes, but Home Assistant still offered them, and picking one lands the user on a mode the charger quietly ignores.

The charger tells us which strategies it accepts. Its web interface builds the same screen from those flags:

```js
toSmartChargingSettings(e) {
  ...
  allowed: e.LocalSmartChargingAllowed,
  solarSettings:             { allowed: e.SolarChargingAllowed, ... },
  scheduledChargingSettings: { allowed: e.ScheduledChargingAllowed },
}
```

So `SolarChargingAllowed` gates `fast_solar`, `pure_solar` and `smart_solar`, `ScheduledChargingAllowed` gates `scheduled`, and `default` is always available. The options are a property computed from the coordinator data rather than a fixed list, so a power meter added later shows up without a reload.

The order is unchanged, so nobody gets a reshuffled list and the snapshot stays as it was.

Deliberately not used: `LocalSmartChargingAllowed`. Hiding the entity on that flag would make it disappear and leave a stale entity behind when an installer changes something. With it off, the list is just `default`, which is the honest answer.

Both flags are true in the fixtures, so the new tests lower them one at a time and assert the resulting option list.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180455
- This PR is related to issue: #180564
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
