### PR TITLE
Bump homematicip to 2.16.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.15.0"]
+  "requirements": ["homematicip==2.16.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1315,7 +1315,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.5
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.15.0
+homematicip==2.16.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Proposed change

2.16.0 brings, relevant for this integration:

- Adds the ELV-SH-TACO (`DeviceType.TEMPERATURE_TILT_VIBRATION_SENSOR` plus a `TemperatureSensorChannel`). The device previously fell back to `BaseDevice` and exposed nothing. Its tilt channel sits at index 2, so a follow-up is needed for the channel lookup before the tilt entities read correctly (hahn-th/homematicip-rest-api#690).
- Adds the HmIP-FSI6 (`DeviceType.FULL_FLUSH_INPUT_SWITCH_COMPACT`), same fallback problem (hahn-th/homematicip-rest-api#686).
- Adds `ignorable_device_channels` to `set_security_zones_activation_with_ignore_list` and `Home.get_security_zone_activation_problem_channels()`, which #179151 needs.
- Drops `requests` and `websockets` from the library's runtime dependencies; neither was imported by it.

Existing tests pass unchanged.

Release notes: https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.16.0
Diff: https://github.com/hahn-th/homematicip-rest-api/compare/2.15.0...2.16.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #179151
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
