### PR TITLE
Let LG ThinQ unload when the network is down

### DIFF
--- a/homeassistant/components/lg_thinq/mqtt.py
+++ b/homeassistant/components/lg_thinq/mqtt.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Any
 
+from aiohttp import ClientError
 from thinqconnect import (
     DeviceType,
     ThinQApi,
@@ -58,7 +59,8 @@ class ThinQMQTT:
         if self.client is not None:
             try:
                 await self.client.async_disconnect()
-            except ThinQAPIException, TypeError, ValueError:
+            except ThinQAPIException, TypeError, ValueError, ClientError, TimeoutError:
+                # Saying goodbye is a courtesy, never a reason to fail the unload
                 _LOGGER.exception("Failed to disconnect")
 
     def _get_failed_device_count(

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -36,6 +36,41 @@ async def test_load_unload_entry(
 
 @pytest.mark.parametrize(
     "exception",
+    [
+        ThinQAPIException(code="1309", message="Not allowed api call", headers={}),
+        TypeError(),
+        ValueError(),
+        ClientError(),
+        TimeoutError(),
+    ],
+)
+async def test_unload_entry_with_failing_disconnect(
+    hass: HomeAssistant,
+    mock_thinq_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """Test the entry unloads even when telling LG we are leaving fails."""
+    with patch(
+        "homeassistant.components.lg_thinq.ThinQMQTT.async_connect",
+        return_value=True,
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    mqtt_client = mock_config_entry.runtime_data.mqtt_client
+    mqtt_client.client = AsyncMock()
+    mqtt_client.client.async_disconnect.side_effect = exception
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    "exception",
     [AttributeError(), TypeError(), ValueError(), ClientError(), TimeoutError()],
 )
 async def test_config_not_ready_mqtt(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A DNS or WAN blip while the entry unloads leaves LG ThinQ permanently broken. No reload works again until Home Assistant restarts.

Why: `ThinQMQTT.async_disconnect` makes REST calls on the way out and catches `ThinQAPIException, TypeError, ValueError`. But `thinqconnect` only raises `ThinQAPIException` for HTTP error responses; its `_async_fetch` calls `session.request` bare, so a network failure surfaces as a raw `aiohttp.ClientError` or `TimeoutError`. Those escape `async_unload_entry`, and `FAILED_UNLOAD` is non-recoverable, so every later unload and reload raises `OperationNotAllowed`.

Setup already catches both of these in `__init__.py`. This brings unload in line.

Reported as defect 3 of #179908. The other two in that issue are design questions and are left alone.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179908
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
