### PR TITLE
Add MQTT token pairing to Victron GX

### DIFF
--- a/homeassistant/components/victron_gx/config_flow.py
+++ b/homeassistant/components/victron_gx/config_flow.py
@@ -5,7 +5,14 @@ import logging
 from typing import Any, override
 from urllib.parse import urlparse
 
-from victron_mqtt import AuthenticationError, CannotConnectError, Hub as VictronVenusHub
+from victron_mqtt import (
+    AuthenticationError,
+    CannotConnectError,
+    Hub as VictronVenusHub,
+    PairingError,
+    PairingToken,
+    request_pairing_token,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IGNORE, ConfigFlow, ConfigFlowResult
@@ -25,6 +32,7 @@ from .const import CONF_INSTALLATION_ID, CONF_SERIAL, DOMAIN
 
 DEFAULT_HOST = "venus.local"
 DEFAULT_PORT = 1883
+DEFAULT_SSL_PORT = 8883
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,11 +54,10 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 STEP_SSDP_AUTH_DATA_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_USERNAME, default=""): selector.TextSelector(),
         vol.Optional(CONF_PASSWORD, default=""): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
-        vol.Optional(CONF_SSL, default=False): selector.BooleanSelector(),
+        vol.Optional(CONF_SSL, default=True): selector.BooleanSelector(),
     }
 )
 
@@ -110,6 +117,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
         self.installation_id: str | None = None
         self.friendly_name: str | None = None
         self.model_name: str | None = None
+        self.mqtt_token_pairing = False
 
     @override
     async def async_step_user(
@@ -177,6 +185,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
         self.installation_id = discovery_info.upnp["X_VrmPortalId"]
         self.model_name = discovery_info.upnp["modelName"]
         self.friendly_name = discovery_info.upnp["friendlyName"]
+        self.mqtt_token_pairing = discovery_info.upnp.get("X_MqttTokenPairing") == "1"
 
         await self.async_set_unique_id(self.installation_id)
 
@@ -207,25 +216,6 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
             "name": self.friendly_name or self.hostname
         }
 
-        # Verify connectivity before showing the confirmation dialog
-        try:
-            ssdp_conf = {
-                CONF_HOST: self.hostname,
-                CONF_PORT: DEFAULT_PORT,
-                CONF_SERIAL: self.serial,
-                CONF_INSTALLATION_ID: self.installation_id,
-            }
-            await validate_input(ssdp_conf)
-        except AuthenticationError:
-            return await self.async_step_ssdp_auth()
-        except CannotConnectError:
-            return self.async_abort(reason="cannot_connect")
-        except Exception:
-            _LOGGER.exception(
-                "Unexpected error validating SSDP discovery for Victron GX"
-            )
-            return self.async_abort(reason="unknown")
-
         return await self.async_step_ssdp_confirm()
 
     async def async_step_ssdp_confirm(
@@ -236,25 +226,112 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self.installation_id is not None
 
         if user_input is not None:
+            data: dict[str, Any] = {
+                CONF_HOST: self.hostname,
+                CONF_PORT: DEFAULT_SSL_PORT,
+                CONF_SERIAL: self.serial,
+                CONF_INSTALLATION_ID: self.installation_id,
+                CONF_MODEL: self.model_name,
+                CONF_SSL: True,
+            }
+            try:
+                await validate_input(data)
+            except AuthenticationError:
+                if self.mqtt_token_pairing:
+                    return await self.async_step_ssdp_token_pairing()
+                return await self.async_step_ssdp_auth()
+            except CannotConnectError:
+                data[CONF_PORT] = DEFAULT_PORT
+                data[CONF_SSL] = False
+                try:
+                    await validate_input(data)
+                except AuthenticationError:
+                    if self.mqtt_token_pairing:
+                        return await self.async_step_ssdp_token_pairing()
+                    return await self.async_step_ssdp_auth()
+                except CannotConnectError:
+                    if self.mqtt_token_pairing:
+                        return await self.async_step_ssdp_token_pairing()
+                    return self.async_abort(reason="cannot_connect")
+                except Exception:
+                    _LOGGER.exception(
+                        "Unexpected error validating SSDP discovery for Victron GX"
+                    )
+                    return self.async_abort(reason="unknown")
+            except Exception:
+                _LOGGER.exception(
+                    "Unexpected error validating SSDP discovery for Victron GX"
+                )
+                return self.async_abort(reason="unknown")
+
             return self.async_create_entry(
                 title=ENTRY_TITLE_FORMAT.format(
                     installation_id=self.installation_id,
                     host=self.hostname,
-                    port=DEFAULT_PORT,
+                    port=data[CONF_PORT],
                 ),
-                data={
-                    CONF_HOST: self.hostname,
-                    CONF_PORT: DEFAULT_PORT,
-                    CONF_SERIAL: self.serial,
-                    CONF_INSTALLATION_ID: self.installation_id,
-                    CONF_MODEL: self.model_name,
-                },
+                data=data,
             )
 
         self._set_confirm_only()
         return self.async_show_form(
             step_id="ssdp_confirm",
             description_placeholders={"name": self.friendly_name or self.hostname},
+        )
+
+    async def async_step_ssdp_token_pairing(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle automatic token pairing with the GX device."""
+        assert self.hostname is not None
+        assert self.installation_id is not None
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                credentials: PairingToken = await request_pairing_token(
+                    self.hostname, self.installation_id
+                )
+            except PairingError:
+                errors["base"] = "pairing_failed"
+            except Exception:
+                _LOGGER.exception("Failed to connect to GX device for token pairing")
+                errors["base"] = "cannot_connect"
+            else:
+                data: dict[str, Any] = {
+                    CONF_HOST: self.hostname,
+                    CONF_PORT: DEFAULT_SSL_PORT,
+                    CONF_SERIAL: self.serial,
+                    CONF_INSTALLATION_ID: self.installation_id,
+                    CONF_MODEL: self.model_name,
+                    CONF_USERNAME: credentials.token_name,
+                    CONF_PASSWORD: credentials.password,
+                    CONF_SSL: True,
+                }
+                try:
+                    await validate_input(data)
+                except AuthenticationError:
+                    errors["base"] = "invalid_auth"
+                except CannotConnectError:
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected error validating paired credentials")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_create_entry(
+                        title=ENTRY_TITLE_FORMAT.format(
+                            installation_id=self.installation_id,
+                            host=self.hostname,
+                            port=DEFAULT_SSL_PORT,
+                        ),
+                        data=data,
+                    )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="ssdp_token_pairing",
+            errors=errors,
+            description_placeholders={CONF_HOST: self.hostname},
         )
 
     async def async_step_ssdp_auth(
@@ -271,14 +348,16 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
                 "SSDP auth user input received: %s",
                 async_redact_data(user_input, TO_REDACT),
             )
+            use_ssl = user_input.get(CONF_SSL, True)
             data: dict[str, Any] = {
                 CONF_HOST: self.hostname,
-                CONF_PORT: DEFAULT_PORT,
+                CONF_PORT: DEFAULT_SSL_PORT if use_ssl else DEFAULT_PORT,
                 CONF_SERIAL: self.serial,
                 CONF_INSTALLATION_ID: self.installation_id,
-                CONF_USERNAME: user_input.get(CONF_USERNAME),
-                CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-                CONF_SSL: user_input.get(CONF_SSL),
+                CONF_MODEL: self.model_name,
+                CONF_USERNAME: "remoteconsole",
+                CONF_PASSWORD: user_input.get(CONF_PASSWORD) or None,
+                CONF_SSL: use_ssl,
             }
 
             try:
@@ -298,7 +377,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
                     title=ENTRY_TITLE_FORMAT.format(
                         installation_id=self.installation_id,
                         host=self.hostname,
-                        port=DEFAULT_PORT,
+                        port=data[CONF_PORT],
                     ),
                     data=data,
                 )

--- a/homeassistant/components/victron_gx/config_flow.py
+++ b/homeassistant/components/victron_gx/config_flow.py
@@ -15,7 +15,12 @@ from victron_mqtt import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IGNORE, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    SOURCE_REAUTH,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_MODEL,
@@ -28,7 +33,7 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.redact import async_redact_data
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import CONF_INSTALLATION_ID, CONF_SERIAL, DOMAIN
+from .const import CONF_INSTALLATION_ID, CONF_MQTT_TOKEN_PAIRING, CONF_SERIAL, DOMAIN
 
 DEFAULT_HOST = "venus.local"
 DEFAULT_PORT = 1883
@@ -57,7 +62,7 @@ STEP_SSDP_AUTH_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_PASSWORD, default=""): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
-        vol.Optional(CONF_SSL, default=True): selector.BooleanSelector(),
+        vol.Optional(CONF_SSL): selector.BooleanSelector(),
     }
 )
 
@@ -118,6 +123,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
         self.friendly_name: str | None = None
         self.model_name: str | None = None
         self.mqtt_token_pairing = False
+        self.ssdp_use_ssl = True
 
     @override
     async def async_step_user(
@@ -243,6 +249,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
             except CannotConnectError:
                 data[CONF_PORT] = DEFAULT_PORT
                 data[CONF_SSL] = False
+                self.ssdp_use_ssl = False
                 try:
                     await validate_input(data)
                 except AuthenticationError:
@@ -304,6 +311,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_SERIAL: self.serial,
                     CONF_INSTALLATION_ID: self.installation_id,
                     CONF_MODEL: self.model_name,
+                    CONF_MQTT_TOKEN_PAIRING: True,
                     CONF_USERNAME: credentials.token_name,
                     CONF_PASSWORD: credentials.password,
                     CONF_SSL: True,
@@ -318,6 +326,10 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
                     _LOGGER.exception("Unexpected error validating paired credentials")
                     errors["base"] = "unknown"
                 else:
+                    if self.source == SOURCE_REAUTH:
+                        return self.async_update_reload_and_abort(
+                            self._get_reauth_entry(), data_updates=data
+                        )
                     return self.async_create_entry(
                         title=ENTRY_TITLE_FORMAT.format(
                             installation_id=self.installation_id,
@@ -348,7 +360,7 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
                 "SSDP auth user input received: %s",
                 async_redact_data(user_input, TO_REDACT),
             )
-            use_ssl = user_input.get(CONF_SSL, True)
+            use_ssl = user_input.get(CONF_SSL, self.ssdp_use_ssl)
             data: dict[str, Any] = {
                 CONF_HOST: self.hostname,
                 CONF_PORT: DEFAULT_SSL_PORT if use_ssl else DEFAULT_PORT,
@@ -385,7 +397,8 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="ssdp_auth",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_SSDP_AUTH_DATA_SCHEMA, user_input
+                STEP_SSDP_AUTH_DATA_SCHEMA,
+                user_input or {CONF_SSL: self.ssdp_use_ssl},
             ),
             errors=errors,
             description_placeholders={CONF_HOST: self.hostname},
@@ -447,6 +460,13 @@ class VictronGXConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, _: Mapping[str, Any]) -> ConfigFlowResult:
         """Handle reauthentication."""
+        reauth_entry = self._get_reauth_entry()
+        if reauth_entry.data.get(CONF_MQTT_TOKEN_PAIRING):
+            self.hostname = reauth_entry.data[CONF_HOST]
+            self.serial = reauth_entry.data.get(CONF_SERIAL)
+            self.installation_id = reauth_entry.data[CONF_INSTALLATION_ID]
+            self.model_name = reauth_entry.data.get(CONF_MODEL)
+            return await self.async_step_ssdp_token_pairing()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(

--- a/homeassistant/components/victron_gx/const.py
+++ b/homeassistant/components/victron_gx/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "victron_gx"
 
 CONF_INSTALLATION_ID = "installation_id"
+CONF_MQTT_TOKEN_PAIRING = "mqtt_token_pairing"
 CONF_SERIAL = "serial"
 
 # Binary sensor enum ids must be "on" for on and "off" for off.

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -12,6 +12,10 @@
     {
       "X_MqttOnLan": "1",
       "manufacturer": "Victron Energy"
+    },
+    {
+      "X_MqttTokenPairing": "1",
+      "manufacturer": "Victron Energy"
     }
   ]
 }

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -118,6 +118,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "pairing_failed": "Token pairing failed. Ensure pairing mode is active on the GX device and try again.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
@@ -153,20 +154,22 @@
       },
       "ssdp_auth": {
         "data": {
-          "password": "[%key:common::config_flow::data::password%]",
-          "ssl": "[%key:common::config_flow::data::ssl%]",
-          "username": "[%key:common::config_flow::data::username%]"
+          "password": "GX password",
+          "ssl": "[%key:common::config_flow::data::ssl%]"
         },
         "data_description": {
           "password": "[%key:component::victron_gx::config::step::user::data_description::password%]",
-          "ssl": "[%key:component::victron_gx::config::step::user::data_description::ssl%]",
-          "username": "[%key:component::victron_gx::config::step::user::data_description::username%]"
+          "ssl": "[%key:component::victron_gx::config::step::user::data_description::ssl%]"
         },
-        "description": "Authentication is required to connect to {host}.",
+        "description": "Enter the GX password for the GX device at {host}.",
         "title": "Authenticate Victron GX"
       },
       "ssdp_confirm": {
         "description": "Do you want to set up the Victron GX device {name}?"
+      },
+      "ssdp_token_pairing": {
+        "description": "Enable pairing mode on the GX device before submitting:\n\n- Via the GX user interface: **Settings** > **Integrations** > **MQTT Devices** > **Pairing mode**\n- On GX devices without a built-in screen: Quickly double-press the built-in button\n\nPairing mode is active for 120 seconds.",
+        "title": "Pair with GX device"
       },
       "user": {
         "data": {

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -389,6 +389,10 @@ SSDP = {
             "X_MqttOnLan": "1",
             "manufacturer": "Victron Energy",
         },
+        {
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
     ],
     "webostv": [
         {

--- a/tests/components/victron_gx/test_config_flow.py
+++ b/tests/components/victron_gx/test_config_flow.py
@@ -3,9 +3,17 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from victron_mqtt import AuthenticationError, CannotConnectError
+from victron_mqtt import (
+    AuthenticationError,
+    CannotConnectError,
+    PairingError,
+    PairingToken,
+)
 
-from homeassistant.components.victron_gx.config_flow import DEFAULT_PORT
+from homeassistant.components.victron_gx.config_flow import (
+    DEFAULT_PORT,
+    DEFAULT_SSL_PORT,
+)
 from homeassistant.components.victron_gx.const import (
     CONF_INSTALLATION_ID,
     CONF_SERIAL,
@@ -45,6 +53,25 @@ def assert_entry_title(
 ) -> None:
     """Assert the config entry title format."""
     assert result["title"] == f"Victron OS {installation_id} ({host}:{port})"
+
+
+def ssdp_discovery_info(token_pairing: str = "0") -> SsdpServiceInfo:
+    """Return Victron GX SSDP discovery data."""
+    upnp = {
+        "serialNumber": MOCK_SERIAL,
+        "X_VrmPortalId": MOCK_INSTALLATION_ID,
+        "modelName": MOCK_MODEL,
+        "friendlyName": MOCK_FRIENDLY_NAME,
+        "X_MqttOnLan": "1",
+        "X_MqttTokenPairing": token_pairing,
+        "manufacturer": "Victron Energy",
+    }
+    return SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp=upnp,
+    )
 
 
 @pytest.fixture
@@ -234,13 +261,14 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == MOCK_INSTALLATION_ID
-    assert_entry_title(result)
+    assert_entry_title(result, port=DEFAULT_SSL_PORT)
     assert result["data"] == {
         CONF_HOST: MOCK_HOST,
-        CONF_PORT: DEFAULT_PORT,
+        CONF_PORT: DEFAULT_SSL_PORT,
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
         CONF_MODEL: MOCK_MODEL,
+        CONF_SSL: True,
     }
 
 
@@ -278,6 +306,13 @@ async def test_ssdp_discovery_error(
         DOMAIN,
         context={"source": SOURCE_SSDP},
         data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -343,6 +378,13 @@ async def test_ssdp_flow_auth_required(
     )
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "ssdp_auth"
 
     # Test providing credentials
@@ -352,22 +394,22 @@ async def test_ssdp_flow_auth_required(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: "test-username",
             CONF_PASSWORD: "test-password",
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == MOCK_INSTALLATION_ID
-    assert_entry_title(result)
+    assert_entry_title(result, port=DEFAULT_SSL_PORT)
     assert result["data"] == {
         CONF_HOST: MOCK_HOST,
-        CONF_PORT: DEFAULT_PORT,
+        CONF_PORT: DEFAULT_SSL_PORT,
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
-        CONF_USERNAME: "test-username",
+        CONF_MODEL: MOCK_MODEL,
+        CONF_USERNAME: "remoteconsole",
         CONF_PASSWORD: "test-password",
-        CONF_SSL: False,
+        CONF_SSL: True,
     }
 
 
@@ -400,6 +442,13 @@ async def test_ssdp_auth_invalid_credentials(
     )
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "ssdp_auth"
 
     # Test with wrong credentials
@@ -410,8 +459,8 @@ async def test_ssdp_auth_invalid_credentials(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: "wrong-user",
             CONF_PASSWORD: "wrong-password",
+            CONF_SSL: False,
         },
     )
 
@@ -425,8 +474,8 @@ async def test_ssdp_auth_invalid_credentials(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: "test-user",
             CONF_PASSWORD: "test-password",
+            CONF_SSL: False,
         },
     )
 
@@ -438,7 +487,8 @@ async def test_ssdp_auth_invalid_credentials(
         CONF_PORT: DEFAULT_PORT,
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
-        CONF_USERNAME: "test-user",
+        CONF_MODEL: MOCK_MODEL,
+        CONF_USERNAME: "remoteconsole",
         CONF_PASSWORD: "test-password",
         CONF_SSL: False,
     }
@@ -483,6 +533,13 @@ async def test_ssdp_auth_error(
     )
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "ssdp_auth"
 
     mock_victron_hub.return_value.connect.side_effect = exception
@@ -490,8 +547,8 @@ async def test_ssdp_auth_error(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: "test-user",
             CONF_PASSWORD: "test-password",
+            CONF_SSL: False,
         },
     )
 
@@ -923,3 +980,238 @@ async def test_ssdp_flow_abort_on_invalid_hostname(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_ssdp_flow_falls_back_to_plain_mqtt(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP setup falls back to plain MQTT when TLS is unavailable."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        CannotConnectError("TLS unavailable"),
+        None,
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info(),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert_entry_title(result)
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"][CONF_SSL] is False
+
+
+@pytest.mark.parametrize(
+    ("second_exception", "result_type", "result_key", "result_value"),
+    [
+        pytest.param(
+            AuthenticationError("Authentication required"),
+            FlowResultType.FORM,
+            "step_id",
+            "ssdp_auth",
+            id="authentication-required",
+        ),
+        pytest.param(
+            Exception("Unexpected error"),
+            FlowResultType.ABORT,
+            "reason",
+            "unknown",
+            id="unexpected-error",
+        ),
+    ],
+)
+async def test_ssdp_flow_tls_fallback_error(
+    hass: HomeAssistant,
+    mock_victron_hub: MagicMock,
+    second_exception: Exception,
+    result_type: FlowResultType,
+    result_key: str,
+    result_value: str,
+) -> None:
+    """Test errors while falling back from TLS during SSDP setup."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        CannotConnectError("TLS unavailable"),
+        second_exception,
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info(),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is result_type
+    assert result[result_key] == result_value
+
+
+@pytest.mark.parametrize(
+    "initial_exceptions",
+    [
+        pytest.param(
+            [AuthenticationError("Authentication required"), None],
+            id="authentication-required",
+        ),
+        pytest.param(
+            [
+                CannotConnectError("TLS unavailable"),
+                AuthenticationError("Authentication required"),
+                None,
+            ],
+            id="plain-mqtt-authentication-required",
+        ),
+        pytest.param(
+            [
+                CannotConnectError("TLS unavailable"),
+                CannotConnectError("Plain MQTT unavailable"),
+                None,
+            ],
+            id="mqtt-unavailable",
+        ),
+    ],
+)
+async def test_ssdp_token_pairing_success(
+    hass: HomeAssistant,
+    mock_victron_hub: MagicMock,
+    initial_exceptions: list[Exception | None],
+) -> None:
+    """Test SSDP token pairing creates an entry with generated credentials."""
+    mock_victron_hub.return_value.connect.side_effect = initial_exceptions
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info("1"),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    with patch(
+        "homeassistant.components.victron_gx.config_flow.request_pairing_token",
+        return_value=PairingToken(
+            token_name="token/homeassistant/homeassistant_abc123",
+            password="generated-password",
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert_entry_title(result, port=DEFAULT_SSL_PORT)
+    assert result["data"] == {
+        CONF_HOST: MOCK_HOST,
+        CONF_PORT: DEFAULT_SSL_PORT,
+        CONF_SERIAL: MOCK_SERIAL,
+        CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
+        CONF_MODEL: MOCK_MODEL,
+        CONF_USERNAME: "token/homeassistant/homeassistant_abc123",
+        CONF_PASSWORD: "generated-password",
+        CONF_SSL: True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        pytest.param(
+            PairingError("Pairing mode inactive"),
+            "pairing_failed",
+            id="pairing-rejected",
+        ),
+        pytest.param(
+            ConnectionError("Connection refused"),
+            "cannot_connect",
+            id="connection-error",
+        ),
+    ],
+)
+async def test_ssdp_token_pairing_request_error(
+    hass: HomeAssistant,
+    mock_victron_hub: MagicMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test errors while requesting token pairing credentials."""
+    mock_victron_hub.return_value.connect.side_effect = AuthenticationError(
+        "Authentication required"
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info("1"),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    with patch(
+        "homeassistant.components.victron_gx.config_flow.request_pairing_token",
+        side_effect=exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+    assert result["errors"] == {"base": error}
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        pytest.param(
+            AuthenticationError("Invalid credentials"),
+            "invalid_auth",
+            id="invalid-auth",
+        ),
+        pytest.param(
+            CannotConnectError("Cannot connect"),
+            "cannot_connect",
+            id="cannot-connect",
+        ),
+        pytest.param(Exception("Unexpected error"), "unknown", id="unknown"),
+    ],
+)
+async def test_ssdp_token_pairing_validation_error(
+    hass: HomeAssistant,
+    mock_victron_hub: MagicMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test errors while validating generated pairing credentials."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        AuthenticationError("Authentication required"),
+        exception,
+    ]
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info("1"),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    with patch(
+        "homeassistant.components.victron_gx.config_flow.request_pairing_token",
+        return_value=PairingToken("token/homeassistant/test", "password"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+    assert result["errors"] == {"base": error}

--- a/tests/components/victron_gx/test_config_flow.py
+++ b/tests/components/victron_gx/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.victron_gx.config_flow import (
 )
 from homeassistant.components.victron_gx.const import (
     CONF_INSTALLATION_ID,
+    CONF_MQTT_TOKEN_PAIRING,
     CONF_SERIAL,
     DOMAIN,
 )
@@ -698,6 +699,48 @@ async def test_reauth_flow_clears_credentials(
     assert mock_config_entry.data[CONF_SSL] is False
 
 
+async def test_reauth_flow_renews_pairing_token(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test reauthentication renews generated pairing credentials."""
+    token_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_INSTALLATION_ID,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PORT: DEFAULT_SSL_PORT,
+            CONF_USERNAME: "token/homeassistant/old",
+            CONF_PASSWORD: "old-password",
+            CONF_SSL: True,
+            CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
+            CONF_MQTT_TOKEN_PAIRING: True,
+            CONF_MODEL: MOCK_MODEL,
+            CONF_SERIAL: MOCK_SERIAL,
+        },
+        title=(f"Victron OS {MOCK_INSTALLATION_ID} ({MOCK_HOST}:{DEFAULT_SSL_PORT})"),
+    )
+    token_entry.add_to_hass(hass)
+
+    result = await token_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    with patch(
+        "homeassistant.components.victron_gx.config_flow.request_pairing_token",
+        return_value=PairingToken("token/homeassistant/new", "new-generated-password"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert token_entry.data[CONF_USERNAME] == "token/homeassistant/new"
+    assert token_entry.data[CONF_PASSWORD] == "new-generated-password"
+    assert token_entry.data[CONF_MQTT_TOKEN_PAIRING] is True
+    mock_victron_hub.return_value.connect.assert_awaited_once()
+
+
 @pytest.mark.parametrize(
     ("exception", "error"),
     [
@@ -1052,6 +1095,37 @@ async def test_ssdp_flow_tls_fallback_error(
     assert result[result_key] == result_value
 
 
+async def test_ssdp_flow_preserves_plain_mqtt_for_authentication(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP authentication preserves the discovered plaintext transport."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        CannotConnectError("TLS unavailable"),
+        AuthenticationError("Authentication required"),
+        None,
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_discovery_info(),
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_auth"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: "test-password"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert_entry_title(result)
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"][CONF_SSL] is False
+
+
 @pytest.mark.parametrize(
     "initial_exceptions",
     [
@@ -1115,6 +1189,7 @@ async def test_ssdp_token_pairing_success(
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
         CONF_MODEL: MOCK_MODEL,
+        CONF_MQTT_TOKEN_PAIRING: True,
         CONF_USERNAME: "token/homeassistant/homeassistant_abc123",
         CONF_PASSWORD: "generated-password",
         CONF_SSL: True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add MQTT token pairing for Victron GX devices that advertise `X_MqttTokenPairing=1` over SSDP. Discovered devices now try TLS MQTT on port 8883 first, fall back to plaintext MQTT on port 1883 for older configurations, and guide users through token pairing or password authentication when credentials are required.

Token pairing requests credentials from the GX device and validates them over TLS before creating the config entry. Manual authentication uses the GX `remoteconsole` username and asks only for the device password. This uses the pairing API already available in the existing `victron-mqtt==2026.8.4` requirement, so this PR does not include a dependency upgrade.

### Why validation happens on confirmation

SSDP already provides the stable installation ID and device metadata needed to identify and de-duplicate a Victron GX device. The active MQTT connection attempts are therefore deferred until the user confirms setup, keeping passive discovery lightweight and avoiding TLS and plaintext probes for every advertised device. The connection is still validated before a config entry is created, satisfying Home Assistant's test-before-configure requirement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47709
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
