### PR TITLE
Migrate the Lyngdorf remote platform to the lyngdorf 2.0 API

### DIFF
--- a/homeassistant/components/lyngdorf/remote.py
+++ b/homeassistant/components/lyngdorf/remote.py
@@ -3,8 +3,7 @@
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, override
 
-from lyngdorf.device import Receiver
-from lyngdorf.exceptions import LyngdorfUnsupportedError
+from lyngdorf import LyngdorfReceiver, LyngdorfUnsupportedError, Remote
 
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.core import HomeAssistant
@@ -29,7 +28,7 @@ async def async_setup_entry(
     receiver = runtime_data.receiver
 
     # The TDAI family has no remote keys at all, so it gets no remote entity.
-    if not receiver.has_remote_keys:
+    if receiver.remote is None:
         return
 
     async_add_entities(
@@ -44,7 +43,7 @@ class LyngdorfRemote(LyngdorfEntity, RemoteEntity):
 
     def __init__(
         self,
-        receiver: Receiver,
+        receiver: LyngdorfReceiver,
         config_entry: LyngdorfConfigEntry,
         device_info: DeviceInfo,
     ) -> None:
@@ -53,6 +52,14 @@ class LyngdorfRemote(LyngdorfEntity, RemoteEntity):
         if TYPE_CHECKING:
             assert config_entry.unique_id
         self._attr_unique_id = config_entry.unique_id
+
+    @property
+    def _remote(self) -> Remote:
+        """Return the remote; this entity exists only when the model has one."""
+        remote = self._receiver.remote
+        if TYPE_CHECKING:
+            assert remote is not None
+        return remote
 
     @override
     @property
@@ -63,24 +70,22 @@ class LyngdorfRemote(LyngdorfEntity, RemoteEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        self._receiver.power_on = True
+        await self._receiver.set_power(True)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        self._receiver.power_on = False
+        await self._receiver.set_power(False)
 
     @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a sequence of remote keys to the device."""
         # delay_secs is dropped: the library already paces its own writes.
         try:
-            self._receiver.send_remote_commands(
-                command, num_repeats=kwargs[ATTR_NUM_REPEATS]
-            )
+            await self._remote.send(command, num_repeats=kwargs[ATTR_NUM_REPEATS])
         except LyngdorfUnsupportedError as err:
             # The member value is what a caller sends: DIGIT_0 is "0", not "digit_0".
-            keys = sorted(key.value for key in self._receiver.available_remote_keys)
+            keys = sorted(key.value for key in self._remote.keys)
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="unsupported_remote_key",

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -11,6 +11,7 @@ from lyngdorf import (
     LyngdorfReceiver,
     NumericControl,
     NumericRange,
+    Remote,
     RemoteKey,
     Trim,
     ZoneB,
@@ -104,6 +105,9 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
             RemoteKey.DIGIT_0,
         }
     )
+    remote = MagicMock(spec=Remote)
+    remote.keys = receiver.available_remote_keys
+    receiver.remote = remote
 
     # Diagnostics reports the whole receiver, so every property it reads
     # needs a value here; an unset one is a mock the response cannot encode.

--- a/tests/components/lyngdorf/test_remote.py
+++ b/tests/components/lyngdorf/test_remote.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from lyngdorf.const import LyngdorfModel
+from lyngdorf import LyngdorfModel
 from lyngdorf.exceptions import LyngdorfUnsupportedError
 from lyngdorf.remote import RemoteKey, resolve_remote_key
 import pytest

--- a/tests/components/lyngdorf/test_remote.py
+++ b/tests/components/lyngdorf/test_remote.py
@@ -61,7 +61,7 @@ async def test_send_command(
         blocking=True,
     )
 
-    mock_receiver.send_remote_commands.assert_called_once_with(
+    mock_receiver.remote.send.assert_awaited_once_with(
         [RemoteKey.MENU, RemoteKey.DOWN, RemoteKey.ENTER], num_repeats=1
     )
 
@@ -83,9 +83,7 @@ async def test_send_command_repeats(
         blocking=True,
     )
 
-    mock_receiver.send_remote_commands.assert_called_once_with(
-        [RemoteKey.DOWN], num_repeats=3
-    )
+    mock_receiver.remote.send.assert_awaited_once_with([RemoteKey.DOWN], num_repeats=3)
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -94,9 +92,7 @@ async def test_send_unsupported_command(
     mock_receiver: MagicMock,
 ) -> None:
     """Test a key the model does not have is reported to the user."""
-    mock_receiver.send_remote_commands.side_effect = LyngdorfUnsupportedError(
-        "no such key"
-    )
+    mock_receiver.remote.send.side_effect = LyngdorfUnsupportedError("no such key")
 
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
@@ -135,7 +131,7 @@ async def test_power(
         blocking=True,
     )
 
-    assert mock_receiver.power_on is expected
+    mock_receiver.set_power.assert_awaited_once_with(expected)
 
 
 @pytest.mark.usefixtures("mock_receiver")
@@ -146,7 +142,7 @@ async def test_no_entity_for_model_without_remote_keys(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test no remote entity is created for a model with no remote keys."""
-    mock_receiver.has_remote_keys = False
+    mock_receiver.remote = None
     mock_config_entry.add_to_hass(hass)
 
     with (


### PR DESCRIPTION
## Proposed change

The remote is an object on the receiver in lyngdorf 2.0 rather than flat
attributes, and its writes are awaited. Its presence — decided when the
receiver is built — is what says whether the model has remote keys, replacing
`has_remote_keys`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The 1.11.0 bump this builds on merged in #180528.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
