### PR TITLE
Stop calling the Tuya doorbell payloads a doorbell

### DIFF
--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -41,15 +41,15 @@ class TuyaEventEntityDescription(EventEntityDescription):
 # end up being events.
 EVENTS: dict[DeviceCategory, tuple[TuyaEventEntityDescription, ...]] = {
     DeviceCategory.SP: (
+        # Neither of these reports the doorbell being rung, which is what the
+        # doorbell device class stands for; they carry what it sent along
         TuyaEventEntityDescription(
             key=DPCode.ALARM_MESSAGE,
-            device_class=EventDeviceClass.DOORBELL,
             translation_key="doorbell_message",
             wrapper_class=Base64Utf8StringEventWrapper,
         ),
         TuyaEventEntityDescription(
             key=DPCode.DOORBELL_PIC,
-            device_class=EventDeviceClass.DOORBELL,
             translation_key="doorbell_picture",
             wrapper_class=Base64Utf8RawEventWrapper,
         ),

--- a/tests/components/tuya/snapshots/test_event.ambr
+++ b/tests/components/tuya/snapshots/test_event.ambr
@@ -1,7 +1,6 @@
 # serializer version: 1
 # name: test_alarm_message_event[event.intercom_doorbell_message-alarm_message-eyJzb21lIjogImpzb24iLCAicmFuZG9tIjogImRhdGEifQ==-sp_csr2fqitalj5o0tq]
   ReadOnlyDict({
-    <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
     <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
@@ -12,7 +11,6 @@
 # ---
 # name: test_alarm_message_event[event.intercom_doorbell_picture-doorbell_pic-aHR0cHM6Ly9zb21lLXBpY3R1cmUtdXJsLmNvbS9pbWFnZS5qcGc=-sp_csr2fqitalj5o0tq]
   ReadOnlyDict({
-    <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
     <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
@@ -235,7 +233,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -250,7 +248,6 @@
 # name: test_platform_setup_and_discovery[event.burocam_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -295,7 +292,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -310,7 +307,6 @@
 # name: test_platform_setup_and_discovery[event.c9_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -355,7 +351,7 @@
     'object_id_base': 'Doorbell picture',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell picture',
     'platform': 'tuya',
@@ -370,7 +366,6 @@
 # name: test_platform_setup_and_discovery[event.c9_doorbell_picture-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -415,7 +410,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -430,7 +425,6 @@
 # name: test_platform_setup_and_discovery[event.dolni_vchod_zapad_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -475,7 +469,7 @@
     'object_id_base': 'Doorbell picture',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell picture',
     'platform': 'tuya',
@@ -490,7 +484,6 @@
 # name: test_platform_setup_and_discovery[event.dolni_vchod_zapad_doorbell_picture-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -535,7 +528,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -550,7 +543,6 @@
 # name: test_platform_setup_and_discovery[event.garage_camera_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -595,7 +587,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -610,7 +602,6 @@
 # name: test_platform_setup_and_discovery[event.intercom_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -655,7 +646,7 @@
     'object_id_base': 'Doorbell picture',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell picture',
     'platform': 'tuya',
@@ -670,7 +661,6 @@
 # name: test_platform_setup_and_discovery[event.intercom_doorbell_picture-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -715,7 +705,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -730,7 +720,6 @@
 # name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -775,7 +764,7 @@
     'object_id_base': 'Doorbell picture',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell picture',
     'platform': 'tuya',
@@ -790,7 +779,6 @@
 # name: test_platform_setup_and_discovery[event.mirilla_puerta_doorbell_picture-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
@@ -835,7 +823,7 @@
     'object_id_base': 'Doorbell message',
     'options': dict({
     }),
-    'original_device_class': <EventDeviceClass.DOORBELL: 'doorbell'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Doorbell message',
     'platform': 'tuya',
@@ -850,7 +838,6 @@
 # name: test_platform_setup_and_discovery[event.security_camera_doorbell_message-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
       <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Core warns about these entities and sends the user here:

```
Entity event.lsc_..._doorbell_message is a doorbell event entity but does not support
the 'ring' event type. This will stop working in Home Assistant 2027.4
```

An event entity carrying `EventDeviceClass.DOORBELL` is expected to be able to report `ring`, because that class stands for the doorbell being rung. Tuya takes its event types from the DP enum of the device, and the committed snapshots show what these two offer:

```
event.intercom_doorbell_message  -> event_types: ['triggered']
event.intercom_doorbell_picture  -> event_types: ['triggered']
```

No `ring`, and rightly so. `alarm_message` and `doorbell_pic` carry the message and the picture the doorbell sent, not the press itself. So the device class is the wrong claim rather than the event types being incomplete, and dropping it leaves them as the plain event entities they are.

Nothing else in the file used `DOORBELL`; `BUTTON` is still used by the switch categories, so the import stays.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/179516
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
