### PR TITLE
Bump aioaquarite to 0.9.2

### DIFF
--- a/homeassistant/components/vistapool/manifest.json
+++ b/homeassistant/components/vistapool/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aioaquarite"],
   "quality_scale": "bronze",
-  "requirements": ["aioaquarite==0.9.0"]
+  "requirements": ["aioaquarite==0.9.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ aioapcaccess==1.0.0
 aioaquacell==1.0.0
 
 # homeassistant.components.vistapool
-aioaquarite==0.9.0
+aioaquarite==0.9.2
 
 # homeassistant.components.aseko_pool_live
 aioaseko==1.0.0

--- a/tests/components/vistapool/test_select.py
+++ b/tests/components/vistapool/test_select.py
@@ -157,6 +157,42 @@ async def test_select_option_writes_index(
     )
 
 
+@pytest.mark.parametrize(
+    ("raw_value", "expected_option"),
+    [
+        pytest.param(0, "slow", id="slow"),
+        pytest.param(1, "medium", id="medium"),
+        pytest.param(2, "high", id="high"),
+    ],
+)
+async def test_filtration_timer_speed_options(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    raw_value: int,
+    expected_option: str,
+) -> None:
+    """Test every timer speed maps onto its option.
+
+    The timer speeds are three-state like the manual pump speed, so high
+    has to survive the library's value coercion; slow and medium would
+    still map correctly even if the value were read as a boolean.
+    """
+    mock_vistapool_client.fetch_pool_data.return_value = {
+        "main": {"version": 1},
+        "filtration": {"timerVel1": raw_value},
+    }
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("select.my_pool_filtration_timer_speed_1").state
+        == expected_option
+    )
+
+
 async def test_select_option_raises_on_api_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `aioaquarite` from 0.9.0 to 0.9.2 for the Vistapool integration. It carries two fixes, one of which is a user-facing bug in the shipped integration.

**Filtration timer speeds read as unknown when set to high.** The three `filtration.timerVel1/2/3` fields carry a pump speed (0 slow, 1 medium, 2 high), the same three-state value as `filtration.manVel`. The library typed them as boolean, so its coercion only accepted 0 and 1: a timer set to high failed coercion, `get_value` returned `None`, and it logged a warning on every read. The integration maps those paths onto `["slow", "medium", "high"]`, so the three `select.*_filtration_timer_speed_*` entities showed `unknown` whenever a timer interval used high speed, with a warning on every Firestore push. Slow and medium kept working because a boolean round-trips to index 0 and 1, which is why this went unnoticed. Writes were never affected — only reads. Reported by @ThierryR42 in fdebrus/aioaquarite#17, fixed in fdebrus/aioaquarite#19.

**Concurrent writes to the same command branch could revert each other.** The command payload is rebuilt from the stored pool document, and that document was only updated after the send completed, so two callers writing different fields of one branch at the same time each snapshotted before the other's update landed and the second command reverted the first field. Commands for the same pool and branch are now serialised under a lock covering payload construction, the send, and the cache update. The integration writes through `set_value` from several platforms onto shared branches — for example `number` on `filtration.intel.temp` and `select` on `filtration.mode` — so it was exposed.

Note that 0.9.1 was never published to PyPI; 0.9.2 carries both fixes.

**On the test in a dependency bump.** The existing fixtures set the timer speeds to 0 and 1 only, so the bug was not reachable by the suite and the bump alone would leave every snapshot byte-identical. I added a parametrized test covering all three speeds rather than changing a fixture, so the suite now catches a regression here without any snapshot churn. Against 0.9.0 it fails with `assert 'unknown' == 'high'` while the slow and medium cases still pass, which is exactly why the bug was easy to miss.

Links:

- PyPI: https://pypi.org/project/aioaquarite/0.9.2/
- Changelog: https://github.com/fdebrus/aioaquarite/blob/main/CHANGES.md
- Full diff: https://github.com/fdebrus/aioaquarite/compare/v0.9.0...v0.9.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Upstream report: https://github.com/fdebrus/aioaquarite/issues/17

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr