### PR TITLE
Remove the vendor status sensor from SolarEdge Modbus

### DIFF
--- a/homeassistant/components/solaredge_modbus/icons.json
+++ b/homeassistant/components/solaredge_modbus/icons.json
@@ -3,9 +3,6 @@
     "sensor": {
       "inverter_status": {
         "default": "mdi:solar-power"
-      },
-      "vendor_status": {
-        "default": "mdi:information-outline"
       }
     }
   }

--- a/homeassistant/components/solaredge_modbus/sensor.py
+++ b/homeassistant/components/solaredge_modbus/sensor.py
@@ -273,13 +273,6 @@ INVERTER_SENSORS: tuple[SolarEdgeModbusSensorEntityDescription, ...] = (
             inverter.status.name.lower() if inverter.status else None
         ),
     ),
-    SolarEdgeModbusSensorEntityDescription(
-        key="vendor_status",
-        translation_key="vendor_status",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        value_fn=lambda inverter: inverter.vendor_status,
-    ),
 )
 
 

--- a/homeassistant/components/solaredge_modbus/strings.json
+++ b/homeassistant/components/solaredge_modbus/strings.json
@@ -99,9 +99,6 @@
           "throttled": "Throttled"
         }
       },
-      "vendor_status": {
-        "name": "Vendor status"
-      },
       "voltage_phase_ab": {
         "name": "Voltage phase A-B"
       },

--- a/tests/components/solaredge_modbus/snapshots/test_sensor.ambr
+++ b/tests/components/solaredge_modbus/snapshots/test_sensor.ambr
@@ -712,56 +712,6 @@
     'state': '47.67',
   })
 # ---
-# name: test_sensors[sensor.solaredge_se10000h_vendor_status-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.solaredge_se10000h_vendor_status',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Vendor status',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Vendor status',
-    'platform': 'solaredge_modbus',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'vendor_status',
-    'unique_id': '7E123ABC_vendor_status',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.solaredge_se10000h_vendor_status-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarEdge SE10000H Vendor status',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.solaredge_se10000h_vendor_status',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '4',
-  })
-# ---
 # name: test_sensors[sensor.solaredge_se10000h_voltage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `vendor_status` sensor is removed. It has not been in a release yet, so nothing existing breaks.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the `vendor_status` diagnostic sensor from the inverter.

The value is SolarEdge's own status code from register 40108, sitting next to the SunSpec status. Every SolarEdge Modbus integration on HACS exposes it, and it is what an installer asks for when a fault needs explaining. That is why it was here: a diagnostic entity, disabled by default.

@joostlek asked for it to be removed in review on #180508, reasoning that without a published list of codes a reader has to look the value up themselves, and that there is no migration path to an enum if those meanings ever surface. So it goes.

To be straight about it: I'm tired, and not in the mood to discuss or battle over review details like this one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
