### PR TITLE
Bump peblar to 1.0.1

### DIFF
--- a/homeassistant/components/peblar/manifest.json
+++ b/homeassistant/components/peblar/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "platinum",
-  "requirements": ["peblar==0.6.0"],
+  "requirements": ["peblar==1.0.1"],
   "zeroconf": [{ "name": "pblr-*", "type": "_http._tcp.local." }]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1872,7 +1872,7 @@ panasonic-viera==0.4.4
 pdunehd==1.3.3
 
 # homeassistant.components.peblar
-peblar==0.6.0
+peblar==1.0.1
 
 # homeassistant.components.peco
 peco==0.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `peblar` from 0.6.0 to 1.0.1. Two changes went in, and neither needs a code change here.

**[#449](https://github.com/frenck/python-peblar/pull/449), the major bump.** `PeblarSystem.active_error_codes` and `active_warning_codes` change from `list[str]` to `list[int]`. The [local REST API](https://developer.peblar.com/local-rest-api) documents both as "An integer array with active error codes", but they were typed as strings, so the codes were being stringified on the way in: a charger reporting `[10, 22]` handed back `['10', '22']`.

This integration is unaffected. It reads both fields in exactly one place, `binary_sensor.py`:

```python
is_on_fn=lambda x: bool(x.system.active_error_codes),
```

`bool()` behaves the same on either type, which I checked against the installed 1.0.1. The one visible difference is the diagnostics dump, which includes `system.to_dict()`: on a charger with an active code it now reports `[10, 22]` instead of `["10", "22"]`. The fixtures have empty lists, so no snapshot moves.

**[#450](https://github.com/frenck/python-peblar/pull/450).** `PackageType` and `PeblarMeterHistory` are now exported from the package. `Peblar.update()` takes the first and `meter_history()` returns the second, so callers previously had to reach into `peblar.const` and `peblar.models`. Not used here yet; it unblocks wiring up firmware installs on the update entities.

Verified with 1.0.1 actually installed: the full peblar test suite passes, 94 tests and 64 snapshots, and hassfest, ruff and mypy are clean.

Diff between the two versions: https://github.com/frenck/python-peblar/compare/v0.6.0...v1.0.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
