### PR TITLE
Add options flow to MCP Server integration

### DIFF
--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -32,6 +32,19 @@ def _llm_api_names(hass: HomeAssistant) -> dict[str, str]:
     return {api.id: api.name for api in llm.async_get_apis(hass)}
 
 
+def _llm_api_title(llm_apis: dict[str, str], api_ids: list[str]) -> str:
+    """Return the entry title generated for the selected LLM APIs."""
+    return ", ".join(llm_apis[api_id] for api_id in api_ids if api_id in llm_apis)
+
+
+def _selected_llm_apis(entry: ConfigEntry, llm_apis: dict[str, str]) -> list[str]:
+    """Return the still registered LLM APIs selected by the config entry."""
+    api_ids = entry.data.get(CONF_LLM_HASS_API) or []
+    if isinstance(api_ids, str):  # Old config entries stored a single API
+        api_ids = [api_ids]
+    return [api_id for api_id in api_ids if api_id in llm_apis]
+
+
 def _llm_api_schema(llm_apis: dict[str, str], default: list[str]) -> vol.Schema:
     """Return the schema for selecting LLM APIs."""
     return vol.Schema(
@@ -81,9 +94,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_LLM_HASS_API] = "llm_api_required"
             else:
                 return self.async_create_entry(
-                    title=", ".join(
-                        llm_apis[api_id] for api_id in user_input[CONF_LLM_HASS_API]
-                    ),
+                    title=_llm_api_title(llm_apis, user_input[CONF_LLM_HASS_API]),
                     data=user_input,
                 )
 
@@ -104,24 +115,26 @@ class ModelContextServerProtocolOptionsFlow(OptionsFlow):
         """Handle the options step."""
         errors: dict[str, str] = {}
         llm_apis = _llm_api_names(self.hass)
+        current = _selected_llm_apis(self.config_entry, llm_apis)
         if user_input is not None:
             if not user_input[CONF_LLM_HASS_API]:
                 errors[CONF_LLM_HASS_API] = "llm_api_required"
             else:
+                updates: dict[str, Any] = {
+                    "data": {**self.config_entry.data, **user_input}
+                }
+                # Keep a title the user renamed, only refresh a generated one.
+                if self.config_entry.title == _llm_api_title(llm_apis, current):
+                    updates["title"] = _llm_api_title(
+                        llm_apis, user_input[CONF_LLM_HASS_API]
+                    )
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data={**self.config_entry.data, **user_input},
-                    title=", ".join(
-                        llm_apis[api_id] for api_id in user_input[CONF_LLM_HASS_API]
-                    ),
+                    self.config_entry, **updates
                 )
+                # An open SSE session keeps serving the APIs it started with.
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
                 return self.async_create_entry(data={})
 
-        current = [
-            api_id
-            for api_id in self.config_entry.data.get(CONF_LLM_HASS_API, [])
-            if api_id in llm_apis
-        ]
         return self.async_show_form(
             step_id="init",
             data_schema=_llm_api_schema(llm_apis, current),

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -5,8 +5,14 @@ from typing import Any, override
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_LLM_HASS_API
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import llm
 from homeassistant.helpers.selector import (
     SelectOptionDict,
@@ -21,10 +27,47 @@ _LOGGER = logging.getLogger(__name__)
 MORE_INFO_URL = "https://www.home-assistant.io/integrations/mcp_server/#configuration"
 
 
+def _llm_api_names(hass: HomeAssistant) -> dict[str, str]:
+    """Return the registered LLM API names keyed by API id."""
+    return {api.id: api.name for api in llm.async_get_apis(hass)}
+
+
+def _llm_api_schema(llm_apis: dict[str, str], default: list[str]) -> vol.Schema:
+    """Return the schema for selecting LLM APIs."""
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_LLM_HASS_API,
+                default=default,
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(
+                            label=name,
+                            value=llm_api_id,
+                        )
+                        for llm_api_id, name in llm_apis.items()
+                    ],
+                    multiple=True,
+                )
+            ),
+        }
+    )
+
+
 class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Model Context Protocol Server."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> ModelContextServerProtocolOptionsFlow:
+        """Create the options flow."""
+        return ModelContextServerProtocolOptionsFlow()
 
     @override
     async def async_step_user(
@@ -32,7 +75,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
-        llm_apis = {api.id: api.name for api in llm.async_get_apis(self.hass)}
+        llm_apis = _llm_api_names(self.hass)
         if user_input is not None:
             if not user_input[CONF_LLM_HASS_API]:
                 errors[CONF_LLM_HASS_API] = "llm_api_required"
@@ -46,25 +89,42 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_LLM_HASS_API,
-                        default=[llm.LLM_API_ASSIST],
-                    ): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[
-                                SelectOptionDict(
-                                    label=name,
-                                    value=llm_api_id,
-                                )
-                                for llm_api_id, name in llm_apis.items()
-                            ],
-                            multiple=True,
-                        )
+            data_schema=_llm_api_schema(llm_apis, [llm.LLM_API_ASSIST]),
+            description_placeholders={"more_info_url": MORE_INFO_URL},
+            errors=errors,
+        )
+
+
+class ModelContextServerProtocolOptionsFlow(OptionsFlow):
+    """Handle an options flow to change the exposed LLM APIs."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the options step."""
+        errors: dict[str, str] = {}
+        llm_apis = _llm_api_names(self.hass)
+        if user_input is not None:
+            if not user_input[CONF_LLM_HASS_API]:
+                errors[CONF_LLM_HASS_API] = "llm_api_required"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={**self.config_entry.data, **user_input},
+                    title=", ".join(
+                        llm_apis[api_id] for api_id in user_input[CONF_LLM_HASS_API]
                     ),
-                }
-            ),
+                )
+                return self.async_create_entry(data={})
+
+        current = [
+            api_id
+            for api_id in self.config_entry.data.get(CONF_LLM_HASS_API, [])
+            if api_id in llm_apis
+        ]
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_llm_api_schema(llm_apis, current),
             description_placeholders={"more_info_url": MORE_INFO_URL},
             errors=errors,
         )

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -17,5 +17,21 @@
         "description": "See the [integration documentation]({more_info_url}) for setup instructions."
       }
     }
+  },
+  "options": {
+    "error": {
+      "llm_api_required": "[%key:component::mcp_server::config::error::llm_api_required%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]"
+        },
+        "data_description": {
+          "llm_hass_api": "[%key:component::mcp_server::config::step::user::data_description::llm_hass_api%]"
+        },
+        "description": "[%key:component::mcp_server::config::step::user::description%]"
+      }
+    }
   }
 }

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -13,6 +13,23 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
+TEST_LLM_API_ID = "test-api"
+
+
+class MockLLMAPI(llm.API):
+    """Test LLM API that does not expose any tools."""
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return a test API instance."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt="Test prompt",
+            llm_context=llm_context,
+            tools=[],
+        )
+
 
 @pytest.fixture(autouse=True)
 async def ensure_homeassistant_loaded(hass: HomeAssistant) -> None:

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -10,6 +10,9 @@ from homeassistant.components.mcp_server.const import DOMAIN
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import llm
+
+from .conftest import TEST_LLM_API_ID, MockLLMAPI
 
 from tests.common import MockConfigEntry
 
@@ -72,22 +75,61 @@ async def test_form_errors(
 
 async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test changing the LLM APIs in the options flow."""
+    llm.async_register_api(hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test"))
+    # The title generated for the APIs the entry was created with
+    hass.config_entries.async_update_entry(config_entry, title="Assist")
     assert await hass.config_entries.async_setup(config_entry.entry_id)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert not result["errors"]
+    assert result["data_schema"]({}) == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: ["assist"]},
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID]},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.data == {CONF_LLM_HASS_API: ["assist"]}
-    assert config_entry.title == "Assist"
+    assert config_entry.data == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID]
+    }
+    assert config_entry.title == "Assist, Test"
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST])
+async def test_options_flow_legacy_single_api(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test the form defaults for an entry that stored a single API as a string."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"]({}) == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+
+
+async def test_options_flow_keeps_custom_title(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test the options flow does not overwrite a title the user changed."""
+    llm.async_register_api(hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test"))
+    hass.config_entries.async_update_entry(config_entry, title="My MCP server")
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: [TEST_LLM_API_ID]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data == {CONF_LLM_HASS_API: [TEST_LLM_API_ID]}
+    assert config_entry.title == "My MCP server"
 
 
 async def test_options_flow_errors(

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -11,6 +11,8 @@ from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
+
 
 @pytest.mark.parametrize(
     "params",
@@ -66,3 +68,41 @@ async def test_form_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == errors
+
+
+async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test changing the LLM APIs in the options flow."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert not result["errors"]
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: ["assist"]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data == {CONF_LLM_HASS_API: ["assist"]}
+    assert config_entry.title == "Assist"
+
+
+async def test_options_flow_errors(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test the options flow requires at least one LLM API."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: []},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_LLM_HASS_API: "llm_api_required"}

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -111,6 +111,15 @@ async def test_options_flow_legacy_single_api(
     assert result["type"] is FlowResultType.FORM
     assert result["data_schema"]({}) == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
 
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+
 
 async def test_options_flow_keeps_custom_title(
     hass: HomeAssistant, config_entry: MockConfigEntry
@@ -148,3 +157,12 @@ async def test_options_flow_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_LLM_HASS_API: "llm_api_required"}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -42,6 +42,8 @@ from homeassistant.helpers import (
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.setup import async_setup_component
 
+from .conftest import TEST_LLM_API_ID, MockLLMAPI
+
 from tests.common import MockConfigEntry, setup_test_component_platform
 from tests.components.light.common import MockLight
 from tests.typing import ClientSessionGenerator
@@ -50,7 +52,6 @@ _LOGGER = logging.getLogger(__name__)
 
 TEST_ENTITY = "light.kitchen"
 SNAPSHOT_RESOURCE_URI = "homeassistant://assist/context-snapshot"
-TEST_LLM_API_ID = "test-api"
 INITIALIZE_MESSAGE = {
     "jsonrpc": "2.0",
     "id": "request-id-1",
@@ -71,21 +72,6 @@ EXPECTED_PROMPT_ENTITY_DEFINITION = """
   domain: light
   areas: Kitchen
 """
-
-
-class MockLLMAPI(llm.API):
-    """Test LLM API that does not expose any tools."""
-
-    async def async_get_api_instance(
-        self, llm_context: llm.LLMContext
-    ) -> llm.APIInstance:
-        """Return a test API instance."""
-        return llm.APIInstance(
-            api=self,
-            api_prompt="Test prompt",
-            llm_context=llm_context,
-            tools=[],
-        )
 
 
 @pytest.fixture
@@ -283,6 +269,40 @@ async def test_http_messages_no_config_entry(
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.LOADED
 
+    response = await client.post(endpoint_url, json=INITIALIZE_MESSAGE)
+    assert response.status == HTTPStatus.NOT_FOUND
+    response_data = await response.text()
+    assert "Could not find session ID" in response_data
+
+
+async def test_options_flow_closes_sessions(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test an open SSE session is closed when the selected APIs change."""
+    llm.async_register_api(
+        hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
+    client = await hass_client()
+
+    # Start an SSE session
+    response = await client.get(SSE_API)
+    assert response.status == HTTPStatus.OK
+    reader = sse_response_reader(response)
+    event, endpoint_url = await anext(reader)
+    assert event == "endpoint"
+
+    # Change the exposed LLM APIs
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: [TEST_LLM_API_ID]},
+    )
+    await hass.async_block_till_done()
+
+    # The session serving the previous APIs is gone
     response = await client.post(endpoint_url, json=INITIALIZE_MESSAGE)
     assert response.status == HTTPStatus.NOT_FOUND
     response_data = await response.text()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an options flow to the MCP Server integration so users can change which LLM APIs are exposed after setup, without removing and re-adding the integration.

The options flow shows the same LLM API multi-select as the initial config flow, pre-filled with the currently selected APIs. The stored selection is filtered to APIs that are still registered, and normalized for older entries that stored a single API as a string rather than a list. Like the config flow, it requires at least one API to be selected.

On submit it updates the config entry data and reloads the entry. The reload is needed for the legacy SSE endpoint: that view reads the selected APIs once when its long lived GET starts, so without it an already open session keeps serving an API that was just removed. Reloading closes those sessions and the client reconnects. The streamable endpoint reads the entry data per request and is not affected.

The entry title is refreshed with the names of the newly selected APIs, unless the title no longer matches the one generated for the previous selection, which means the user renamed the entry and their title is kept.

This enables a configure button on the new MCP card on the AI settings page in the frontend, which shows the options flow gear button based on `supports_options`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQUrBPMXN35UQ19ZYPRpEZ