### PR TITLE
Refresh the Alexa to-do list after writing to it

### DIFF
--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -308,6 +308,17 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
                     todo_list.id
                 ] = await self.api.get_todo_list_items(todo_list.id)
 
+    async def refresh_todo_list_items(self, list_id: str) -> None:
+        """Refresh the cached items of a single to-do list.
+
+        Cached items are otherwise only filled by the initial sync and by
+        pushed events, so a write of our own needs a pull to become visible.
+        """
+        async with alexa_api_call(self):
+            self._todo_list_items[list_id] = await self.api.get_todo_list_items(list_id)
+
+        self.async_update_listeners()
+
     async def todo_event_handler(self, list_event: AmazonListEvent) -> None:
         """Handle changes on To-Do lists."""
         if list_event.type == AmazonListEventType.DELETED:

--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -1,5 +1,6 @@
 """Support for Alexa Devices."""
 
+from asyncio import Lock
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -167,6 +168,7 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
         }
 
         self._todo_list_items: dict[str, dict[str, AmazonListItem]] = {}
+        self._todo_refresh_lock = Lock()
         self.api.on_todo_event.append(self.todo_event_handler)
         self.api.on_todo_event.freeze()
 
@@ -313,9 +315,15 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
 
         Cached items are otherwise only filled by the initial sync and by
         pushed events, so a write of our own needs a pull to become visible.
+
+        The pulls are serialized, as an older answer landing last would leave
+        the cache behind with nothing to repair it.
         """
-        async with alexa_api_call(self):
+        async with self._todo_refresh_lock, alexa_api_call(self):
             self._todo_list_items[list_id] = await self.api.get_todo_list_items(list_id)
+
+            # Reading the list back proves the API answers again
+            self.last_update_success = True
 
         self.async_update_listeners()
 

--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -328,22 +328,27 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
         self.async_update_listeners()
 
     async def todo_event_handler(self, list_event: AmazonListEvent) -> None:
-        """Handle changes on To-Do lists."""
-        if list_event.type == AmazonListEventType.DELETED:
-            self._todo_list_items.get(list_event.list_id, {}).pop(
-                list_event.item_id, None
-            )
-        elif (
-            list_event.type
-            in (AmazonListEventType.UPDATED, AmazonListEventType.CREATED)
-        ) and list_event.items:
-            if list_event.list_id not in self._todo_list_items:
-                # List was newly created after initial sync
-                self._todo_list_items[list_event.list_id] = {}
+        """Handle changes on To-Do lists.
 
-            self._todo_list_items[list_event.list_id][list_event.item_id] = (
-                list_event.items
-            )
+        Takes the refresh lock, so an event arriving while a list is being
+        read back is applied on top of that read instead of under it.
+        """
+        async with self._todo_refresh_lock:
+            if list_event.type == AmazonListEventType.DELETED:
+                self._todo_list_items.get(list_event.list_id, {}).pop(
+                    list_event.item_id, None
+                )
+            elif (
+                list_event.type
+                in (AmazonListEventType.UPDATED, AmazonListEventType.CREATED)
+            ) and list_event.items:
+                if list_event.list_id not in self._todo_list_items:
+                    # List was newly created after initial sync
+                    self._todo_list_items[list_event.list_id] = {}
+
+                self._todo_list_items[list_event.list_id][list_event.item_id] = (
+                    list_event.items
+                )
 
         self.async_update_listeners()
 

--- a/homeassistant/components/alexa_devices/todo.py
+++ b/homeassistant/components/alexa_devices/todo.py
@@ -135,27 +135,29 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
 
         list_items_lookup = self.coordinator.todo_list_items[self._list.id]
 
-        for uid in uids:
-            existing_item = list_items_lookup[uid]
+        try:
+            for uid in uids:
+                existing_item = list_items_lookup[uid]
 
-            LOGGER.debug(
-                "Deleting item %s (ID: %s) with version %s",
-                existing_item.name,
-                uid,
-                existing_item.version,
-            )
-            async with alexa_api_call(self.coordinator):
-                await self.coordinator.api.delete_todo_list_item(
-                    self._list.id, uid, existing_item.version
+                LOGGER.debug(
+                    "Deleting item %s (ID: %s) with version %s",
+                    existing_item.name,
+                    uid,
+                    existing_item.version,
                 )
-            LOGGER.debug(
-                "Successfully deleted item %s (ID: %s) with version %s",
-                existing_item.name,
-                uid,
-                existing_item.version,
-            )
-
-        await self.coordinator.refresh_todo_list_items(self._list.id)
+                async with alexa_api_call(self.coordinator):
+                    await self.coordinator.api.delete_todo_list_item(
+                        self._list.id, uid, existing_item.version
+                    )
+                LOGGER.debug(
+                    "Successfully deleted item %s (ID: %s) with version %s",
+                    existing_item.name,
+                    uid,
+                    existing_item.version,
+                )
+        finally:
+            # A later delete can fail after an earlier one went through
+            await self.coordinator.refresh_todo_list_items(self._list.id)
 
     @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
@@ -170,42 +172,53 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
 
         existing_item = list_items_lookup[item.uid]
 
-        if has_completed_changed := (
+        has_completed_changed = (
             existing_item.status == AmazonListItemStatus.COMPLETE
-        ) != (item.status == TodoItemStatus.COMPLETED):
-            # Update the checked status
-            LOGGER.debug(
-                "Updating item %s with checked status %s", item.uid, item.status
-            )
+        ) != (item.status == TodoItemStatus.COMPLETED)
+        has_renamed = existing_item.name != item.summary
 
-            async with alexa_api_call(self.coordinator):
-                await self.coordinator.api.set_todo_list_item_checked_status(
-                    self._list.id,
+        if not has_completed_changed and not has_renamed:
+            return
+
+        try:
+            if has_completed_changed:
+                # Update the checked status
+                LOGGER.debug(
+                    "Updating item %s with checked status %s", item.uid, item.status
+                )
+
+                async with alexa_api_call(self.coordinator):
+                    await self.coordinator.api.set_todo_list_item_checked_status(
+                        self._list.id,
+                        item.uid,
+                        item.status == TodoItemStatus.COMPLETED,
+                        existing_item.version,
+                    )
+
+                LOGGER.debug(
+                    "Successfully updated item %s with checked status %s",
                     item.uid,
-                    item.status == TodoItemStatus.COMPLETED,
-                    existing_item.version,
+                    item.status,
                 )
 
-            LOGGER.debug(
-                "Successfully updated item %s with checked status %s",
-                item.uid,
-                item.status,
-            )
-
-        if has_renamed := (existing_item.name != item.summary):
-            # Name has changed, update it
-            LOGGER.debug("Updating item %s with new name %s", item.uid, item.summary)
-
-            # If both have changed -> Increase item version by 1
-            version = existing_item.version + int(has_completed_changed)
-
-            async with alexa_api_call(self.coordinator):
-                await self.coordinator.api.rename_todo_list_item(
-                    self._list.id, item.uid, item.summary, version
+            if has_renamed:
+                # Name has changed, update it
+                LOGGER.debug(
+                    "Updating item %s with new name %s", item.uid, item.summary
                 )
-            LOGGER.debug(
-                "Successfully updated item %s with new name %s", item.uid, item.summary
-            )
 
-        if has_completed_changed or has_renamed:
+                # If both have changed -> Increase item version by 1
+                version = existing_item.version + int(has_completed_changed)
+
+                async with alexa_api_call(self.coordinator):
+                    await self.coordinator.api.rename_todo_list_item(
+                        self._list.id, item.uid, item.summary, version
+                    )
+                LOGGER.debug(
+                    "Successfully updated item %s with new name %s",
+                    item.uid,
+                    item.summary,
+                )
+        finally:
+            # A rename can fail after the status change went through
             await self.coordinator.refresh_todo_list_items(self._list.id)

--- a/homeassistant/components/alexa_devices/todo.py
+++ b/homeassistant/components/alexa_devices/todo.py
@@ -126,6 +126,8 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
             self._list.name,
         )
 
+        await self.coordinator.refresh_todo_list_items(self._list.id)
+
     @override
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete items from the to-do list."""
@@ -152,6 +154,8 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
                 uid,
                 existing_item.version,
             )
+
+        await self.coordinator.refresh_todo_list_items(self._list.id)
 
     @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
@@ -188,7 +192,7 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
                 item.status,
             )
 
-        if existing_item.name != item.summary:
+        if has_renamed := (existing_item.name != item.summary):
             # Name has changed, update it
             LOGGER.debug("Updating item %s with new name %s", item.uid, item.summary)
 
@@ -202,3 +206,6 @@ class AlexaToDoList(AmazonServiceEntity, TodoListEntity):
             LOGGER.debug(
                 "Successfully updated item %s with new name %s", item.uid, item.summary
             )
+
+        if has_completed_changed or has_renamed:
+            await self.coordinator.refresh_todo_list_items(self._list.id)

--- a/tests/components/alexa_devices/test_todo.py
+++ b/tests/components/alexa_devices/test_todo.py
@@ -229,6 +229,75 @@ async def test_concurrent_writes_keep_the_newest_answer(
     assert hass.states.get(entity_id).state == "2"
 
 
+async def test_pushed_event_survives_a_refresh(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_todo_lists: list[AmazonListInfo],
+) -> None:
+    """Test an event arriving during a read back is not lost by that read."""
+    mock_amazon_devices_client.todo_lists = mock_todo_lists
+    list_items: dict[str, AmazonListItem] = {}
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(
+        side_effect=lambda list_id: dict(list_items)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    entity_id = MOCK_TODO_LIST_ENTITY_ID
+
+    def add_item(list_id: str, name: str) -> None:
+        list_items[name] = AmazonListItem(
+            id=name, name=name, status=AmazonListItemStatus.ACTIVE, version=1
+        )
+
+    mock_amazon_devices_client.add_todo_list_item = AsyncMock(side_effect=add_item)
+
+    # Hold the read back until the event has been handled
+    released = asyncio.Event()
+
+    async def read_items(list_id: str) -> dict[str, AmazonListItem]:
+        items = dict(list_items)
+        await released.wait()
+        return items
+
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(side_effect=read_items)
+
+    write = asyncio.create_task(
+        hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.ADD_ITEM,
+            {ATTR_ENTITY_ID: entity_id, "item": "Written task"},
+            blocking=True,
+        )
+    )
+    await asyncio.sleep(0)
+
+    # Alexa reports an item of its own while the read back is in flight
+    pushed = asyncio.create_task(
+        coordinator.todo_event_handler(
+            AmazonListEvent(
+                list_id="todo_list_id",
+                item_id="item_6",
+                type=AmazonListEventType.CREATED,
+                items=AmazonListItem(
+                    id="item_6",
+                    name="Spoken task",
+                    status=AmazonListItemStatus.ACTIVE,
+                    version=1,
+                ),
+            )
+        )
+    )
+    await asyncio.sleep(0)
+    released.set()
+    await write
+    await pushed
+
+    assert hass.states.get(entity_id).state == "2"
+
+
 async def test_delete_todo_item(
     hass: HomeAssistant,
     mock_amazon_devices_client: AsyncMock,

--- a/tests/components/alexa_devices/test_todo.py
+++ b/tests/components/alexa_devices/test_todo.py
@@ -132,11 +132,30 @@ async def test_add_todo_item(
 ) -> None:
     """Test adding a todo item."""
     mock_amazon_devices_client.todo_lists = mock_todo_lists
-    mock_amazon_devices_client.get_todo_list_items = AsyncMock(return_value={})
+    list_items: dict[str, AmazonListItem] = {}
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(
+        side_effect=lambda list_id: list_items
+    )
 
     await setup_integration(hass, mock_config_entry)
 
     entity_id = MOCK_TODO_LIST_ENTITY_ID
+
+    assert hass.states.get(entity_id).state == "0"
+
+    # Amazon has the item from the moment the call returns
+    mock_amazon_devices_client.add_todo_list_item = AsyncMock(
+        side_effect=lambda list_id, name: list_items.update(
+            {
+                "item_6": AmazonListItem(
+                    id="item_6",
+                    name=name,
+                    status=AmazonListItemStatus.ACTIVE,
+                    version=1,
+                )
+            }
+        )
+    )
 
     await hass.services.async_call(
         TODO_DOMAIN,
@@ -148,6 +167,7 @@ async def test_add_todo_item(
     mock_amazon_devices_client.add_todo_list_item.assert_called_once_with(
         "todo_list_id", "New Task"
     )
+    assert hass.states.get(entity_id).state == "1"
 
 
 async def test_delete_todo_item(
@@ -167,6 +187,15 @@ async def test_delete_todo_item(
 
     entity_id = MOCK_TODO_LIST_ENTITY_ID
 
+    assert hass.states.get(entity_id).state == "1"
+
+    # Amazon has dropped the item from the moment the call returns
+    mock_amazon_devices_client.delete_todo_list_item = AsyncMock(
+        side_effect=lambda list_id, item_id, version: mock_todo_items[list_id].pop(
+            item_id
+        )
+    )
+
     # Delete item_2
     await hass.services.async_call(
         TODO_DOMAIN,
@@ -178,6 +207,7 @@ async def test_delete_todo_item(
     mock_amazon_devices_client.delete_todo_list_item.assert_called_once_with(
         "todo_list_id", "item_2", 1
     )
+    assert hass.states.get(entity_id).state == "0"
 
 
 async def test_update_todo_item(

--- a/tests/components/alexa_devices/test_todo.py
+++ b/tests/components/alexa_devices/test_todo.py
@@ -1,5 +1,6 @@
 """Test Alexa Devices todo entities."""
 
+from dataclasses import replace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -26,6 +27,7 @@ from homeassistant.components.todo import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
@@ -115,7 +117,7 @@ async def test_all_entities(
     """Test all entities."""
     mock_amazon_devices_client.todo_lists = mock_todo_lists
     mock_amazon_devices_client.get_todo_list_items = AsyncMock(
-        side_effect=lambda list_id: mock_todo_items.get(list_id, {})
+        side_effect=lambda list_id: dict(mock_todo_items.get(list_id, {}))
     )
 
     with patch("homeassistant.components.alexa_devices.PLATFORMS", [Platform.TODO]):
@@ -134,7 +136,7 @@ async def test_add_todo_item(
     mock_amazon_devices_client.todo_lists = mock_todo_lists
     list_items: dict[str, AmazonListItem] = {}
     mock_amazon_devices_client.get_todo_list_items = AsyncMock(
-        side_effect=lambda list_id: list_items
+        side_effect=lambda list_id: dict(list_items)
     )
 
     await setup_integration(hass, mock_config_entry)
@@ -180,7 +182,7 @@ async def test_delete_todo_item(
     """Test deleting a todo item."""
     mock_amazon_devices_client.todo_lists = mock_todo_lists
     mock_amazon_devices_client.get_todo_list_items = AsyncMock(
-        side_effect=lambda list_id: mock_todo_items.get(list_id, {})
+        side_effect=lambda list_id: dict(mock_todo_items.get(list_id, {}))
     )
 
     await setup_integration(hass, mock_config_entry)
@@ -210,6 +212,52 @@ async def test_delete_todo_item(
     assert hass.states.get(entity_id).state == "0"
 
 
+async def test_delete_todo_items_partial_failure(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_todo_lists: list[AmazonListInfo],
+    mock_todo_items: dict[str, Any],
+) -> None:
+    """Test a delete that went through is not left in the cache by a later failure."""
+    mock_amazon_devices_client.todo_lists = mock_todo_lists
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(
+        side_effect=lambda list_id: dict(mock_todo_items.get(list_id, {}))
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = MOCK_TODO_LIST_ENTITY_ID
+
+    assert hass.states.get(entity_id).state == "1"
+
+    # Amazon drops item_2 and then stops answering
+    def delete_item(list_id: str, item_id: str, version: int) -> None:
+        if item_id == "item_3":
+            raise CannotConnect
+        mock_todo_items[list_id].pop(item_id)
+
+    mock_amazon_devices_client.delete_todo_list_item = AsyncMock(
+        side_effect=delete_item
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.REMOVE_ITEM,
+            {ATTR_ENTITY_ID: entity_id, "item": ["item_2", "item_3"]},
+            blocking=True,
+        )
+
+    # The failure takes the entity down, the next poll brings it back
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "0"
+
+
 async def test_update_todo_item(
     hass: HomeAssistant,
     mock_amazon_devices_client: AsyncMock,
@@ -220,7 +268,7 @@ async def test_update_todo_item(
     """Test updating a todo item."""
     mock_amazon_devices_client.todo_lists = mock_todo_lists
     mock_amazon_devices_client.get_todo_list_items = AsyncMock(
-        side_effect=lambda list_id: mock_todo_items.get(list_id, {})
+        side_effect=lambda list_id: dict(mock_todo_items.get(list_id, {}))
     )
 
     await setup_integration(hass, mock_config_entry)
@@ -282,6 +330,49 @@ async def test_update_todo_item(
     mock_amazon_devices_client.rename_todo_list_item.assert_called_once_with(
         "todo_list_id", "item_2", "Both Changed", 2
     )
+
+
+async def test_update_todo_item_refreshes_state(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_todo_lists: list[AmazonListInfo],
+    mock_todo_items: dict[str, Any],
+) -> None:
+    """Test the entity reflects an updated item once the call returns."""
+    mock_amazon_devices_client.todo_lists = mock_todo_lists
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(
+        side_effect=lambda list_id: dict(mock_todo_items.get(list_id, {}))
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = MOCK_TODO_LIST_ENTITY_ID
+
+    assert hass.states.get(entity_id).state == "1"
+
+    # Amazon has the item checked from the moment the call returns
+    def check_item(list_id: str, item_id: str, checked: bool, version: int) -> None:
+        mock_todo_items[list_id][item_id] = replace(
+            mock_todo_items[list_id][item_id], status=AmazonListItemStatus.COMPLETE
+        )
+
+    mock_amazon_devices_client.set_todo_list_item_checked_status = AsyncMock(
+        side_effect=check_item
+    )
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            "item": "item_2",
+            "status": TodoItemStatus.COMPLETED,
+        },
+        blocking=True,
+    )
+
+    assert hass.states.get(entity_id).state == "0"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/alexa_devices/test_todo.py
+++ b/tests/components/alexa_devices/test_todo.py
@@ -1,5 +1,6 @@
 """Test Alexa Devices todo entities."""
 
+import asyncio
 from dataclasses import replace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -172,6 +173,62 @@ async def test_add_todo_item(
     assert hass.states.get(entity_id).state == "1"
 
 
+async def test_concurrent_writes_keep_the_newest_answer(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_todo_lists: list[AmazonListInfo],
+) -> None:
+    """Test a slow read of an older list does not overwrite a newer one."""
+    mock_amazon_devices_client.todo_lists = mock_todo_lists
+    list_items: dict[str, AmazonListItem] = {}
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(
+        side_effect=lambda list_id: dict(list_items)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = MOCK_TODO_LIST_ENTITY_ID
+
+    def add_item(list_id: str, name: str) -> None:
+        list_items[name] = AmazonListItem(
+            id=name, name=name, status=AmazonListItemStatus.ACTIVE, version=1
+        )
+
+    mock_amazon_devices_client.add_todo_list_item = AsyncMock(side_effect=add_item)
+
+    # Hold the first read until both items have been written
+    released = asyncio.Event()
+    reads = 0
+
+    async def read_items(list_id: str) -> dict[str, AmazonListItem]:
+        nonlocal reads
+        reads += 1
+        items = dict(list_items)
+        if reads == 1:
+            await released.wait()
+        return items
+
+    mock_amazon_devices_client.get_todo_list_items = AsyncMock(side_effect=read_items)
+
+    writes = asyncio.gather(
+        *[
+            hass.services.async_call(
+                TODO_DOMAIN,
+                TodoServices.ADD_ITEM,
+                {ATTR_ENTITY_ID: entity_id, "item": item},
+                blocking=True,
+            )
+            for item in ("First task", "Second task")
+        ]
+    )
+    await asyncio.sleep(0)
+    released.set()
+    await writes
+
+    assert hass.states.get(entity_id).state == "2"
+
+
 async def test_delete_todo_item(
     hass: HomeAssistant,
     mock_amazon_devices_client: AsyncMock,
@@ -214,7 +271,6 @@ async def test_delete_todo_item(
 
 async def test_delete_todo_items_partial_failure(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
     mock_amazon_devices_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     mock_todo_lists: list[AmazonListInfo],
@@ -250,11 +306,7 @@ async def test_delete_todo_items_partial_failure(
             blocking=True,
         )
 
-    # The failure takes the entity down, the next poll brings it back
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
+    # Reading the list back worked, so the entity stays usable
     assert hass.states.get(entity_id).state == "0"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an item to an Alexa to-do list, and the entity does not show it. Delete one, it stays. Only a reload or a lucky push event from Amazon fixes it.

Why: `sync_todo_list_items` runs once, at setup. `_async_update_data` never touches the item cache. So after that, only pushed list events keep it current, and our own writes are not echoed back.

Fix: pull the affected list back after each write, then notify listeners. One list, one call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179990
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
