### PR TITLE
Add state class selector

### DIFF
--- a/homeassistant/components/history_stats/config_flow.py
+++ b/homeassistant/components/history_stats/config_flow.py
@@ -145,7 +145,7 @@ def _get_options_schema_with_entity_id(entity_id: str, type: str) -> vol.Schema:
                 DurationSelectorConfig(enable_day=True, allow_negative=False),
             ),
             vol.Optional(CONF_STATE_CLASS): StateClassSelector(
-                StateClassSelectorConfig(state_classes_filter=state_class_options),
+                StateClassSelectorConfig(state_classes=state_class_options),
             ),
             vol.Optional(SECTION_ADDITIONAL_SETTINGS): section(
                 vol.Schema(

--- a/homeassistant/components/history_stats/config_flow.py
+++ b/homeassistant/components/history_stats/config_flow.py
@@ -26,6 +26,8 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    StateClassSelector,
+    StateClassSelectorConfig,
     StateSelector,
     StateSelectorConfig,
     TemplateSelector,
@@ -142,12 +144,8 @@ def _get_options_schema_with_entity_id(entity_id: str, type: str) -> vol.Schema:
             vol.Optional(CONF_DURATION): DurationSelector(
                 DurationSelectorConfig(enable_day=True, allow_negative=False),
             ),
-            vol.Optional(CONF_STATE_CLASS): SelectSelector(
-                SelectSelectorConfig(
-                    options=state_class_options,
-                    translation_key=CONF_STATE_CLASS,
-                    mode=SelectSelectorMode.DROPDOWN,
-                ),
+            vol.Optional(CONF_STATE_CLASS): StateClassSelector(
+                StateClassSelectorConfig(state_classes_filter=state_class_options),
             ),
             vol.Optional(SECTION_ADDITIONAL_SETTINGS): section(
                 vol.Schema(

--- a/homeassistant/components/history_stats/strings.json
+++ b/homeassistant/components/history_stats/strings.json
@@ -107,12 +107,6 @@
     }
   },
   "selector": {
-    "state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
     "type": {
       "options": {
         "count": "Count",

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -16,7 +16,6 @@ from homeassistant.components.sensor import (
     CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
     DEVICE_CLASS_UNITS as SENSOR_DEVICE_CLASS_UNITS,
     SensorDeviceClass,
-    SensorStateClass,
 )
 from homeassistant.components.text import TextMode
 from homeassistant.const import (
@@ -955,13 +954,7 @@ SENSOR_KNX_SCHEMA = AllSerializeFirst(
                     sort=True,
                 )
             ),
-            probatio.Optional(CONF_SENSOR_STATE_CLASS): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=list(SensorStateClass),
-                    translation_key="component.knx.selector.sensor_state_class",
-                    mode=selector.SelectSelectorMode.DROPDOWN,
-                )
-            ),
+            probatio.Optional(CONF_SENSOR_STATE_CLASS): selector.StateClassSelector(),
             probatio.Optional(CONF_ALWAYS_CALLBACK): selector.BooleanSelector(),
             probatio.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
                 allow_false=True

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1389,14 +1389,6 @@
     }
   },
   "selector": {
-    "sensor_state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
     "telegram_backend": {
       "options": {
         "postgres": "PostgreSQL (External)",

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -52,7 +52,6 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_UNITS,
     STATE_CLASS_UNITS,
     SensorDeviceClass,
-    SensorStateClass,
 )
 from homeassistant.components.valve import ValveState
 from homeassistant.config_entries import (
@@ -122,6 +121,7 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    StateClassSelector,
     TemplateSelector,
     TemplateSelectorConfig,
     TextSelector,
@@ -761,13 +761,7 @@ SENSOR_ENTITY_CATEGORY_SELECTOR = SelectSelector(
         sort=True,
     )
 )
-SENSOR_STATE_CLASS_SELECTOR = SelectSelector(
-    SelectSelectorConfig(
-        options=[device_class.value for device_class in SensorStateClass],
-        mode=SelectSelectorMode.DROPDOWN,
-        translation_key=CONF_STATE_CLASS,
-    )
-)
+SENSOR_STATE_CLASS_SELECTOR = StateClassSelector()
 STEP_SELECTOR = NumberSelector(NumberSelectorConfig(min=1e-3, step=1e-3))
 SUPPORTED_COLOR_MODES_SELECTOR = SelectSelector(
     SelectSelectorConfig(

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1321,14 +1321,6 @@
         "off": "[%key:common::state::off%]"
       }
     },
-    "state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
     "supported_color_modes": {
       "options": {
         "brightness": "[%key:component::light::entity_component::_::state_attributes::color_mode::state::brightness%]",

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.rest.schema import (  # pylint: disable=home-assis
     DEFAULT_METHOD,
     METHODS,
 )
-from homeassistant.components.sensor import CONF_STATE_CLASS, SensorStateClass
+from homeassistant.components.sensor import CONF_STATE_CLASS
 from homeassistant.config_entries import (
     SOURCE_USER,
     ConfigEntry,
@@ -59,6 +59,7 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    StateClassSelector,
     TemplateSelector,
     TextSelector,
     TextSelectorConfig,
@@ -155,14 +156,7 @@ SENSOR_SETTINGS = vol.Schema(
                     vol.Optional(CONF_DEVICE_CLASS): DeviceClassSelector(
                         DeviceClassSelectorConfig(domain=Platform.SENSOR)
                     ),
-                    vol.Optional(CONF_STATE_CLASS): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[cls.value for cls in SensorStateClass],
-                            mode=SelectSelectorMode.DROPDOWN,
-                            translation_key="state_class",
-                            sort=True,
-                        )
-                    ),
+                    vol.Optional(CONF_STATE_CLASS): StateClassSelector(),
                     vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
                         SelectSelectorConfig(
                             options=[cls.value for cls in UnitOfTemperature],

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -177,14 +177,6 @@
     }
   },
   "selector": {
-    "state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
     "unit_of_measurement": {
       "options": {
         "none": "No unit of measurement"

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 import voluptuous as vol
 
 from homeassistant.components.recorder import CONF_DB_URL, get_instance
-from homeassistant.components.sensor import CONF_STATE_CLASS, SensorStateClass
+from homeassistant.components.sensor import CONF_STATE_CLASS
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -55,14 +55,7 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
                     vol.Optional(CONF_DEVICE_CLASS): selector.DeviceClassSelector(
                         selector.DeviceClassSelectorConfig(domain=Platform.SENSOR)
                     ),
-                    vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=[cls.value for cls in SensorStateClass],
-                            mode=selector.SelectSelectorMode.DROPDOWN,
-                            translation_key="state_class",
-                            sort=True,
-                        )
-                    ),
+                    vol.Optional(CONF_STATE_CLASS): selector.StateClassSelector(),
                 }
             ),
             {"collapsed": True},

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -107,16 +107,6 @@
       }
     }
   },
-  "selector": {
-    "state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    }
-  },
   "services": {
     "query": {
       "description": "Executes a SQL query and returns the result.",

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     DEVICE_CLASS_STATE_CLASSES,
     DEVICE_CLASS_UNITS,
-    SensorStateClass,
 )
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -324,14 +323,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_DEVICE_CLASS): selector.DeviceClassSelector(
                 selector.DeviceClassSelectorConfig(domain=Platform.SENSOR),
             ),
-            vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=[cls.value for cls in SensorStateClass],
-                    mode=selector.SelectSelectorMode.DROPDOWN,
-                    translation_key="sensor_state_class",
-                    sort=True,
-                ),
-            ),
+            vol.Optional(CONF_STATE_CLASS): selector.StateClassSelector(),
         }
 
     if domain == Platform.SWITCH:

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -1146,14 +1146,6 @@
         "text": "Text"
       }
     },
-    "sensor_state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    },
     "sensor_unit_of_measurement": {
       "options": {
         "none": "No unit of measurement"

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1989,12 +1989,17 @@ class StateClassSelector(Selector[StateClassSelectorConfig]):
     )
 
     def __init__(self, config: StateClassSelectorConfig | None = None) -> None:
-        """Instantiate a device class selector."""
+        """Instantiate a state class selector."""
         super().__init__(config)
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        valid_options = _enum_options(Platform.SENSOR, "SensorStateClass")
+        state_classes_filter = self.config.get("state_classes")
+        valid_options = [
+            option
+            for option in _enum_options(Platform.SENSOR, "SensorStateClass")
+            if state_classes_filter is None or option in state_classes_filter
+        ]
         options_schema = vol.In(valid_options)
 
         if not self.config["multiple"]:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1972,7 +1972,7 @@ class StateClassSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent a sensor state class selector config."""
 
     multiple: bool
-    state_classes_filter: Sequence[str | SensorStateClass]
+    state_classes: Sequence[str | SensorStateClass]
 
 
 @SELECTORS.register("state_class")
@@ -1984,7 +1984,7 @@ class StateClassSelector(Selector[StateClassSelectorConfig]):
     CONFIG_SCHEMA = make_selector_config_schema(
         {
             vol.Optional("multiple", default=False): cv.boolean,
-            vol.Optional("state_classes_filter"): vol.All(cv.ensure_list, [str]),
+            vol.Optional("state_classes"): vol.All(cv.ensure_list, [str]),
         }
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1972,7 +1972,7 @@ class StateClassSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent a sensor state class selector config."""
 
     multiple: bool
-    state_classes_filter: list[str | SensorStateClass]
+    state_classes_filter: Sequence[str | SensorStateClass]
 
 
 @SELECTORS.register("state_class")

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from enum import StrEnum
 from functools import cache
 import importlib
-from typing import Any, Literal, Required, TypedDict, cast, override
+from typing import TYPE_CHECKING, Any, Literal, Required, TypedDict, cast, override
 from uuid import UUID
 
 import voluptuous as vol
@@ -19,6 +19,9 @@ from homeassistant.util.yaml import dumper
 from . import config_validation as cv
 
 SELECTORS: decorator.Registry[str, type[Selector]] = decorator.Registry()
+
+if TYPE_CHECKING:
+    from homeassistant.components.sensor import SensorStateClass
 
 
 def _get_selector_type_and_class(config: Any) -> tuple[str, type[Selector]]:
@@ -1963,6 +1966,42 @@ class SerialPortSelector(Selector[SerialPortSelectorConfig]):
         """Validate the passed selection."""
         serial: str = vol.Schema(str)(data)
         return serial
+
+
+class StateClassSelectorConfig(BaseSelectorConfig, total=False):
+    """Class to represent a sensor state class selector config."""
+
+    multiple: bool
+    state_classes_filter: list[SensorStateClass]
+
+
+@SELECTORS.register("state_class")
+class StateClassSelector(Selector[StateClassSelectorConfig]):
+    """Selector for sensor state class."""
+
+    selector_type = "state_class"
+
+    CONFIG_SCHEMA = make_selector_config_schema(
+        {
+            vol.Optional("multiple", default=False): cv.boolean,
+            vol.Optional("state_classes_filter"): vol.All(cv.ensure_list, [str]),
+        }
+    )
+
+    def __init__(self, config: StateClassSelectorConfig | None = None) -> None:
+        """Instantiate a device class selector."""
+        super().__init__(config)
+
+    def __call__(self, data: Any) -> Any:
+        """Validate the passed selection."""
+        valid_options = _enum_options(Platform.SENSOR, "SensorStateClass")
+        options_schema = vol.In(valid_options)
+
+        if not self.config["multiple"]:
+            return options_schema(vol.Schema(str)(data))
+        if not isinstance(data, list):
+            raise vol.Invalid("Value should be a list")
+        return [options_schema(vol.Schema(str)(val)) for val in data]
 
 
 class StateSelectorConfig(BaseSelectorConfig, total=False):

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1981,11 +1981,21 @@ class StateClassSelector(Selector[StateClassSelectorConfig]):
 
     selector_type = "state_class"
 
-    CONFIG_SCHEMA = make_selector_config_schema(
-        {
-            vol.Optional("multiple", default=False): cv.boolean,
-            vol.Optional("state_classes"): vol.All(cv.ensure_list, [str]),
-        }
+    @staticmethod
+    def _valid_state_classes(options: list[str]) -> list[str]:
+        """Validate state classes and raise if invalid."""
+        vol.In(_enum_options(Platform.SENSOR, "SensorStateClass"))(options)
+        return options
+
+    CONFIG_SCHEMA = vol.All(
+        make_selector_config_schema(
+            {
+                vol.Optional("multiple", default=False): cv.boolean,
+                vol.Optional("state_classes"): vol.All(
+                    cv.ensure_list, [str], [_valid_state_classes]
+                ),
+            },
+        ),
     )
 
     def __init__(self, config: StateClassSelectorConfig | None = None) -> None:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1972,7 +1972,7 @@ class StateClassSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent a sensor state class selector config."""
 
     multiple: bool
-    state_classes_filter: list[SensorStateClass]
+    state_classes_filter: list[str | SensorStateClass]
 
 
 @SELECTORS.register("state_class")

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2418,18 +2418,8 @@
         'optional': True,
         'required': False,
         'selector': dict({
-          'select': dict({
-            'custom_value': False,
-            'mode': 'dropdown',
+          'state_class': dict({
             'multiple': False,
-            'options': list([
-              'measurement',
-              'measurement_angle',
-              'total',
-              'total_increasing',
-            ]),
-            'sort': False,
-            'translation_key': 'component.knx.selector.sensor_state_class',
           }),
         }),
         'type': 'ha_selector',

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1723,7 +1723,14 @@ def test_device_class_selector_schema(
                 "multiple": True,
             },
             (["measurement"], ["total", "total_increasing"]),
-            ("measurement", 0, None, ["cat"]),
+            ("measurement", 0, None, ["cat"], ["measurement_angle"]),
+        ),
+        (
+            {
+                "state_classes": ["measurement", "total", "total_increasing"],
+            },
+            ("measurement", "total", "total_increasing"),
+            (["measurement"], 0, None, "dog", "measurement_angle"),
         ),
     ],
 )

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1719,7 +1719,7 @@ def test_device_class_selector_schema(
         ),
         (
             {
-                "state_classes_filter": ["measurement", "total", "total_increasing"],
+                "state_classes": ["measurement", "total", "total_increasing"],
                 "multiple": True,
             },
             (["measurement"], ["total", "total_increasing"]),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1703,6 +1703,41 @@ def test_device_class_selector_schema(
     ("schema", "valid_selections", "invalid_selections"),
     [
         (
+            {},
+            ("measurement", "total", "total_increasing", "measurement_angle"),
+            ("cat", 0, None, ["measurement"]),
+        ),
+        (
+            None,
+            ("measurement", "total", "total_increasing", "measurement_angle"),
+            ("cat", 0, None, ["measurement"]),
+        ),
+        (
+            {"multiple": True},
+            (["measurement"], ["total", "total_increasing", "measurement_angle"]),
+            ("measurement", 0, None, ["cat"]),
+        ),
+        (
+            {
+                "state_classes_filter": ["measurement", "total", "total_increasing"],
+                "multiple": True,
+            },
+            (["measurement"], ["total", "total_increasing"]),
+            ("measurement", 0, None, ["cat"]),
+        ),
+    ],
+)
+def test_state_class_selector_schema(
+    schema, valid_selections, invalid_selections
+) -> None:
+    """Test state class selector."""
+    _test_selector("state_class", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    ("schema", "valid_selections", "invalid_selections"),
+    [
+        (
             {"entity_id": "sensor.abc"},
             ("friendly_name", "device_class"),
             (None,),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1700,6 +1700,31 @@ def test_device_class_selector_schema(
 
 
 @pytest.mark.parametrize(
+    ("schema", "raises"),
+    [
+        (None, does_not_raise()),
+        ({}, does_not_raise()),
+        ({"multiple": False}, does_not_raise()),
+        ({"multiple": True}, does_not_raise()),
+        ({"state_classes": "total"}, does_not_raise()),
+        ({"state_classes": ["total"]}, does_not_raise()),
+        ({"state_classes": ["total", "measurement"]}, does_not_raise()),
+        ({"state_classes": ["cat"]}, pytest.raises(vol.Invalid)),
+        ({"state_classes": ["total", "beer"]}, pytest.raises(vol.Invalid)),
+        ({"state_classes": ["cat", "total"]}, pytest.raises(vol.Invalid)),
+    ],
+)
+def test_state_class_selector_validate_schema(
+    schema: dict, raises: AbstractContextManager
+) -> None:
+    """Test state class selector schemas."""
+    # Validate selector configuration
+
+    with raises:
+        selector.validate_selector({"state_class": schema})
+
+
+@pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Select selector were used by various integrations to select sensor state classes. This causes translation links to be copied, making translations harder to maintain.

This PR adds a a new selector `StateClassSelector`. Standard it showws all 4 existing state classes in a drop down box. The optional `state_classes_filter` allows to limit the state classes show to the list of state classes supplied.

In the PR existing integrations using a `SelectSelector` to select a sensor state class are updated to use the new selector, and translation strings are cleaned up.

<img width="1053" height="760" alt="afbeelding" src="https://github.com/user-attachments/assets/1c3b80e4-907f-4352-95c9-5390ede378a5" />

Checklist:
- [x] Frontend PR: https://github.com/home-assistant/frontend/pull/53880
- [x] User documentation PR: https://github.com/home-assistant/home-assistant.io/pull/47722
- [x] Developer blog PR: https://github.com/home-assistant/developers.home-assistant/pull/3314

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47722
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3314
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53880

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
