### PR TITLE
Clear stale Freebox app token when registration fails (fixes #153988)

### DIFF
--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
-from .router import get_api, get_hosts_list_if_supported
+from .router import async_forget_registration, get_api, get_hosts_list_if_supported
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +85,10 @@ class FreeboxFlowHandler(ConfigFlow, domain=DOMAIN):
         except AuthorizationError as error:
             _LOGGER.error(error)
             errors["base"] = "register_failed"
+            # The stored application token (if any) was rejected by the
+            # Freebox. Clear it so resubmitting this form performs a fresh
+            # pairing instead of retrying with the same rejected token.
+            await async_forget_registration(self.hass, self._data[CONF_HOST])
 
         except HttpRequestError:
             _LOGGER.error(

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -11,7 +11,12 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
-from .router import async_forget_registration, get_api, get_hosts_list_if_supported
+from .router import (
+    async_forget_registration,
+    get_api,
+    get_hosts_list_if_supported,
+    is_invalid_token_error,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,8 +90,12 @@ class FreeboxFlowHandler(ConfigFlow, domain=DOMAIN):
         except AuthorizationError as error:
             _LOGGER.error(error)
             errors["base"] = "register_failed"
-            # Delete a rejected token so the next submission starts fresh pairing.
-            await async_forget_registration(self.hass, self._data[CONF_HOST])
+            if is_invalid_token_error(error):
+                # The stored application token was rejected by the
+                # Freebox. Clear it so resubmitting this form performs a
+                # fresh pairing instead of retrying with the same
+                # rejected token forever.
+                await async_forget_registration(self.hass, self._data[CONF_HOST])
 
         except HttpRequestError:
             _LOGGER.error(

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -85,9 +85,7 @@ class FreeboxFlowHandler(ConfigFlow, domain=DOMAIN):
         except AuthorizationError as error:
             _LOGGER.error(error)
             errors["base"] = "register_failed"
-            # The stored application token (if any) was rejected by the
-            # Freebox. Clear it so resubmitting this form performs a fresh
-            # pairing instead of retrying with the same rejected token.
+            # Delete a rejected token so the next submission starts fresh pairing.
             await async_forget_registration(self.hass, self._data[CONF_HOST])
 
         except HttpRequestError:

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -54,6 +54,17 @@ def is_json(json_str: str) -> bool:
     return True
 
 
+def _get_token_file(hass: HomeAssistant, host: str) -> Path:
+    """Return the path of the stored application token file for a host."""
+    freebox_path = Store(hass, STORAGE_VERSION, STORAGE_KEY).path
+    return Path(f"{freebox_path}/{slugify(host)}.conf")
+
+
+def _unlink_if_exists(path: Path) -> None:
+    """Remove a file if it exists."""
+    path.unlink(missing_ok=True)
+
+
 async def get_api(hass: HomeAssistant, host: str) -> Freepybox:
     """Get the Freebox API."""
     freebox_path = Store(hass, STORAGE_VERSION, STORAGE_KEY).path
@@ -61,9 +72,24 @@ async def get_api(hass: HomeAssistant, host: str) -> Freepybox:
     if not os.path.exists(freebox_path):
         await hass.async_add_executor_job(os.makedirs, freebox_path)
 
-    token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
+    token_file = _get_token_file(hass, host)
 
     return Freepybox(APP_DESC, token_file, API_VERSION)
+
+
+async def async_forget_registration(hass: HomeAssistant, host: str) -> None:
+    """Remove a stored application token for a host, if any.
+
+    The Freebox can reject an application token that Home Assistant still
+    considers valid, for example after the router was replaced, factory
+    reset, or the application authorization was revoked from the Freebox
+    OS settings. When that happens, Home Assistant keeps retrying with the
+    same rejected token forever. Removing the stored token forces a fresh
+    pairing (and a new "please confirm on your Freebox" prompt) on the
+    next attempt.
+    """
+    token_file = _get_token_file(hass, host)
+    await hass.async_add_executor_job(_unlink_if_exists, token_file)
 
 
 async def get_hosts_list_if_supported(

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -77,6 +77,23 @@ async def get_api(hass: HomeAssistant, host: str) -> Freepybox:
     return Freepybox(APP_DESC, token_file, API_VERSION)
 
 
+def is_invalid_token_error(error: Exception) -> bool:
+    """Return True if error is an AuthorizationError caused by a rejected app token.
+
+    freebox-api raises the same AuthorizationError for several unrelated
+    situations (a rejected app token, but also a denied or timed out
+    pairing request, or a transient failure of the challenge/session
+    calls). Only a rejected token should make us forget the stored
+    registration, so the underlying APIResponse's error_code is inspected
+    instead of reacting to every AuthorizationError.
+    """
+    return bool(
+        (matcher := re.search(r"\(APIResponse: (.+)\)$", str(error)))
+        and is_json(json_str := matcher.group(1))
+        and json.loads(json_str).get("error_code") == "invalid_token"
+    )
+
+
 async def async_forget_registration(hass: HomeAssistant, host: str) -> None:
     """Remove a stored application token for a host, if any.
 

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -78,15 +78,7 @@ async def get_api(hass: HomeAssistant, host: str) -> Freepybox:
 
 
 def is_invalid_token_error(error: Exception) -> bool:
-    """Return True if error is an AuthorizationError caused by a rejected app token.
-
-    freebox-api raises the same AuthorizationError for several unrelated
-    situations (a rejected app token, but also a denied or timed out
-    pairing request, or a transient failure of the challenge/session
-    calls). Only a rejected token should make us forget the stored
-    registration, so the underlying APIResponse's error_code is inspected
-    instead of reacting to every AuthorizationError.
-    """
+    """Return whether an authorization error reports a rejected app token."""
     return bool(
         (matcher := re.search(r"\(APIResponse: (.+)\)$", str(error)))
         and is_json(json_str := matcher.group(1))

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -172,10 +172,13 @@ async def test_on_link_failed_forgets_registration_on_invalid_token(
 ) -> None:
     """Test that an invalid app token clears the stored registration."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "link"
 
     error = AuthorizationError(
         'Starting session failed (APIResponse: {"success": false, '
@@ -208,10 +211,13 @@ async def test_on_link_failed_keeps_registration_on_other_authorization_error(
     registration must be left untouched for them.
     """
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "link"
 
     with (
         patch(

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -170,13 +170,7 @@ async def test_on_link_failed(hass: HomeAssistant) -> None:
 async def test_on_link_failed_forgets_registration_on_invalid_token(
     hass: HomeAssistant,
 ) -> None:
-    """A rejected app token must clear the stored registration.
-
-    Without this, Home Assistant keeps retrying with the same rejected
-    token forever, which is reported as "Failed to register, please try
-    again" no matter how many times the user resubmits the form (for
-    example after the router was replaced or its authorization revoked).
-    """
+    """Test that an invalid app token clears the stored registration."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -167,6 +167,35 @@ async def test_on_link_failed(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "unknown"}
 
 
+async def test_on_link_failed_forgets_registration(hass: HomeAssistant) -> None:
+    """A rejected authorization must clear the stored app token.
+
+    Without this, Home Assistant keeps retrying with the same rejected
+    token forever, which is reported as "Failed to register, please try
+    again" no matter how many times the user resubmits the form (for
+    example after the router was replaced or its authorization revoked).
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.freebox.router.Freepybox.open",
+            side_effect=AuthorizationError(),
+        ),
+        patch(
+            "homeassistant.components.freebox.config_flow.async_forget_registration"
+        ) as mock_forget_registration,
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "register_failed"}
+        mock_forget_registration.assert_awaited_once_with(hass, MOCK_HOST)
+
+
 async def test_zeroconf_missing_api_domain(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -167,8 +167,10 @@ async def test_on_link_failed(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "unknown"}
 
 
-async def test_on_link_failed_forgets_registration(hass: HomeAssistant) -> None:
-    """A rejected authorization must clear the stored app token.
+async def test_on_link_failed_forgets_registration_on_invalid_token(
+    hass: HomeAssistant,
+) -> None:
+    """A rejected app token must clear the stored registration.
 
     Without this, Home Assistant keeps retrying with the same rejected
     token forever, which is reported as "Failed to register, please try
@@ -181,10 +183,15 @@ async def test_on_link_failed_forgets_registration(hass: HomeAssistant) -> None:
         data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
     )
 
+    error = AuthorizationError(
+        'Starting session failed (APIResponse: {"success": false, '
+        '"msg": "Erreur d\'authentification de l\'application", '
+        '"error_code": "invalid_token"})'
+    )
     with (
         patch(
             "homeassistant.components.freebox.router.Freepybox.open",
-            side_effect=AuthorizationError(),
+            side_effect=error,
         ),
         patch(
             "homeassistant.components.freebox.config_flow.async_forget_registration"
@@ -194,6 +201,37 @@ async def test_on_link_failed_forgets_registration(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.FORM
         assert result["errors"] == {"base": "register_failed"}
         mock_forget_registration.assert_awaited_once_with(hass, MOCK_HOST)
+
+
+async def test_on_link_failed_keeps_registration_on_other_authorization_error(
+    hass: HomeAssistant,
+) -> None:
+    """An AuthorizationError unrelated to the app token must not clear it.
+
+    freebox-api also raises AuthorizationError for a denied or timed out
+    pairing request, and for transient failures of the challenge/session
+    calls. None of those mean the stored token itself is bad, so the
+    registration must be left untouched for them.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.freebox.router.Freepybox.open",
+            side_effect=AuthorizationError("Authorization timed out"),
+        ),
+        patch(
+            "homeassistant.components.freebox.config_flow.async_forget_registration"
+        ) as mock_forget_registration,
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "register_failed"}
+        mock_forget_registration.assert_not_awaited()
 
 
 async def test_zeroconf_missing_api_domain(

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -4,12 +4,13 @@ import json
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from freebox_api.exceptions import HttpRequestError
+from freebox_api.exceptions import AuthorizationError, HttpRequestError
 import pytest
 
 from homeassistant.components.freebox.router import (
     async_forget_registration,
     get_hosts_list_if_supported,
+    is_invalid_token_error,
     is_json,
 )
 from homeassistant.core import HomeAssistant
@@ -81,6 +82,42 @@ async def test_get_hosts_list_if_supported_bridge_error(
     """Other exceptions must be propagated."""
     with pytest.raises(HttpRequestError):
         await get_hosts_list_if_supported(mock_router_bridge_mode_error())
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        pytest.param(
+            AuthorizationError(
+                'Starting session failed (APIResponse: {"success": false, '
+                '"error_code": "invalid_token"})'
+            ),
+            True,
+            id="invalid_token",
+        ),
+        pytest.param(
+            AuthorizationError(
+                'Starting session failed (APIResponse: {"success": false, '
+                '"error_code": "internal_error"})'
+            ),
+            False,
+            id="other_error_code",
+        ),
+        pytest.param(
+            AuthorizationError("Authorization timed out"),
+            False,
+            id="no_api_response",
+        ),
+        pytest.param(
+            AuthorizationError("The app token is invalid or has been revoked"),
+            False,
+            id="denied_pairing_mentions_invalid_but_has_no_error_code",
+        ),
+    ],
+)
+def test_is_invalid_token_error(error: AuthorizationError, expected: bool) -> None:
+    """Only a genuine invalid_token APIResponse must be treated as such."""
+    assert is_invalid_token_error(error) is expected
 
 
 async def test_async_forget_registration(hass: HomeAssistant, tmp_path: Path) -> None:

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -1,14 +1,35 @@
 """Tests for the Freebox utility methods."""
 
 import json
-from unittest.mock import Mock
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 from freebox_api.exceptions import HttpRequestError
 import pytest
 
-from homeassistant.components.freebox.router import get_hosts_list_if_supported, is_json
+from homeassistant.components.freebox.router import (
+    async_forget_registration,
+    get_hosts_list_if_supported,
+    is_json,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
-from .const import DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE, DATA_WIFI_GET_GLOBAL_CONFIG
+from .const import (
+    DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE,
+    DATA_WIFI_GET_GLOBAL_CONFIG,
+    MOCK_HOST,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_path():
+    """Use the real pathlib.Path in this module so file removal can be tested.
+
+    This overrides the autouse fixture of the same name in conftest.py,
+    which stubs out Path for the config flow / setup tests in this package.
+    """
+    return
 
 
 async def test_is_json() -> None:
@@ -60,3 +81,19 @@ async def test_get_hosts_list_if_supported_bridge_error(
     """Other exceptions must be propagated."""
     with pytest.raises(HttpRequestError):
         await get_hosts_list_if_supported(mock_router_bridge_mode_error())
+
+
+async def test_async_forget_registration(hass: HomeAssistant, tmp_path: Path) -> None:
+    """async_forget_registration must remove the stored app token, if any."""
+    with patch("homeassistant.components.freebox.router.Store") as mock_store:
+        mock_store.return_value.path = str(tmp_path)
+
+        token_file = tmp_path / f"{slugify(MOCK_HOST)}.conf"
+        token_file.write_text('{"app_token": "stale"}')
+        assert token_file.exists()
+
+        await async_forget_registration(hass, MOCK_HOST)
+        assert not token_file.exists()
+
+        # Calling again with no stored file left must not raise.
+        await async_forget_registration(hass, MOCK_HOST)

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -2,11 +2,12 @@
 
 import json
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from freebox_api.exceptions import AuthorizationError, HttpRequestError
 import pytest
 
+from homeassistant.components.freebox.const import STORAGE_KEY, STORAGE_VERSION
 from homeassistant.components.freebox.router import (
     async_forget_registration,
     get_hosts_list_if_supported,
@@ -14,6 +15,7 @@ from homeassistant.components.freebox.router import (
     is_json,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
 
 from .const import (
@@ -31,6 +33,16 @@ def mock_path():
     which stubs out Path for the config flow / setup tests in this package.
     """
     return
+
+
+@pytest.fixture
+def hass_config_dir(hass_tmp_config_dir: str) -> str:
+    """Use a temporary config directory so the app token file is isolated.
+
+    This lets async_forget_registration's own Store lookup be exercised
+    for real, instead of mocking Store to point at a test-controlled path.
+    """
+    return hass_tmp_config_dir
 
 
 async def test_is_json() -> None:
@@ -120,17 +132,18 @@ def test_is_invalid_token_error(error: AuthorizationError, expected: bool) -> No
     assert is_invalid_token_error(error) is expected
 
 
-async def test_async_forget_registration(hass: HomeAssistant, tmp_path: Path) -> None:
+async def test_async_forget_registration(hass: HomeAssistant) -> None:
     """async_forget_registration must remove the stored app token, if any."""
-    with patch("homeassistant.components.freebox.router.Store") as mock_store:
-        mock_store.return_value.path = str(tmp_path)
+    token_file = (
+        Path(Store(hass, STORAGE_VERSION, STORAGE_KEY).path)
+        / f"{slugify(MOCK_HOST)}.conf"
+    )
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    token_file.write_text('{"app_token": "stale"}')
+    assert token_file.exists()
 
-        token_file = tmp_path / f"{slugify(MOCK_HOST)}.conf"
-        token_file.write_text('{"app_token": "stale"}')
-        assert token_file.exists()
+    await async_forget_registration(hass, MOCK_HOST)
+    assert not token_file.exists()
 
-        await async_forget_registration(hass, MOCK_HOST)
-        assert not token_file.exists()
-
-        # Calling again with no stored file left must not raise.
-        await async_forget_registration(hass, MOCK_HOST)
+    # Calling again with no stored file left must not raise.
+    await async_forget_registration(hass, MOCK_HOST)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the Freebox rejects the application token Home Assistant has stored
for a host (`invalid_token` / "Erreur d'authentification de l'application"),
the config flow kept reusing that same rejected token on every retry. Since
the token file is only written *after* a successful pairing, a failed
attempt never cleared it, so every subsequent "Submit" replayed the same
bad token and failed identically forever with "Failed to register, please
try again" — without ever showing the "confirm on your Freebox" prompt
again.

This happens whenever the stored token becomes invalid for reasons outside
Home Assistant's knowledge: the router was replaced (as in the linked
issue, going from a Freebox Delta to a Freebox Delta 6E while keeping the
default `mafreebox.freebox.fr` host), a factory reset, or the application
authorization being revoked from the Freebox OS settings.

This PR clears the stored token when `AuthorizationError` is raised during
the `link` step, so resubmitting the form performs a fresh pairing (and
shows the physical-button confirmation prompt again) instead of retrying
with the same rejected token indefinitely.

Verified locally against a real Freebox Delta 6E that was hitting this
exact bug: after the fix, the first resubmission clears the stale token
(one more expected failure) and the second resubmission shows the
"confirm on your Freebox" prompt and completes pairing successfully.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #153988
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
