### PR TITLE
Add option to require an admin user for the MCP server endpoint

### DIFF
--- a/homeassistant/components/mcp_server/__init__.py
+++ b/homeassistant/components/mcp_server/__init__.py
@@ -27,8 +27,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: MCPServerConfigEntry) 
     """Migrate a config entry."""
     if entry.version == 1 and entry.minor_version == 1:
         # 1.1 -> 1.2: Endpoints served before this option existed stay open.
-        # A disabled entry migrates only once enabled, so keep the choice the
-        # options flow may have saved in the meantime.
+        # A disabled config entry migrates only once enabled, so keep the
+        # choice the options flow may have saved in the meantime.
         hass.config_entries.async_update_entry(
             entry,
             data={CONF_REQUIRE_ADMIN: False, **entry.data},

--- a/homeassistant/components/mcp_server/__init__.py
+++ b/homeassistant/components/mcp_server/__init__.py
@@ -26,10 +26,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, entry: MCPServerConfigEntry) -> bool:
     """Migrate a config entry."""
     if entry.version == 1 and entry.minor_version == 1:
-        # 1.1 -> 1.2: Endpoints served before this option existed stay open
+        # 1.1 -> 1.2: Endpoints served before this option existed stay open.
+        # A disabled entry migrates only once enabled, so keep the choice the
+        # options flow may have saved in the meantime.
         hass.config_entries.async_update_entry(
             entry,
-            data={**entry.data, CONF_REQUIRE_ADMIN: False},
+            data={CONF_REQUIRE_ADMIN: False, **entry.data},
             minor_version=2,
         )
 

--- a/homeassistant/components/mcp_server/__init__.py
+++ b/homeassistant/components/mcp_server/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from . import http
-from .const import DOMAIN
+from .const import CONF_REQUIRE_ADMIN, DOMAIN
 from .session import SessionManager
 from .types import MCPServerConfigEntry
 
@@ -20,6 +20,19 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Model Context Protocol component."""
     http.async_register(hass)
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: MCPServerConfigEntry) -> bool:
+    """Migrate a config entry."""
+    if entry.version == 1 and entry.minor_version == 1:
+        # 1.1 -> 1.2: Endpoints served before this option existed stay open
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_REQUIRE_ADMIN: False},
+            minor_version=2,
+        )
+
     return True
 
 

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -151,7 +151,10 @@ class ModelContextServerProtocolOptionsFlow(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=_options_schema(
-                llm_apis, current, self.config_entry.data[CONF_REQUIRE_ADMIN]
+                llm_apis,
+                current,
+                # A disabled entry has not migrated yet
+                self.config_entry.data.get(CONF_REQUIRE_ADMIN, False),
             ),
             description_placeholders={"more_info_url": MORE_INFO_URL},
             errors=errors,

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -153,7 +153,7 @@ class ModelContextServerProtocolOptionsFlow(OptionsFlow):
             data_schema=_options_schema(
                 llm_apis,
                 current,
-                # A disabled entry has not migrated yet
+                # A disabled config entry has not migrated yet
                 self.config_entry.data.get(CONF_REQUIRE_ADMIN, False),
             ),
             description_placeholders={"more_info_url": MORE_INFO_URL},

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -84,6 +84,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Model Context Protocol Server."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     @staticmethod
     @callback
@@ -150,7 +151,7 @@ class ModelContextServerProtocolOptionsFlow(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=_options_schema(
-                llm_apis, current, self.config_entry.data.get(CONF_REQUIRE_ADMIN, False)
+                llm_apis, current, self.config_entry.data[CONF_REQUIRE_ADMIN]
             ),
             description_placeholders={"more_info_url": MORE_INFO_URL},
             errors=errors,

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -15,12 +15,13 @@ from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import llm
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
 )
 
-from .const import DOMAIN
+from .const import CONF_REQUIRE_ADMIN, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +69,17 @@ def _llm_api_schema(llm_apis: dict[str, str], default: list[str]) -> vol.Schema:
     )
 
 
+def _options_schema(
+    llm_apis: dict[str, str], default: list[str], require_admin: bool
+) -> vol.Schema:
+    """Return the schema for the options flow."""
+    return _llm_api_schema(llm_apis, default).extend(
+        {
+            vol.Required(CONF_REQUIRE_ADMIN, default=require_admin): BooleanSelector(),
+        }
+    )
+
+
 class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Model Context Protocol Server."""
 
@@ -95,7 +107,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_create_entry(
                     title=_llm_api_title(llm_apis, user_input[CONF_LLM_HASS_API]),
-                    data=user_input,
+                    data={**user_input, CONF_REQUIRE_ADMIN: True},
                 )
 
         return self.async_show_form(
@@ -137,7 +149,9 @@ class ModelContextServerProtocolOptionsFlow(OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=_llm_api_schema(llm_apis, current),
+            data_schema=_options_schema(
+                llm_apis, current, self.config_entry.data.get(CONF_REQUIRE_ADMIN, False)
+            ),
             description_placeholders={"more_info_url": MORE_INFO_URL},
             errors=errors,
         )

--- a/homeassistant/components/mcp_server/const.py
+++ b/homeassistant/components/mcp_server/const.py
@@ -1,6 +1,7 @@
 """Constants for the Model Context Protocol Server integration."""
 
 DOMAIN = "mcp_server"
+CONF_REQUIRE_ADMIN = "require_admin"
 TITLE = "Model Context Protocol Server"
 # The Stateless API is no longer registered explicitly, but this
 # name may still exist in the users config entry.

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -94,11 +94,8 @@ def async_get_config_entry(hass: HomeAssistant) -> MCPServerConfigEntry:
 
 
 def _validate_admin(request: web.Request, entry: MCPServerConfigEntry) -> None:
-    """Verify the user may use the endpoints serving the configured LLM APIs.
-
-    Entries created before this option existed do not require an admin user.
-    """
-    if entry.data.get(CONF_REQUIRE_ADMIN, False) and not request["hass_user"].is_admin:
+    """Verify the user may use the endpoints serving the configured LLM APIs."""
+    if entry.data[CONF_REQUIRE_ADMIN] and not request["hass_user"].is_admin:
         raise Unauthorized
 
 

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -8,8 +8,8 @@ The Streamable HTTP protocol uses these HTTP endpoints:
 - /api/mcp: The Streamable HTTP endpoint currently implements the
   stateless protocol for simplicity. This receives client requests and
   sends them to the MCP server, then waits for a response to send back to
-  the client. This serves the configured LLM APIs and does not require
-  admin access.
+  the client. This serves the configured LLM APIs and requires admin access
+  when the config entry is configured to require it.
 - /api/mcp/<API ID>: The same Streamable HTTP endpoint, but exposing a
   specific LLM API selected by its ID. These endpoints require admin access,
   except for the Assist API.
@@ -50,7 +50,7 @@ from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import llm
 
-from .const import DOMAIN
+from .const import CONF_REQUIRE_ADMIN, DOMAIN
 from .server import create_server
 from .session import Session
 from .types import MCPServerConfigEntry
@@ -91,6 +91,15 @@ def async_get_config_entry(hass: HomeAssistant) -> MCPServerConfigEntry:
     if len(config_entries) > 1:
         raise HTTPNotFound(text="Found multiple Model Context Protocol configurations")
     return config_entries[0]
+
+
+def _validate_admin(request: web.Request, entry: MCPServerConfigEntry) -> None:
+    """Verify the user may use the endpoints serving the configured LLM APIs.
+
+    Entries created before this option existed do not require an admin user.
+    """
+    if entry.data.get(CONF_REQUIRE_ADMIN, False) and not request["hass_user"].is_admin:
+        raise Unauthorized
 
 
 @dataclass
@@ -173,6 +182,7 @@ class ModelContextProtocolSSEView(HomeAssistantView):
         """
         hass = request.app[KEY_HASS]
         entry = async_get_config_entry(hass)
+        _validate_admin(request, entry)
         session_manager = entry.runtime_data
 
         server, options = await create_mcp_server(
@@ -225,6 +235,7 @@ class ModelContextProtocolMessagesView(HomeAssistantView):
         """
         hass = request.app[KEY_HASS]
         config_entry = async_get_config_entry(hass)
+        _validate_admin(request, config_entry)
 
         session_manager = config_entry.runtime_data
         if (session := session_manager.get(session_id)) is None:
@@ -297,7 +308,8 @@ async def _async_handle_streamable_message(
 class ModelContextProtocolStreamableView(HomeAssistantView):
     """Model Context Protocol Streamable HTTP endpoint.
 
-    This serves the configured LLM APIs and does not require admin access.
+    This serves the configured LLM APIs and requires admin access when the
+    config entry is configured to require it.
     """
 
     name = f"{DOMAIN}:streamable"
@@ -307,6 +319,7 @@ class ModelContextProtocolStreamableView(HomeAssistantView):
         """Process JSON-RPC messages for the configured LLM APIs."""
         hass = request.app[KEY_HASS]
         entry = async_get_config_entry(hass)
+        _validate_admin(request, entry)
         return await _async_handle_streamable_message(
             request, self.context(request), entry.data[CONF_LLM_HASS_API]
         )

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -25,10 +25,12 @@
     "step": {
       "init": {
         "data": {
-          "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]"
+          "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
+          "require_admin": "Require an administrator account"
         },
         "data_description": {
-          "llm_hass_api": "[%key:component::mcp_server::config::step::user::data_description::llm_hass_api%]"
+          "llm_hass_api": "[%key:component::mcp_server::config::step::user::data_description::llm_hass_api%]",
+          "require_admin": "Only allow administrator accounts to use the Model Context Protocol endpoints."
         },
         "description": "[%key:component::mcp_server::config::step::user::description%]"
       }

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "llm_hass_api": "[%key:component::mcp_server::config::step::user::data_description::llm_hass_api%]",
-          "require_admin": "Only allow administrator accounts to use the Model Context Protocol endpoints."
+          "require_admin": "Only allow administrator accounts to use the Model Context Protocol endpoint."
         },
         "description": "[%key:component::mcp_server::config::step::user::description%]"
       }

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -1,12 +1,11 @@
 """Common fixtures for the Model Context Protocol Server tests."""
 
 from collections.abc import Generator
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.mcp_server.const import DOMAIN
+from homeassistant.components.mcp_server.const import CONF_REQUIRE_ADMIN, DOMAIN
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
@@ -53,23 +52,24 @@ def llm_hass_api_fixture() -> list[str]:
     return [llm.LLM_API_ASSIST]
 
 
-@pytest.fixture(name="entry_data")
-def entry_data_fixture() -> dict[str, Any]:
-    """Fixture for config entry data on top of the selected LLM APIs."""
-    return {}
+@pytest.fixture(name="require_admin")
+def require_admin_fixture() -> bool:
+    """Fixture for the config entry require admin option."""
+    return False
 
 
 @pytest.fixture(name="config_entry")
 def mock_config_entry(
-    hass: HomeAssistant, llm_hass_api: str | list[str], entry_data: dict[str, Any]
+    hass: HomeAssistant, llm_hass_api: str | list[str], require_admin: bool
 ) -> MockConfigEntry:
     """Fixture to load the integration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_LLM_HASS_API: llm_hass_api,
-            **entry_data,
+            CONF_REQUIRE_ADMIN: require_admin,
         },
+        minor_version=2,
     )
     config_entry.add_to_hass(hass)
     return config_entry

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -1,6 +1,7 @@
 """Common fixtures for the Model Context Protocol Server tests."""
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -52,15 +53,22 @@ def llm_hass_api_fixture() -> list[str]:
     return [llm.LLM_API_ASSIST]
 
 
+@pytest.fixture(name="entry_data")
+def entry_data_fixture() -> dict[str, Any]:
+    """Fixture for config entry data on top of the selected LLM APIs."""
+    return {}
+
+
 @pytest.fixture(name="config_entry")
 def mock_config_entry(
-    hass: HomeAssistant, llm_hass_api: str | list[str]
+    hass: HomeAssistant, llm_hass_api: str | list[str], entry_data: dict[str, Any]
 ) -> MockConfigEntry:
     """Fixture to load the integration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_LLM_HASS_API: llm_hass_api,
+            **entry_data,
         },
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -193,7 +193,7 @@ async def test_options_flow_errors(
 
 
 async def test_options_flow_unmigrated_entry(hass: HomeAssistant) -> None:
-    """Test the options flow on a disabled entry that has not migrated yet."""
+    """Test the options flow on a disabled config entry that has not migrated."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.mcp_server.const import CONF_REQUIRE_ADMIN, DOMAIN
+from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -189,3 +190,30 @@ async def test_options_flow_errors(
         CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
         CONF_REQUIRE_ADMIN: False,
     }
+
+
+async def test_options_flow_unmigrated_entry(hass: HomeAssistant) -> None:
+    """Test the options flow on a disabled entry that has not migrated yet."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+        minor_version=1,
+        disabled_by=ConfigEntryDisabler.USER,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"]({}) == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST], CONF_REQUIRE_ADMIN: True},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data[CONF_REQUIRE_ADMIN] is True

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -43,6 +43,7 @@ async def test_form(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Assist"
     assert len(mock_setup_entry.mock_calls) == 1
+    assert result["minor_version"] == 2
     assert result["data"] == {
         CONF_LLM_HASS_API: ["assist"],
         CONF_REQUIRE_ADMIN: True,

--- a/tests/components/mcp_server/test_config_flow.py
+++ b/tests/components/mcp_server/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.mcp_server.const import DOMAIN
+from homeassistant.components.mcp_server.const import CONF_REQUIRE_ADMIN, DOMAIN
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -43,7 +43,10 @@ async def test_form(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Assist"
     assert len(mock_setup_entry.mock_calls) == 1
-    assert result["data"] == {CONF_LLM_HASS_API: ["assist"]}
+    assert result["data"] == {
+        CONF_LLM_HASS_API: ["assist"],
+        CONF_REQUIRE_ADMIN: True,
+    }
 
 
 @pytest.mark.parametrize(
@@ -84,17 +87,24 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert not result["errors"]
-    assert result["data_schema"]({}) == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+    assert result["data_schema"]({}) == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID]},
+        {
+            CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID],
+            CONF_REQUIRE_ADMIN: True,
+        },
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert config_entry.data == {
-        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID]
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST, TEST_LLM_API_ID],
+        CONF_REQUIRE_ADMIN: True,
     }
     assert config_entry.title == "Assist, Test"
 
@@ -109,16 +119,22 @@ async def test_options_flow_legacy_single_api(
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["data_schema"]({}) == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+    assert result["data_schema"]({}) == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST], CONF_REQUIRE_ADMIN: False},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.data == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+    assert config_entry.data == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }
 
 
 async def test_options_flow_keeps_custom_title(
@@ -132,12 +148,15 @@ async def test_options_flow_keeps_custom_title(
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: [TEST_LLM_API_ID]},
+        {CONF_LLM_HASS_API: [TEST_LLM_API_ID], CONF_REQUIRE_ADMIN: False},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.data == {CONF_LLM_HASS_API: [TEST_LLM_API_ID]}
+    assert config_entry.data == {
+        CONF_LLM_HASS_API: [TEST_LLM_API_ID],
+        CONF_REQUIRE_ADMIN: False,
+    }
     assert config_entry.title == "My MCP server"
 
 
@@ -152,7 +171,7 @@ async def test_options_flow_errors(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: []},
+        {CONF_LLM_HASS_API: [], CONF_REQUIRE_ADMIN: False},
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -160,9 +179,12 @@ async def test_options_flow_errors(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+        {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST], CONF_REQUIRE_ADMIN: False},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.data == {CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]}
+    assert config_entry.data == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -19,11 +19,7 @@ import pytest
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.mcp_server.const import (
-    CONF_REQUIRE_ADMIN,
-    DOMAIN,
-    STATELESS_LLM_API,
-)
+from homeassistant.components.mcp_server.const import DOMAIN, STATELESS_LLM_API
 from homeassistant.components.mcp_server.http import (
     MESSAGES_API,
     SSE_API,
@@ -742,13 +738,10 @@ async def test_streamable_api_id_unknown(
 
 
 @pytest.mark.parametrize(
-    ("entry_data", "expected_status"),
+    ("require_admin", "expected_status"),
     [
-        pytest.param({}, HTTPStatus.OK, id="unset"),
-        pytest.param({CONF_REQUIRE_ADMIN: False}, HTTPStatus.OK, id="not_required"),
-        pytest.param(
-            {CONF_REQUIRE_ADMIN: True}, HTTPStatus.UNAUTHORIZED, id="required"
-        ),
+        pytest.param(False, HTTPStatus.OK, id="not_required"),
+        pytest.param(True, HTTPStatus.UNAUTHORIZED, id="required"),
     ],
 )
 async def test_require_admin_option(
@@ -769,7 +762,7 @@ async def test_require_admin_option(
     assert response.status == expected_status
 
 
-@pytest.mark.parametrize("entry_data", [{CONF_REQUIRE_ADMIN: True}])
+@pytest.mark.parametrize("require_admin", [True])
 async def test_require_admin_blocks_sse_endpoints(
     hass: HomeAssistant,
     setup_integration: None,
@@ -786,7 +779,7 @@ async def test_require_admin_blocks_sse_endpoints(
     assert response.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize("entry_data", [{CONF_REQUIRE_ADMIN: True}])
+@pytest.mark.parametrize("require_admin", [True])
 async def test_require_admin_allows_admin(
     hass: HomeAssistant,
     setup_integration: None,

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -19,7 +19,11 @@ import pytest
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.mcp_server.const import DOMAIN, STATELESS_LLM_API
+from homeassistant.components.mcp_server.const import (
+    CONF_REQUIRE_ADMIN,
+    DOMAIN,
+    STATELESS_LLM_API,
+)
 from homeassistant.components.mcp_server.http import (
     MESSAGES_API,
     SSE_API,
@@ -735,3 +739,65 @@ async def test_streamable_api_id_unknown(
     )
     assert response.status == HTTPStatus.NOT_FOUND
     assert "Unknown LLM API" in await response.text()
+
+
+@pytest.mark.parametrize(
+    ("entry_data", "expected_status"),
+    [
+        pytest.param({}, HTTPStatus.OK, id="unset"),
+        pytest.param({CONF_REQUIRE_ADMIN: False}, HTTPStatus.OK, id="not_required"),
+        pytest.param(
+            {CONF_REQUIRE_ADMIN: True}, HTTPStatus.UNAUTHORIZED, id="required"
+        ),
+    ],
+)
+async def test_require_admin_option(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    hass_read_only_access_token: str,
+    expected_status: HTTPStatus,
+) -> None:
+    """Test the require admin option applied to a non-admin user."""
+    client = await hass_client(hass_read_only_access_token)
+
+    response = await client.post(
+        STREAMABLE_API,
+        json=INITIALIZE_MESSAGE,
+        headers={"accept": CONTENT_TYPE_JSON},
+    )
+    assert response.status == expected_status
+
+
+@pytest.mark.parametrize("entry_data", [{CONF_REQUIRE_ADMIN: True}])
+async def test_require_admin_blocks_sse_endpoints(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test the require admin option applied to the SSE endpoints."""
+    client = await hass_client(hass_read_only_access_token)
+
+    response = await client.get(SSE_API)
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+    response = await client.post(MESSAGES_API.format(session_id="session-id"))
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize("entry_data", [{CONF_REQUIRE_ADMIN: True}])
+async def test_require_admin_allows_admin(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test an admin user may use the endpoint that requires an admin."""
+    client = await hass_client()
+
+    response = await client.post(
+        STREAMABLE_API,
+        json=INITIALIZE_MESSAGE,
+        headers={"accept": CONTENT_TYPE_JSON},
+    )
+    assert response.status == HTTPStatus.OK

--- a/tests/components/mcp_server/test_init.py
+++ b/tests/components/mcp_server/test_init.py
@@ -1,7 +1,10 @@
 """Test the Model Context Protocol Server init module."""
 
+from homeassistant.components.mcp_server.const import CONF_REQUIRE_ADMIN, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
 
 from tests.common import MockConfigEntry
 
@@ -13,3 +16,22 @@ async def test_init(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_migrate_entry_require_admin(hass: HomeAssistant) -> None:
+    """Test an entry created before the require admin option keeps the endpoints open."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LLM_HASS_API: [llm.LLM_API_ASSIST]},
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert config_entry.minor_version == 2
+    assert config_entry.data == {
+        CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
+        CONF_REQUIRE_ADMIN: False,
+    }

--- a/tests/components/mcp_server/test_init.py
+++ b/tests/components/mcp_server/test_init.py
@@ -35,3 +35,19 @@ async def test_migrate_entry_require_admin(hass: HomeAssistant) -> None:
         CONF_LLM_HASS_API: [llm.LLM_API_ASSIST],
         CONF_REQUIRE_ADMIN: False,
     }
+
+
+async def test_migrate_entry_keeps_require_admin(hass: HomeAssistant) -> None:
+    """Test the migration keeps an option the options flow saved before it ran."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LLM_HASS_API: [llm.LLM_API_ASSIST], CONF_REQUIRE_ADMIN: True},
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert config_entry.minor_version == 2
+    assert config_entry.data[CONF_REQUIRE_ADMIN] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The endpoints that serve the LLM APIs selected in the config entry (`/api/mcp`, `/mcp_server/sse` and `/mcp_server/messages`) are open to any authenticated user. The keyed `/api/mcp/<API ID>` endpoints already restrict themselves to administrators, except for Assist.

This adds a `require_admin` option that restricts the endpoint to administrator accounts. New config entries enable it. A minor version migration adds the option as disabled to existing entries, so their behavior does not change. The option is toggled in the options flow only, which keeps the initial setup unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47731
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_016tM699fnW4Jnd6LYMs3ntJ)_