### PR TITLE
Add power-on and Wi-Fi signal entities to Elgato

### DIFF
--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -10,7 +10,14 @@ from .coordinator import ElgatoConfigEntry, ElgatoDataUpdateCoordinator
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.LIGHT,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/elgato/helpers.py
+++ b/homeassistant/components/elgato/helpers.py
@@ -8,7 +8,30 @@ from elgato import ElgatoConnectionError, ElgatoError
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
+from .coordinator import ElgatoData
 from .entity import ElgatoEntity
+
+# Elgato lights that can do color reach less far at either end.
+COLOR_TEMPERATURE_RANGE = (2900, 6993)  # 344 - 143 mireds
+COLOR_TEMPERATURE_RANGE_COLOR = (3500, 6500)  # 285 - 153 mireds
+
+COLOR_CAPABLE_PRODUCTS = ("Elgato Light Strip", "Elgato Light Strip Pro")
+
+
+def supports_color(data: ElgatoData) -> bool:
+    """Return if an Elgato Light does more than white."""
+    return bool(
+        data.info.product_name in COLOR_CAPABLE_PRODUCTS
+        or data.settings.power_on_hue
+        or data.state.hue is not None
+    )
+
+
+def color_temperature_range(data: ElgatoData) -> tuple[int, int]:
+    """Return the color temperature range in Kelvin a device supports."""
+    if supports_color(data):
+        return COLOR_TEMPERATURE_RANGE_COLOR
+    return COLOR_TEMPERATURE_RANGE
 
 
 def elgato_exception_handler[_ElgatoEntityT: ElgatoEntity, **_P](

--- a/homeassistant/components/elgato/icons.json
+++ b/homeassistant/components/elgato/icons.json
@@ -1,5 +1,18 @@
 {
   "entity": {
+    "number": {
+      "power_on_brightness": {
+        "default": "mdi:brightness-percent"
+      },
+      "power_on_temperature": {
+        "default": "mdi:thermometer"
+      }
+    },
+    "select": {
+      "power_on_behavior": {
+        "default": "mdi:power-settings"
+      }
+    },
     "switch": {
       "bypass": {
         "default": "mdi:battery-off-outline"

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -15,7 +15,7 @@ from homeassistant.util import color as color_util
 
 from .coordinator import ElgatoConfigEntry, ElgatoDataUpdateCoordinator
 from .entity import ElgatoEntity
-from .helpers import elgato_exception_handler
+from .helpers import color_temperature_range, elgato_exception_handler, supports_color
 
 PARALLEL_UPDATES = 1
 
@@ -34,8 +34,6 @@ class ElgatoLight(ElgatoEntity, LightEntity):
     """Defines an Elgato Light."""
 
     _attr_name = None
-    _attr_min_color_temp_kelvin = 2900  # 344 Mireds
-    _attr_max_color_temp_kelvin = 6993  # 143 Mireds
 
     def __init__(self, coordinator: ElgatoDataUpdateCoordinator) -> None:
         """Initialize Elgato Light."""
@@ -43,19 +41,13 @@ class ElgatoLight(ElgatoEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
         self._attr_unique_id = coordinator.data.info.serial_number
 
-        # Elgato Light supporting color, have a different temperature range
-        if (
-            self.coordinator.data.info.product_name
-            in (
-                "Elgato Light Strip",
-                "Elgato Light Strip Pro",
-            )
-            or self.coordinator.data.settings.power_on_hue
-            or self.coordinator.data.state.hue is not None
-        ):
+        if supports_color(coordinator.data):
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
-            self._attr_min_color_temp_kelvin = 3500  # 285 Mireds
-            self._attr_max_color_temp_kelvin = 6500  # 153 Mireds
+
+        (
+            self._attr_min_color_temp_kelvin,
+            self._attr_max_color_temp_kelvin,
+        ) = color_temperature_range(coordinator.data)
 
     @property
     @override

--- a/homeassistant/components/elgato/number.py
+++ b/homeassistant/components/elgato/number.py
@@ -1,0 +1,116 @@
+"""Support for Elgato numbers."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from elgato import Elgato
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired,
+    color_temperature_mired_to_kelvin,
+)
+
+from .coordinator import ElgatoConfigEntry, ElgatoData, ElgatoDataUpdateCoordinator
+from .entity import ElgatoEntity
+from .helpers import elgato_exception_handler
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElgatoNumberEntityDescription(NumberEntityDescription):
+    """Class describing Elgato number entities."""
+
+    has_fn: Callable[[ElgatoData], bool] = lambda _: True
+    value_fn: Callable[[ElgatoData], float | None]
+    set_fn: Callable[[Elgato, float], Awaitable[Any]]
+
+
+NUMBERS = [
+    ElgatoNumberEntityDescription(
+        key="power_on_brightness",
+        translation_key="power_on_brightness",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        value_fn=lambda x: x.settings.power_on_brightness,
+        set_fn=lambda client, value: client.power_on_behavior(brightness=int(value)),
+    ),
+    ElgatoNumberEntityDescription(
+        key="power_on_temperature",
+        translation_key="power_on_temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        # The same range the light itself exposes. The device stores mireds,
+        # which run the other way, so both ends are converted at the edge.
+        native_min_value=2900,
+        native_max_value=6993,
+        native_step=50,
+        has_fn=lambda x: bool(x.settings.power_on_temperature),
+        value_fn=lambda x: (
+            color_temperature_mired_to_kelvin(x.settings.power_on_temperature)
+            if x.settings.power_on_temperature
+            else None
+        ),
+        set_fn=lambda client, value: client.power_on_behavior(
+            temperature=color_temperature_kelvin_to_mired(value)
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElgatoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Elgato numbers based on a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        ElgatoNumberEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in NUMBERS
+        if description.has_fn(coordinator.data)
+    )
+
+
+class ElgatoNumberEntity(ElgatoEntity, NumberEntity):
+    """Representation of an Elgato number."""
+
+    entity_description: ElgatoNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ElgatoDataUpdateCoordinator,
+        description: ElgatoNumberEntityDescription,
+    ) -> None:
+        """Initiate Elgato number."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.info.serial_number}_{description.key}"
+        )
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the number value."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    @elgato_exception_handler
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Change the number value."""
+        await self.entity_description.set_fn(self.coordinator.client, value)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/elgato/number.py
+++ b/homeassistant/components/elgato/number.py
@@ -17,7 +17,7 @@ from homeassistant.util.color import (
 
 from .coordinator import ElgatoConfigEntry, ElgatoData, ElgatoDataUpdateCoordinator
 from .entity import ElgatoEntity
-from .helpers import elgato_exception_handler
+from .helpers import color_temperature_range, elgato_exception_handler
 
 PARALLEL_UPDATES = 1
 
@@ -27,6 +27,7 @@ class ElgatoNumberEntityDescription(NumberEntityDescription):
     """Class describing Elgato number entities."""
 
     has_fn: Callable[[ElgatoData], bool] = lambda _: True
+    range_fn: Callable[[ElgatoData], tuple[int, int]] | None = None
     value_fn: Callable[[ElgatoData], float | None]
     set_fn: Callable[[Elgato, float], Awaitable[Any]]
 
@@ -48,10 +49,10 @@ NUMBERS = [
         translation_key="power_on_temperature",
         entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=UnitOfTemperature.KELVIN,
-        # The same range the light itself exposes. The device stores mireds,
-        # which run the other way, so both ends are converted at the edge.
-        native_min_value=2900,
-        native_max_value=6993,
+        # Whatever range the light itself exposes; a device that does color
+        # reaches less far at either end. The device stores mireds, which run
+        # the other way, so both ends are converted at the edge.
+        range_fn=color_temperature_range,
         native_step=50,
         has_fn=lambda x: bool(x.settings.power_on_temperature),
         value_fn=lambda x: (
@@ -101,6 +102,12 @@ class ElgatoNumberEntity(ElgatoEntity, NumberEntity):
         self._attr_unique_id = (
             f"{coordinator.data.info.serial_number}_{description.key}"
         )
+
+        if description.range_fn is not None:
+            (
+                self._attr_native_min_value,
+                self._attr_native_max_value,
+            ) = description.range_fn(coordinator.data)
 
     @property
     @override

--- a/homeassistant/components/elgato/select.py
+++ b/homeassistant/components/elgato/select.py
@@ -1,0 +1,100 @@
+"""Support for Elgato select entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from elgato import Elgato, PowerOnBehavior
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ElgatoConfigEntry, ElgatoData, ElgatoDataUpdateCoordinator
+from .entity import ElgatoEntity
+from .helpers import elgato_exception_handler
+
+PARALLEL_UPDATES = 1
+
+# The device also has a value 0, which it reports when it has no opinion yet.
+# It cannot be selected, so it is not an option, and it leaves the entity
+# unknown until the behavior is actually set.
+POWER_ON_BEHAVIORS = {
+    PowerOnBehavior.RESTORE_LAST: "restore_last",
+    PowerOnBehavior.USE_DEFAULTS: "use_defaults",
+}
+POWER_ON_BEHAVIOR_OPTIONS = {value: key for key, value in POWER_ON_BEHAVIORS.items()}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElgatoSelectEntityDescription(SelectEntityDescription):
+    """Class describing Elgato select entities."""
+
+    has_fn: Callable[[ElgatoData], bool] = lambda _: True
+    current_fn: Callable[[ElgatoData], str | None]
+    select_fn: Callable[[Elgato, str], Awaitable[Any]]
+
+
+SELECTS = [
+    ElgatoSelectEntityDescription(
+        key="power_on_behavior",
+        translation_key="power_on_behavior",
+        entity_category=EntityCategory.CONFIG,
+        options=list(POWER_ON_BEHAVIORS.values()),
+        current_fn=lambda x: POWER_ON_BEHAVIORS.get(x.settings.power_on_behavior),
+        select_fn=lambda client, option: client.power_on_behavior(
+            behavior=POWER_ON_BEHAVIOR_OPTIONS[option]
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElgatoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Elgato select entities based on a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        ElgatoSelectEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SELECTS
+        if description.has_fn(coordinator.data)
+    )
+
+
+class ElgatoSelectEntity(ElgatoEntity, SelectEntity):
+    """Representation of an Elgato select entity."""
+
+    entity_description: ElgatoSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ElgatoDataUpdateCoordinator,
+        description: ElgatoSelectEntityDescription,
+    ) -> None:
+        """Initiate Elgato select entity."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.info.serial_number}_{description.key}"
+        )
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the selected option."""
+        return self.entity_description.current_fn(self.coordinator.data)
+
+    @elgato_exception_handler
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.entity_description.select_fn(self.coordinator.client, option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/elgato/sensor.py
+++ b/homeassistant/components/elgato/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -96,6 +97,17 @@ SENSORS = [
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         has_fn=lambda x: x.battery is not None,
         value_fn=lambda x: x.battery.input_charge_voltage if x.battery else None,
+    ),
+    ElgatoSensorEntityDescription(
+        key="wifi_signal",
+        translation_key="wifi_signal",
+        entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda x: x.info.wifi is not None,
+        value_fn=lambda x: x.info.wifi.rssi if x.info.wifi else None,
     ),
 ]
 

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -36,6 +36,23 @@
     }
   },
   "entity": {
+    "number": {
+      "power_on_brightness": {
+        "name": "Power-on brightness"
+      },
+      "power_on_temperature": {
+        "name": "Power-on color temperature"
+      }
+    },
+    "select": {
+      "power_on_behavior": {
+        "name": "Power-on behavior",
+        "state": {
+          "restore_last": "Restore last state",
+          "use_defaults": "Use defaults"
+        }
+      }
+    },
     "sensor": {
       "charge_power": {
         "name": "Charging power"
@@ -48,6 +65,9 @@
       },
       "voltage": {
         "name": "Battery voltage"
+      },
+      "wifi_signal": {
+        "name": "Wi-Fi signal"
       }
     },
     "switch": {

--- a/tests/components/elgato/fixtures/light-strip-power-on-temperature/info.json
+++ b/tests/components/elgato/fixtures/light-strip-power-on-temperature/info.json
@@ -1,0 +1,9 @@
+{
+  "productName": "Elgato Light Strip",
+  "hardwareBoardType": 53,
+  "firmwareBuildNumber": 192,
+  "firmwareVersion": "1.0.3",
+  "serialNumber": "CN11A1A00001",
+  "displayName": "Frenck",
+  "features": ["lights"]
+}

--- a/tests/components/elgato/fixtures/light-strip-power-on-temperature/settings.json
+++ b/tests/components/elgato/fixtures/light-strip-power-on-temperature/settings.json
@@ -1,0 +1,10 @@
+{
+  "powerOnBehavior": 2,
+  "powerOnHue": 0.0,
+  "powerOnSaturation": 0.0,
+  "powerOnBrightness": 40,
+  "powerOnTemperature": 230,
+  "switchOnDurationMs": 150,
+  "switchOffDurationMs": 400,
+  "colorChangeDurationMs": 150
+}

--- a/tests/components/elgato/fixtures/light-strip-power-on-temperature/state.json
+++ b/tests/components/elgato/fixtures/light-strip-power-on-temperature/state.json
@@ -1,0 +1,6 @@
+{
+  "on": 1,
+  "hue": 358.0,
+  "saturation": 6.0,
+  "brightness": 50
+}

--- a/tests/components/elgato/snapshots/test_number.ambr
+++ b/tests/components/elgato/snapshots/test_number.ambr
@@ -1,0 +1,189 @@
+# serializer version: 1
+# name: test_numbers[number.frenck_power_on_brightness-50-expected0-key-light]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Power-on brightness',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.frenck_power_on_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
+  })
+# ---
+# name: test_numbers[number.frenck_power_on_brightness-50-expected0-key-light].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.frenck_power_on_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power-on brightness',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power-on brightness',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_on_brightness',
+    'unique_id': 'CN11A1A00001_power_on_brightness',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_numbers[number.frenck_power_on_brightness-50-expected0-key-light].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'CN11A1A00001',
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_numbers[number.frenck_power_on_color_temperature-5000-expected1-key-light]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Power-on color temperature',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 6993,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 2900,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 50,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.KELVIN: 'K'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.frenck_power_on_color_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4694',
+  })
+# ---
+# name: test_numbers[number.frenck_power_on_color_temperature-5000-expected1-key-light].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 6993,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 2900,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 50,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.frenck_power_on_color_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power-on color temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power-on color temperature',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_on_temperature',
+    'unique_id': 'CN11A1A00001_power_on_temperature',
+    'unit_of_measurement': <UnitOfTemperature.KELVIN: 'K'>,
+  })
+# ---
+# name: test_numbers[number.frenck_power_on_color_temperature-5000-expected1-key-light].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'CN11A1A00001',
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/snapshots/test_select.ambr
+++ b/tests/components/elgato/snapshots/test_select.ambr
@@ -1,0 +1,94 @@
+# serializer version: 1
+# name: test_power_on_behavior[key-light]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Power-on behavior',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'restore_last',
+        'use_defaults',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.frenck_power_on_behavior',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'restore_last',
+  })
+# ---
+# name: test_power_on_behavior[key-light].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'restore_last',
+        'use_defaults',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.frenck_power_on_behavior',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power-on behavior',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power-on behavior',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_on_behavior',
+    'unique_id': 'CN11A1A00001_power_on_behavior',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_power_on_behavior[key-light].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'CN11A1A00001',
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/snapshots/test_sensor.ambr
+++ b/tests/components/elgato/snapshots/test_sensor.ambr
@@ -468,3 +468,92 @@
     'via_device_id': None,
   })
 # ---
+# name: test_sensors[sensor.frenck_wi_fi_signal-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Wi-Fi signal',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.frenck_wi_fi_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-41',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_signal-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.frenck_wi_fi_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi signal',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Wi-Fi signal',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_signal',
+    'unique_id': 'GW24L1A02987_wifi_signal',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_signal-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'GW24L1A02987',
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/test_number.py
+++ b/tests/components/elgato/test_number.py
@@ -1,0 +1,85 @@
+"""Tests for the Elgato number platform."""
+
+from unittest.mock import MagicMock
+
+from elgato import ElgatoError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = [pytest.mark.usefixtures("init_integration")]
+
+
+@pytest.mark.parametrize("device_fixtures", ["key-light"])
+@pytest.mark.parametrize(
+    ("entity_id", "value", "expected"),
+    [
+        ("number.frenck_power_on_brightness", 50, {"brightness": 50}),
+        ("number.frenck_power_on_color_temperature", 5000, {"temperature": 200}),
+    ],
+)
+async def test_numbers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_elgato: MagicMock,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+    value: float,
+    expected: dict[str, int],
+) -> None:
+    """Test the Elgato numbers."""
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry == snapshot
+
+    assert entry.device_id
+    assert (device_entry := device_registry.async_get(entry.device_id))
+    assert device_entry == snapshot
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 1
+    mock_elgato.power_on_behavior.assert_called_once_with(**expected)
+
+    mock_elgato.power_on_behavior.side_effect = ElgatoError
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="An unknown error occurred while communicating with the Elgato device",
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+            blocking=True,
+        )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 2
+
+
+@pytest.mark.parametrize("device_fixtures", ["light-strip"])
+async def test_no_power_on_temperature(hass: HomeAssistant) -> None:
+    """Test a light that powers on to a color has no temperature number.
+
+    The light strip reports a power-on temperature of zero, which is not a
+    color temperature at all.
+    """
+    assert hass.states.get("number.frenck_power_on_brightness")
+    assert not hass.states.get("number.frenck_power_on_color_temperature")

--- a/tests/components/elgato/test_number.py
+++ b/tests/components/elgato/test_number.py
@@ -83,3 +83,26 @@ async def test_no_power_on_temperature(hass: HomeAssistant) -> None:
     """
     assert hass.states.get("number.frenck_power_on_brightness")
     assert not hass.states.get("number.frenck_power_on_color_temperature")
+
+
+@pytest.mark.parametrize(
+    ("device_fixtures", "expected_range"),
+    [
+        ("key-light", (2900, 6993)),
+        ("light-strip-power-on-temperature", (3500, 6500)),
+    ],
+)
+async def test_power_on_temperature_range(
+    hass: HomeAssistant,
+    expected_range: tuple[int, int],
+) -> None:
+    """Test the number stays inside what the device can actually do.
+
+    A light that does color reaches less far at either end, and the number
+    has to agree with the light entity about that.
+    """
+    minimum, maximum = expected_range
+
+    assert (state := hass.states.get("number.frenck_power_on_color_temperature"))
+    assert state.attributes["min"] == minimum
+    assert state.attributes["max"] == maximum

--- a/tests/components/elgato/test_select.py
+++ b/tests/components/elgato/test_select.py
@@ -1,0 +1,70 @@
+"""Tests for the Elgato select platform."""
+
+from unittest.mock import MagicMock
+
+from elgato import ElgatoError, PowerOnBehavior
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = [
+    pytest.mark.parametrize("device_fixtures", ["key-light"]),
+    pytest.mark.usefixtures("device_fixtures", "init_integration"),
+]
+
+
+async def test_power_on_behavior(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_elgato: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Elgato power-on behavior select."""
+    entity_id = "select.frenck_power_on_behavior"
+
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry == snapshot
+
+    assert entry.device_id
+    assert (device_entry := device_registry.async_get(entry.device_id))
+    assert device_entry == snapshot
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "use_defaults"},
+        blocking=True,
+    )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 1
+    mock_elgato.power_on_behavior.assert_called_once_with(
+        behavior=PowerOnBehavior.USE_DEFAULTS
+    )
+
+    mock_elgato.power_on_behavior.side_effect = ElgatoError
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="An unknown error occurred while communicating with the Elgato device",
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "restore_last"},
+            blocking=True,
+        )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 2

--- a/tests/components/elgato/test_sensor.py
+++ b/tests/components/elgato/test_sensor.py
@@ -21,6 +21,7 @@ pytestmark = [
         "sensor.frenck_charging_current",
         "sensor.frenck_charging_power",
         "sensor.frenck_charging_voltage",
+        "sensor.frenck_wi_fi_signal",
     ],
 )
 async def test_sensors(
@@ -50,6 +51,7 @@ async def test_sensors(
         "sensor.frenck_charging_current",
         "sensor.frenck_charging_power",
         "sensor.frenck_charging_voltage",
+        "sensor.frenck_wi_fi_signal",
     ],
 )
 async def test_disabled_by_default_sensors(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Exposes settings the integration was already reading from the device on every poll and then discarding.

- **Power-on behavior** as a `select`: restore last state, or use the power-on defaults.
- **Power-on brightness** and **power-on color temperature** as `number` entities.
- **Wi-Fi signal strength** as a diagnostic `sensor`, disabled by default.

Two details worth flagging for review:

The device stores its power-on colour temperature in mireds and Home Assistant speaks Kelvin, so the number converts at both ends. A stored 213 mired reads back as 4694 K, and setting 5000 K writes 200 mired.

A light that powers on to a colour rather than a temperature reports `powerOnTemperature: 0`. That is not a colour temperature, and converting it would divide by zero, so the entity is not created for those devices. There is a test against the light strip fixture asserting it stays absent.

The Wi-Fi SSID and band are also available, but they are static values, so they stay in the diagnostics download rather than becoming entities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47733
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

