### PR TITLE
Fix philips_js remote turn_off waking a TV already in standby

### DIFF
--- a/homeassistant/components/philips_js/remote.py
+++ b/homeassistant/components/philips_js/remote.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
 from . import LOGGER
+from .const import TV_STATE_OFF, TV_STATE_ON
 from .coordinator import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
@@ -61,9 +62,11 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
     @override
     def is_on(self) -> bool | None:
         """Return true if device is on."""
-        return bool(
-            self._tv.on and (self._tv.powerstate == "On" or self._tv.powerstate is None)
-        )
+        if not self._tv.on:
+            return False
+        if self._tv.powerstate is not None:
+            return self._tv.powerstate == TV_STATE_ON
+        return self._tv.screenstate != TV_STATE_OFF
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -77,11 +80,14 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if self._tv.on:
-            await self._tv.sendKey("Standby")
-            self.async_write_ha_state()
-        else:
+        if not self.is_on:
             LOGGER.debug("Tv was already turned off")
+            return
+        if self._tv.powerstate:
+            await self._tv.setPowerState("Standby")
+        else:
+            await self._tv.sendKey("Standby")
+        self.async_write_ha_state()
 
     @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:

--- a/tests/components/philips_js/test_remote.py
+++ b/tests/components/philips_js/test_remote.py
@@ -1,0 +1,143 @@
+"""Tests for the Philips TV remote."""
+
+from unittest.mock import _Call, call
+
+from haphilipsjs import PhilipsTV
+import pytest
+
+from homeassistant.components.remote import (
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+REMOTE_ENTITY_ID = "remote.philips_tv_remote"
+
+
+async def setup_remote(
+    hass: HomeAssistant, mock_tv: PhilipsTV, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the integration with the mocked TV."""
+    mock_tv.json_feature_supported.return_value = False
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("on", "powerstate", "screenstate", "expected_state"),
+    [
+        pytest.param(True, "On", None, STATE_ON, id="powerstate-on"),
+        pytest.param(True, "On", "Off", STATE_ON, id="powerstate-on-screen-off"),
+        pytest.param(True, "Standby", None, STATE_OFF, id="powerstate-standby"),
+        pytest.param(True, "StandbyKeep", None, STATE_OFF, id="powerstate-standbykeep"),
+        pytest.param(True, None, None, STATE_ON, id="no-powerstate-reachable"),
+        pytest.param(True, None, "On", STATE_ON, id="no-powerstate-screen-on"),
+        pytest.param(True, None, "Off", STATE_OFF, id="no-powerstate-screen-off"),
+        pytest.param(False, None, None, STATE_OFF, id="unreachable"),
+    ],
+)
+async def test_state(
+    hass: HomeAssistant,
+    mock_tv: PhilipsTV,
+    mock_config_entry: MockConfigEntry,
+    on: bool,
+    powerstate: str | None,
+    screenstate: str | None,
+    expected_state: str,
+) -> None:
+    """Test the remote state matches the media player's on/off rule."""
+    mock_tv.on = on
+    mock_tv.powerstate = powerstate
+    mock_tv.screenstate = screenstate
+
+    await setup_remote(hass, mock_tv, mock_config_entry)
+
+    assert (state := hass.states.get(REMOTE_ENTITY_ID))
+    assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("on", "powerstate", "screenstate", "set_power_state_calls", "send_key_calls"),
+    [
+        pytest.param(
+            True,
+            "On",
+            None,
+            [call("Standby")],
+            [],
+            id="powerstate-uses-set-power-state",
+        ),
+        pytest.param(
+            True,
+            None,
+            None,
+            [],
+            [call("Standby")],
+            id="no-powerstate-falls-back-to-key",
+        ),
+        pytest.param(
+            True, None, "On", [], [call("Standby")], id="no-powerstate-screen-on"
+        ),
+        pytest.param(
+            True, "Standby", None, [], [], id="already-in-standby-sends-nothing"
+        ),
+        pytest.param(
+            True, None, "Off", [], [], id="no-powerstate-screen-off-sends-nothing"
+        ),
+        pytest.param(False, None, None, [], [], id="unreachable-sends-nothing"),
+    ],
+)
+async def test_turn_off(
+    hass: HomeAssistant,
+    mock_tv: PhilipsTV,
+    mock_config_entry: MockConfigEntry,
+    on: bool,
+    powerstate: str | None,
+    screenstate: str | None,
+    set_power_state_calls: list[_Call],
+    send_key_calls: list[_Call],
+) -> None:
+    """Test turning off.
+
+    A TV in network standby still answers the API, so `on` is True while
+    `powerstate` is "Standby" (or, without powerstate, `screenstate` is
+    "Off"). The Standby key is a power toggle, so nothing may be sent then.
+    """
+    mock_tv.on = on
+    mock_tv.powerstate = powerstate
+    mock_tv.screenstate = screenstate
+
+    await setup_remote(hass, mock_tv, mock_config_entry)
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: REMOTE_ENTITY_ID},
+        blocking=True,
+    )
+
+    assert mock_tv.setPowerState.mock_calls == set_power_state_calls
+    assert mock_tv.sendKey.mock_calls == send_key_calls
+
+
+async def test_turn_on_with_powerstate(
+    hass: HomeAssistant, mock_tv: PhilipsTV, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test turning on a reachable TV that supports powerstate."""
+    mock_tv.on = True
+    mock_tv.powerstate = "Standby"
+
+    await setup_remote(hass, mock_tv, mock_config_entry)
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: REMOTE_ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_tv.setPowerState.assert_called_once_with("On")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`PhilipsTVRemote.async_turn_off` sent the `Standby` key whenever `self._tv.on` was true. `_tv.on` only means the JointSpace API answered, which it does while the TV is in network standby (the mode needed for wake-on-LAN `turn_on`). On these sets `Standby` is a power *toggle*, so `remote.turn_off` on a TV that was already off turned it **on**.

The `media_player` platform in the same integration already guards on its own entity state and ignores the call otherwise, so `media_player.turn_off` was safe while `remote.turn_off` was not. And the remote's own `async_turn_on` already uses `setPowerState("On")` when `powerstate` is supported.

This change:

- guards on the entity's own `is_on` (which already accounts for `powerstate`), matching the media player, so an already-off TV is left alone;
- prefers `setPowerState("Standby")` when the TV reports `powerstate` — an absolute command, not a toggle — and only falls back to the `Standby` key for TVs without it.

The remote's `is_on` now uses the same rule as the media player: with `powerstate` reported, on only when it is `"On"`; without it, on unless `screenstate` is `"Off"` (how the media player recognises standby on sets that lack the `powerstate` endpoint). Previously the remote treated every reachable TV without `powerstate` as on.

Observed on a 2020s Android TV set with network standby on: TV put in standby at 17:20:12; an automation called `remote.turn_off` at 17:24:12.67; the entity went `off → on` at 17:24:13.25 and the TV was on.

Adds `tests/components/philips_js/test_remote.py` (the remote platform had no tests) covering state mapping, both turn-off paths, the already-in-standby and unreachable no-op cases, and turn-on.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180669
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] I understand the code I am submitting and can explain how it works.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+sort%3Aupdated-desc+review%3Anone+-status%3Afailure+-status%3Apending+-status%3Asuccess+no%3Areviewer+draft%3Afalse

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
