### PR TITLE
Guard the Hydrawise zone and sensor of an entity like its controller

### DIFF
--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -80,11 +80,16 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     @override
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the state."""
-        # Guard against updates arriving after the controller has been removed
+        # Guard against updates arriving after what the entity reads on has gone
         # but before the entity has been unsubscribed from the coordinator.
-        if self.controller.id not in self.coordinator.data.controllers:
+        data = self.coordinator.data
+        if (
+            self.controller.id not in data.controllers
+            or (self.zone_id is not None and self.zone_id not in data.zones)
+            or (self.sensor_id is not None and self.sensor_id not in data.sensors)
+        ):
             return
-        self.controller = self.coordinator.data.controllers[self.controller.id]
+        self.controller = data.controllers[self.controller.id]
         self._update_attrs()
         super()._handle_coordinator_update()
 

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller, User, Zone
+import pytest
 
 from homeassistant.components.hydrawise.const import DOMAIN, MAIN_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
@@ -161,3 +162,34 @@ async def test_auto_remove_devices(
         device_registry, mock_added_config_entry.entry_id
     )
     assert len(all_devices) == 0
+
+
+async def test_zones_of_one_controller_go_missing(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a controller answering without its zones does not crash the update.
+
+    The controller is still there, so the entities of its zones are still
+    subscribed when the refresh that drops them arrives.
+    """
+    assert hass.states.get("binary_sensor.zone_one_watering") is not None
+
+    mock_pydrawise.get_zones.return_value = []
+
+    freezer.tick(MAIN_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_pydrawise.get_zones.return_value = zones
+
+    freezer.tick(MAIN_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("binary_sensor.zone_one_watering") is not None
+    assert "KeyError" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


An entity reads three things out of the coordinator data, and only one of them was checked for still being there:

```python
        # Guard against updates arriving after the controller has been removed
        # but before the entity has been unsubscribed from the coordinator.
        if self.controller.id not in self.coordinator.data.controllers:
            return
```

That guard came from https://github.com/home-assistant/core/pull/166708. The controller was covered; `zone` and `sensor` read out of the same data a line later and were not.

It is reachable because zones are fetched per controller:

```python
        for controller in data.user.controllers:
            data.controllers[controller.id] = controller
            controller.zones = await self.api.get_zones(controller)
```

A controller that answers without its zones keeps its place in `data.controllers` while its zones lose theirs in `data.zones`. The check passes, `_update_attrs` reads `data.zones[self.zone_id]`, and it raises, once per entity per refresh, which is where the reporter's 102 occurrences come from. The same refresh has `_add_remove_zones` delete those devices and the next one bring them back, which is the flicker they describe.

The test has `get_zones` answer with nothing for one refresh and recover on the next. On `dev` it fails with `KeyError` in the log; with this the entity survives the round trip.

Scope worth stating: this stops the crash, not the disappearance. Why a controller comes back without its zones is upstream of here, and whether an empty answer should be taken to mean the zones are gone is a separate call I would leave to the code owner.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/179033
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
