### PR TITLE
Abort the Silla Prism config flow when MQTT is unavailable

### DIFF
--- a/homeassistant/components/silla_prism/config_flow.py
+++ b/homeassistant/components/silla_prism/config_flow.py
@@ -50,14 +50,16 @@ class PrismConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(base_topic)
                 self._abort_if_unique_id_configured()
 
+                # Nothing the user can enter in this form brings the broker
+                # back, so this is a dead end rather than a form error.
                 if not await async_wait_for_mqtt_client(self.hass):
-                    errors["base"] = "mqtt_unavailable"
-                elif not await self._async_probe(base_topic):
-                    errors["base"] = "no_device"
-                else:
+                    return self.async_abort(reason="mqtt_unavailable")
+
+                if await self._async_probe(base_topic):
                     return self.async_create_entry(
                         title="Silla Prism", data={CONF_BASE_TOPIC: base_topic}
                     )
+                errors["base"] = "no_device"
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/silla_prism/strings.json
+++ b/homeassistant/components/silla_prism/strings.json
@@ -2,11 +2,11 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "invalid_discovery_info": "Invalid discovery information received."
+      "invalid_discovery_info": "Invalid discovery information received.",
+      "mqtt_unavailable": "The MQTT integration is not available. Set it up first."
     },
     "error": {
       "invalid_base_topic": "This is not a valid MQTT topic. Enter the plain topic prefix from the Silla app, without wildcards.",
-      "mqtt_unavailable": "The MQTT integration is not available. Set it up first.",
       "no_device": "No Prism messages were received on this base topic. Check that the topic matches the one configured in the Silla app and that Prism is online."
     },
     "flow_title": "{serial}",

--- a/tests/components/silla_prism/test_config_flow.py
+++ b/tests/components/silla_prism/test_config_flow.py
@@ -70,7 +70,7 @@ async def test_user_flow(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> No
 async def test_user_flow_no_device(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
-    """Test the user flow errors when no traffic is seen."""
+    """Test the user flow errors when no traffic is seen, then recovers."""
     with patch(_PROBE_PATH, return_value=False):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -80,19 +80,27 @@ async def test_user_flow_no_device(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "no_device"}
 
+    with patch(_PROBE_PATH, return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_BASE_TOPIC: BASE_TOPIC}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_BASE_TOPIC: BASE_TOPIC}
+
 
 async def test_user_flow_mqtt_unavailable(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
-    """Test the user flow errors when MQTT is not available."""
+    """Test the user flow aborts when MQTT is not available."""
     with patch(_MQTT_CLIENT_PATH, return_value=False):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
             data={CONF_BASE_TOPIC: BASE_TOPIC},
         )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "mqtt_unavailable"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "mqtt_unavailable"
 
 
 @pytest.mark.parametrize(
@@ -103,7 +111,7 @@ async def test_user_flow_mqtt_unavailable(
 async def test_user_flow_invalid_base_topic(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, base_topic: str
 ) -> None:
-    """Test the user flow rejects base topics that are not valid MQTT topics."""
+    """Test the user flow rejects invalid base topics, then recovers."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -111,6 +119,14 @@ async def test_user_flow_invalid_base_topic(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_BASE_TOPIC: "invalid_base_topic"}
+
+    with patch(_PROBE_PATH, return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_BASE_TOPIC: BASE_TOPIC}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_BASE_TOPIC: BASE_TOPIC}
 
 
 async def test_user_flow_already_configured(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to the two review comments left on #176785 shortly before it was merged.

The user step reported `mqtt_unavailable` as a form error, but no base topic the user can enter brings the MQTT broker back, so re-showing the form is a dead end dressed up as a correctable field. It now aborts, and the string moved from `config.error` to `config.abort`. The `no_device` case stays a form error, since a wrong base topic really is something the user can fix.

The config flow tests that stopped at the error assertion now continue the flow and end in `CREATE_ENTRY` (or `ABORT` for the MQTT case), so they also cover that the form is still usable after an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176785
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
