### PR TITLE
Translate the update install and skip errors

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -139,7 +139,11 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
         entity.installed_version == entity.latest_version
         or entity.latest_version is None
     ):
-        raise HomeAssistantError(f"No update available for {entity.entity_id}")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_update_available",
+            translation_placeholders={"entity_id": entity.entity_id},
+        )
 
     # If version is specified, but not supported by the entity.
     if (
@@ -147,19 +151,27 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
         and UpdateEntityFeature.SPECIFIC_VERSION not in entity.supported_features
     ):
         raise HomeAssistantError(
-            f"Installing a specific version is not supported for {entity.entity_id}"
+            translation_domain=DOMAIN,
+            translation_key="specific_version_not_supported",
+            translation_placeholders={"entity_id": entity.entity_id},
         )
 
     # If backup is requested, but not supported by the entity.
     if (
         backup := service_call.data[ATTR_BACKUP]
     ) and UpdateEntityFeature.BACKUP not in entity.supported_features:
-        raise HomeAssistantError(f"Backup is not supported for {entity.entity_id}")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="backup_not_supported",
+            translation_placeholders={"entity_id": entity.entity_id},
+        )
 
     # Update is already in progress.
     if entity.in_progress is not False:
         raise HomeAssistantError(
-            f"Update installation already in progress for {entity.entity_id}"
+            translation_domain=DOMAIN,
+            translation_key="update_in_progress",
+            translation_placeholders={"entity_id": entity.entity_id},
         )
 
     await entity.async_install_with_progress(version, backup)
@@ -169,7 +181,9 @@ async def async_skip(entity: UpdateEntity, service_call: ServiceCall) -> None:
     """Service call wrapper to validate the call."""
     if entity.auto_update:
         raise HomeAssistantError(
-            f"Skipping update is not supported for {entity.entity_id}"
+            translation_domain=DOMAIN,
+            translation_key="skip_not_supported",
+            translation_placeholders={"entity_id": entity.entity_id},
         )
     await entity.async_skip()
 
@@ -178,7 +192,9 @@ async def async_clear_skipped(entity: UpdateEntity, service_call: ServiceCall) -
     """Service call wrapper to validate the call."""
     if entity.auto_update:
         raise HomeAssistantError(
-            f"Clearing skipped update is not supported for {entity.entity_id}"
+            translation_domain=DOMAIN,
+            translation_key="clear_skipped_not_supported",
+            translation_placeholders={"entity_id": entity.entity_id},
         )
     await entity.async_clear_skipped()
 
@@ -362,9 +378,17 @@ class UpdateEntity(
     async def async_skip(self) -> None:
         """Skip the current offered version to update."""
         if (latest_version := self.latest_version) is None:
-            raise HomeAssistantError(f"Cannot skip an unknown version for {self.name}")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unknown_version_to_skip",
+                translation_placeholders={"entity_id": self.entity_id},
+            )
         if self.installed_version == latest_version:
-            raise HomeAssistantError(f"No update available to skip for {self.name}")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="no_update_available_to_skip",
+                translation_placeholders={"entity_id": self.entity_id},
+            )
         self.__skipped_version = latest_version
         self.async_write_ha_state()
 

--- a/homeassistant/components/update/strings.json
+++ b/homeassistant/components/update/strings.json
@@ -87,6 +87,32 @@
       "name": "Firmware"
     }
   },
+  "exceptions": {
+    "backup_not_supported": {
+      "message": "Backup is not supported for {entity_id}."
+    },
+    "clear_skipped_not_supported": {
+      "message": "Clearing skipped update is not supported for {entity_id}."
+    },
+    "no_update_available": {
+      "message": "No update available for {entity_id}."
+    },
+    "no_update_available_to_skip": {
+      "message": "No update available to skip for {entity_id}."
+    },
+    "skip_not_supported": {
+      "message": "Skipping update is not supported for {entity_id}."
+    },
+    "specific_version_not_supported": {
+      "message": "Installing a specific version is not supported for {entity_id}."
+    },
+    "unknown_version_to_skip": {
+      "message": "Cannot skip an unknown version for {entity_id}."
+    },
+    "update_in_progress": {
+      "message": "Update installation already in progress for {entity_id}."
+    }
+  },
   "services": {
     "clear_skipped": {
       "description": "Removes the skipped version marker from an update.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An integration with `exception-translations: done` cannot write a test that trips any of the `update` install or skip guards. The autouse check in `tests/components/conftest.py` sees `translation_key is None` and blames the integration under test, which has no way to fix it: core raises the error, not the integration.

So the refusal you most want covered, a second install while one is already running, is the one thing that cannot be asserted.

All eight raises get a key. Two small changes come with it: the messages gain a trailing period, and the two in `async_skip` name the entity by `entity_id` like the other six, since an entity using `has_entity_name` has no name of its own.

Existing `match=` assertions keep working, as `HomeAssistantError.__str__` renders the English message from the key.

No new tests: `_check_exception_translation` now takes its validating branch and checks `update.exceptions.<key>.message` and its placeholders every time an existing test trips one of these. Pointing a raise at a key that does not exist turns `test_entity_with_specific_version` red.

Same shape as #180600, which is left alone: `Unauthorized` has no obvious domain to translate under.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180601
- This PR is related to issue: #180600
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
