### PR TITLE
Ask Google for the calendar access the entry is set to

### DIFF
--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -87,11 +87,21 @@ class OAuth2FlowHandler(
         return logging.getLogger(__name__)
 
     @property
+    def _calendar_access(self) -> FeatureAccess:
+        """Return the access the entry being authorized asks for."""
+        if self.source == SOURCE_REAUTH and (
+            reauth_options := self._get_reauth_entry().options
+        ):
+            return FeatureAccess[reauth_options[CONF_CALENDAR_ACCESS]]
+
+        return DEFAULT_FEATURE_ACCESS
+
+    @property
     @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "scope": DEFAULT_FEATURE_ACCESS.scope,
+            "scope": self._calendar_access.scope,
             # Add params to ensure we get back a refresh token
             "access_type": "offline",
             "prompt": "consent",
@@ -121,17 +131,12 @@ class OAuth2FlowHandler(
                     self.flow_impl,
                 )
                 return self.async_abort(reason="oauth_error")
-            calendar_access = DEFAULT_FEATURE_ACCESS
-            if self.source == SOURCE_REAUTH and (
-                reauth_options := self._get_reauth_entry().options
-            ):
-                calendar_access = FeatureAccess[reauth_options[CONF_CALENDAR_ACCESS]]
             try:
                 device_flow = await async_create_device_flow(
                     self.hass,
                     self.flow_impl.client_id,
                     self.flow_impl.client_secret,
-                    calendar_access,
+                    self._calendar_access,
                 )
             except TimeoutError as err:
                 _LOGGER.error("Timeout initializing device flow: %s", str(err))

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -741,6 +741,59 @@ async def test_web_auth_compatibility(
 
 
 @pytest.mark.parametrize(
+    ("options", "expected_scope"),
+    [
+        ({}, "https://www.googleapis.com/auth/calendar"),
+        (
+            {CONF_CALENDAR_ACCESS: FeatureAccess.read_write.name},
+            "https://www.googleapis.com/auth/calendar",
+        ),
+        (
+            {CONF_CALENDAR_ACCESS: FeatureAccess.read_only.name},
+            "https://www.googleapis.com/auth/calendar.readonly",
+        ),
+    ],
+)
+async def test_web_reauth_flow_asks_for_configured_access(
+    hass: HomeAssistant,
+    mock_code_flow: Mock,
+    options: dict[str, Any],
+    expected_scope: str,
+) -> None:
+    """Test reauth asks for the access the entry is configured for."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_CREDENTIAL_TYPE: CredentialType.WEB_AUTH,
+            "auth_implementation": DOMAIN,
+            "token": {"access_token": "OLD_ACCESS_TOKEN"},
+        },
+        options=options,
+    )
+    config_entry.add_to_hass(hass)
+    await async_import_client_credential(
+        hass, DOMAIN, ClientCredential(CLIENT_ID, CLIENT_SECRET)
+    )
+
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.google.api.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        side_effect=OAuth2DeviceCodeError(
+            "Invalid response 401. Error: invalid_client"
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id=result["flow_id"],
+            user_input={},
+        )
+
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
+    assert f"&scope={expected_scope}&" in result["url"]
+
+
+@pytest.mark.parametrize(
     "entry_data",
     [
         {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch Google Calendar to Read-only on a web OAuth entry and it never comes back. Reauthenticate all you like, the entry keeps failing with `Required scopes are not available, reauth required`.

Why: changing the option makes `async_entry_has_scopes` fail, which starts a reauthentication. The device auth path reads `CONF_CALENDAR_ACCESS` off the entry to pick its scope, but `extra_authorize_data`, which web auth uses, hardcoded `DEFAULT_FEATURE_ACCESS.scope`. So Google was asked for read/write again and the token never gained `calendar.readonly`.

Only that direction breaks. Read-only to Read/Write works by accident, since the hardcoded default happens to be the scope it needs.

Moved the existing device-path logic into a property and used it for both.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180576
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
