### PR TITLE
Move the Elgato color temperature range out of the light entity

### DIFF
--- a/homeassistant/components/elgato/helpers.py
+++ b/homeassistant/components/elgato/helpers.py
@@ -8,7 +8,30 @@ from elgato import ElgatoConnectionError, ElgatoError
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
+from .coordinator import ElgatoData
 from .entity import ElgatoEntity
+
+# Elgato lights that can do color reach less far at either end.
+COLOR_TEMPERATURE_RANGE = (2900, 6993)  # 344 - 143 mireds
+COLOR_TEMPERATURE_RANGE_COLOR = (3500, 6500)  # 285 - 153 mireds
+
+COLOR_CAPABLE_PRODUCTS = ("Elgato Light Strip", "Elgato Light Strip Pro")
+
+
+def supports_color(data: ElgatoData) -> bool:
+    """Return if an Elgato Light does more than white."""
+    return bool(
+        data.info.product_name in COLOR_CAPABLE_PRODUCTS
+        or data.settings.power_on_hue
+        or data.state.hue is not None
+    )
+
+
+def color_temperature_range(data: ElgatoData) -> tuple[int, int]:
+    """Return the color temperature range in Kelvin a device supports."""
+    if supports_color(data):
+        return COLOR_TEMPERATURE_RANGE_COLOR
+    return COLOR_TEMPERATURE_RANGE
 
 
 def elgato_exception_handler[_ElgatoEntityT: ElgatoEntity, **_P](

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -15,7 +15,7 @@ from homeassistant.util import color as color_util
 
 from .coordinator import ElgatoConfigEntry, ElgatoDataUpdateCoordinator
 from .entity import ElgatoEntity
-from .helpers import elgato_exception_handler
+from .helpers import color_temperature_range, elgato_exception_handler, supports_color
 
 PARALLEL_UPDATES = 1
 
@@ -34,8 +34,6 @@ class ElgatoLight(ElgatoEntity, LightEntity):
     """Defines an Elgato Light."""
 
     _attr_name = None
-    _attr_min_color_temp_kelvin = 2900  # 344 Mireds
-    _attr_max_color_temp_kelvin = 6993  # 143 Mireds
 
     def __init__(self, coordinator: ElgatoDataUpdateCoordinator) -> None:
         """Initialize Elgato Light."""
@@ -43,19 +41,13 @@ class ElgatoLight(ElgatoEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
         self._attr_unique_id = coordinator.data.info.serial_number
 
-        # Elgato Light supporting color, have a different temperature range
-        if (
-            self.coordinator.data.info.product_name
-            in (
-                "Elgato Light Strip",
-                "Elgato Light Strip Pro",
-            )
-            or self.coordinator.data.settings.power_on_hue
-            or self.coordinator.data.state.hue is not None
-        ):
+        if supports_color(coordinator.data):
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
-            self._attr_min_color_temp_kelvin = 3500  # 285 Mireds
-            self._attr_max_color_temp_kelvin = 6500  # 153 Mireds
+
+        (
+            self._attr_min_color_temp_kelvin,
+            self._attr_max_color_temp_kelvin,
+        ) = color_temperature_range(coordinator.data)
 
     @property
     @override


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pure refactor, no behaviour change.

`ElgatoLight.__init__` decided two things inline: whether a device does color, and which color temperature range it supports. Both answers come from the same three fields, and both are about the device rather than about the light entity, so they move into `helpers.py` as `supports_color()` and `color_temperature_range()`.

I am splitting this out because a power-on color temperature number entity needs the same range, and having a second copy of the rule is how the two drift apart. Same devices, same range, existing tests unchanged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
