### PR TITLE
Add binary sensors to SolarEdge Modbus

### DIFF
--- a/homeassistant/components/solaredge_modbus/__init__.py
+++ b/homeassistant/components/solaredge_modbus/__init__.py
@@ -38,7 +38,7 @@ from .coordinator import (
 from .entity import attachment_identity, inverter_device_info
 from .helpers import create_modbus_params
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/solaredge_modbus/binary_sensor.py
+++ b/homeassistant/components/solaredge_modbus/binary_sensor.py
@@ -1,0 +1,136 @@
+"""Support for SolarEdge Modbus binary sensor entities."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from solaredged import (
+    Battery,
+    BatteryStatus,
+    Inverter,
+    InverterExtended,
+    InverterStatus,
+)
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import SolarEdgeModbusConfigEntry
+from .entity import SolarEdgeModbusBatteryEntity, SolarEdgeModbusInverterEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class SolarEdgeModbusBinarySensorEntityDescription[ComponentT](
+    BinarySensorEntityDescription
+):
+    """Describes a SolarEdge Modbus binary sensor entity."""
+
+    exists_fn: Callable[[ComponentT], bool] = lambda _: True
+    is_on_fn: Callable[[ComponentT], bool | None]
+
+
+def _faulted(inverter: Inverter) -> bool | None:
+    """Whether the inverter reports a fault, unknown while its status is."""
+    if inverter.status is None:
+        return None
+    return inverter.status is InverterStatus.FAULT
+
+
+def _charging(battery: Battery) -> bool | None:
+    """Whether the battery is taking charge, unknown while its status is."""
+    if battery.status is None:
+        return None
+    return battery.status is BatteryStatus.CHARGE
+
+
+INVERTER_BINARY_SENSORS: tuple[
+    SolarEdgeModbusBinarySensorEntityDescription[Inverter], ...
+] = (
+    SolarEdgeModbusBinarySensorEntityDescription(
+        key="problem",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_faulted,
+    ),
+    SolarEdgeModbusBinarySensorEntityDescription(
+        key="on_grid",
+        translation_key="on_grid",
+        # Grid status is a firmware extension; without it there is nothing to
+        # show, and the library only carries the field where it answered.
+        exists_fn=lambda inverter: isinstance(inverter, InverterExtended),
+        is_on_fn=lambda inverter: inverter.on_grid,
+    ),
+)
+
+BATTERY_BINARY_SENSORS: tuple[
+    SolarEdgeModbusBinarySensorEntityDescription[Battery], ...
+] = (
+    # The status sensor carries the whole story, but Home Assistant's
+    # battery-charging triggers and conditions only look at this device class.
+    SolarEdgeModbusBinarySensorEntityDescription(
+        key="charging",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        is_on_fn=_charging,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SolarEdgeModbusConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up SolarEdge Modbus binary sensor entities based on a config entry."""
+    solaredge = entry.runtime_data.solaredge
+
+    entities: list[BinarySensorEntity] = [
+        SolarEdgeModbusInverterBinarySensorEntity(entry=entry, description=description)
+        for description in INVERTER_BINARY_SENSORS
+        if description.exists_fn(solaredge.inverter)
+    ]
+    entities.extend(
+        SolarEdgeModbusBatteryBinarySensorEntity(
+            entry=entry, description=description, index=index
+        )
+        for index in range(1, len(solaredge.batteries) + 1)
+        for description in BATTERY_BINARY_SENSORS
+        if description.exists_fn(solaredge.batteries[index - 1])
+    )
+
+    async_add_entities(entities)
+
+
+class SolarEdgeModbusInverterBinarySensorEntity(
+    SolarEdgeModbusInverterEntity, BinarySensorEntity
+):
+    """Defines a SolarEdge Modbus inverter binary sensor entity."""
+
+    entity_description: SolarEdgeModbusBinarySensorEntityDescription[Inverter]
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        return self.entity_description.is_on_fn(self.coordinator.solaredge.inverter)
+
+
+class SolarEdgeModbusBatteryBinarySensorEntity(
+    SolarEdgeModbusBatteryEntity, BinarySensorEntity
+):
+    """Defines a SolarEdge Modbus battery binary sensor entity."""
+
+    entity_description: SolarEdgeModbusBinarySensorEntityDescription[Battery]
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        return self.entity_description.is_on_fn(
+            self.coordinator.solaredge.batteries[self._index - 1]
+        )

--- a/homeassistant/components/solaredge_modbus/icons.json
+++ b/homeassistant/components/solaredge_modbus/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "binary_sensor": {
+      "on_grid": {
+        "default": "mdi:transmission-tower",
+        "state": {
+          "off": "mdi:transmission-tower-off"
+        }
+      }
+    },
     "sensor": {
       "battery_status": {
         "default": "mdi:home-battery"

--- a/homeassistant/components/solaredge_modbus/strings.json
+++ b/homeassistant/components/solaredge_modbus/strings.json
@@ -100,6 +100,15 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "on_grid": {
+        "name": "On grid",
+        "state": {
+          "off": "[%key:common::state::no%]",
+          "on": "[%key:common::state::yes%]"
+        }
+      }
+    },
     "sensor": {
       "battery_status": {
         "name": "Status",

--- a/tests/components/solaredge_modbus/snapshots/test_binary_sensor.ambr
+++ b/tests/components/solaredge_modbus/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,204 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.battery_1_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.battery_1_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'solaredge_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7E123ABC_battery_7E7C33E4_charging',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.battery_1_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery_charging',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Battery 1 Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.battery_1_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.battery_2_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.battery_2_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'solaredge_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7E123ABC_battery_7E8D44F5_charging',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.battery_2_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery_charging',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Battery 2 Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.battery_2_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.solaredge_se10000h_on_grid-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.solaredge_se10000h_on_grid',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'On grid',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'On grid',
+    'platform': 'solaredge_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'on_grid',
+    'unique_id': '7E123ABC_on_grid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.solaredge_se10000h_on_grid-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarEdge SE10000H On grid',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solaredge_se10000h_on_grid',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.solaredge_se10000h_problem-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.solaredge_se10000h_problem',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Problem',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Problem',
+    'platform': 'solaredge_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7E123ABC_problem',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.solaredge_se10000h_problem-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarEdge SE10000H Problem',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solaredge_se10000h_problem',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/solaredge_modbus/test_binary_sensor.py
+++ b/tests/components/solaredge_modbus/test_binary_sensor.py
@@ -1,0 +1,118 @@
+"""Tests for the SolarEdge Modbus binary sensor entities."""
+
+from unittest.mock import patch
+
+from modbus_connection import IllegalDataAddressError
+from modbus_connection.encode import encode_int
+from modbus_connection.mock import MockModbusUnit
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+CHARGING_ENTITY = "binary_sensor.battery_1_charging"
+PROBLEM_ENTITY = "binary_sensor.solaredge_se10000h_problem"
+ON_GRID_ENTITY = "binary_sensor.solaredge_se10000h_on_grid"
+BATTERY_STATUS_REGISTER = 57734
+
+
+async def _setup_binary_sensor_platform(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    with patch(
+        "homeassistant.components.solaredge_modbus.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """All binary sensor entities and their states match the snapshot."""
+    await _setup_binary_sensor_platform(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_no_on_grid_sensor_without_grid_status_extension(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """Firmware without the grid status extension gets no on-grid sensor."""
+    # A real device answers reads of the absent extension with a Modbus
+    # exception (illegal data address).
+    mock_modbus_unit.fail_read(40113, IllegalDataAddressError())
+
+    await _setup_binary_sensor_platform(hass, mock_config_entry)
+
+    assert hass.states.get(ON_GRID_ENTITY) is None
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        pytest.param(3, STATE_ON, id="charging"),
+        pytest.param(4, STATE_OFF, id="discharging"),
+        pytest.param(6, STATE_OFF, id="preserving charge"),
+        pytest.param(0xFFFFFFFF, STATE_UNKNOWN, id="not implemented"),
+    ],
+)
+async def test_battery_charging(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+    status: int,
+    expected: str,
+) -> None:
+    """The charging sensor follows the battery status, and admits ignorance.
+
+    Home Assistant's battery-charging triggers and conditions key on this
+    device class, so the status enum alone would leave them out of reach.
+    """
+    # The battery block is word-swapped, which the encoder can do itself.
+    words = encode_int(status, count=2, word_order="little")
+    for offset, word in enumerate(words):
+        mock_modbus_unit.holding[BATTERY_STATUS_REGISTER + offset] = word
+
+    await _setup_binary_sensor_platform(hass, mock_config_entry)
+
+    state = hass.states.get(CHARGING_ENTITY)
+    assert state is not None
+    assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        pytest.param(7, STATE_ON, id="fault"),
+        pytest.param(4, STATE_OFF, id="producing"),
+        pytest.param(2, STATE_OFF, id="sleeping"),
+        pytest.param(99, STATE_UNKNOWN, id="not a known status"),
+    ],
+)
+async def test_inverter_problem(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+    status: int,
+    expected: str,
+) -> None:
+    """A faulted inverter is a problem, and an unreadable status is unknown."""
+    mock_modbus_unit.holding[40107] = status
+
+    await _setup_binary_sensor_platform(hass, mock_config_entry)
+
+    state = hass.states.get(PROBLEM_ENTITY)
+    assert state is not None
+    assert state.state == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the binary sensor platform to `solaredge_modbus`, after the inverter (#180508), meters (#180572) and batteries (#180657). Three states, each here for its own reason.

**Battery charging**, per battery. The status sensor already tells the whole story, but Home Assistant's `battery.started_charging`, `battery.stopped_charging` and `battery.is_charging` look at nothing but this device class, so without it those triggers and conditions cannot reach a SolarEdge battery at all.

**Problem**, on the inverter, on when it reports a fault. No trigger provider exists for this device class; it is here because "the device has a problem" is a concept people already know, where a status of `fault` is a value they have to learn first.

**On grid**, on the inverter, for firmware that has the grid status extension. The library only carries that field where the block answered, so on firmware without it the entity does not exist rather than sitting there as unknown forever.

All three report `unknown` rather than a guess while the underlying status is unknown.

The captured dump used in the tests happens to cover this well: it has the grid status extension, and two batteries that are both preserving charge rather than charging. The charging state is parameterized over charging, discharging, preserving charge, and the `0xFFFFFFFF` that SolarEdge returns for a value it does not implement.

Documentation is in home-assistant/home-assistant.io#47679, which also picks up the batteries from #180657.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47679
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

