### PR TITLE
Add Elgato power-on behavior select

### DIFF
--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -10,7 +10,13 @@ from .coordinator import ElgatoConfigEntry, ElgatoDataUpdateCoordinator
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.LIGHT,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/elgato/icons.json
+++ b/homeassistant/components/elgato/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "select": {
+      "power_on_behavior": {
+        "default": "mdi:power-settings"
+      }
+    },
     "switch": {
       "bypass": {
         "default": "mdi:battery-off-outline"

--- a/homeassistant/components/elgato/select.py
+++ b/homeassistant/components/elgato/select.py
@@ -1,0 +1,100 @@
+"""Support for Elgato select entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from elgato import Elgato, PowerOnBehavior
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ElgatoConfigEntry, ElgatoData, ElgatoDataUpdateCoordinator
+from .entity import ElgatoEntity
+from .helpers import elgato_exception_handler
+
+PARALLEL_UPDATES = 1
+
+# The device also has a value 0, which it reports when it has no opinion yet.
+# It cannot be selected, so it is not an option, and it leaves the entity
+# unknown until the behavior is actually set.
+POWER_ON_BEHAVIORS = {
+    PowerOnBehavior.RESTORE_LAST: "restore_last",
+    PowerOnBehavior.USE_DEFAULTS: "use_defaults",
+}
+POWER_ON_BEHAVIOR_OPTIONS = {value: key for key, value in POWER_ON_BEHAVIORS.items()}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElgatoSelectEntityDescription(SelectEntityDescription):
+    """Class describing Elgato select entities."""
+
+    has_fn: Callable[[ElgatoData], bool] = lambda _: True
+    current_fn: Callable[[ElgatoData], str | None]
+    select_fn: Callable[[Elgato, str], Awaitable[Any]]
+
+
+SELECTS = [
+    ElgatoSelectEntityDescription(
+        key="power_on_behavior",
+        translation_key="power_on_behavior",
+        entity_category=EntityCategory.CONFIG,
+        options=list(POWER_ON_BEHAVIORS.values()),
+        current_fn=lambda x: POWER_ON_BEHAVIORS.get(x.settings.power_on_behavior),
+        select_fn=lambda client, option: client.power_on_behavior(
+            behavior=POWER_ON_BEHAVIOR_OPTIONS[option]
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElgatoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Elgato select entities based on a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        ElgatoSelectEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SELECTS
+        if description.has_fn(coordinator.data)
+    )
+
+
+class ElgatoSelectEntity(ElgatoEntity, SelectEntity):
+    """Representation of an Elgato select entity."""
+
+    entity_description: ElgatoSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ElgatoDataUpdateCoordinator,
+        description: ElgatoSelectEntityDescription,
+    ) -> None:
+        """Initiate Elgato select entity."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.info.serial_number}_{description.key}"
+        )
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the selected option."""
+        return self.entity_description.current_fn(self.coordinator.data)
+
+    @elgato_exception_handler
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.entity_description.select_fn(self.coordinator.client, option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -36,6 +36,15 @@
     }
   },
   "entity": {
+    "select": {
+      "power_on_behavior": {
+        "name": "Power-on behavior",
+        "state": {
+          "restore_last": "Restore last state",
+          "use_defaults": "Use defaults"
+        }
+      }
+    },
     "sensor": {
       "charge_power": {
         "name": "Charging power"

--- a/tests/components/elgato/snapshots/test_select.ambr
+++ b/tests/components/elgato/snapshots/test_select.ambr
@@ -1,0 +1,94 @@
+# serializer version: 1
+# name: test_power_on_behavior[key-light]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Power-on behavior',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'restore_last',
+        'use_defaults',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.frenck_power_on_behavior',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'restore_last',
+  })
+# ---
+# name: test_power_on_behavior[key-light].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'restore_last',
+        'use_defaults',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.frenck_power_on_behavior',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power-on behavior',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power-on behavior',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_on_behavior',
+    'unique_id': 'CN11A1A00001_power_on_behavior',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_power_on_behavior[key-light].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'CN11A1A00001',
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/test_select.py
+++ b/tests/components/elgato/test_select.py
@@ -1,0 +1,70 @@
+"""Tests for the Elgato select platform."""
+
+from unittest.mock import MagicMock
+
+from elgato import ElgatoError, PowerOnBehavior
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+pytestmark = [
+    pytest.mark.parametrize("device_fixtures", ["key-light"]),
+    pytest.mark.usefixtures("device_fixtures", "init_integration"),
+]
+
+
+async def test_power_on_behavior(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_elgato: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Elgato power-on behavior select."""
+    entity_id = "select.frenck_power_on_behavior"
+
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry == snapshot
+
+    assert entry.device_id
+    assert (device_entry := device_registry.async_get(entry.device_id))
+    assert device_entry == snapshot
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "use_defaults"},
+        blocking=True,
+    )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 1
+    mock_elgato.power_on_behavior.assert_called_once_with(
+        behavior=PowerOnBehavior.USE_DEFAULTS
+    )
+
+    mock_elgato.power_on_behavior.side_effect = ElgatoError
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="An unknown error occurred while communicating with the Elgato device",
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "restore_last"},
+            blocking=True,
+        )
+
+    assert len(mock_elgato.power_on_behavior.mock_calls) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a select for the power-on behavior, which the integration was already reading from the device on every poll and then discarding.

- **Restore last state**: the light returns to how it was before it lost power.
- **Use defaults**: the light applies its stored power-on brightness and color temperature instead.

The device reports a third value, `0`, when it has no opinion yet. It cannot be selected, so it is not offered as an option and the entity stays unknown until the behavior is actually set.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47735
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

