### PR TITLE
Improve Speedtest.net server selection

### DIFF
--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -1,8 +1,10 @@
 """Coordinator for speedtestdotnet."""
 
+from collections.abc import Iterable
 from datetime import timedelta
 import logging
 from typing import Any, cast, override
+from xml.etree import ElementTree
 
 import speedtest
 
@@ -14,7 +16,157 @@ from .const import CONF_SERVER_ID, DEFAULT_SCAN_INTERVAL, DEFAULT_SERVER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+DYNAMIC_SERVERS_URL = "://www.speedtest.net/speedtest-servers.php"
+
 type SpeedTestConfigEntry = ConfigEntry[SpeedTestDataCoordinator]
+type SpeedTestServers = dict[float, list[dict[str, Any]]]
+
+
+def _normalize_server_ids(server_ids: Iterable[Any] | None) -> set[int]:
+    """Normalize server IDs to integers."""
+    if server_ids is None:
+        return set()
+
+    normalized_server_ids = set()
+    for server_id in server_ids:
+        try:
+            normalized_server_ids.add(int(server_id))
+        except (TypeError, ValueError) as err:
+            raise speedtest.InvalidServerIDType(
+                f"{server_id} is an invalid server type, must be int"
+            ) from err
+
+    return normalized_server_ids
+
+
+def _read_response(response: Any) -> bytes:
+    """Read an HTTP response from speedtest-cli."""
+    response_chunks: list[bytes] = []
+    stream: Any | None = None
+    try:
+        stream = speedtest.get_response_stream(response)
+        while True:
+            try:
+                chunk = stream.read(1024)
+            except (OSError, EOFError) as err:
+                raise speedtest.ServersRetrievalError(err) from err
+            if len(chunk) == 0:
+                break
+            response_chunks.append(chunk)
+    finally:
+        if stream is not None:
+            stream.close()
+        response.close()
+
+    return b"".join(response_chunks)
+
+
+def _get_dynamic_servers(
+    api: speedtest.Speedtest, servers: Iterable[Any] | None = None
+) -> SpeedTestServers:
+    """Retrieve servers from the dynamic speedtest.net server endpoint."""
+    selected_server_ids = _normalize_server_ids(servers)
+
+    headers = {}
+    if speedtest.gzip:
+        headers["Accept-Encoding"] = "gzip"
+
+    request = speedtest.build_request(
+        f"{DYNAMIC_SERVERS_URL}?threads={api.config['threads']['download']}",
+        headers=headers,
+        secure=getattr(api, "_secure", False),
+    )
+    response, error = speedtest.catch_request(
+        request, opener=getattr(api, "_opener", None)
+    )
+    if error:
+        raise speedtest.ServersRetrievalError(error)
+    if response is None:
+        raise speedtest.ServersRetrievalError()
+
+    servers_xml = _read_response(response)
+    if int(response.code) != 200:
+        raise speedtest.ServersRetrievalError()
+
+    try:
+        root = ElementTree.fromstring(servers_xml)
+    except ElementTree.ParseError as err:
+        raise speedtest.SpeedtestServersError(
+            f"Malformed speedtest.net server list: {err}"
+        ) from err
+
+    ignore_servers = set(api.config.get("ignore_servers", []))
+    dynamic_servers: SpeedTestServers = {}
+    for server in root.iter("server"):
+        attrib = dict(server.attrib)
+        try:
+            server_id = int(attrib["id"])
+        except (KeyError, ValueError):
+            continue
+
+        if selected_server_ids and server_id not in selected_server_ids:
+            continue
+        if server_id in ignore_servers:
+            continue
+
+        try:
+            distance = speedtest.distance(
+                api.lat_lon,
+                (float(attrib["lat"]), float(attrib["lon"])),
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        attrib["d"] = distance
+        dynamic_servers.setdefault(distance, []).append(attrib)
+
+    if selected_server_ids and not dynamic_servers:
+        raise speedtest.NoMatchedServers()
+
+    return dynamic_servers
+
+
+def _merge_servers(
+    servers: SpeedTestServers, servers_to_merge: SpeedTestServers
+) -> None:
+    """Merge additional servers into a speedtest-cli server list."""
+    known_server_ids = {
+        str(server.get("id"))
+        for server_list in servers.values()
+        for server in server_list
+    }
+
+    for distance, server_list in servers_to_merge.items():
+        target_server_list = servers.setdefault(distance, [])
+        for server in server_list:
+            server_id = str(server.get("id"))
+            if server_id in known_server_ids:
+                continue
+            target_server_list.append(server)
+            known_server_ids.add(server_id)
+
+
+def _filter_servers_by_id(
+    servers: SpeedTestServers, server_id: Any
+) -> SpeedTestServers:
+    """Filter a speedtest-cli server list to one server ID."""
+    selected_server_ids = _normalize_server_ids([server_id])
+    matching_servers: SpeedTestServers = {}
+
+    for distance, server_list in servers.items():
+        for server in server_list:
+            try:
+                if int(server["id"]) not in selected_server_ids:
+                    continue
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            matching_servers.setdefault(distance, []).append(server)
+
+    if not matching_servers:
+        raise speedtest.NoMatchedServers()
+
+    return matching_servers
 
 
 class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -42,6 +194,14 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def update_servers(self) -> None:
         """Update list of test servers."""
         test_servers = self.api.get_servers()
+        try:
+            _merge_servers(test_servers, _get_dynamic_servers(self.api))
+        except speedtest.SpeedtestException as err:
+            _LOGGER.debug(
+                "Unable to retrieve dynamic speedtest.net server list: %s", err
+            )
+        self.api.servers = test_servers
+
         test_servers_list = [
             server for servers in test_servers.values() for server in servers
         ]
@@ -61,9 +221,11 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Get the latest data from speedtest.net."""
         self.update_servers()
         self.api.closest.clear()
-        if self.config_entry.options.get(CONF_SERVER_ID):
-            server_id = self.config_entry.options.get(CONF_SERVER_ID)
-            self.api.get_servers(servers=[server_id])
+        if server_id := self.config_entry.options.get(CONF_SERVER_ID):
+            try:
+                self.api.servers = _filter_servers_by_id(self.api.servers, server_id)
+            except speedtest.NoMatchedServers:
+                self.api.servers = _get_dynamic_servers(self.api, servers=[server_id])
 
         best_server = self.api.get_best_server()
         _LOGGER.debug(

--- a/tests/components/speedtestdotnet/conftest.py
+++ b/tests/components/speedtestdotnet/conftest.py
@@ -20,6 +20,12 @@ def mock_setup_entry():
 @pytest.fixture
 def mock_api():
     """Mock entry setup."""
-    with patch("speedtest.Speedtest") as mock_api:
+    with (
+        patch("speedtest.Speedtest") as mock_api,
+        patch(
+            "homeassistant.components.speedtestdotnet.coordinator._get_dynamic_servers",
+            return_value={},
+        ),
+    ):
         mock_api.return_value.get_servers.return_value = MOCK_SERVERS
         yield mock_api

--- a/tests/components/speedtestdotnet/test_init.py
+++ b/tests/components/speedtestdotnet/test_init.py
@@ -1,7 +1,8 @@
 """Tests for SpeedTest integration."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from io import BytesIO
+from unittest.mock import MagicMock, patch, sentinel
 
 import speedtest
 
@@ -12,13 +13,30 @@ from homeassistant.components.speedtestdotnet.const import (
 )
 from homeassistant.components.speedtestdotnet.coordinator import (
     SpeedTestDataCoordinator,
+    _get_dynamic_servers,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
+from . import MOCK_RESULTS, MOCK_SERVERS
+
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+DYNAMIC_SERVER = {
+    "url": "http://server_3:8080/speedtest/upload.php",
+    "lat": "3",
+    "lon": "3",
+    "name": "Server3",
+    "country": "Country3",
+    "cc": "LL3",
+    "sponsor": "Sponsor3",
+    "id": "3",
+    "host": "server3:8080",
+    "d": 0.5,
+}
+DYNAMIC_SERVERS = {0.5: [DYNAMIC_SERVER]}
 
 
 async def test_setup_failed(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -108,3 +126,110 @@ async def test_get_best_server_error(hass: HomeAssistant, mock_api: MagicMock) -
     state = hass.states.get("sensor.speedtest_ping")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+def test_get_dynamic_servers() -> None:
+    """Test retrieving servers from the dynamic endpoint."""
+    api = MagicMock()
+    api.config = {"threads": {"download": 8}, "ignore_servers": [2]}
+    api.lat_lon = (60.0, 24.0)
+    setattr(api, "_opener", sentinel.opener)
+    setattr(api, "_secure", True)
+    response = MagicMock()
+    response.code = 200
+    servers_xml = (
+        b"<settings><servers>"
+        b'<server url="http://server_1:8080/speedtest/upload.php" '
+        b'lat="60.1" lon="24.1" name="Helsinki" '
+        b'country="Finland" cc="FI" sponsor="Sponsor1" '
+        b'id="1" host="server1:8080" />'
+        b'<server url="http://server_2:8080/speedtest/upload.php" '
+        b'lat="60.2" lon="24.2" name="Ignored" '
+        b'country="Finland" cc="FI" sponsor="Sponsor2" '
+        b'id="2" host="server2:8080" />'
+        b'<server url="http://server_3:8080/speedtest/upload.php" '
+        b'lat="broken" lon="24.3" name="Invalid" '
+        b'country="Finland" cc="FI" sponsor="Sponsor3" '
+        b'id="3" host="server3:8080" />'
+        b"</servers></settings>"
+    )
+
+    with (
+        patch(
+            "homeassistant.components.speedtestdotnet.coordinator.speedtest.gzip",
+            object(),
+        ),
+        patch(
+            "homeassistant.components.speedtestdotnet.coordinator.speedtest.build_request",
+            return_value=sentinel.request,
+        ) as mock_build_request,
+        patch(
+            "homeassistant.components.speedtestdotnet.coordinator.speedtest.catch_request",
+            return_value=(response, False),
+        ) as mock_catch_request,
+        patch(
+            "homeassistant.components.speedtestdotnet.coordinator.speedtest.get_response_stream",
+            return_value=BytesIO(servers_xml),
+        ),
+    ):
+        servers = _get_dynamic_servers(api, servers=["1"])
+
+    mock_build_request.assert_called_once_with(
+        "://www.speedtest.net/speedtest-servers.php?threads=8",
+        headers={"Accept-Encoding": "gzip"},
+        secure=True,
+    )
+    mock_catch_request.assert_called_once_with(
+        sentinel.request, opener=sentinel.opener
+    )
+    response.close.assert_called_once()
+    server = next(iter(servers.values()))[0]
+    assert server["id"] == "1"
+    assert server["name"] == "Helsinki"
+    assert isinstance(server["d"], float)
+
+
+def test_update_servers_adds_dynamic_servers(hass: HomeAssistant) -> None:
+    """Test dynamic servers are added to the available server list."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    api = MagicMock()
+    api.get_servers.return_value = {1: [MOCK_SERVERS[1][0]]}
+
+    with patch(
+        "homeassistant.components.speedtestdotnet.coordinator._get_dynamic_servers",
+        return_value=DYNAMIC_SERVERS,
+    ) as mock_get_dynamic_servers:
+        coordinator = SpeedTestDataCoordinator(hass, entry, api)
+        coordinator.update_servers()
+
+    mock_get_dynamic_servers.assert_called_once_with(api)
+    assert "Country1 - Sponsor1 - Server1" in coordinator.servers
+    assert "Country3 - Sponsor3 - Server3" in coordinator.servers
+
+
+def test_update_data_falls_back_to_dynamic_selected_server(
+    hass: HomeAssistant,
+) -> None:
+    """Test selected servers can be retrieved from the dynamic endpoint."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_SERVER_ID: "3"},
+    )
+    entry.add_to_hass(hass)
+    api = MagicMock()
+    api.closest = []
+    api.get_servers.return_value = {1: [MOCK_SERVERS[1][0]]}
+    api.get_best_server.return_value = DYNAMIC_SERVER
+    api.results.dict.return_value = MOCK_RESULTS
+
+    with patch(
+        "homeassistant.components.speedtestdotnet.coordinator._get_dynamic_servers",
+        side_effect=[speedtest.ServersRetrievalError(), DYNAMIC_SERVERS],
+    ) as mock_get_dynamic_servers:
+        coordinator = SpeedTestDataCoordinator(hass, entry, api)
+        assert coordinator.update_data() == MOCK_RESULTS
+
+    assert api.servers == DYNAMIC_SERVERS
+    mock_get_dynamic_servers.assert_called_with(api, servers=["3"])
+    api.get_best_server.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
No breaking change.

## Proposed change
The Speedtest.net integration currently relies on `speedtest-cli`'s default server retrieval. `speedtest-cli` stops after the first successful server endpoint response, which can be the static server list. In some regions the static list can contain servers from the wrong country, while `speedtest-servers.php` returns the expected nearby servers.

This makes auto-detect choose a poor server and also leaves the options flow unable to show the correct manual choices.

This PR supplements the existing server list with the dynamic `speedtest-servers.php` endpoint, deduplicates servers by ID, and filters selected servers from the merged list before falling back to a targeted dynamic lookup.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #179173
- This PR is related to issue: #115775
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Testing
Added tests covering dynamic server parsing, merged server options, and selected server fallback. Local tests were not run in this GitHub API based environment.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
