### PR TITLE
Split the Amber Electric user flow init from its data

### DIFF
--- a/tests/components/amberelectric/test_config_flow.py
+++ b/tests/components/amberelectric/test_config_flow.py
@@ -161,9 +161,15 @@ async def test_single_pending_site(
 
     # Test filling in API key
     enter_api_key_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: API_KEY},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert enter_api_key_result["type"] is FlowResultType.FORM
+    assert enter_api_key_result["step_id"] == "user"
+
+    enter_api_key_result = await hass.config_entries.flow.async_configure(
+        enter_api_key_result["flow_id"],
+        user_input={CONF_API_TOKEN: API_KEY},
     )
     assert enter_api_key_result.get("type") is FlowResultType.FORM
     assert enter_api_key_result.get("step_id") == "site"
@@ -192,9 +198,15 @@ async def test_single_site(hass: HomeAssistant, single_site_api: Mock) -> None:
 
     # Test filling in API key
     enter_api_key_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: API_KEY},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert enter_api_key_result["type"] is FlowResultType.FORM
+    assert enter_api_key_result["step_id"] == "user"
+
+    enter_api_key_result = await hass.config_entries.flow.async_configure(
+        enter_api_key_result["flow_id"],
+        user_input={CONF_API_TOKEN: API_KEY},
     )
     assert enter_api_key_result.get("type") is FlowResultType.FORM
     assert enter_api_key_result.get("step_id") == "site"
@@ -218,9 +230,15 @@ async def test_single_closed_site_no_closed_date(
 ) -> None:
     """Test single closed site with no closed date is filtered out."""
     enter_api_key_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: API_KEY},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert enter_api_key_result["type"] is FlowResultType.FORM
+    assert enter_api_key_result["step_id"] == "user"
+
+    enter_api_key_result = await hass.config_entries.flow.async_configure(
+        enter_api_key_result["flow_id"],
+        user_input={CONF_API_TOKEN: API_KEY},
     )
     assert enter_api_key_result.get("type") is FlowResultType.FORM
     assert enter_api_key_result.get("step_id") == "user"
@@ -239,9 +257,15 @@ async def test_single_site_rejoin(
 
     # Test filling in API key
     enter_api_key_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: API_KEY},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert enter_api_key_result["type"] is FlowResultType.FORM
+    assert enter_api_key_result["step_id"] == "user"
+
+    enter_api_key_result = await hass.config_entries.flow.async_configure(
+        enter_api_key_result["flow_id"],
+        user_input={CONF_API_TOKEN: API_KEY},
     )
     assert enter_api_key_result.get("type") is FlowResultType.FORM
     assert enter_api_key_result.get("step_id") == "site"
@@ -263,9 +287,15 @@ async def test_single_site_rejoin(
 async def test_no_site(hass: HomeAssistant, no_site_api: Mock) -> None:
     """Test no site."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: "psk_123456789"},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_TOKEN: "psk_123456789"},
     )
 
     assert result.get("type") is FlowResultType.FORM
@@ -284,9 +314,15 @@ async def test_invalid_key(hass: HomeAssistant, invalid_key_api: Mock) -> None:
 
     # Test filling in API key
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: "psk_123456789"},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_TOKEN: "psk_123456789"},
     )
     assert result.get("type") is FlowResultType.FORM
     # Goes back to the user step
@@ -304,9 +340,15 @@ async def test_unknown_error(hass: HomeAssistant, api_error: Mock) -> None:
 
     # Test filling in API key
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_API_TOKEN: "psk_123456789"},
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_TOKEN: "psk_123456789"},
     )
     assert result.get("type") is FlowResultType.FORM
     # Goes back to the user step


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The flagged call sites started the flow with `data` prefilled, which no user can do. Split into `async_init`, assert the form, then `async_configure`.

Part of home-assistant/epics#119.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178820
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
