### PR TITLE
Authorize a Peblar charge session

### DIFF
--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -88,6 +88,9 @@
     "add_vehicle_token": {
       "service": "mdi:car-connected"
     },
+    "authorize_charge_session": {
+      "service": "mdi:card-account-details-star"
+    },
     "delete_rfid_token": {
       "service": "mdi:card-remove"
     },

--- a/homeassistant/components/peblar/services.py
+++ b/homeassistant/components/peblar/services.py
@@ -3,7 +3,13 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from peblar import Peblar, PeblarAuthenticationError, PeblarConnectionError, PeblarError
+from peblar import (
+    Peblar,
+    PeblarApi,
+    PeblarAuthenticationError,
+    PeblarConnectionError,
+    PeblarError,
+)
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_ALIAS, CONF_DESCRIPTION
@@ -15,6 +21,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import (
     async_get_config_entry,
     async_register_admin_service,
@@ -24,6 +31,7 @@ from .const import CONF_EVCC_ID, CONF_UID, DOMAIN
 from .coordinator import PeblarConfigEntry
 
 SERVICE_ADD_RFID_TOKEN = "add_rfid_token"
+SERVICE_AUTHORIZE_CHARGE_SESSION = "authorize_charge_session"
 SERVICE_ADD_VEHICLE_TOKEN = "add_vehicle_token"
 SERVICE_DELETE_RFID_TOKEN = "delete_rfid_token"
 SERVICE_DELETE_VEHICLE_TOKEN = "delete_vehicle_token"
@@ -37,6 +45,18 @@ ADD_TOKEN_SCHEMA = TOKEN_SCHEMA.extend({vol.Required(CONF_DESCRIPTION): str})
 
 VEHICLE_SCHEMA = CHARGER_SCHEMA.extend({vol.Required(CONF_EVCC_ID): str})
 ADD_VEHICLE_SCHEMA = VEHICLE_SCHEMA.extend({vol.Required(CONF_ALIAS): str})
+
+# The charger takes the token by UID or by description, and wants exactly
+# one of the two.
+AUTHORIZE_SCHEMA = vol.All(
+    CHARGER_SCHEMA.extend(
+        {
+            vol.Exclusive(CONF_UID, "token"): str,
+            vol.Exclusive(CONF_DESCRIPTION, "token"): str,
+        }
+    ),
+    cv.has_at_least_one_key(CONF_UID, CONF_DESCRIPTION),
+)
 
 
 def _get_rfid_peblar(hass: HomeAssistant, entry_id: str) -> Peblar:
@@ -56,6 +76,47 @@ def _get_rfid_peblar(hass: HomeAssistant, entry_id: str) -> Peblar:
         )
 
     return entry.runtime_data.user_configuration_coordinator.peblar
+
+
+def _get_authorizing_api(hass: HomeAssistant, entry_id: str) -> PeblarApi:
+    """Return the local REST API, for a charger that authorizes sessions.
+
+    Presenting a token lives on the local REST API rather than the web
+    one, unlike the actions that manage the lists it draws from.
+
+    The token comes from the standalone authorization list, so the reader
+    has to be there. Beyond that there are two ways for this to be
+    pointless: a charger managed by a backoffice over OCPP decides for
+    itself and refuses the request, and a charger set to charge without
+    authorization has nothing to authorize in the first place.
+    """
+    entry: PeblarConfigEntry = async_get_config_entry(hass, DOMAIN, entry_id)
+    runtime_data = entry.runtime_data
+
+    if not runtime_data.system_information.hardware_has_rfid:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_rfid_hardware",
+            translation_placeholders={"charger": entry.title},
+        )
+
+    configuration = runtime_data.user_configuration_coordinator.data
+
+    if configuration.secc_ocpp_active:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="managed_by_backoffice",
+            translation_placeholders={"charger": entry.title},
+        )
+
+    if configuration.session_manager_charge_without_authentication:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="authorization_not_required",
+            translation_placeholders={"charger": entry.title},
+        )
+
+    return runtime_data.data_coordinator.api
 
 
 def _get_autocharge_peblar(hass: HomeAssistant, entry_id: str) -> Peblar:
@@ -143,6 +204,15 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async with _handle_peblar_errors(hass, entry_id):
             await peblar.delete_rfid_token(uid=call.data[CONF_UID])
 
+    async def _handle_authorize_charge_session(call: ServiceCall) -> None:
+        entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
+        api = _get_authorizing_api(hass, entry_id)
+        async with _handle_peblar_errors(hass, entry_id):
+            await api.authorize_charge_session(
+                token=call.data.get(CONF_UID),
+                name=call.data.get(CONF_DESCRIPTION),
+            )
+
     async def _handle_list_vehicle_tokens(call: ServiceCall) -> ServiceResponse:
         entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
         peblar = _get_autocharge_peblar(hass, entry_id)
@@ -213,4 +283,11 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_DELETE_VEHICLE_TOKEN,
         _handle_delete_vehicle_token,
         schema=VEHICLE_SCHEMA,
+    )
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_AUTHORIZE_CHARGE_SESSION,
+        _handle_authorize_charge_session,
+        schema=AUTHORIZE_SCHEMA,
     )

--- a/homeassistant/components/peblar/services.yaml
+++ b/homeassistant/components/peblar/services.yaml
@@ -69,3 +69,17 @@ delete_vehicle_token:
       required: true
       selector:
         text:
+
+authorize_charge_session:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: peblar
+    uid:
+      selector:
+        text:
+    description:
+      selector:
+        text:

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -203,8 +203,14 @@
     "authentication_error": {
       "message": "An authentication failure occurred while communicating with the Peblar EV charger."
     },
+    "authorization_not_required": {
+      "message": "{charger} is set to charge without authorization, so there is nothing to authorize."
+    },
     "communication_error": {
       "message": "An error occurred while communicating with the Peblar EV charger: {error}"
+    },
+    "managed_by_backoffice": {
+      "message": "{charger} is managed over OCPP, so its sessions are authorized by the backoffice."
     },
     "no_autocharge_hardware": {
       "message": "{charger} has no power line communication hardware, so it cannot use autocharge."
@@ -252,6 +258,24 @@
         }
       },
       "name": "Add autocharge vehicle"
+    },
+    "authorize_charge_session": {
+      "description": "Presents a token to the charger, as if it were held against the reader. This authorizes a session that is waiting for it, and stops one that is already running.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Peblar EV charger to present the token to.",
+          "name": "Peblar EV charger"
+        },
+        "description": {
+          "description": "The label of the RFID token to present, instead of its UID.",
+          "name": "Description"
+        },
+        "uid": {
+          "description": "The unique identifier of the RFID token to present.",
+          "name": "UID"
+        }
+      },
+      "name": "Authorize charge session"
     },
     "delete_rfid_token": {
       "description": "Deletes an RFID token from the charger's standalone authorization list.",

--- a/tests/components/peblar/test_services.py
+++ b/tests/components/peblar/test_services.py
@@ -11,11 +11,13 @@ from peblar import (
     PeblarVehicleToken,
 )
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.peblar.const import DOMAIN
 from homeassistant.components.peblar.services import (
     SERVICE_ADD_RFID_TOKEN,
     SERVICE_ADD_VEHICLE_TOKEN,
+    SERVICE_AUTHORIZE_CHARGE_SESSION,
     SERVICE_DELETE_RFID_TOKEN,
     SERVICE_DELETE_VEHICLE_TOKEN,
     SERVICE_LIST_RFID_TOKENS,
@@ -409,3 +411,94 @@ async def test_autocharge_needs_power_line_communication(
 
     assert excinfo.value.translation_domain == DOMAIN
     assert excinfo.value.translation_key == "no_autocharge_hardware"
+
+
+@pytest.mark.parametrize(
+    ("service_data", "expected"),
+    [
+        ({"uid": "0123456789ABCD"}, {"token": "0123456789ABCD", "name": None}),
+        ({"description": "My card"}, {"token": None, "name": "My card"}),
+    ],
+    ids=["by uid", "by description"],
+)
+async def test_authorize_charge_session(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+    service_data: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    """Test the token can be presented by either of the two names for it."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_AUTHORIZE_CHARGE_SESSION,
+        {"config_entry_id": init_integration.entry_id, **service_data},
+        blocking=True,
+    )
+
+    mock_peblar.rest_api.return_value.authorize_charge_session.assert_called_once_with(
+        **expected
+    )
+
+
+@pytest.mark.parametrize(
+    "service_data",
+    [
+        {},
+        {"uid": "0123456789ABCD", "description": "My card"},
+    ],
+    ids=["neither", "both"],
+)
+async def test_authorize_charge_session_needs_exactly_one_token(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+    service_data: dict[str, Any],
+) -> None:
+    """Test the charger is told which token to present, and only one."""
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_AUTHORIZE_CHARGE_SESSION,
+            {"config_entry_id": init_integration.entry_id, **service_data},
+            blocking=True,
+        )
+
+    mock_peblar.rest_api.return_value.authorize_charge_session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mock_peblar", "translation_key"),
+    [
+        ({"HwHasRfid": False}, "no_rfid_hardware"),
+        ({"SeccOcppActive": True}, "managed_by_backoffice"),
+        ({"SessionManagerChargeWithoutAuth": True}, "authorization_not_required"),
+    ],
+    ids=["no reader", "managed over OCPP", "no authorization needed"],
+    indirect=["mock_peblar"],
+)
+async def test_authorize_charge_session_is_refused(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+    translation_key: str,
+) -> None:
+    """Test a charger that cannot or need not authorize is turned away.
+
+    The API refuses this outright on a charger managed over OCPP, and a
+    charger that charges without authorization has nothing to authorize.
+    """
+    with pytest.raises(ServiceValidationError) as excinfo:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_AUTHORIZE_CHARGE_SESSION,
+            {
+                "config_entry_id": init_integration.entry_id,
+                "uid": "0123456789ABCD",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == translation_key
+    mock_peblar.rest_api.return_value.authorize_charge_session.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `peblar.authorize_charge_session`, which presents a token to the charger as if it were held against the reader. The token is identified by its UID or by its label, exactly one of the two, which is what the API's `oneOf` asks for.

Home Assistant can already manage both token lists. Until now it could not act on a session waiting for one of them.

**It toggles, and the description says so.** From the [local REST API](https://developer.peblar.com/local-rest-api), this call is documented as the method to "simulate with the given token", so a session waiting for authorization gets it and one already running is stopped. That is what holding a card against a reader does. The action description spells it out rather than leaving the second press as a surprise.

**This one lives on the local REST API**, unlike the actions that manage the lists it draws from, which use the web API. Worth knowing, because it means it goes through `data_coordinator.api` rather than the `Peblar` client every other action here uses.

**Three ways for it not to apply**, each with its own message rather than a failed request:

| Condition | Why |
| --------- | --- |
| No RFID reader | The token comes from the standalone authorization list, which lives on the reader |
| `SeccOcppActive` | The API answers 403 in managed mode: a charger on an OCPP backoffice has its sessions authorized there |
| `SessionManagerChargeWithoutAuth` | The charger charges without authorization, so there is nothing to authorize |

The last one came out of reading a real charger's configuration and is set on the one I have access to, so without it the action would be pointless there, or would stop a running session.

The action is deliberately not exercised against real hardware: it toggles, and the charger I can reach has a car connected.

Verified: 117 tests pass, 100% coverage on `services.py`. Four mutation checks, each failing two tests: both new conditions, and the exactly-one-token rule.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47723
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
