### PR TITLE
Add Elgato Wi-Fi signal sensors

### DIFF
--- a/homeassistant/components/elgato/icons.json
+++ b/homeassistant/components/elgato/icons.json
@@ -13,6 +13,11 @@
         "default": "mdi:power-settings"
       }
     },
+    "sensor": {
+      "wifi_signal_strength": {
+        "default": "mdi:wifi"
+      }
+    },
     "switch": {
       "bypass": {
         "default": "mdi:battery-off-outline"

--- a/homeassistant/components/elgato/sensor.py
+++ b/homeassistant/components/elgato/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -96,6 +97,26 @@ SENSORS = [
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         has_fn=lambda x: x.battery is not None,
         value_fn=lambda x: x.battery.input_charge_voltage if x.battery else None,
+    ),
+    ElgatoSensorEntityDescription(
+        key="wifi_signal_strength",
+        translation_key="wifi_signal_strength",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda x: x.info.wifi is not None,
+        value_fn=lambda x: x.info.wifi.signal_strength if x.info.wifi else None,
+    ),
+    ElgatoSensorEntityDescription(
+        key="wifi_rssi",
+        translation_key="wifi_rssi",
+        entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda x: x.info.wifi is not None,
+        value_fn=lambda x: x.info.wifi.rssi if x.info.wifi else None,
     ),
 ]
 

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -65,6 +65,12 @@
       },
       "voltage": {
         "name": "Battery voltage"
+      },
+      "wifi_rssi": {
+        "name": "Wi-Fi RSSI"
+      },
+      "wifi_signal_strength": {
+        "name": "Wi-Fi signal strength"
       }
     },
     "switch": {

--- a/tests/components/elgato/snapshots/test_sensor.ambr
+++ b/tests/components/elgato/snapshots/test_sensor.ambr
@@ -468,3 +468,180 @@
     'via_device_id': None,
   })
 # ---
+# name: test_sensors[sensor.frenck_wi_fi_rssi-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Wi-Fi RSSI',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.frenck_wi_fi_rssi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-41',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_rssi-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.frenck_wi_fi_rssi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi RSSI',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Wi-Fi RSSI',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_rssi',
+    'unique_id': 'GW24L1A02987_wifi_rssi',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_rssi-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'GW24L1A02987',
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_signal_strength-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Frenck Wi-Fi signal strength',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.frenck_wi_fi_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_signal_strength-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.frenck_wi_fi_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi signal strength',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi signal strength',
+    'platform': 'elgato',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_signal_strength',
+    'unique_id': 'GW24L1A02987_wifi_signal_strength',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.frenck_wi_fi_signal_strength-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'model_id': None,
+    'name': 'Frenck',
+    'name_by_user': None,
+    'serial_number': 'GW24L1A02987',
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/test_sensor.py
+++ b/tests/components/elgato/test_sensor.py
@@ -21,6 +21,8 @@ pytestmark = [
         "sensor.frenck_charging_current",
         "sensor.frenck_charging_power",
         "sensor.frenck_charging_voltage",
+        "sensor.frenck_wi_fi_rssi",
+        "sensor.frenck_wi_fi_signal_strength",
     ],
 )
 async def test_sensors(
@@ -50,6 +52,7 @@ async def test_sensors(
         "sensor.frenck_charging_current",
         "sensor.frenck_charging_power",
         "sensor.frenck_charging_voltage",
+        "sensor.frenck_wi_fi_rssi",
     ],
 )
 async def test_disabled_by_default_sensors(
@@ -61,3 +64,19 @@ async def test_disabled_by_default_sensors(
     assert (entry := entity_registry.async_get(entity_id))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_wifi_signal_strength_is_enabled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the signal strength percentage is on without asking for it.
+
+    A percentage is what someone can actually read, so it is the one that
+    shows up by default. The dBm behind it stays available but off.
+    """
+    assert (state := hass.states.get("sensor.frenck_wi_fi_signal_strength"))
+    assert state.state == "100"
+
+    assert (entry := entity_registry.async_get("sensor.frenck_wi_fi_signal_strength"))
+    assert not entry.disabled


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds two diagnostic sensors for the Wi-Fi signal, which every mains powered Elgato already reports on each poll and nothing looked at.

- **Wi-Fi signal strength**, a percentage, enabled by default.
- **Wi-Fi RSSI**, in dBm, disabled by default.

The percentage is the one that shows up on its own, because it is the number someone can read without knowing what a dBm is. The raw unit stays available for whoever wants it.

For an integration whose most common complaint is a device going unavailable, being able to graph the signal is worth having.

No conversion happens here. `Wifi.signal_strength` landed in elgato 6.1.0 and this only reads it, since Core is not the place to be doing arithmetic on device values.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47739
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

