### PR TITLE
Migrate Lyngdorf diagnostics to the lyngdorf 2.0 API

### DIFF
--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -3,6 +3,8 @@
 from dataclasses import asdict
 from typing import Any
 
+from lyngdorf import Trim
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.components.ssdp import async_get_discovery_info_by_st
 from homeassistant.const import CONF_HOST
@@ -12,10 +14,16 @@ from homeassistant.helpers.service_info.ssdp import ATTR_UPNP_SERIAL
 from .const import CONF_SERIAL_NUMBER, SSDP_ST
 from .models import LyngdorfConfigEntry
 
-_TRIM_NAMES = tuple(
-    f"trim_{trim}" for trim in ("bass", "treble", "centre", "height", "lfe", "surround")
-)
-_RANGE_NAMES = ("lipsync_range", *(f"{name}_range" for name in _TRIM_NAMES))
+# Reported under the integration's own names, which do not all match the
+# library's spelling of the band.
+_TRIMS = {
+    "trim_bass": Trim.BASS,
+    "trim_treble": Trim.TREBLE,
+    "trim_centre": Trim.CENTER,
+    "trim_height": Trim.HEIGHT,
+    "trim_lfe": Trim.LFE,
+    "trim_surround": Trim.SURROUND,
+}
 
 # The serial doubles as the device MAC and as the config entry unique_id, so it
 # needs redacting wherever it surfaces, including inside the UPnP description.
@@ -56,43 +64,55 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     receiver = config_entry.runtime_data.receiver
+    volume = receiver.volume
+    lipsync = receiver.lipsync
+    zone_b = receiver.zone_b
 
     state: dict[str, Any] = {
         "connected": receiver.connected,
         "model": receiver.model.name,
         "power_on": receiver.power_on,
-        "volume": receiver.volume,
+        "volume": volume.value if volume is not None else None,
         "max_volume": receiver.max_volume,
-        "mute_enabled": receiver.mute_enabled,
+        "mute_enabled": receiver.muted,
         "source": receiver.source,
-        "available_sources": receiver.available_sources,
+        "available_sources": receiver.sources,
         "sound_mode": receiver.sound_mode,
-        "available_sound_modes": receiver.available_sound_modes,
+        "available_sound_modes": receiver.sound_modes,
         "audio_input": receiver.audio_input,
-        "available_audio_inputs": receiver.available_audio_inputs,
+        "available_audio_inputs": receiver.audio_inputs,
         "video_input": receiver.video_input,
-        "available_video_inputs": receiver.available_video_inputs,
+        "available_video_inputs": receiver.video_inputs,
         "audio_information": receiver.audio_information,
         "video_information": receiver.video_information,
         "streaming_source": receiver.streaming_source,
-        "available_stream_types": receiver.available_stream_types,
+        "available_stream_types": receiver.stream_types,
         "room_perfect_position": receiver.room_perfect_position,
-        "available_room_perfect_positions": receiver.available_room_perfect_positions,
+        "available_room_perfect_positions": receiver.room_perfect_positions,
         "voicing": receiver.voicing,
-        "available_voicings": receiver.available_voicings,
-        "lipsync": receiver.lipsync,
-        "zone_b_power_on": receiver.zone_b_power_on,
-        "zone_b_volume": receiver.zone_b_volume,
-        "zone_b_mute_enabled": receiver.zone_b_mute_enabled,
-        "zone_b_source": receiver.zone_b_source,
-        "zone_b_audio_input": receiver.zone_b_audio_input,
-        "zone_b_streaming_source": receiver.zone_b_streaming_source,
+        "available_voicings": receiver.voicings,
+        "lipsync": lipsync.value if lipsync is not None else None,
+        "zone_b_power_on": zone_b.power_on if zone_b is not None else None,
+        "zone_b_volume": zone_b.volume.value if zone_b is not None else None,
+        "zone_b_mute_enabled": zone_b.muted if zone_b is not None else None,
+        "zone_b_source": zone_b.source if zone_b is not None else None,
+        "zone_b_audio_input": zone_b.audio_input if zone_b is not None else None,
+        "zone_b_streaming_source": zone_b.streaming_source
+        if zone_b is not None
+        else None,
     }
-    state |= {name: getattr(receiver, name) for name in _TRIM_NAMES}
+    trims = {name: receiver.trims.get(trim) for name, trim in _TRIMS.items()}
+    state |= {
+        name: control.value if control is not None else None
+        for name, control in trims.items()
+    }
 
-    ranges = {
-        name: asdict(value) if (value := getattr(receiver, name)) is not None else None
-        for name in _RANGE_NAMES
+    ranges: dict[str, Any] = {
+        "lipsync_range": asdict(lipsync.range) if lipsync is not None else None
+    }
+    ranges |= {
+        f"{name}_range": asdict(control.range) if control is not None else None
+        for name, control in trims.items()
     }
 
     return async_redact_data(

--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -107,8 +107,11 @@ async def async_get_config_entry_diagnostics(
         for name, control in trims.items()
     }
 
+    # Not lipsync.range: the control reads None until the device reports a
+    # value, while the range is known from the model as soon as it connects.
+    lipsync_range = receiver.lipsync_range
     ranges: dict[str, Any] = {
-        "lipsync_range": asdict(lipsync.range) if lipsync is not None else None
+        "lipsync_range": asdict(lipsync_range) if lipsync_range is not None else None
     }
     ranges |= {
         f"{name}_range": asdict(control.range) if control is not None else None

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -151,7 +151,7 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.can_shuffle = False
     receiver.available_repeat_modes = frozenset()
 
-    receiver.lipsync = _FloatControl(50, NumericRange(0, 500, 1))
+    receiver.lipsync = _FloatControl(50.0, NumericRange(0, 500, 1))
     receiver.lipsync_range = NumericRange(0, 500, 1)
     receiver.trims = {
         Trim.BASS: _control(3.0, NumericRange(-12.0, 12.0, 0.1)),

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -151,7 +151,7 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.can_shuffle = False
     receiver.available_repeat_modes = frozenset()
 
-    receiver.lipsync = _FloatControl(50.0, NumericRange(0, 500, 1))
+    receiver.lipsync = _FloatControl(50, NumericRange(0, 500, 1))
     receiver.lipsync_range = NumericRange(0, 500, 1)
     receiver.trims = {
         Trim.BASS: _control(3.0, NumericRange(-12.0, 12.0, 0.1)),

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -13,6 +13,7 @@ from lyngdorf import (
     NumericRange,
     RemoteKey,
     Trim,
+    ZoneB,
 )
 import pytest
 
@@ -150,7 +151,7 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.can_shuffle = False
     receiver.available_repeat_modes = frozenset()
 
-    receiver.lipsync = _FloatControl(50, NumericRange(0, 500, 1))
+    receiver.lipsync = _FloatControl(50.0, NumericRange(0, 500, 1))
     receiver.lipsync_range = NumericRange(0, 500, 1)
     receiver.trims = {
         Trim.BASS: _control(3.0, NumericRange(-12.0, 12.0, 0.1)),
@@ -178,6 +179,25 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.zone_b_available_sources = []
     receiver.zone_b_audio_input = "aux"
     receiver.zone_b_streaming_source = "DLNA"
+
+    receiver.volume = _FloatControl(-40.0, NumericRange(-99.9, 24.0, 0.1))
+    receiver.muted = False
+    receiver.sources = []
+    receiver.sound_modes = []
+    receiver.audio_inputs = ["optical", "aux"]
+    receiver.video_inputs = ["hdmi"]
+    receiver.stream_types = ["AirPlay", "DLNA"]
+    receiver.room_perfect_positions = ["Global", "Focus 1"]
+    receiver.voicings = ["Neutral", "Music", "Movie"]
+
+    zone_b = MagicMock(spec=ZoneB)
+    zone_b.power_on = False
+    zone_b.muted = False
+    zone_b.source = None
+    zone_b.audio_input = "aux"
+    zone_b.streaming_source = "DLNA"
+    zone_b.volume = _FloatControl(-40.0, NumericRange(-99.9, 24.0, 0.1))
+    receiver.zone_b = zone_b
 
     mock_create_receiver.return_value = receiver
     return receiver

--- a/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
+++ b/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
@@ -89,7 +89,7 @@
         'Movie',
       ]),
       'connected': True,
-      'lipsync': 50.0,
+      'lipsync': 50,
       'max_volume': 0.0,
       'model': 'MP_60',
       'mute_enabled': False,

--- a/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
+++ b/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
@@ -89,7 +89,7 @@
         'Movie',
       ]),
       'connected': True,
-      'lipsync': 50,
+      'lipsync': 50.0,
       'max_volume': 0.0,
       'model': 'MP_60',
       'mute_enabled': False,

--- a/tests/components/lyngdorf/snapshots/test_number.ambr
+++ b/tests/components/lyngdorf/snapshots/test_number.ambr
@@ -57,7 +57,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50',
   })
 # ---
 # name: test_entities[number.mock_lyngdorf_trim_bass-entry]

--- a/tests/components/lyngdorf/snapshots/test_number.ambr
+++ b/tests/components/lyngdorf/snapshots/test_number.ambr
@@ -57,7 +57,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50',
+    'state': '50.0',
   })
 # ---
 # name: test_entities[number.mock_lyngdorf_trim_bass-entry]

--- a/tests/components/lyngdorf/test_diagnostics.py
+++ b/tests/components/lyngdorf/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Tests for the Lyngdorf diagnostics."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -32,6 +32,23 @@ async def test_diagnostics(
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == snapshot(exclude=props("entry_id", "created_at", "modified_at"))
+
+
+async def test_lipsync_range_reported_before_the_device_reports_a_value(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test the lipsync range still reports before the first value arrives."""
+    mock_receiver.lipsync = None
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    )
+
+    assert diagnostics["state"]["lipsync"] is None
+    assert diagnostics["ranges"]["lipsync_range"] is not None
 
 
 async def test_diagnostics_includes_ssdp_description(


### PR DESCRIPTION
## Proposed change

Values come from the trim mapping, the volume and lipsync controls and the Zone
B object rather than flat attributes. The reported keys are unchanged — they
name the integration's own report, not the library.

Snapshot: lipsync `50` -> `50.0`. The library casts the wire value to a float,
so that is what the entity already reports; the fixture was an int.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The 1.11.0 bump this builds on merged in #180528.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr