### PR TITLE
Include contributor reviewed 2 PRs in ha merge queue skill

### DIFF
--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -91,7 +91,7 @@ Compare the returned count against the reported total and keep fetching until th
    blocker whether or not anyone is arguing about it.
 
 6. **Peer-Review Checklist Verification (Priority Boost)** — inspect the PR body text for
-   the template checkbox: `[x] I have reviewed two other open pull requests in this repository.`
+   the template checkbox: `- [x] I have reviewed two other [open pull requests][prs] in this repository.`
    - **Checked (`[x]`):** Give this PR higher priority in ranking to reward contributors helping
      clear the review backlog.
    - **Unchecked (`[ ]` or missing):** Keep in queue with standard priority (do not disqualify).

--- a/.claude/skills/ha-merge-queue/SKILL.md
+++ b/.claude/skills/ha-merge-queue/SKILL.md
@@ -27,7 +27,7 @@ verify every finalist with the per-PR checks below.
 
 ## Verify each finalist
 
-Check all five. A PR fails the shortlist if any one fails.
+Check all six conditions. A PR fails the shortlist if any of checks 1 through 5 fail.
 
 Paginate every list response before deciding. Check runs, reviews and review threads are all
 paged, typically 30 per page, and a full-suite Home Assistant PR runs to 40-odd check runs —
@@ -90,12 +90,27 @@ Compare the returned count against the reported total and keep fetching until th
    discount one for the category it appears to fall into; an unaddressed defect is a
    blocker whether or not anyone is arguing about it.
 
+6. **Peer-Review Checklist Verification (Priority Boost)** — inspect the PR body text for
+   the template checkbox: `[x] I have reviewed two other open pull requests in this repository.`
+   - **Checked (`[x]`):** Give this PR higher priority in ranking to reward contributors helping
+     clear the review backlog.
+   - **Unchecked (`[ ]` or missing):** Keep in queue with standard priority (do not disqualify).
+
 ## Report
 
-Rank by how little work each PR needs: `clean` first, then `blocked` with everything else
-green. For each PR give the number as a full markdown link, the integration or core area,
-one line on what it does, and its blocking state. Plenty of `home-assistant/core` PRs touch
-helpers, the framework, the recorder or repo tooling and have no integration at all — name
+Rank and order candidates primarily by their status readiness (`clean` first, then `blocked`
+with everything else green), and **secondarily by peer-review participation**:
+
+1. **Clean PRs** with the `[x] I have reviewed two other open pull requests...` checkbox checked.
+2. **Clean PRs** without the checkbox checked.
+3. **Blocked/Near-miss PRs** with the `[x] I have reviewed two other open pull requests...` checkbox checked.
+4. **Blocked/Near-miss PRs** without the checkbox checked.
+
+For each PR give the number as a full markdown link, the integration or core area,
+one line on what it does, its blocking state, and explicitly note if the author checked the
+peer-review box (e.g., "⭐ *Contributor reviewed 2 PRs*").
+
+Plenty of `home-assistant/core` PRs touch helpers, the framework, the recorder or repo tooling and have no integration at all — name
 what they touch instead, rather than dropping them or inventing one.
 
 Then list the near-misses separately, each with the one action that unblocks it. The


### PR DESCRIPTION
## Proposed change
Include a priority boost in merge queue skill when the contributor reviewed 2 other pull requests. 
I don't use the skills but I was asked to submit a pull request to include this per my suggestion. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
