### PR TITLE
Add temporary access code support to Schlage

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -36,6 +36,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Required("name"): cv.string,
             vol.Required("code"): vol.All(cv.string, cv.matches_regex(r"^\d{4,8}$")),
             vol.Optional("notify_on_use", default=True): cv.boolean,
+            vol.Optional("start_datetime"): cv.datetime,
+            vol.Optional("end_datetime"): cv.datetime,
         },
         func=SERVICE_ADD_CODE,
     )

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -201,10 +201,46 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
         await self.coordinator.async_request_refresh()
 
     @staticmethod
+    def _serialize_recurring(schedule: RecurringSchedule) -> dict[str, Any]:
+        """Serialize a single RecurringSchedule to a dict."""
+        return {
+            "days_of_week": {
+                "sun": schedule.days_of_week.sun,
+                "mon": schedule.days_of_week.mon,
+                "tue": schedule.days_of_week.tue,
+                "wed": schedule.days_of_week.wed,
+                "thu": schedule.days_of_week.thu,
+                "fri": schedule.days_of_week.fri,
+                "sat": schedule.days_of_week.sat,
+            },
+            "start_hour": schedule.start_hour,
+            "start_minute": schedule.start_minute,
+            "end_hour": schedule.end_hour,
+            "end_minute": schedule.end_minute,
+        }
+
+    @staticmethod
     def _serialize_schedule(
         schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None,
     ) -> dict[str, Any] | None:
-        """Serialize a pyschlage schedule to a dict."""
+        """Serialize a pyschlage schedule to a dict.
+
+        The returned shape depends on the schedule type.
+
+        ``recurring``: {"type": "recurring", "days_of_week": {"sun": bool, ...},
+        "start_hour": int, "start_minute": int, "end_hour": int, "end_minute": int}.
+        Times use natural hour and minute values from the pyschlage model.
+
+        ``multi_recurring``: {"type": "multi_recurring", "windows": [<window>, ...]},
+        where each window is a dict with the same keys as ``recurring`` (days_of_week,
+        start_hour, start_minute, end_hour, end_minute) but without the ``type`` key.
+        At most two windows are present.
+
+        ``temporary``: {"type": "temporary", "start_datetime": str, "end_datetime": str}.
+        Datetime values are ISO 8601 strings.
+
+        ``None`` returns ``None``.
+        """
         if isinstance(schedule, TemporarySchedule):
             return {
                 "type": "temporary",
@@ -212,9 +248,19 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
                 "end_datetime": schedule.end.isoformat(),
             }
         if isinstance(schedule, MultiRecurringSchedule):
-            return {"type": "multi_recurring", "raw": str(schedule)}
+            schedules: list[RecurringSchedule] = []
+            if schedule.schedule1 is not None:
+                schedules.append(schedule.schedule1)
+            if schedule.schedule2 is not None:
+                schedules.append(schedule.schedule2)
+            windows = [
+                SchlageLockEntity._serialize_recurring(sched) for sched in schedules
+            ]
+            return {"type": "multi_recurring", "windows": windows}
         if isinstance(schedule, RecurringSchedule):
-            return {"type": "recurring", "raw": str(schedule)}
+            result = SchlageLockEntity._serialize_recurring(schedule)
+            result["type"] = "recurring"
+            return result
         return None
 
     async def get_codes(self) -> ServiceResponse:

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -1,14 +1,21 @@
 """Platform for Schlage lock integration."""
 
+from datetime import datetime
 from typing import Any, override
 
-from pyschlage.code import AccessCode
+from pyschlage.code import (
+    AccessCode,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.exceptions import Error as SchlageError
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant, ServiceResponse, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import LockData, SchlageConfigEntry, SchlageDataUpdateCoordinator
@@ -114,14 +121,45 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
             ) from ex
         return self._lock.access_codes
 
-    async def add_code(self, name: str, code: str, notify_on_use: bool = True) -> None:
+    async def add_code(
+        self,
+        name: str,
+        code: str,
+        notify_on_use: bool = True,
+        start_datetime: datetime | None = None,
+        end_datetime: datetime | None = None,
+    ) -> None:
         """Add a lock code."""
-
         codes = await self._async_fetch_access_codes()
         self._validate_code_name(codes, name)
         self._validate_code_value(codes, code)
 
-        access_code = AccessCode(name=name, code=code, notify_on_use=notify_on_use)
+        has_start = start_datetime is not None
+        has_end = end_datetime is not None
+
+        if has_start != has_end:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="schlage_temporary_dates_required",
+            )
+
+        schedule = None
+        if start_datetime is not None and end_datetime is not None:
+            start_utc = dt_util.as_utc(start_datetime)
+            end_utc = dt_util.as_utc(end_datetime)
+            if start_utc >= end_utc:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="schlage_start_after_end",
+                )
+            schedule = TemporarySchedule(start=start_utc, end=end_utc)
+
+        access_code = AccessCode(
+            name=name,
+            code=code,
+            notify_on_use=notify_on_use,
+            schedule=schedule,
+        )
         try:
             await self.hass.async_add_executor_job(
                 self._lock.add_access_code, access_code
@@ -162,6 +200,23 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
             ) from ex
         await self.coordinator.async_request_refresh()
 
+    @staticmethod
+    def _serialize_schedule(
+        schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None,
+    ) -> dict[str, Any] | None:
+        """Serialize a pyschlage schedule to a dict."""
+        if isinstance(schedule, TemporarySchedule):
+            return {
+                "type": "temporary",
+                "start_datetime": schedule.start.isoformat(),
+                "end_datetime": schedule.end.isoformat(),
+            }
+        if isinstance(schedule, MultiRecurringSchedule):
+            return {"type": "multi_recurring", "raw": str(schedule)}
+        if isinstance(schedule, RecurringSchedule):
+            return {"type": "recurring", "raw": str(schedule)}
+        return None
+
     async def get_codes(self) -> ServiceResponse:
         """Get lock codes."""
         await self._async_fetch_access_codes()
@@ -171,6 +226,10 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
                 code: {
                     "name": self._lock.access_codes[code].name,
                     "code": self._lock.access_codes[code].code,
+                    "access_code_id": self._lock.access_codes[code].access_code_id,
+                    "schedule": self._serialize_schedule(
+                        self._lock.access_codes[code].schedule
+                    ),
                 }
                 for code in self._lock.access_codes
             }

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -130,10 +130,6 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
         end_datetime: datetime | None = None,
     ) -> None:
         """Add a lock code."""
-        codes = await self._async_fetch_access_codes()
-        self._validate_code_name(codes, name)
-        self._validate_code_value(codes, code)
-
         has_start = start_datetime is not None
         has_end = end_datetime is not None
 
@@ -153,6 +149,10 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
                     translation_key="schlage_start_after_end",
                 )
             schedule = TemporarySchedule(start=start_utc, end=end_utc)
+
+        codes = await self._async_fetch_access_codes()
+        self._validate_code_name(codes, name)
+        self._validate_code_value(codes, code)
 
         access_code = AccessCode(
             name=name,
@@ -223,23 +223,13 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
     def _serialize_schedule(
         schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None,
     ) -> dict[str, Any] | None:
-        """Serialize a pyschlage schedule to a dict.
+        """Serialize a pyschlage schedule to a dict, or ``None`` for ``None`` input.
 
-        The returned shape depends on the schedule type.
-
-        ``recurring``: {"type": "recurring", "days_of_week": {"sun": bool, ...},
-        "start_hour": int, "start_minute": int, "end_hour": int, "end_minute": int}.
-        Times use natural hour and minute values from the pyschlage model.
-
-        ``multi_recurring``: {"type": "multi_recurring", "windows": [<window>, ...]},
-        where each window is a dict with the same keys as ``recurring`` (days_of_week,
-        start_hour, start_minute, end_hour, end_minute) but without the ``type`` key.
-        At most two windows are present.
-
-        ``temporary``: {"type": "temporary", "start_datetime": str, "end_datetime": str}.
-        Datetime values are ISO 8601 strings.
-
-        ``None`` returns ``None``.
+        A ``TemporarySchedule`` is serialized with ``"type": "temporary"`` and ISO 8601
+        datetime strings for ``start_datetime`` and ``end_datetime``.  Recurring shapes
+        are serialized from pyschlage attributes (``days_of_week`` booleans,
+        ``start_hour``, ``start_minute``, ``end_hour``, ``end_minute``), with
+        ``"type"`` set to ``"recurring"`` or ``"multi_recurring"`` as appropriate.
         """
         if isinstance(schedule, TemporarySchedule):
             return {

--- a/homeassistant/components/schlage/services.yaml
+++ b/homeassistant/components/schlage/services.yaml
@@ -28,6 +28,16 @@ add_code:
       default: true
       selector:
         boolean:
+    start_datetime:
+      required: false
+      example: "2024-12-25 18:00:00"
+      selector:
+        datetime:
+    end_datetime:
+      required: false
+      example: "2024-12-26 08:00:00"
+      selector:
+        datetime:
 
 delete_code:
   target:

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -83,6 +83,12 @@
     },
     "schlage_refresh_failed": {
       "message": "Failed to refresh Schlage data."
+    },
+    "schlage_start_after_end": {
+      "message": "Start datetime must be before end datetime."
+    },
+    "schlage_temporary_dates_required": {
+      "message": "Both start and end datetimes must be provided for a temporary PIN."
     }
   },
   "services": {
@@ -93,6 +99,10 @@
           "description": "The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.",
           "name": "PIN code"
         },
+        "end_datetime": {
+          "description": "When the PIN code should stop working. Leave empty for an always-active code.",
+          "name": "End time"
+        },
         "name": {
           "description": "Name for PIN code. Must be case insensitively unique to the lock.",
           "name": "PIN name"
@@ -100,6 +110,10 @@
         "notify_on_use": {
           "description": "Whether the native Schlage notification should be sent when this PIN is used.",
           "name": "Notify when PIN is used"
+        },
+        "start_datetime": {
+          "description": "When the PIN code should become active. Leave empty for an always-active code.",
+          "name": "Start time"
         }
       },
       "name": "Add PIN code"

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -100,7 +100,7 @@
           "name": "PIN code"
         },
         "end_datetime": {
-          "description": "When the PIN code should stop working. Leave empty for an always-active code.",
+          "description": "When the PIN code should stop working. Providing an end time makes the PIN temporary; both a start and an end time are required. Leave both fields empty for a permanent PIN.",
           "name": "End time"
         },
         "name": {
@@ -112,7 +112,7 @@
           "name": "Notify when PIN is used"
         },
         "start_datetime": {
-          "description": "When the PIN code should become active. Leave empty for an always-active code.",
+          "description": "When the PIN code should become active. Providing a start time makes the PIN temporary; both a start and an end time are required. Leave both fields empty for a permanent PIN.",
           "name": "Start time"
         }
       },

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -1,10 +1,16 @@
 """Test schlage lock."""
 
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from pyschlage.code import AccessCode
+from pyschlage.code import (
+    AccessCode,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.exceptions import Error as SchlageError
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -18,6 +24,7 @@ from homeassistant.components.schlage.const import (
     SERVICE_GET_CODES,
     UPDATE_INTERVAL,
 )
+from homeassistant.components.schlage.lock import SchlageLockEntity
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_LOCK,
@@ -429,9 +436,13 @@ async def test_get_codes_service(
     code1 = Mock()
     code1.name = "user1"
     code1.code = "1234"
+    code1.access_code_id = "ac_001"
+    code1.schedule = None
     code2 = Mock()
     code2.name = "user2"
     code2.code = "5678"
+    code2.access_code_id = "ac_002"
+    code2.schedule = None
     mock_lock.access_codes = {"1": code1, "2": code2}
 
     response = await hass.services.async_call(
@@ -447,8 +458,18 @@ async def test_get_codes_service(
 
     assert response == {
         "lock.vault_door": {
-            "1": {"name": "user1", "code": "1234"},
-            "2": {"name": "user2", "code": "5678"},
+            "1": {
+                "name": "user1",
+                "code": "1234",
+                "access_code_id": "ac_001",
+                "schedule": None,
+            },
+            "2": {
+                "name": "user2",
+                "code": "5678",
+                "access_code_id": "ac_002",
+                "schedule": None,
+            },
         }
     }
 
@@ -615,3 +636,297 @@ async def test_get_codes_service_refresh_error(
             return_response=True,
         )
     assert exc_info.value.translation_key == "schlage_refresh_failed"
+
+
+async def test_add_code_service_temporary_pin(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service with temporary PIN (both start and end)."""
+
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    start = datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC)
+    end = datetime(2025, 1, 1, 18, 0, 0, tzinfo=UTC)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "temp_user",
+            "code": "1234",
+            "notify_on_use": True,
+            "start_datetime": start.isoformat(),
+            "end_datetime": end.isoformat(),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert isinstance(call_args, AccessCode)
+    assert call_args.name == "temp_user"
+    assert call_args.code == "1234"
+    assert isinstance(call_args.schedule, TemporarySchedule)
+    assert call_args.schedule.start == start
+    assert call_args.schedule.end == end
+
+
+async def test_add_code_service_start_without_end(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service rejects start without end."""
+
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Both start and end datetimes must be provided",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC).isoformat(),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_temporary_dates_required"
+
+
+async def test_add_code_service_end_without_start(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service rejects end without start."""
+
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Both start and end datetimes must be provided",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "end_datetime": datetime(2025, 1, 1, 18, 0, 0, tzinfo=UTC).isoformat(),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_temporary_dates_required"
+
+
+async def test_add_code_service_start_after_end(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service rejects start after end."""
+
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start datetime must be before end datetime",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": datetime(
+                    2025, 1, 1, 18, 0, 0, tzinfo=UTC
+                ).isoformat(),
+                "end_datetime": datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC).isoformat(),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_start_after_end"
+
+
+async def test_add_code_service_start_equals_end(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service rejects start equal to end."""
+
+    mock_lock.access_codes = {}
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Start datetime must be before end datetime",
+    ) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC).isoformat(),
+                "end_datetime": datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC).isoformat(),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_start_after_end"
+
+
+async def test_add_code_service_temporary_pin_utc_normalization(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test add_code service normalizes naive datetimes to UTC."""
+
+    mock_lock.access_codes = {}
+    mock_lock.add_access_code = Mock()
+
+    # Provide naive datetimes (cv.datetime returns naive datetimes)
+    start_naive = datetime(2025, 1, 1, 8, 0, 0)
+    end_naive = datetime(2025, 1, 1, 18, 0, 0)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_CODE,
+        service_data={
+            "entity_id": "lock.vault_door",
+            "name": "temp_user",
+            "code": "1234",
+            "start_datetime": start_naive.isoformat(),
+            "end_datetime": end_naive.isoformat(),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_lock.add_access_code.assert_called_once()
+    call_args = mock_lock.add_access_code.call_args[0][0]
+    assert call_args.schedule is not None
+    # The schedule should have timezone-aware UTC datetimes
+    assert call_args.schedule.start.tzinfo is not None
+    assert call_args.schedule.end.tzinfo is not None
+
+
+async def test_get_codes_service_with_access_code_id_and_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test get_codes returns access_code_id and schedule."""
+
+    code1 = Mock()
+    code1.name = "user1"
+    code1.code = "1234"
+    code1.access_code_id = "ac_001"
+    code1.schedule = TemporarySchedule(
+        start=datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC),
+        end=datetime(2025, 1, 1, 18, 0, 0, tzinfo=UTC),
+    )
+    code2 = Mock()
+    code2.name = "user2"
+    code2.code = "5678"
+    code2.access_code_id = "ac_002"
+    code2.schedule = None
+    mock_lock.access_codes = {"1": code1, "2": code2}
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    assert response == {
+        "lock.vault_door": {
+            "1": {
+                "name": "user1",
+                "code": "1234",
+                "access_code_id": "ac_001",
+                "schedule": {
+                    "type": "temporary",
+                    "start_datetime": "2025-01-01T08:00:00+00:00",
+                    "end_datetime": "2025-01-01T18:00:00+00:00",
+                },
+            },
+            "2": {
+                "name": "user2",
+                "code": "5678",
+                "access_code_id": "ac_002",
+                "schedule": None,
+            },
+        }
+    }
+
+
+async def test_serialize_schedule_none(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test _serialize_schedule returns None for permanent code."""
+
+    result = SchlageLockEntity._serialize_schedule(None)
+    assert result is None
+
+
+async def test_serialize_schedule_recurring(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test _serialize_schedule for RecurringSchedule."""
+
+    schedule = RecurringSchedule()
+    result = SchlageLockEntity._serialize_schedule(schedule)
+    assert result is not None
+    assert result["type"] == "recurring"
+    assert "raw" in result
+
+
+async def test_serialize_schedule_multi_recurring(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test _serialize_schedule for MultiRecurringSchedule."""
+
+    schedule = MultiRecurringSchedule(schedule1=RecurringSchedule(), schedule2=None)
+    result = SchlageLockEntity._serialize_schedule(schedule)
+    assert result is not None
+    assert result["type"] == "multi_recurring"
+    assert "raw" in result
+
+
+async def test_serialize_schedule_temporary(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test _serialize_schedule for TemporarySchedule."""
+
+    schedule = TemporarySchedule(
+        start=datetime(2025, 6, 15, 10, 0, 0, tzinfo=UTC),
+        end=datetime(2025, 6, 15, 22, 0, 0, tzinfo=UTC),
+    )
+    result = SchlageLockEntity._serialize_schedule(schedule)
+    assert result is not None
+    assert result["type"] == "temporary"
+    assert result["start_datetime"] == "2025-06-15T10:00:00+00:00"
+    assert result["end_datetime"] == "2025-06-15T22:00:00+00:00"

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import MockSchlageConfigEntry
 
@@ -788,40 +789,74 @@ async def test_add_code_service_start_equals_end(
     assert exc_info.value.translation_key == "schlage_start_after_end"
 
 
-async def test_add_code_service_temporary_pin_utc_normalization(
+async def test_add_code_service_temporary_pin_non_utc_timezone(
     hass: HomeAssistant,
     mock_lock: Mock,
     mock_added_config_entry: MockSchlageConfigEntry,
 ) -> None:
-    """Test add_code service normalizes naive datetimes to UTC."""
+    """Test add_code service converts naive datetimes from non UTC timezone to UTC."""
 
-    mock_lock.access_codes = {}
-    mock_lock.add_access_code = Mock()
+    dt_util.set_default_time_zone(dt_util.get_time_zone("America/New_York"))
+    try:
+        mock_lock.access_codes = {}
+        mock_lock.add_access_code = Mock()
 
-    # Provide naive datetimes (cv.datetime returns naive datetimes)
-    start_naive = datetime(2025, 1, 1, 8, 0, 0)
-    end_naive = datetime(2025, 1, 1, 18, 0, 0)
+        # September 2026: America/New_York is EDT (UTC-4).
+        # Naive local 08:00 becomes 12:00 UTC, naive local 18:00 becomes 22:00 UTC.
+        start_naive = datetime(2026, 9, 1, 8, 0, 0)
+        end_naive = datetime(2026, 9, 1, 18, 0, 0)
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_ADD_CODE,
-        service_data={
-            "entity_id": "lock.vault_door",
-            "name": "temp_user",
-            "code": "1234",
-            "start_datetime": start_naive.isoformat(),
-            "end_datetime": end_naive.isoformat(),
-        },
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "temp_user",
+                "code": "1234",
+                "start_datetime": start_naive.isoformat(),
+                "end_datetime": end_naive.isoformat(),
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
 
-    mock_lock.add_access_code.assert_called_once()
-    call_args = mock_lock.add_access_code.call_args[0][0]
-    assert call_args.schedule is not None
-    # The schedule should have timezone-aware UTC datetimes
-    assert call_args.schedule.start.tzinfo is not None
-    assert call_args.schedule.end.tzinfo is not None
+        mock_lock.add_access_code.assert_called_once()
+        call_args = mock_lock.add_access_code.call_args[0][0]
+        assert call_args.schedule is not None
+
+        expected_start = datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC)
+        expected_end = datetime(2026, 9, 1, 22, 0, 0, tzinfo=UTC)
+
+        # If 08:00 local is incorrectly treated as 08:00 UTC the assertion fails.
+        assert call_args.schedule.start == expected_start
+        assert call_args.schedule.end == expected_end
+
+        # Verify the serialized dict in get_codes output carries the same instants.
+        code = Mock()
+        code.name = "temp_user"
+        code.code = "1234"
+        code.access_code_id = "ac_001"
+        code.schedule = call_args.schedule
+        mock_lock.access_codes = {"1": code}
+
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_CODES,
+            service_data={
+                "entity_id": "lock.vault_door",
+            },
+            blocking=True,
+            return_response=True,
+        )
+        await hass.async_block_till_done()
+
+        assert response["lock.vault_door"]["1"]["schedule"] == {
+            "type": "temporary",
+            "start_datetime": "2026-09-01T12:00:00+00:00",
+            "end_datetime": "2026-09-01T22:00:00+00:00",
+        }
+    finally:
+        dt_util.set_default_time_zone(UTC)
 
 
 async def test_get_codes_service_with_access_code_id_and_schedule(
@@ -899,7 +934,19 @@ async def test_serialize_schedule_recurring(
     result = SchlageLockEntity._serialize_schedule(schedule)
     assert result is not None
     assert result["type"] == "recurring"
-    assert "raw" in result
+    assert result["days_of_week"] == {
+        "sun": True,
+        "mon": True,
+        "tue": True,
+        "wed": True,
+        "thu": True,
+        "fri": True,
+        "sat": True,
+    }
+    assert result["start_hour"] == 0
+    assert result["start_minute"] == 0
+    assert result["end_hour"] == 23
+    assert result["end_minute"] == 59
 
 
 async def test_serialize_schedule_multi_recurring(
@@ -912,7 +959,21 @@ async def test_serialize_schedule_multi_recurring(
     result = SchlageLockEntity._serialize_schedule(schedule)
     assert result is not None
     assert result["type"] == "multi_recurring"
-    assert "raw" in result
+    assert len(result["windows"]) == 1
+    window = result["windows"][0]
+    assert window["days_of_week"] == {
+        "sun": True,
+        "mon": True,
+        "tue": True,
+        "wed": True,
+        "thu": True,
+        "fri": True,
+        "sat": True,
+    }
+    assert window["start_hour"] == 0
+    assert window["start_minute"] == 0
+    assert window["end_hour"] == 23
+    assert window["end_minute"] == 59
 
 
 async def test_serialize_schedule_temporary(

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -24,7 +24,6 @@ from homeassistant.components.schlage.const import (
     SERVICE_GET_CODES,
     UPDATE_INTERVAL,
 )
-from homeassistant.components.schlage.lock import SchlageLockEntity
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_LOCK,
@@ -704,6 +703,30 @@ async def test_add_code_service_start_without_end(
     assert exc_info.value.translation_key == "schlage_temporary_dates_required"
 
 
+async def test_add_code_service_validation_before_refresh(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test local date validation fires before the access code refresh."""
+    mock_lock.refresh_access_codes.side_effect = SchlageError("API error")
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_CODE,
+            service_data={
+                "entity_id": "lock.vault_door",
+                "name": "test_user",
+                "code": "1234",
+                "start_datetime": datetime(2025, 1, 1, 8, 0, 0, tzinfo=UTC).isoformat(),
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "schlage_temporary_dates_required"
+    mock_lock.refresh_access_codes.assert_not_called()
+
+
 async def test_add_code_service_end_without_start(
     hass: HomeAssistant,
     mock_lock: Mock,
@@ -914,80 +937,93 @@ async def test_get_codes_service_with_access_code_id_and_schedule(
     }
 
 
-async def test_serialize_schedule_none(
+async def test_get_codes_service_recurring_schedule(
     hass: HomeAssistant,
+    mock_lock: Mock,
     mock_added_config_entry: MockSchlageConfigEntry,
 ) -> None:
-    """Test _serialize_schedule returns None for permanent code."""
+    """Test get_codes serializes a recurring schedule through the public action."""
 
-    result = SchlageLockEntity._serialize_schedule(None)
-    assert result is None
+    code = Mock()
+    code.name = "weekday_user"
+    code.code = "1234"
+    code.access_code_id = "ac_001"
+    code.schedule = RecurringSchedule()
+    mock_lock.access_codes = {"1": code}
 
-
-async def test_serialize_schedule_recurring(
-    hass: HomeAssistant,
-    mock_added_config_entry: MockSchlageConfigEntry,
-) -> None:
-    """Test _serialize_schedule for RecurringSchedule."""
-
-    schedule = RecurringSchedule()
-    result = SchlageLockEntity._serialize_schedule(schedule)
-    assert result is not None
-    assert result["type"] == "recurring"
-    assert result["days_of_week"] == {
-        "sun": True,
-        "mon": True,
-        "tue": True,
-        "wed": True,
-        "thu": True,
-        "fri": True,
-        "sat": True,
-    }
-    assert result["start_hour"] == 0
-    assert result["start_minute"] == 0
-    assert result["end_hour"] == 23
-    assert result["end_minute"] == 59
-
-
-async def test_serialize_schedule_multi_recurring(
-    hass: HomeAssistant,
-    mock_added_config_entry: MockSchlageConfigEntry,
-) -> None:
-    """Test _serialize_schedule for MultiRecurringSchedule."""
-
-    schedule = MultiRecurringSchedule(schedule1=RecurringSchedule(), schedule2=None)
-    result = SchlageLockEntity._serialize_schedule(schedule)
-    assert result is not None
-    assert result["type"] == "multi_recurring"
-    assert len(result["windows"]) == 1
-    window = result["windows"][0]
-    assert window["days_of_week"] == {
-        "sun": True,
-        "mon": True,
-        "tue": True,
-        "wed": True,
-        "thu": True,
-        "fri": True,
-        "sat": True,
-    }
-    assert window["start_hour"] == 0
-    assert window["start_minute"] == 0
-    assert window["end_hour"] == 23
-    assert window["end_minute"] == 59
-
-
-async def test_serialize_schedule_temporary(
-    hass: HomeAssistant,
-    mock_added_config_entry: MockSchlageConfigEntry,
-) -> None:
-    """Test _serialize_schedule for TemporarySchedule."""
-
-    schedule = TemporarySchedule(
-        start=datetime(2025, 6, 15, 10, 0, 0, tzinfo=UTC),
-        end=datetime(2025, 6, 15, 22, 0, 0, tzinfo=UTC),
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
     )
-    result = SchlageLockEntity._serialize_schedule(schedule)
-    assert result is not None
-    assert result["type"] == "temporary"
-    assert result["start_datetime"] == "2025-06-15T10:00:00+00:00"
-    assert result["end_datetime"] == "2025-06-15T22:00:00+00:00"
+    await hass.async_block_till_done()
+
+    assert response["lock.vault_door"]["1"]["schedule"] == {
+        "type": "recurring",
+        "days_of_week": {
+            "sun": True,
+            "mon": True,
+            "tue": True,
+            "wed": True,
+            "thu": True,
+            "fri": True,
+            "sat": True,
+        },
+        "start_hour": 0,
+        "start_minute": 0,
+        "end_hour": 23,
+        "end_minute": 59,
+    }
+
+
+async def test_get_codes_service_multi_recurring_schedule(
+    hass: HomeAssistant,
+    mock_lock: Mock,
+    mock_added_config_entry: MockSchlageConfigEntry,
+) -> None:
+    """Test get_codes serializes a multi recurring schedule through the public action."""
+
+    code = Mock()
+    code.name = "multi_user"
+    code.code = "5678"
+    code.access_code_id = "ac_002"
+    code.schedule = MultiRecurringSchedule(
+        schedule1=RecurringSchedule(), schedule2=None
+    )
+    mock_lock.access_codes = {"1": code}
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_CODES,
+        service_data={
+            "entity_id": "lock.vault_door",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    assert response["lock.vault_door"]["1"]["schedule"] == {
+        "type": "multi_recurring",
+        "windows": [
+            {
+                "days_of_week": {
+                    "sun": True,
+                    "mon": True,
+                    "tue": True,
+                    "wed": True,
+                    "thu": True,
+                    "fri": True,
+                    "sat": True,
+                },
+                "start_hour": 0,
+                "start_minute": 0,
+                "end_hour": 23,
+                "end_minute": 59,
+            }
+        ],
+    }

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -850,11 +850,9 @@ async def test_add_code_service_temporary_pin_non_utc_timezone(
         expected_start = datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC)
         expected_end = datetime(2026, 9, 1, 22, 0, 0, tzinfo=UTC)
 
-        # If 08:00 local is incorrectly treated as 08:00 UTC the assertion fails.
         assert call_args.schedule.start == expected_start
         assert call_args.schedule.end == expected_end
 
-        # Verify the serialized dict in get_codes output carries the same instants.
         code = Mock()
         code.name = "temp_user"
         code.code = "1234"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR is not a breaking change. Existing `schlage.add_code` calls without the new optional fields behave exactly as before.

## Proposed change

Adds temporary PIN support to the Schlage integration: `schlage.add_code` gains optional `start_datetime` and `end_datetime` fields. Providing both creates a PIN active only during that window; neither keeps the permanent behavior unchanged. Exactly one raises `schlage_temporary_dates_required`, and a start after end raises `schlage_start_after_end`. Datetimes are normalized to UTC before scheduling.

`schlage.get_codes` now returns each PIN's `access_code_id` and its serialized `schedule` (`"temporary"` shape with datetimes, recurring shapes as returned by the lock, or `null` for permanent), so temporary state is visible in Home Assistant.

Type of change:

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is a partial replacement for #180503 (closed). Scope deliberately narrowed to temporary code scheduling on the existing `add_code`/`get_codes` actions only; no new actions.
- This PR fixes or closes issue: N/A (greenfield scheduling support for Schlage locks, which the app supports natively)
- This PR is related to issue: N/A
- Link to documentation pull request: home-assistant/home-assistant.io#47742
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Additional information

- This PR is tested and works locally.
- The code change is tested: yes. New tests cover UTC conversion on a non-UTC default timezone (exact instant assertions), the paired-dates rule, start-after-end rejection, and all `get_codes` schedule shapes (temporary, recurring, multi-recurring, permanent).
- The integration is tested by QA: no QA entry exists for schlage.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass** — CI runs `pytest --durations=10` etc.
- [x] There is no commented-out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_guidelines/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#create-a-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

Any AI use is disclosed: parts of this PR were developed with AI assistance, reviewed and tested by a human.