### PR TITLE
Follow the Peblar charging session as it changes

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -97,9 +97,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
         version_coordinator=version_coordinator,
     )
 
-    # Follow the charging session as it changes, rather than waiting for
-    # the next poll to notice. The poll stays where it is: this only asks
-    # it to catch up early.
     listener = PeblarSessionListener(hass, entry, peblar, meter_coordinator)
     entry.async_create_background_task(
         hass, listener.async_run(), name=f"Peblar {entry.title} event stream"

--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -27,6 +27,7 @@ from .coordinator import (
     PeblarVersionDataUpdateCoordinator,
 )
 from .services import async_setup_services
+from .websocket import PeblarSessionListener
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -94,6 +95,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
         system_information=system_information,
         user_configuration_coordinator=user_configuration_coordinator,
         version_coordinator=version_coordinator,
+    )
+
+    # Follow the charging session as it changes, rather than waiting for
+    # the next poll to notice. The poll stays where it is: this only asks
+    # it to catch up early.
+    listener = PeblarSessionListener(hass, entry, peblar, meter_coordinator)
+    entry.async_create_background_task(
+        hass, listener.async_run(), name=f"Peblar {entry.title} event stream"
     )
 
     # Forward the setup to the platforms

--- a/homeassistant/components/peblar/const.py
+++ b/homeassistant/components/peblar/const.py
@@ -1,5 +1,6 @@
 """Constants for the Peblar integration."""
 
+from datetime import timedelta
 import logging
 from typing import Final
 
@@ -9,6 +10,13 @@ DOMAIN: Final = "peblar"
 
 CONF_EVCC_ID: Final = "evcc_id"
 CONF_UID: Final = "uid"
+
+# How long to wait before opening the event stream again after it fell
+# over, doubling up to the maximum. The stream only makes the poll
+# quicker, so there is no hurry and no point hammering a charger that is
+# switched off.
+EVENT_STREAM_RETRY_MINIMUM: Final = timedelta(seconds=5)
+EVENT_STREAM_RETRY_MAXIMUM: Final = timedelta(minutes=5)
 
 LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/peblar/const.py
+++ b/homeassistant/components/peblar/const.py
@@ -11,10 +11,8 @@ DOMAIN: Final = "peblar"
 CONF_EVCC_ID: Final = "evcc_id"
 CONF_UID: Final = "uid"
 
-# How long to wait before opening the event stream again after it fell
-# over, doubling up to the maximum. The stream only makes the poll
-# quicker, so there is no hurry and no point hammering a charger that is
-# switched off.
+# The stream only makes the poll quicker, so there is no hurry, and no
+# point hammering a charger that is switched off.
 EVENT_STREAM_RETRY_MINIMUM: Final = timedelta(seconds=5)
 EVENT_STREAM_RETRY_MAXIMUM: Final = timedelta(minutes=5)
 

--- a/homeassistant/components/peblar/websocket.py
+++ b/homeassistant/components/peblar/websocket.py
@@ -1,0 +1,75 @@
+"""Live event stream for the Peblar integration."""
+
+import asyncio
+
+from peblar import Peblar, PeblarError, PeblarSessionStatus
+
+from homeassistant.core import HomeAssistant, callback
+
+from .const import EVENT_STREAM_RETRY_MAXIMUM, EVENT_STREAM_RETRY_MINIMUM, LOGGER
+from .coordinator import PeblarConfigEntry, PeblarDataUpdateCoordinator
+
+
+class PeblarSessionListener:
+    """Follows the charging session over the charger's event stream.
+
+    The charger pushes a session change as it happens, which the poll
+    would otherwise take up to its interval to notice. This only tells the
+    poll to catch up early, so a stream that never comes up, or one that
+    falls over, costs nothing beyond going back to the poll on its own.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: PeblarConfigEntry,
+        peblar: Peblar,
+        coordinator: PeblarDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the listener."""
+        self._hass = hass
+        self._entry = entry
+        self._peblar = peblar
+        self._coordinator = coordinator
+
+    async def async_run(self) -> None:
+        """Keep a subscription up for as long as the entry is loaded."""
+        retry = EVENT_STREAM_RETRY_MINIMUM
+
+        while True:
+            try:
+                await self._async_listen()
+            except PeblarError as error:
+                LOGGER.debug(
+                    "Peblar event stream for %s stopped: %s", self._entry.title, error
+                )
+            else:
+                # The charger closed the stream on us rather than failing,
+                # so start over from the shortest wait.
+                retry = EVENT_STREAM_RETRY_MINIMUM
+
+            await asyncio.sleep(retry.total_seconds())
+            retry = min(retry * 2, EVENT_STREAM_RETRY_MAXIMUM)
+
+    async def _async_listen(self) -> None:
+        """Open the stream and stay on it until it closes."""
+        websocket = self._peblar.websocket()
+        try:
+            await websocket.connect()
+            await websocket.subscribe_session_status(self._handle_session_status)
+            await websocket.listen()
+        finally:
+            await websocket.disconnect()
+
+    @callback
+    def _handle_session_status(self, status: PeblarSessionStatus) -> None:
+        """Ask the poll to catch up, now the session has moved on.
+
+        The charger sends the current status right after subscribing, so
+        the first call says nothing new. Refreshing anyway is harmless and
+        cheaper than working out which one that was.
+        """
+        LOGGER.debug("Peblar session for %s is %s", self._entry.title, status.state)
+        self._entry.async_create_task(
+            self._hass, self._coordinator.async_request_refresh(), eager_start=False
+        )

--- a/homeassistant/components/peblar/websocket.py
+++ b/homeassistant/components/peblar/websocket.py
@@ -31,10 +31,11 @@ class PeblarSessionListener:
         self._entry = entry
         self._peblar = peblar
         self._coordinator = coordinator
+        self._retry = EVENT_STREAM_RETRY_MINIMUM
 
     async def async_run(self) -> None:
         """Keep a subscription up for as long as the entry is loaded."""
-        retry = EVENT_STREAM_RETRY_MINIMUM
+        self._retry = EVENT_STREAM_RETRY_MINIMUM
 
         while True:
             try:
@@ -43,19 +44,21 @@ class PeblarSessionListener:
                 LOGGER.debug(
                     "Peblar event stream for %s stopped: %s", self._entry.title, error
                 )
-            else:
-                # The charger closed the stream on us rather than failing,
-                # so start over from the shortest wait.
-                retry = EVENT_STREAM_RETRY_MINIMUM
 
-            await asyncio.sleep(retry.total_seconds())
-            retry = min(retry * 2, EVENT_STREAM_RETRY_MAXIMUM)
+            await asyncio.sleep(self._retry.total_seconds())
+            self._retry = min(self._retry * 2, EVENT_STREAM_RETRY_MAXIMUM)
 
     async def _async_listen(self) -> None:
         """Open the stream and stay on it until it closes."""
         websocket = self._peblar.websocket()
         try:
             await websocket.connect()
+
+            # A charger that was unreachable at startup can leave the wait
+            # at its longest. Reaching it at all settles that, so a drop
+            # hours later is not held against whatever went before.
+            self._retry = EVENT_STREAM_RETRY_MINIMUM
+
             await websocket.subscribe_session_status(self._handle_session_status)
             await websocket.listen()
         finally:

--- a/homeassistant/components/peblar/websocket.py
+++ b/homeassistant/components/peblar/websocket.py
@@ -53,13 +53,15 @@ class PeblarSessionListener:
         websocket = self._peblar.websocket()
         try:
             await websocket.connect()
+            await websocket.subscribe_session_status(self._handle_session_status)
 
             # A charger that was unreachable at startup can leave the wait
-            # at its longest. Reaching it at all settles that, so a drop
-            # hours later is not held against whatever went before.
+            # at its longest. A subscription that landed settles that, so a
+            # drop hours later is not held against whatever went before.
+            # Taking the socket without ever getting this far is not a
+            # working stream, and keeps backing off.
             self._retry = EVENT_STREAM_RETRY_MINIMUM
 
-            await websocket.subscribe_session_status(self._handle_session_status)
             await websocket.listen()
         finally:
             await websocket.disconnect()

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -1,9 +1,10 @@
 """Fixtures for the Peblar integration tests."""
 
+import asyncio
 from collections.abc import Generator
 from contextlib import nullcontext
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from peblar import (
     PeblarEVInterface,
@@ -80,6 +81,15 @@ def mock_peblar(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         peblar.system_information.return_value = PeblarSystemInformation.from_dict(
             system_information
         )
+
+        # The event stream parks here until the entry unloads, the way a
+        # real one waits on the charger rather than returning.
+        async def _listen_until_cancelled() -> None:
+            await asyncio.Event().wait()
+
+        websocket = AsyncMock()
+        websocket.listen.side_effect = _listen_until_cancelled
+        peblar.websocket.return_value = websocket
 
         api = peblar.rest_api.return_value
         api.ev_interface.return_value = PeblarEVInterface.from_json(

--- a/tests/components/peblar/test_websocket.py
+++ b/tests/components/peblar/test_websocket.py
@@ -1,7 +1,6 @@
 """Tests for the Peblar event stream."""
 
 import asyncio
-from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from peblar import PeblarConnectionError, PeblarSessionStatus, SessionState
@@ -18,17 +17,7 @@ pytestmark = [
 ]
 
 
-def _session_callback(mock_peblar: MagicMock):
-    """Return the callback the listener subscribed with."""
-    websocket = mock_peblar.websocket.return_value
-    websocket.subscribe_session_status.assert_called_once()
-    return websocket.subscribe_session_status.call_args.args[0]
-
-
-async def test_the_stream_is_subscribed_to(
-    hass: HomeAssistant,
-    mock_peblar: MagicMock,
-) -> None:
+async def test_the_stream_is_subscribed_to(mock_peblar: MagicMock) -> None:
     """Test the charger's session is followed as soon as the entry loads."""
     websocket = mock_peblar.websocket.return_value
     websocket.connect.assert_awaited_once()
@@ -43,7 +32,9 @@ async def test_a_session_change_pulls_the_poll_forward(
     meter = mock_peblar.rest_api.return_value.meter
     meter.reset_mock()
 
-    _session_callback(mock_peblar)(
+    websocket = mock_peblar.websocket.return_value
+    handle_session_status = websocket.subscribe_session_status.call_args.args[0]
+    handle_session_status(
         PeblarSessionStatus(state=SessionState.CHARGING, meter_data=None)
     )
     await hass.async_block_till_done()
@@ -51,71 +42,48 @@ async def test_a_session_change_pulls_the_poll_forward(
     meter.assert_awaited()
 
 
-async def test_the_stream_is_opened_again_after_it_falls_over(
+async def test_the_wait_backs_off_and_settles_once_the_charger_answers(
     hass: HomeAssistant,
     mock_peblar: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test a charger that drops off is picked back up.
+    """Test how long the stream waits between attempts.
 
-    The stream only makes the poll quicker, so losing it is not fatal, but
-    losing it for good would quietly undo the whole thing.
+    A charger that cannot be reached is given more room each time. Once it
+    answers, that is settled: a drop hours later starts over from the
+    shortest wait rather than the longest one reached at startup.
     """
     websocket = mock_peblar.websocket.return_value
-    attempts = 0
+    websocket.connect.side_effect = [
+        PeblarConnectionError("Gone"),
+        PeblarConnectionError("Still gone"),
+        None,
+        None,
+    ]
 
-    async def _fall_over_once() -> None:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise PeblarConnectionError("Gone")
-        await asyncio.Event().wait()
-
-    websocket.listen.side_effect = _fall_over_once
-    websocket.connect.reset_mock()
-
-    with patch(
-        "homeassistant.components.peblar.websocket.EVENT_STREAM_RETRY_MINIMUM",
-        timedelta(0),
-    ):
-        await hass.config_entries.async_reload(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert attempts > 1
-    assert websocket.connect.await_count > 1
-
-
-async def test_a_stream_the_charger_closes_is_opened_again(
-    hass: HomeAssistant,
-    mock_peblar: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a charger hanging up cleanly is not treated as a failure.
-
-    Nothing went wrong, so there is no reason to start backing off.
-    """
-    websocket = mock_peblar.websocket.return_value
-    attempts = 0
+    hang_ups = 0
 
     async def _hang_up_once() -> None:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
+        nonlocal hang_ups
+        hang_ups += 1
+        if hang_ups == 1:
             return
         await asyncio.Event().wait()
 
     websocket.listen.side_effect = _hang_up_once
-    websocket.connect.reset_mock()
 
-    with patch(
-        "homeassistant.components.peblar.websocket.EVENT_STREAM_RETRY_MINIMUM",
-        timedelta(0),
-    ):
+    waits: list[float] = []
+
+    async def _record(delay: float) -> None:
+        waits.append(delay)
+
+    with patch("homeassistant.components.peblar.websocket.asyncio.sleep", _record):
         await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert attempts > 1
-    assert websocket.connect.await_count > 1
+    # Five seconds, then ten while the charger stays away. It answers on
+    # the third try and hangs up, and the wait is back to five.
+    assert waits[:3] == [5, 10, 5]
 
 
 async def test_the_stream_is_closed_when_the_entry_unloads(

--- a/tests/components/peblar/test_websocket.py
+++ b/tests/components/peblar/test_websocket.py
@@ -86,6 +86,41 @@ async def test_the_wait_backs_off_and_settles_once_the_charger_answers(
     assert waits[:3] == [5, 10, 5]
 
 
+async def test_a_subscription_that_never_lands_keeps_backing_off(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test taking the socket is not the same as having a stream.
+
+    A charger that accepts the connection but never completes the
+    subscription would otherwise be retried every five seconds forever.
+    """
+    websocket = mock_peblar.websocket.return_value
+    subscriptions = 0
+
+    async def _refuse_twice(_callback: object) -> None:
+        nonlocal subscriptions
+        subscriptions += 1
+        if subscriptions <= 2:
+            raise PeblarConnectionError("Not listening")
+
+    websocket.subscribe_session_status.side_effect = _refuse_twice
+
+    waits: list[float] = []
+
+    async def _record(delay: float) -> None:
+        waits.append(delay)
+
+    with patch("homeassistant.components.peblar.websocket.asyncio.sleep", _record):
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # The socket opened every time, so a reset on that alone would have
+    # left both waits at five seconds.
+    assert waits[:2] == [5, 10]
+
+
 async def test_the_stream_is_closed_when_the_entry_unloads(
     hass: HomeAssistant,
     mock_peblar: MagicMock,

--- a/tests/components/peblar/test_websocket.py
+++ b/tests/components/peblar/test_websocket.py
@@ -1,0 +1,130 @@
+"""Tests for the Peblar event stream."""
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from peblar import PeblarConnectionError, PeblarSessionStatus, SessionState
+import pytest
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+pytestmark = [
+    pytest.mark.parametrize("init_integration", [Platform.SENSOR], indirect=True),
+    pytest.mark.usefixtures("init_integration"),
+]
+
+
+def _session_callback(mock_peblar: MagicMock):
+    """Return the callback the listener subscribed with."""
+    websocket = mock_peblar.websocket.return_value
+    websocket.subscribe_session_status.assert_called_once()
+    return websocket.subscribe_session_status.call_args.args[0]
+
+
+async def test_the_stream_is_subscribed_to(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+) -> None:
+    """Test the charger's session is followed as soon as the entry loads."""
+    websocket = mock_peblar.websocket.return_value
+    websocket.connect.assert_awaited_once()
+    websocket.subscribe_session_status.assert_awaited_once()
+
+
+async def test_a_session_change_pulls_the_poll_forward(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+) -> None:
+    """Test an event asks the poll to catch up rather than waiting it out."""
+    meter = mock_peblar.rest_api.return_value.meter
+    meter.reset_mock()
+
+    _session_callback(mock_peblar)(
+        PeblarSessionStatus(state=SessionState.CHARGING, meter_data=None)
+    )
+    await hass.async_block_till_done()
+
+    meter.assert_awaited()
+
+
+async def test_the_stream_is_opened_again_after_it_falls_over(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a charger that drops off is picked back up.
+
+    The stream only makes the poll quicker, so losing it is not fatal, but
+    losing it for good would quietly undo the whole thing.
+    """
+    websocket = mock_peblar.websocket.return_value
+    attempts = 0
+
+    async def _fall_over_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PeblarConnectionError("Gone")
+        await asyncio.Event().wait()
+
+    websocket.listen.side_effect = _fall_over_once
+    websocket.connect.reset_mock()
+
+    with patch(
+        "homeassistant.components.peblar.websocket.EVENT_STREAM_RETRY_MINIMUM",
+        timedelta(0),
+    ):
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert attempts > 1
+    assert websocket.connect.await_count > 1
+
+
+async def test_a_stream_the_charger_closes_is_opened_again(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a charger hanging up cleanly is not treated as a failure.
+
+    Nothing went wrong, so there is no reason to start backing off.
+    """
+    websocket = mock_peblar.websocket.return_value
+    attempts = 0
+
+    async def _hang_up_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return
+        await asyncio.Event().wait()
+
+    websocket.listen.side_effect = _hang_up_once
+    websocket.connect.reset_mock()
+
+    with patch(
+        "homeassistant.components.peblar.websocket.EVENT_STREAM_RETRY_MINIMUM",
+        timedelta(0),
+    ):
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert attempts > 1
+    assert websocket.connect.await_count > 1
+
+
+async def test_the_stream_is_closed_when_the_entry_unloads(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the charger is let go of when the entry goes away."""
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_peblar.websocket.return_value.disconnect.assert_awaited()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The charger has an event stream on its web API that pushes a session change as it happens. Until now the integration only polled, every ten seconds, so plugging a car in took up to that long to show up.

This subscribes to the session topic and asks the data coordinator to catch up whenever something changes.

**Polling stays exactly where it is.** The stream only pulls the poll forward, so a stream that never comes up, or one that falls over, costs nothing beyond the behaviour on `dev` today. That is deliberate, and it is why the `iot_class` stays `local_polling`: nothing here depends on push.

**It reconnects**, backing off from five seconds to five minutes. A charger that hangs up cleanly did not fail, so the backoff starts over from the shortest wait rather than climbing.

**Kept small on purpose.** One topic, one connector. The charger has three more topics, `statuschanged`, `tokenfound` and `fwupdate/status`, and dual socket models have a second connector. All of those fit on this without changing its shape, and the last one would finally let #180581 report whether an update succeeded.

One thing I checked rather than assumed, because it would have made the whole change pointless: `async_request_refresh` is debounced, but `REQUEST_REFRESH_DEFAULT_IMMEDIATE` is `True`, so the first call goes through at once and the cooldown only rate limits a burst behind it. Exactly what is wanted here.

Verified: 122 tests pass, 100% coverage on the new module and on `__init__.py`. Two mutation checks, each failing two tests: dropping the refresh on an event, and dropping the reconnect loop.

Note for reviewers on the tests: the retry loop uses `asyncio.sleep`, which the time helpers do not fast forward, so the tests patch the delay to zero rather than moving the clock.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
