### PR TITLE
Bump probatio to 0.11.4

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -52,7 +52,7 @@ orjson==3.12.0
 packaging>=23.1
 paho-mqtt==2.1.0
 Pillow==12.3.0
-probatio==0.11.3
+probatio==0.11.4
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
   "ulid-transform==2.2.9",
   "urllib3>=2.0",
   "uv==0.12.5",
-  "probatio==0.11.3",
+  "probatio==0.11.4",
   "yarl==1.24.5",
   "webrtc-models==0.3.0",
   "zeroconf==0.151.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mutagen==1.48.1
 orjson==3.12.0
 packaging>=23.1
 Pillow==12.3.0
-probatio==0.11.3
+probatio==0.11.4
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps probatio from 0.11.3 to 0.11.4.

- Release: https://github.com/frenck/probatio/releases/tag/v0.11.4
- Diff: https://github.com/frenck/probatio/compare/v0.11.3...v0.11.4

One bug fix, [frenck/probatio#336](https://github.com/frenck/probatio/pull/336): the `AUTO` policy's auto-compile counter could call itself. Once a schema crosses 50 calls it generates code, and the counter delegated through `self._compiled` from the threshold onward. During generation `self._compiled` is still the counter, so a caller crossing the threshold in that window landed back on the counter, incremented, was still past the threshold, and recursed until the stack gave out.

That reaches us. Automation config is validated from an executor thread against the blueprint and selector schemas, which are big enough for generation to hold the window open. It reads as `Setup failed for 'automation': Invalid config`, and it recovers on its own once generation finishes, so it presents as intermittent rather than as a dead schema. Not a regression: the counter has delegated that way since [frenck/probatio#55](https://github.com/frenck/probatio/pull/55).

The counter now reads `_compiled` once and never calls it while it is still itself, validating interpreted for the handful of calls in that window. No lock on the hot path, resolved case unchanged.

The rest of the release is six dependency updates inside probatio's own tooling (ruff, astro, starlight, pydantic, two sbom-action bumps). Source-wise the compare is `src/probatio/schema.py` (+11/-3), `tests/test_codegen.py` (+33), `pyproject.toml` and `uv.lock`.

No Home Assistant changes are needed.

Ran 4082 tests across the areas that lean hardest on schema validation, all green: `tests/helpers` (3662), automation, blueprint, script and config (512), plus `test_config.py`, websocket_api and template (3570). `gen_requirements_all` produced no further changes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
