### PR TITLE
Bump zeroconf to 0.151.1

### DIFF
--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["zeroconf"],
   "quality_scale": "internal",
-  "requirements": ["zeroconf==0.151.0"]
+  "requirements": ["zeroconf==0.151.1"]
 }

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["zeroconf"],
   "quality_scale": "internal",
-  "requirements": ["zeroconf==0.150.0"]
+  "requirements": ["zeroconf==0.151.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -75,7 +75,7 @@ urllib3>=2.0
 uv==0.12.5
 webrtc-models==0.3.0
 yarl==1.24.5
-zeroconf==0.151.0
+zeroconf==0.151.1
 
 # Constrain pycryptodome to avoid vulnerability
 # see https://github.com/home-assistant/core/pull/16238

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -75,7 +75,7 @@ urllib3>=2.0
 uv==0.12.5
 webrtc-models==0.3.0
 yarl==1.24.5
-zeroconf==0.150.0
+zeroconf==0.151.0
 
 # Constrain pycryptodome to avoid vulnerability
 # see https://github.com/home-assistant/core/pull/16238

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "probatio==0.11.3",
   "yarl==1.24.5",
   "webrtc-models==0.3.0",
-  "zeroconf==0.151.0",
+  "zeroconf==0.151.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "probatio==0.11.3",
   "yarl==1.24.5",
   "webrtc-models==0.3.0",
-  "zeroconf==0.150.0",
+  "zeroconf==0.151.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,4 +60,4 @@ urllib3>=2.0
 uv==0.12.5
 webrtc-models==0.3.0
 yarl==1.24.5
-zeroconf==0.150.0
+zeroconf==0.151.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,4 +60,4 @@ urllib3>=2.0
 uv==0.12.5
 webrtc-models==0.3.0
 yarl==1.24.5
-zeroconf==0.151.0
+zeroconf==0.151.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3519,7 +3519,7 @@ zamg==0.4.1
 zcc-helper==3.8
 
 # homeassistant.components.zeroconf
-zeroconf==0.150.0
+zeroconf==0.151.0
 
 # homeassistant.components.zeversolar
 zeversolar==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3519,7 +3519,7 @@ zamg==0.4.1
 zcc-helper==3.8
 
 # homeassistant.components.zeroconf
-zeroconf==0.151.0
+zeroconf==0.151.1
 
 # homeassistant.components.zeversolar
 zeversolar==0.3.2

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,6 +1,5 @@
 """Test Zeroconf component setup process."""
 
-from ipaddress import ip_address
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
@@ -936,10 +935,7 @@ async def test_info_from_service_with_link_local_address_first(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [
-        ip_address("169.254.12.3").packed,
-        ip_address("192.168.66.12").packed,
-    ]
+    service_info.addresses = ["169.254.12.3", "192.168.66.12"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["169.254.12.3", "192.168.66.12"]
@@ -951,10 +947,7 @@ async def test_info_from_service_with_unspecified_address_first(
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [
-        ip_address("0.0.0.0").packed,
-        ip_address("192.168.66.12").packed,
-    ]
+    service_info.addresses = ["0.0.0.0", "192.168.66.12"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["0.0.0.0", "192.168.66.12"]
@@ -966,7 +959,7 @@ async def test_info_from_service_with_unspecified_address_only(
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [ip_address("0.0.0.0").packed]
+    service_info.addresses = ["0.0.0.0"]
     info = zeroconf.info_from_service(service_info)
     assert info is None
 
@@ -977,10 +970,7 @@ async def test_info_from_service_with_link_local_address_second(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [
-        ip_address("192.168.66.12").packed,
-        ip_address("169.254.12.3").packed,
-    ]
+    service_info.addresses = ["192.168.66.12", "169.254.12.3"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["192.168.66.12", "169.254.12.3"]
@@ -992,7 +982,7 @@ async def test_info_from_service_with_link_local_address_only(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [ip_address("169.254.12.3").packed]
+    service_info.addresses = ["169.254.12.3"]
     info = zeroconf.info_from_service(service_info)
     assert info is None
 
@@ -1001,10 +991,7 @@ async def test_info_from_service_prefers_ipv4(hass: HomeAssistant) -> None:
     """Test that ipv4 addresses are preferred."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [
-        ip_address("2001:db8:3333:4444:5555:6666:7777:8888").packed,
-        ip_address("192.168.66.12").packed,
-    ]
+    service_info.addresses = ["2001:db8:3333:4444:5555:6666:7777:8888", "192.168.66.12"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
 
@@ -1013,7 +1000,7 @@ async def test_info_from_service_can_return_ipv6(hass: HomeAssistant) -> None:
     """Test that IPv6-only devices can be discovered."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = [ip_address("fd11:1111:1111:0:1234:1234:1234:1234").packed]
+    service_info.addresses = ["fd11:1111:1111:0:1234:1234:1234:1234"]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "fd11:1111:1111:0:1234:1234:1234:1234"
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,5 +1,6 @@
 """Test Zeroconf component setup process."""
 
+from ipaddress import ip_address
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
@@ -935,7 +936,10 @@ async def test_info_from_service_with_link_local_address_first(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["169.254.12.3", "192.168.66.12"]
+    service_info.addresses = [
+        ip_address("169.254.12.3").packed,
+        ip_address("192.168.66.12").packed,
+    ]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["169.254.12.3", "192.168.66.12"]
@@ -947,7 +951,10 @@ async def test_info_from_service_with_unspecified_address_first(
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["0.0.0.0", "192.168.66.12"]
+    service_info.addresses = [
+        ip_address("0.0.0.0").packed,
+        ip_address("192.168.66.12").packed,
+    ]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["0.0.0.0", "192.168.66.12"]
@@ -959,7 +966,7 @@ async def test_info_from_service_with_unspecified_address_only(
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["0.0.0.0"]
+    service_info.addresses = [ip_address("0.0.0.0").packed]
     info = zeroconf.info_from_service(service_info)
     assert info is None
 
@@ -970,7 +977,10 @@ async def test_info_from_service_with_link_local_address_second(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["192.168.66.12", "169.254.12.3"]
+    service_info.addresses = [
+        ip_address("192.168.66.12").packed,
+        ip_address("169.254.12.3").packed,
+    ]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
     assert info.addresses == ["192.168.66.12", "169.254.12.3"]
@@ -982,7 +992,7 @@ async def test_info_from_service_with_link_local_address_only(
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["169.254.12.3"]
+    service_info.addresses = [ip_address("169.254.12.3").packed]
     info = zeroconf.info_from_service(service_info)
     assert info is None
 
@@ -991,7 +1001,10 @@ async def test_info_from_service_prefers_ipv4(hass: HomeAssistant) -> None:
     """Test that ipv4 addresses are preferred."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["2001:db8:3333:4444:5555:6666:7777:8888", "192.168.66.12"]
+    service_info.addresses = [
+        ip_address("2001:db8:3333:4444:5555:6666:7777:8888").packed,
+        ip_address("192.168.66.12").packed,
+    ]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "192.168.66.12"
 
@@ -1000,7 +1013,7 @@ async def test_info_from_service_can_return_ipv6(hass: HomeAssistant) -> None:
     """Test that IPv6-only devices can be discovered."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
-    service_info.addresses = ["fd11:1111:1111:0:1234:1234:1234:1234"]
+    service_info.addresses = [ip_address("fd11:1111:1111:0:1234:1234:1234:1234").packed]
     info = zeroconf.info_from_service(service_info)
     assert info.host == "fd11:1111:1111:0:1234:1234:1234:1234"
 

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -21,6 +21,14 @@ from homeassistant.setup import async_setup_component
 
 from tests.typing import WebSocketGenerator
 
+PROPERTIES = {
+    "md": "HASS Bridge W9DN",
+    "pv": "1.0",
+    "id": "11:8E:DB:5B:5C:C5",
+    "c#": "12",
+    "s#": "1",
+}
+
 
 async def test_subscribe_discovery(
     hass: HomeAssistant,
@@ -62,7 +70,7 @@ async def test_subscribe_discovery(
                 socket.inet_aton("127.0.0.1"),
             ),
             DNSText(
-                "foo2.local.",
+                "foo2._fakeservice._tcp.local.",
                 const._TYPE_TXT,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
@@ -87,7 +95,7 @@ async def test_subscribe_discovery(
                 "foo3.local.",
             ),
             DNSText(
-                "foo3.local.",
+                "foo3._fakeservice._tcp.local.",
                 const._TYPE_TXT,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
@@ -122,7 +130,7 @@ async def test_subscribe_discovery(
                 "ip_addresses": ["127.0.0.1"],
                 "name": "foo2._fakeservice._tcp.local.",
                 "port": 1234,
-                "properties": {},
+                "properties": PROPERTIES,
                 "type": "_fakeservice._tcp.local.",
             }
         ]
@@ -152,7 +160,7 @@ async def test_subscribe_discovery(
                 "ip_addresses": ["127.0.0.1"],
                 "name": "foo3._fakeservice._tcp.local.",
                 "port": 1234,
-                "properties": {},
+                "properties": PROPERTIES,
                 "type": "_fakeservice._tcp.local.",
             }
         ]
@@ -166,7 +174,7 @@ async def test_subscribe_discovery(
                 "ip_addresses": ["127.0.0.1"],
                 "name": "foo3._fakeservice._tcp.local.",
                 "port": 1234,
-                "properties": {},
+                "properties": PROPERTIES,
                 "type": "_fakeservice._tcp.local.",
             }
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps zeroconf from 0.150.0 to 0.151.1.

0.150.3 fixes a long standing regression from 0.80.0 where a TXT record was supposed to be required before a service is considered complete but was not; the websocket test relied on that and is updated to put the TXT record on the service name. Devices that never publish a TXT record will no longer be discovered, so we should watch for reports after this lands.

Release notes: https://github.com/python-zeroconf/python-zeroconf/releases/tag/0.151.1
Changes: https://github.com/python-zeroconf/python-zeroconf/compare/0.150.0...0.151.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
