### PR TITLE
Gate the Sofar waiting-ends sensor on an active countdown

### DIFF
--- a/homeassistant/components/sofar/sensor.py
+++ b/homeassistant/components/sofar/sensor.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import cast, override
 
 from sofar_modbus.modern.device import SofarInverter
+from sofar_modbus.modern.enums import SystemState
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -142,6 +143,9 @@ class SofarSensor(SofarEntity, SensorEntity):
 class SofarCountdownSensor(SofarSensor):
     """Defines a Sofar countdown, published as the moment it runs out."""
 
+    # A positive register alone doesn't mean the countdown is active.
+    _ACTIVE_STATES = (SystemState.WAITING, SystemState.CHECKING)
+
     def __init__(
         self,
         runtime_data: SofarRuntimeData,
@@ -156,7 +160,11 @@ class SofarCountdownSensor(SofarSensor):
     def native_value(self) -> datetime | None:
         component = getattr(self.coordinator.device, self.entity_description.component)
         seconds = getattr(component, self.entity_description.key)
-        if not isinstance(seconds, int) or seconds <= 0:
+        if (
+            not isinstance(seconds, int)
+            or seconds <= 0
+            or component.system_state not in self._ACTIVE_STATES
+        ):
             # A restart must not land inside the finished countdown's slack.
             self._deadline = _deadline_filter()
             return None

--- a/tests/components/sofar/test_sensor.py
+++ b/tests/components/sofar/test_sensor.py
@@ -426,6 +426,7 @@ async def test_countdown_holds_its_deadline_until_it_restarts(
     """Test a countdown ticking with the clock keeps one deadline."""
     mock_config_entry.add_to_hass(hass)
     unit = mock_connection.for_unit(1)
+    unit.holding[0x0404] = 0  # Waiting
     unit.holding[0x0417] = 300
 
     with patch(
@@ -460,6 +461,34 @@ async def test_countdown_holds_its_deadline_until_it_restarts(
     assert hass.states.get(entity_id).state != deadline
 
 
+async def test_countdown_ignores_a_stale_register_while_grid_connected(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_connection: MockModbusConnection,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a positive register is ignored once the inverter is connected."""
+    mock_config_entry.add_to_hass(hass)
+    unit = mock_connection.for_unit(1)
+    unit.holding[0x0404] = 2  # Grid connected
+    unit.holding[0x0417] = 60  # Left over from the last startup wait
+
+    with patch(
+        "homeassistant.components.sofar.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+            unit_id
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_waiting_time"
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+
 async def test_countdown_restarting_after_idle_gets_a_new_deadline(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -470,6 +499,7 @@ async def test_countdown_restarting_after_idle_gets_a_new_deadline(
     """Test a finished countdown's deadline is not reused by the next one."""
     mock_config_entry.add_to_hass(hass)
     unit = mock_connection.for_unit(1)
+    unit.holding[0x0404] = 0  # Waiting
     unit.holding[0x0417] = 10
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`waiting_time` (register 0x0417) holds the last configured wait duration
and never clears once grid-connected, so `waiting_ends` kept publishing a
sliding fake deadline forever. Verified on real hardware: the register sat
at `60` for minutes while `system_state` was `GRID_CONNECTED`.

Fix: only trust the countdown while `system_state` is `WAITING` or
`CHECKING`; otherwise report unknown.

It would be great if this could be added to the 2026.9 milestone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
