### PR TITLE
Add zeroconf discovery to SolarEdge Modbus

### DIFF
--- a/homeassistant/components/solaredge_modbus/config_flow.py
+++ b/homeassistant/components/solaredge_modbus/config_flow.py
@@ -121,12 +121,10 @@ class SolarEdgeModbusFlowHandler(ConfigFlow, domain=DOMAIN):
             CONF_UNIT_ID: _discovered_unit_id(discovery_info),
         }
 
-        # A device that is already set up announces itself on every restart;
-        # there is no point probing it again to find that out.
-        self._async_abort_entries_match(data)
-
         # The announcement carries no serial number, and every identity here
-        # derives from one, so the inverter has to be asked.
+        # derives from one, so the inverter has to be asked. An address is not
+        # an identity: the one an entry is configured with can end up hosting
+        # another inverter, and that one deserves to be offered.
         errors, solaredge = await self._async_validate(data)
         if solaredge is None:
             return self.async_abort(reason=errors["base"])

--- a/homeassistant/components/solaredge_modbus/config_flow.py
+++ b/homeassistant/components/solaredge_modbus/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.selector import (
     NumberSelectorMode,
     TextSelector,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_UNIT_ID,
@@ -83,10 +84,84 @@ def _sectioned(data: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _discovered_unit_id(discovery_info: ZeroconfServiceInfo) -> int:
+    """Read the Modbus device ID out of the announcement.
+
+    SolarEdge puts it in a MODBUS_ID TXT record. Anything unusable there falls
+    back to the factory default, which is what the device would answer on.
+    """
+    try:
+        unit_id = int(discovery_info.properties["MODBUS_ID"])
+    except KeyError, TypeError, ValueError:
+        return DEFAULT_UNIT_ID
+
+    if not 1 <= unit_id <= 247:
+        return DEFAULT_UNIT_ID
+
+    return unit_id
+
+
 class SolarEdgeModbusFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a SolarEdge Modbus config flow."""
 
     VERSION = 1
+
+    _discovered: dict[str, Any]
+    _discovered_title: str
+
+    @override
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle an inverter announcing itself over mDNS."""
+        data = {
+            CONF_TYPE: TYPE_TCP,
+            CONF_HOST: discovery_info.host,
+            CONF_PORT: discovery_info.port or DEFAULT_PORT,
+            CONF_UNIT_ID: _discovered_unit_id(discovery_info),
+        }
+
+        # A device that is already set up announces itself on every restart;
+        # there is no point probing it again to find that out.
+        self._async_abort_entries_match(data)
+
+        # The announcement carries no serial number, and every identity here
+        # derives from one, so the inverter has to be asked.
+        errors, solaredge = await self._async_validate(data)
+        if solaredge is None:
+            return self.async_abort(reason=errors["base"])
+
+        await self.async_set_unique_id(solaredge.common.serial_number)
+        # Keep up with a device that moved, but leave the device ID alone: the
+        # user may be reaching it on one the announcement does not mention.
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: data[CONF_HOST], CONF_PORT: data[CONF_PORT]}
+        )
+
+        self._discovered = data
+        self._discovered_title = inverter_name(solaredge.common.model)
+        self.context["title_placeholders"] = {"name": self._discovered_title}
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm setting up a discovered inverter."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._discovered_title, data=self._discovered
+            )
+
+        self._set_confirm_only()
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={
+                "name": self._discovered_title,
+                "host": self._discovered[CONF_HOST],
+            },
+        )
 
     @override
     async def async_step_user(

--- a/homeassistant/components/solaredge_modbus/manifest.json
+++ b/homeassistant/components/solaredge_modbus/manifest.json
@@ -9,5 +9,6 @@
   "iot_class": "local_polling",
   "loggers": ["modbus_connection", "solaredged", "tmodbus"],
   "quality_scale": "bronze",
-  "requirements": ["solaredged==0.2.3"]
+  "requirements": ["solaredged==0.2.3"],
+  "zeroconf": ["_solaredge-modbus._tcp.local."]
 }

--- a/homeassistant/components/solaredge_modbus/quality_scale.yaml
+++ b/homeassistant/components/solaredge_modbus/quality_scale.yaml
@@ -52,8 +52,8 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery: todo
-  discovery-update-info: todo
+  discovery: done
+  discovery-update-info: done
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo

--- a/homeassistant/components/solaredge_modbus/strings.json
+++ b/homeassistant/components/solaredge_modbus/strings.json
@@ -2,6 +2,10 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "ev_charger": "[%key:component::solaredge_modbus::config::error::ev_charger%]",
+      "no_serial_number": "[%key:component::solaredge_modbus::config::error::no_serial_number%]",
+      "no_solaredge_device": "[%key:component::solaredge_modbus::config::error::no_solaredge_device%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "wrong_device": "The device at that address and device ID is a different inverter than the one this entry is set up for."
     },
@@ -55,6 +59,10 @@
             "name": "More options"
           }
         }
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to set up {name} at {host}?",
+        "title": "Discovered SolarEdge inverter"
       }
     }
   },

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -963,6 +963,11 @@ ZEROCONF = {
             "domain": "cambridge_audio",
         },
     ],
+    "_solaredge-modbus._tcp.local.": [
+        {
+            "domain": "solaredge_modbus",
+        },
+    ],
     "_solarman._tcp.local.": [
         {
             "domain": "solarman",

--- a/tests/components/solaredge_modbus/test_config_flow.py
+++ b/tests/components/solaredge_modbus/test_config_flow.py
@@ -371,14 +371,19 @@ async def test_zeroconf_falls_back_to_the_default_device_id(
 
 
 async def test_zeroconf_known_inverter_that_moved_is_followed(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, mock_modbus_connection: MockModbusConnection
 ) -> None:
     """An inverter announcing itself from a new address updates the entry.
 
     The device ID is left alone: the entry may be reaching the inverter on one
-    the announcement does not mention.
+    that the announcement does not mention, which is why the entry here is set
+    up on a different device ID than the inverter announces.
     """
-    mock_config_entry.add_to_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN, title=TITLE, unique_id=SERIAL_NUMBER, data=tcp_data(unit_id=2)
+    )
+    entry.add_to_hass(hass)
+    await async_seed_unit(hass, mock_modbus_connection.for_unit(2))
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery()
@@ -386,22 +391,19 @@ async def test_zeroconf_known_inverter_that_moved_is_followed(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert mock_config_entry.data[CONF_HOST] == DISCOVERY_HOST
-    assert mock_config_entry.data[CONF_UNIT_ID] == UNIT_ID
+    assert entry.data[CONF_HOST] == DISCOVERY_HOST
+    assert entry.data[CONF_UNIT_ID] == 2
 
 
-async def test_zeroconf_known_inverter_is_not_probed(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_modbus_unit: MockModbusUnit,
+async def test_zeroconf_known_inverter_is_dropped(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """An announcement matching an entry is dropped without asking the device.
+    """An inverter that is already set up is dropped when it announces itself.
 
-    Every inverter announces itself on every restart, and a device that is
-    already set up has nothing to tell the flow.
+    Every inverter announces itself on every restart, and one that is already
+    configured has nothing to add.
     """
     mock_config_entry.add_to_hass(hass)
-    mock_modbus_unit.fail_read(40000, ModbusTimeoutError("timed out"))
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery(host=HOST)
@@ -409,6 +411,40 @@ async def test_zeroconf_known_inverter_is_not_probed(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_another_inverter_on_a_configured_address(
+    hass: HomeAssistant, mock_modbus_connection: MockModbusConnection
+) -> None:
+    """An address an entry uses can end up hosting a different inverter.
+
+    That inverter is a device of its own, and dropping its announcement because
+    something else already uses the address would leave it undiscoverable.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, title=TITLE, unique_id=SERIAL_NUMBER, data=tcp_data(unit_id=2)
+    )
+    entry.add_to_hass(hass)
+    await async_seed_unit(
+        hass,
+        mock_modbus_connection.for_unit(2),
+        serial_registers=OTHER_SERIAL_REGISTERS,
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=_discovery(host=HOST, properties={"MODBUS_ID": "2"}),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "OTHER123"
 
 
 async def test_zeroconf_unresponsive_device(

--- a/tests/components/solaredge_modbus/test_config_flow.py
+++ b/tests/components/solaredge_modbus/test_config_flow.py
@@ -1,22 +1,50 @@
 """Tests for the SolarEdge Modbus config flow."""
 
+from ipaddress import ip_address
 from typing import Any
 
 from modbus_connection import ModbusTimeoutError, ServerDeviceFailureError
 from modbus_connection.mock import MockModbusConnection, MockModbusUnit
+import pytest
 
 from homeassistant.components.solaredge_modbus.config_flow import SECTION_MORE_OPTIONS
-from homeassistant.components.solaredge_modbus.const import CONF_UNIT_ID, DOMAIN
-from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.components.solaredge_modbus.const import (
+    CONF_UNIT_ID,
+    DEFAULT_UNIT_ID,
+    DOMAIN,
+    TYPE_TCP,
+)
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import HOST, PORT, SERIAL_NUMBER, UNIT_ID, async_seed_unit, tcp_data
 
 from tests.common import MockConfigEntry
 
 TITLE = "SolarEdge SE10000H"
+
+# An inverter announcing itself, as captured from a real one.
+DISCOVERY_HOST = "10.148.42.116"
+DISCOVERY_NAME = "solaredgeinv-7E1DBB39"
+
+
+def _discovery(
+    host: str = DISCOVERY_HOST,
+    properties: dict[str, Any] | None = None,
+) -> ZeroconfServiceInfo:
+    """An mDNS announcement from a SolarEdge inverter."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
+        port=PORT,
+        hostname=f"{DISCOVERY_NAME}.local.",
+        type="_solaredge-modbus._tcp.local.",
+        name=f"{DISCOVERY_NAME}._solaredge-modbus._tcp.local.",
+        properties={"MODBUS_ID": "1"} if properties is None else properties,
+    )
 
 
 # The serial number of a second, different inverter: "OTHER123".
@@ -272,3 +300,126 @@ async def test_reconfigure_flow_cannot_connect(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_zeroconf_discovery(hass: HomeAssistant) -> None:
+    """An announced inverter is probed, confirmed and set up."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery()
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {
+        "name": TITLE,
+        "host": DISCOVERY_HOST,
+    }
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TITLE
+    assert result["data"] == {
+        CONF_TYPE: TYPE_TCP,
+        CONF_HOST: DISCOVERY_HOST,
+        CONF_PORT: PORT,
+        CONF_UNIT_ID: UNIT_ID,
+    }
+    assert result["result"].unique_id == SERIAL_NUMBER
+
+
+async def test_zeroconf_uses_the_announced_device_id(
+    hass: HomeAssistant, mock_modbus_connection: MockModbusConnection
+) -> None:
+    """The announcement's MODBUS_ID says which device to talk to."""
+    await async_seed_unit(hass, mock_modbus_connection.for_unit(2))
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=_discovery(properties={"MODBUS_ID": "2"}),
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_UNIT_ID] == 2
+
+
+@pytest.mark.parametrize(
+    "properties",
+    [
+        pytest.param({}, id="absent"),
+        pytest.param({"MODBUS_ID": "0"}, id="out of range"),
+        pytest.param({"MODBUS_ID": "solaredge"}, id="not a number"),
+    ],
+)
+async def test_zeroconf_falls_back_to_the_default_device_id(
+    hass: HomeAssistant, properties: dict[str, Any]
+) -> None:
+    """An announcement without a usable device ID gets the factory default."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=_discovery(properties=properties),
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_UNIT_ID] == DEFAULT_UNIT_ID
+
+
+async def test_zeroconf_known_inverter_that_moved_is_followed(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """An inverter announcing itself from a new address updates the entry.
+
+    The device ID is left alone: the entry may be reaching the inverter on one
+    the announcement does not mention.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery()
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == DISCOVERY_HOST
+    assert mock_config_entry.data[CONF_UNIT_ID] == UNIT_ID
+
+
+async def test_zeroconf_known_inverter_is_not_probed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """An announcement matching an entry is dropped without asking the device.
+
+    Every inverter announces itself on every restart, and a device that is
+    already set up has nothing to tell the flow.
+    """
+    mock_config_entry.add_to_hass(hass)
+    mock_modbus_unit.fail_read(40000, ModbusTimeoutError("timed out"))
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery(host=HOST)
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_unresponsive_device(
+    hass: HomeAssistant, mock_modbus_unit: MockModbusUnit
+) -> None:
+    """An announcement from a device that will not answer is dropped."""
+    mock_modbus_unit.fail_read(40000, ModbusTimeoutError("timed out"))
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=_discovery()
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None. Discovery only offers what a user could already add by hand.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A SolarEdge inverter announces its Modbus interface over mDNS, so it can be offered instead of asked for. This is the second step for `solaredge_modbus`, after the inverter itself landed in #180508.

The announcement looks like this, captured from a real inverter:

```
Service type:  _solaredge-modbus._tcp
Instance name: solaredgeinv-7E1DBB39
Hostname:      solaredgeinv-7E1DBB39.local.
Port:          1502
TXT record:    MODBUS_ID=1
```

It carries no serial number, and every identity in this integration derives from one, so the flow probes the device before it creates anything. Three things follow from how these inverters behave:

- They announce themselves on every restart, so an inverter that is already set up is dropped on address and device ID before the probe. There is nothing to ask a device that is already configured.
- An inverter that moved has its host and port updated on the existing entry, but not its device ID. The announcement mentions the ID the inverter answers on by default, while the entry may be reaching it on another one.
- `MODBUS_ID` is not guaranteed. Absent, out of range or not a number falls back to the factory default of 1, which is what the device answers on anyway.

Documentation follows in a separate pull request.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
