### PR TITLE
Add subtask support to the To-do list platform

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -34,6 +34,8 @@ from .const import (
     ATTR_DUE_DATE,
     ATTR_DUE_DATETIME,
     ATTR_ITEM,
+    ATTR_PARENT,
+    ATTR_PARENT_UID,
     ATTR_RENAME,
     ATTR_STATUS,
     DATA_COMPONENT,
@@ -86,6 +88,12 @@ TODO_ITEM_FIELDS = [
         validation=vol.Any(cv.string, None),
         todo_item_field=ATTR_DESCRIPTION,
         required_feature=TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM,
+    ),
+    TodoItemFieldDescription(
+        service_field=ATTR_PARENT,
+        validation=vol.Any(cv.string, None),
+        todo_item_field=ATTR_PARENT_UID,
+        required_feature=TodoListEntityFeature.SET_PARENT_ON_ITEM,
     ),
 ]
 
@@ -227,6 +235,13 @@ class TodoItem:
 
     completed: datetime.datetime | None = None
     """The date and time that a to-do item was marked completed."""
+
+    parent_uid: str | None = None
+    """The uid of the To-do item this item is a subtask of.
+
+    A subtask may not have subtasks of its own, so an item with a `parent_uid`
+    is always at the second and last level of the hierarchy.
+    """
 
 
 _TODO_ITEM_FIELD_NAMES: tuple[str, ...] = tuple(
@@ -467,6 +482,64 @@ def _find_by_uid_or_summary(
     return None
 
 
+def _resolve_parent_uid(
+    entity: TodoListEntity, parent: str | None, uid: str | None
+) -> str | None:
+    """Resolve the parent of a To-do item to a uid, rejecting invalid hierarchies.
+
+    Subtasks are limited to a single level, so neither the parent nor the item
+    being reparented may already be part of a parent/subtask relationship.
+    """
+    if parent is None:
+        return None
+
+    found = _find_by_uid_or_summary(parent, entity.todo_items)
+    if not found or not found.uid:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="parent_not_found",
+            translation_placeholders={"parent": parent},
+        )
+    if found.uid == uid:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="parent_is_self",
+            translation_placeholders={"parent": parent},
+        )
+    if found.parent_uid is not None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="parent_is_subtask",
+            translation_placeholders={"parent": parent},
+        )
+    if uid is not None and any(
+        item.parent_uid == uid for item in entity.todo_items or ()
+    ):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="item_has_subtasks",
+            translation_placeholders={"parent": parent},
+        )
+    return found.uid
+
+
+def _todo_item_fields(
+    entity: TodoListEntity, call: ServiceCall, uid: str | None = None
+) -> dict[str, Any]:
+    """Map the To-do item fields of a service call onto TodoItem fields."""
+    fields = {
+        desc.todo_item_field: call.data[desc.service_field]
+        for desc in TODO_ITEM_FIELDS
+        if desc.service_field in call.data
+    }
+    if ATTR_PARENT in call.data:
+        # The parent is named by uid or summary, but stored as a uid.
+        fields[ATTR_PARENT_UID] = _resolve_parent_uid(
+            entity, call.data[ATTR_PARENT], uid
+        )
+    return fields
+
+
 async def _async_add_todo_item(entity: TodoListEntity, call: ServiceCall) -> None:
     """Add an item to the To-do list."""
     _validate_supported_features(entity.supported_features, call.data)
@@ -474,11 +547,7 @@ async def _async_add_todo_item(entity: TodoListEntity, call: ServiceCall) -> Non
         item=TodoItem(
             summary=call.data["item"],
             status=TodoItemStatus.NEEDS_ACTION,
-            **{
-                desc.todo_item_field: call.data[desc.service_field]
-                for desc in TODO_ITEM_FIELDS
-                if desc.service_field in call.data
-            },
+            **_todo_item_fields(entity, call),
         )
     )
 
@@ -504,13 +573,7 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
         updated_data["summary"] = summary
     if status := call.data.get("status"):
         updated_data["status"] = status
-    updated_data.update(
-        {
-            desc.todo_item_field: call.data[desc.service_field]
-            for desc in TODO_ITEM_FIELDS
-            if desc.service_field in call.data
-        }
-    )
+    updated_data.update(_todo_item_fields(entity, call, found.uid))
     await entity.async_update_todo_item(item=TodoItem(**updated_data))
 
 

--- a/homeassistant/components/todo/const.py
+++ b/homeassistant/components/todo/const.py
@@ -18,6 +18,8 @@ ATTR_DUE_DATE = "due_date"
 ATTR_DUE_DATETIME = "due_datetime"
 ATTR_DESCRIPTION = "description"
 ATTR_ITEM = "item"
+ATTR_PARENT = "parent"
+ATTR_PARENT_UID = "parent_uid"
 ATTR_RENAME = "rename"
 ATTR_STATUS = "status"
 
@@ -42,6 +44,7 @@ class TodoListEntityFeature(IntFlag):
     SET_DUE_DATE_ON_ITEM = 16
     SET_DUE_DATETIME_ON_ITEM = 32
     SET_DESCRIPTION_ON_ITEM = 64
+    SET_PARENT_ON_ITEM = 128
 
 
 class TodoItemStatus(StrEnum):

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -46,6 +46,13 @@ add_item:
       example: "A more complete description of the to-do item than that provided by the summary."
       selector:
         text:
+    parent:
+      filter:
+        supported_features:
+          - todo.TodoListEntityFeature.SET_PARENT_ON_ITEM
+      example: "File taxes"
+      selector:
+        text:
 update_item:
   target:
     entity:
@@ -89,6 +96,13 @@ update_item:
         supported_features:
           - todo.TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
       example: "A more complete description of the to-do item than that provided by the summary."
+      selector:
+        text:
+    parent:
+      filter:
+        supported_features:
+          - todo.TodoListEntityFeature.SET_PARENT_ON_ITEM
+      example: "File taxes"
       selector:
         text:
 remove_item:

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -39,8 +39,20 @@
     }
   },
   "exceptions": {
+    "item_has_subtasks": {
+      "message": "Unable to make a to-do list item that has subtasks of its own a subtask of: {parent}"
+    },
     "item_not_found": {
       "message": "Unable to find to-do list item: {item}"
+    },
+    "parent_is_self": {
+      "message": "Unable to make a to-do list item a subtask of itself: {parent}"
+    },
+    "parent_is_subtask": {
+      "message": "Unable to add a subtask to a to-do list item that is itself a subtask: {parent}"
+    },
+    "parent_not_found": {
+      "message": "Unable to find the parent to-do list item: {parent}"
     },
     "update_field_not_supported": {
       "message": "Entity does not support setting field: {service_field}"
@@ -73,6 +85,10 @@
         "item": {
           "description": "The name that represents the to-do item.",
           "name": "Item name"
+        },
+        "parent": {
+          "description": "The name or UID of the to-do item to add this item under as a subtask. Subtasks cannot have subtasks of their own.",
+          "name": "Parent item"
         }
       },
       "name": "Add to-do list item"
@@ -119,6 +135,10 @@
         "item": {
           "description": "The name/summary of the to-do item. If you have items with duplicate names, you can reference specific ones using their UID instead.",
           "name": "Item name or UID"
+        },
+        "parent": {
+          "description": "The name or UID of the to-do item to move this item under as a subtask. Leave empty to turn a subtask back into a top-level item.",
+          "name": "[%key:component::todo::services::add_item::fields::parent::name%]"
         },
         "rename": {
           "description": "The new name for the to-do item",

--- a/tests/components/todo/snapshots/test_init.ambr
+++ b/tests/components/todo/snapshots/test_init.ambr
@@ -4,6 +4,7 @@
     'completed': 'datetime.datetime | None',
     'description': 'str | None',
     'due': 'datetime.date | datetime.datetime | None',
+    'parent_uid': 'str | None',
     'status': 'homeassistant.components.todo.const.TodoItemStatus | None',
     'summary': 'str | None',
     'uid': 'str | None',

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.components.todo import (
     ATTR_DUE_DATE,
     ATTR_DUE_DATETIME,
     ATTR_ITEM,
+    ATTR_PARENT,
     ATTR_RENAME,
     ATTR_STATUS,
     DOMAIN,
@@ -738,6 +739,218 @@ async def test_update_todo_item_extended_fields_overwrite_existing_values(
     assert item == expected_update
 
 
+def _hierarchy_items() -> list[TodoItem]:
+    """Return item #2 as a subtask of item #1, plus a standalone item #3."""
+    return [
+        TodoItem(uid="1", summary="Item #1", status=TodoItemStatus.NEEDS_ACTION),
+        TodoItem(
+            uid="2",
+            summary="Item #2",
+            status=TodoItemStatus.NEEDS_ACTION,
+            parent_uid="1",
+        ),
+        TodoItem(uid="3", summary="Item #3", status=TodoItemStatus.NEEDS_ACTION),
+    ]
+
+
+@pytest.mark.parametrize(
+    "parent",
+    ["3", "Item #3"],
+    ids=["by_uid", "by_summary"],
+)
+async def test_add_todo_item_service_with_parent(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    parent: str,
+) -> None:
+    """Test adding a subtask to a To-do list."""
+
+    assert test_entity._attr_supported_features is not None
+    test_entity._attr_supported_features |= TodoListEntityFeature.SET_PARENT_ON_ITEM
+    test_entity._attr_todo_items = _hierarchy_items()
+    await create_mock_platform(hass, [test_entity])
+
+    await hass.services.async_call(
+        DOMAIN,
+        TodoServices.ADD_ITEM,
+        {ATTR_ITEM: "New item", ATTR_PARENT: parent},
+        target={ATTR_ENTITY_ID: "todo.entity1"},
+        blocking=True,
+    )
+
+    args = test_entity.async_create_todo_item.call_args
+    assert args
+    assert args.kwargs.get("item") == TodoItem(
+        summary="New item",
+        status=TodoItemStatus.NEEDS_ACTION,
+        parent_uid="3",
+    )
+
+
+@pytest.mark.parametrize(
+    ("item", "parent", "expected_parent_uid"),
+    [
+        ("3", "1", "1"),
+        ("Item #3", "Item #1", "1"),
+        ("2", None, None),
+    ],
+    ids=["by_uid", "by_summary", "clear_parent"],
+)
+async def test_update_todo_item_service_with_parent(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    item: str,
+    parent: str | None,
+    expected_parent_uid: str | None,
+) -> None:
+    """Test moving an item under a parent, and back out again."""
+
+    assert test_entity._attr_supported_features is not None
+    test_entity._attr_supported_features |= TodoListEntityFeature.SET_PARENT_ON_ITEM
+    test_entity._attr_todo_items = _hierarchy_items()
+    await create_mock_platform(hass, [test_entity])
+
+    await hass.services.async_call(
+        DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: item, ATTR_PARENT: parent},
+        target={ATTR_ENTITY_ID: "todo.entity1"},
+        blocking=True,
+    )
+
+    args = test_entity.async_update_todo_item.call_args
+    assert args
+    updated = args.kwargs.get("item")
+    assert updated
+    assert updated.parent_uid == expected_parent_uid
+
+
+async def test_update_todo_item_service_keeps_parent(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+) -> None:
+    """Test that an update that omits the parent leaves the item a subtask."""
+
+    test_entity._attr_todo_items = _hierarchy_items()
+    await create_mock_platform(hass, [test_entity])
+
+    await hass.services.async_call(
+        DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "2", ATTR_RENAME: "Updated item"},
+        target={ATTR_ENTITY_ID: "todo.entity1"},
+        blocking=True,
+    )
+
+    args = test_entity.async_update_todo_item.call_args
+    assert args
+    assert args.kwargs.get("item") == TodoItem(
+        uid="2",
+        summary="Updated item",
+        status=TodoItemStatus.NEEDS_ACTION,
+        parent_uid="1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data"),
+    [
+        (TodoServices.ADD_ITEM, {ATTR_ITEM: "New item", ATTR_PARENT: "1"}),
+        (TodoServices.UPDATE_ITEM, {ATTR_ITEM: "3", ATTR_PARENT: "1"}),
+    ],
+    ids=["add_item", "update_item"],
+)
+async def test_set_parent_not_supported(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    service: str,
+    service_data: dict[str, Any],
+) -> None:
+    """Test setting a parent on an entity that does not support subtasks."""
+
+    test_entity._attr_todo_items = _hierarchy_items()
+    await create_mock_platform(hass, [test_entity])
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Entity does not support setting field: parent",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            service_data,
+            target={ATTR_ENTITY_ID: "todo.entity1"},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "expected_error"),
+    [
+        (
+            TodoServices.ADD_ITEM,
+            {ATTR_ITEM: "New item", ATTR_PARENT: "Unknown"},
+            "Unable to find the parent to-do list item: Unknown",
+        ),
+        (
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "3", ATTR_PARENT: "Unknown"},
+            "Unable to find the parent to-do list item: Unknown",
+        ),
+        (
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "1", ATTR_PARENT: "1"},
+            "Unable to make a to-do list item a subtask of itself: 1",
+        ),
+        (
+            TodoServices.ADD_ITEM,
+            {ATTR_ITEM: "New item", ATTR_PARENT: "2"},
+            "Unable to add a subtask to a to-do list item that is itself a subtask: 2",
+        ),
+        (
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "3", ATTR_PARENT: "2"},
+            "Unable to add a subtask to a to-do list item that is itself a subtask: 2",
+        ),
+        (
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "1", ATTR_PARENT: "3"},
+            "Unable to make a to-do list item that has subtasks of its own a subtask of: 3",
+        ),
+    ],
+    ids=[
+        "add_parent_not_found",
+        "update_parent_not_found",
+        "parent_is_self",
+        "add_parent_is_subtask",
+        "update_parent_is_subtask",
+        "item_has_subtasks",
+    ],
+)
+async def test_set_parent_invalid_hierarchy(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    service: str,
+    service_data: dict[str, Any],
+    expected_error: str,
+) -> None:
+    """Test the parent/subtask hierarchy is validated to a single level."""
+
+    assert test_entity._attr_supported_features is not None
+    test_entity._attr_supported_features |= TodoListEntityFeature.SET_PARENT_ON_ITEM
+    test_entity._attr_todo_items = _hierarchy_items()
+    await create_mock_platform(hass, [test_entity])
+
+    with pytest.raises(ServiceValidationError, match=expected_error):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            service_data,
+            target={ATTR_ENTITY_ID: "todo.entity1"},
+            blocking=True,
+        )
+
+
 async def test_remove_todo_item_service_by_id(
     hass: HomeAssistant,
     test_entity: TodoListEntity,
@@ -1093,6 +1306,7 @@ async def test_subscribe(
                 "due": None,
                 "description": None,
                 "completed": None,
+                "parent_uid": None,
             },
             {
                 "summary": "Item #2",
@@ -1101,6 +1315,7 @@ async def test_subscribe(
                 "due": None,
                 "description": None,
                 "completed": f"2026-03-27T11:00:00{TEST_OFFSET}",
+                "parent_uid": None,
             },
         ]
     }
@@ -1121,6 +1336,7 @@ async def test_subscribe(
                 "due": None,
                 "description": None,
                 "completed": None,
+                "parent_uid": None,
             },
             {
                 "summary": "Item #2",
@@ -1129,6 +1345,7 @@ async def test_subscribe(
                 "due": None,
                 "description": None,
                 "completed": f"2026-03-27T11:00:00{TEST_OFFSET}",
+                "parent_uid": None,
             },
             {
                 "summary": "Item #3",
@@ -1137,6 +1354,7 @@ async def test_subscribe(
                 "due": None,
                 "description": None,
                 "completed": None,
+                "parent_uid": None,
             },
         ]
     }
@@ -1255,6 +1473,7 @@ def test_todo_item_fields(snapshot: SnapshotAssertion) -> None:
             {"due": f"2023-11-17T17:00:00{TEST_OFFSET}"},
         ),
         ({"description": "Some description"}, {"description": "Some description"}),
+        ({"parent_uid": "2"}, {"parent_uid": "2"}),
     ],
 )
 async def test_list_todo_items_extended_fields(


### PR DESCRIPTION
## Proposed change

Adds subtask support to the To-do list entity platform.

Several to-do backends model subtasks, but Home Assistant has no way to
represent them, so integrations currently have to discard the hierarchy. Google
Tasks filters subtasks out entirely, with a comment in `_order_tasks` saying
that "Home Assistant To-do items do not support the Google Task parent/sibling
relationships and the desired behavior is for them to be filtered". CalDAV and
Local to-do both sit on RFC 5545, which expresses this with
`RELATED-TO;RELTYPE=PARENT`.

This PR adds the platform-level pieces only. No integration is changed here, so
that the base contract can be reviewed on its own before backends adopt it:

- `TodoItem` gains a `parent_uid` field, holding the uid of the item a subtask
  belongs to.
- `TodoListEntityFeature.SET_PARENT_ON_ITEM` lets an entity advertise support.
- `todo.add_item` and `todo.update_item` gain a `parent` field naming the parent
  by uid or summary, matching how the existing `item` field already resolves.
  Passing an empty `parent` to `todo.update_item` turns a subtask back into a
  top-level item.

Subtasks are limited to a single level, which is what the backends that support
them do in practice, and what the frontend renders. `_resolve_parent_uid`
enforces this: the parent must exist, an item cannot be its own parent, the
parent may not itself be a subtask, and an item that already has subtasks cannot
be reparented. That last pair of rules is what keeps the tree from ever growing
a third level, and it also makes cycles impossible.

Existing serialization picks the new field up automatically, so `todo.get_items`
and the `todo/item/list` and `todo/item/subscribe` websocket commands expose
`parent_uid` without further changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Architecture discussion: https://github.com/home-assistant/architecture/discussions/1453
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47737
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53885

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

