### PR TITLE
Fix K‑series that need encrypted pairing in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -98,6 +98,18 @@ def model_requires_encryption(model: str | None) -> bool:
     return model is not None and len(model) > 4 and model[4] in ("H", "J")
 
 
+def model_may_require_encryption(model: str | None) -> bool:
+    """Return True for models that might need encrypted pairing.
+
+    Some 2016 K-series models advertise the plain websocket method in their REST
+    device info but only pair via the encrypted PIN flow. Unlike H/J models (see
+    model_requires_encryption), other sets in the same series work with the
+    websocket method, so the encrypted method is only tried as a fallback once
+    websocket pairing has failed to connect.
+    """
+    return model is not None and len(model) > 4 and model[4] == "K"
+
+
 async def async_get_device_info(
     hass: HomeAssistant,
     host: str,

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -39,7 +39,12 @@ from homeassistant.helpers.service_info.ssdp import (
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .bridge import SamsungTVBridge, async_get_device_info, mac_from_device_info
+from .bridge import (
+    SamsungTVBridge,
+    async_get_device_info,
+    mac_from_device_info,
+    model_may_require_encryption,
+)
 from .const import (
     CONF_MANUFACTURER,
     CONF_SESSION_ID,
@@ -47,6 +52,7 @@ from .const import (
     CONF_SSDP_RENDERING_CONTROL_LOCATION,
     DEFAULT_MANUFACTURER,
     DOMAIN,
+    ENCRYPTED_WEBSOCKET_PORT,
     LOGGER,
     METHOD_ENCRYPTED_WEBSOCKET,
     METHOD_LEGACY,
@@ -324,6 +330,23 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
             result = await self._bridge.async_try_connect()
             if result == RESULT_SUCCESS:
                 return self._get_entry_from_bridge()
+            if result == RESULT_CANNOT_CONNECT and model_may_require_encryption(
+                self._model
+            ):
+                # Some 2016 K-series sets advertise the websocket method but only
+                # pair via the encrypted PIN flow; try it before giving up
+                LOGGER.debug(
+                    "Websocket pairing failed for %s (%s), falling back to encrypted",
+                    self._host,
+                    self._model,
+                )
+                self._bridge = SamsungTVBridge.get_bridge(
+                    self.hass,
+                    METHOD_ENCRYPTED_WEBSOCKET,
+                    self._host,
+                    ENCRYPTED_WEBSOCKET_PORT,
+                )
+                return await self.async_step_encrypted_pairing()
             if result != RESULT_AUTH_MISSING:
                 raise AbortFlow(result)
             errors = {"base": RESULT_AUTH_MISSING}

--- a/tests/components/samsungtv/fixtures/device_info_UN55KU6290.json
+++ b/tests/components/samsungtv/fixtures/device_info_UN55KU6290.json
@@ -1,0 +1,28 @@
+{
+  "id": "uuid:0dd7f9c9-b9a0-4b7e-8c3e-1f2b3c4d5e6f",
+  "name": "[TV] Samsung 6 Series (55)",
+  "version": "2.1.0",
+  "device": {
+    "type": "Samsung SmartTV",
+    "duid": "uuid:0dd7f9c9-b9a0-4b7e-8c3e-1f2b3c4d5e6f",
+    "model": "16_JAZZL_UHD_BASIC",
+    "modelName": "UN55KU6290",
+    "description": "Samsung DTV RCR",
+    "networkType": "wired",
+    "ssid": "",
+    "ip": "1.2.3.4",
+    "firmwareVersion": "Unknown",
+    "name": "[TV] Samsung 6 Series (55)",
+    "id": "uuid:0dd7f9c9-b9a0-4b7e-8c3e-1f2b3c4d5e6f",
+    "udn": "uuid:0dd7f9c9-b9a0-4b7e-8c3e-1f2b3c4d5e6f",
+    "resolution": "3840x2160",
+    "countryCode": "US",
+    "msfVersion": "2.1.0",
+    "smartHubAgreement": "true",
+    "wifiMac": "aa:bb:aa:aa:aa:aa",
+    "developerMode": "0",
+    "developerIP": ""
+  },
+  "type": "Samsung SmartTV",
+  "uri": "https://1.2.3.4:8002/api/v2/"
+}

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -30,8 +30,11 @@ from homeassistant.components.samsungtv.const import (
     CONF_SSDP_RENDERING_CONTROL_LOCATION,
     DEFAULT_MANUFACTURER,
     DOMAIN,
+    ENCRYPTED_WEBSOCKET_PORT,
     LEGACY_PORT,
+    METHOD_ENCRYPTED_WEBSOCKET,
     METHOD_LEGACY,
+    METHOD_WEBSOCKET,
     RESULT_AUTH_MISSING,
     RESULT_CANNOT_CONNECT,
     RESULT_NOT_SUPPORTED,
@@ -281,6 +284,92 @@ async def test_user_encrypted_websocket(
     assert result4["data"][CONF_TOKEN] == "037739871315caef138547b03e348b72"
     assert result4["data"][CONF_SESSION_ID] == "1"
     assert result4["result"].unique_id == "223da676-497a-4e06-9507-5e27ec4f0fb3"
+
+
+@pytest.mark.usefixtures("rest_api")
+async def test_user_websocket_k_series_encrypted_fallback(
+    hass: HomeAssistant, rest_api: Mock
+) -> None:
+    """Test a 2016 K-series set falls back to encrypted pairing (#177252).
+
+    Its REST device info selects the websocket method, but the token handshake
+    times out (RESULT_CANNOT_CONNECT) because it only pairs via the encrypted
+    CloudPINPage flow.
+    """
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UN55KU6290.json", DOMAIN
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote.open",
+            side_effect=OSError("timed out"),
+        ),
+        patch(
+            "homeassistant.components.samsungtv.config_flow.SamsungTVEncryptedWSAsyncAuthenticator",
+            autospec=True,
+        ) as authenticator_mock,
+    ):
+        authenticator_mock.return_value.try_pin.side_effect = [
+            None,
+            "037739871315caef138547b03e348b72",
+        ]
+        authenticator_mock.return_value.get_session_id_and_close.return_value = "1"
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result2["type"] is FlowResultType.FORM
+        assert result2["step_id"] == "encrypted_pairing"
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], user_input={CONF_PIN: "invalid"}
+        )
+        assert result3["step_id"] == "encrypted_pairing"
+        assert result3["errors"] == {"base": "invalid_pin"}
+
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"], user_input={CONF_PIN: "1234"}
+        )
+
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["data"][CONF_METHOD] == METHOD_ENCRYPTED_WEBSOCKET
+    assert result4["data"][CONF_MODEL] == "UN55KU6290"
+    assert result4["data"][CONF_PORT] == ENCRYPTED_WEBSOCKET_PORT
+    assert result4["data"][CONF_TOKEN] == "037739871315caef138547b03e348b72"
+    assert result4["data"][CONF_SESSION_ID] == "1"
+
+
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
+async def test_user_websocket_k_series_stays_on_websocket(
+    hass: HomeAssistant, rest_api: Mock
+) -> None:
+    """Test a K-series set that pairs over websocket is not pushed to encrypted.
+
+    Regression guard for #70708 (UE32K5600): the encrypted fallback must only
+    trigger when the websocket pairing genuinely fails to connect.
+    """
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UN55KU6290.json", DOMAIN
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_USER_DATA
+    )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_METHOD] == METHOD_WEBSOCKET
+    assert result2["data"][CONF_MODEL] == "UN55KU6290"
+    assert result2["data"][CONF_PORT] == 8002
 
 
 @pytest.mark.usefixtures("rest_api_failing")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix K‑series that need encrypted pairing in SamsungTV

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177252
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
