### PR TITLE
Add KACO Modbus integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -330,6 +330,7 @@ homeassistant.components.isy994.*
 homeassistant.components.jellyfin.*
 homeassistant.components.jewish_calendar.*
 homeassistant.components.jvc_projector.*
+homeassistant.components.kaco_modbus.*
 homeassistant.components.kaleidescape.*
 homeassistant.components.knocki.*
 homeassistant.components.knx.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -964,6 +964,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/justnimbus/ @kvanzuijlen
 /homeassistant/components/jvc_projector/ @SteveEasley
 /tests/components/jvc_projector/ @SteveEasley
+/homeassistant/components/kaco_modbus/ @g4bri3lDev
+/tests/components/kaco_modbus/ @g4bri3lDev
 /homeassistant/components/kaiterra/ @Michsior14
 /homeassistant/components/kaleidescape/ @SteveEasley
 /tests/components/kaleidescape/ @SteveEasley

--- a/homeassistant/components/kaco_modbus/__init__.py
+++ b/homeassistant/components/kaco_modbus/__init__.py
@@ -1,0 +1,37 @@
+"""The KACO Modbus integration."""
+
+from kaco_modbus import KacoInverter
+from modbus_connection import ModbusTcpParams
+
+from homeassistant.components.modbus import async_get_unit
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_UNIT_ID
+from .coordinator import KacoConfigEntry, KacoDataUpdateCoordinator
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: KacoConfigEntry) -> bool:
+    """Set up KACO Modbus from a config entry."""
+    # Shared with any other integration on this gateway, and closed when the
+    # last entry holding a unit on it unloads.
+    unit = async_get_unit(
+        hass,
+        entry,
+        ModbusTcpParams(host=entry.data[CONF_HOST], port=entry.data[CONF_PORT]),
+        entry.data[CONF_UNIT_ID],
+    )
+
+    coordinator = KacoDataUpdateCoordinator(hass, entry, KacoInverter(unit))
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: KacoConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/kaco_modbus/config_flow.py
+++ b/homeassistant/components/kaco_modbus/config_flow.py
@@ -1,0 +1,86 @@
+"""Adding an inverter by address."""
+
+from typing import Any, override
+
+from kaco_modbus import KacoError, KacoInverter, NotAKacoInverterError
+from modbus_connection import ModbusError, ModbusTcpParams
+import voluptuous as vol
+
+from homeassistant.components.modbus import async_get_temporary_unit
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    TextSelector,
+)
+
+from .const import CONF_UNIT_ID, DEFAULT_PORT, DEFAULT_UNIT_ID, DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): TextSelector(),
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.All(
+            NumberSelector(
+                NumberSelectorConfig(mode=NumberSelectorMode.BOX, min=1, max=65535)
+            ),
+            vol.Coerce(int),
+        ),
+        vol.Required(CONF_UNIT_ID, default=DEFAULT_UNIT_ID): vol.All(
+            NumberSelector(
+                NumberSelectorConfig(mode=NumberSelectorMode.BOX, min=1, max=247)
+            ),
+            vol.Coerce(int),
+        ),
+    }
+)
+
+
+class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for KACO Modbus."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask for an address and check a KACO inverter answers there."""
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
+
+        if user_input is not None:
+            params = ModbusTcpParams(
+                host=user_input[CONF_HOST], port=user_input[CONF_PORT]
+            )
+            try:
+                async with async_get_temporary_unit(
+                    self.hass, params, user_input[CONF_UNIT_ID]
+                ) as unit:
+                    device = KacoInverter(unit)
+                    await device.async_update_readings()
+            except NotAKacoInverterError as err:
+                errors["base"] = "not_a_kaco_inverter"
+                description_placeholders["error"] = str(err)
+            except KacoError as err:
+                errors["base"] = "not_a_sunspec_inverter"
+                description_placeholders["error"] = str(err)
+            except (ModbusError, HomeAssistantError) as err:
+                errors["base"] = "cannot_connect"
+                description_placeholders["error"] = str(err)
+            else:
+                info = device.info
+                assert info is not None
+                # Stable across address changes, which a host or port is not.
+                await self.async_set_unique_id(info.serial_number)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info.model, data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )

--- a/homeassistant/components/kaco_modbus/config_flow.py
+++ b/homeassistant/components/kaco_modbus/config_flow.py
@@ -1,5 +1,6 @@
 """Adding an inverter by address."""
 
+import logging
 from typing import Any, override
 
 from kaco_modbus import KacoError, KacoInverter, NotAKacoInverterError
@@ -18,6 +19,8 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import CONF_UNIT_ID, DEFAULT_PORT, DEFAULT_UNIT_ID, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -49,7 +52,6 @@ class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Ask for an address and check a KACO inverter answers there."""
         errors: dict[str, str] = {}
-        description_placeholders: dict[str, str] = {}
 
         if user_input is not None:
             params = ModbusTcpParams(
@@ -61,15 +63,15 @@ class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
                 ) as unit:
                     device = KacoInverter(unit)
                     await device.async_update_readings()
-            except NotAKacoInverterError as err:
+            except NotAKacoInverterError:
                 errors["base"] = "not_a_kaco_inverter"
-                description_placeholders["error"] = str(err)
-            except KacoError as err:
+            except KacoError:
                 errors["base"] = "not_a_sunspec_inverter"
-                description_placeholders["error"] = str(err)
-            except (ModbusError, HomeAssistantError) as err:
+            except ModbusError, HomeAssistantError:
                 errors["base"] = "cannot_connect"
-                description_placeholders["error"] = str(err)
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
             else:
                 info = device.info
                 assert info is not None
@@ -82,5 +84,4 @@ class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
-            description_placeholders=description_placeholders,
         )

--- a/homeassistant/components/kaco_modbus/const.py
+++ b/homeassistant/components/kaco_modbus/const.py
@@ -1,0 +1,9 @@
+"""Constants for the KACO Modbus integration."""
+
+DOMAIN = "kaco_modbus"
+
+CONF_UNIT_ID = "unit_id"
+
+DEFAULT_PORT = 502
+# Ignored by TCP-native inverters, but not by one behind an RS485 gateway.
+DEFAULT_UNIT_ID = 1

--- a/homeassistant/components/kaco_modbus/coordinator.py
+++ b/homeassistant/components/kaco_modbus/coordinator.py
@@ -1,0 +1,103 @@
+"""Polling, and what to do when an inverter stops answering."""
+
+from datetime import timedelta
+import logging
+from typing import override
+
+from kaco_modbus import (
+    KacoInverter,
+    NotAKacoInverterError,
+    SunSpecMapShiftError,
+    UpdateReport,
+)
+from modbus_connection import ModbusError
+from propcache.api import cached_property
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+type KacoConfigEntry = ConfigEntry[KacoDataUpdateCoordinator]
+
+
+class KacoDataUpdateCoordinator(DataUpdateCoordinator[UpdateReport]):
+    """Poll the inverter's readings, and report what actually came back."""
+
+    config_entry: KacoConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: KacoConfigEntry,
+        device: KacoInverter,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=entry.title,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.device = device
+
+    @cached_property
+    def device_info(self) -> DeviceInfo:
+        """The one inverter every entity on this config entry belongs to."""
+        info = self.device.info
+        assert info is not None
+        return DeviceInfo(
+            identifiers={(DOMAIN, info.serial_number)},
+            manufacturer=info.manufacturer,
+            model=info.model,
+            sw_version=info.firmware,
+            serial_number=info.serial_number,
+        )
+
+    @override
+    async def _async_update_data(self) -> UpdateReport:
+        try:
+            report = await self.device.async_update_readings()
+        except NotAKacoInverterError as err:
+            # Identity is settled on the first poll, so a swapped device
+            # surfaces here. Retrying cannot make it a KACO.
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="not_a_kaco_inverter",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        except SunSpecMapShiftError as err:
+            # Every bound register offset is stale; only rediscovery fixes it.
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="sunspec_map_moved",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        except ModbusError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+        if not report.updated:
+            # A KACO after dark accepts the connection and answers nothing.
+            # The library records that per component rather than raising it.
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="no_component_answered",
+                translation_placeholders={"name": self.name},
+            ) from ExceptionGroup(
+                "every component failed to refresh", list(report.failed.values())
+            )
+
+        return report

--- a/homeassistant/components/kaco_modbus/entity.py
+++ b/homeassistant/components/kaco_modbus/entity.py
@@ -44,6 +44,7 @@ class KacoEntity(CoordinatorEntity[KacoDataUpdateCoordinator]):
     @override
     def available(self) -> bool:
         """Whether this entity's own component answered the last poll."""
-        if not super().available:
-            return False
-        return self.entity_description.component in self.coordinator.data.updated
+        return (
+            super().available
+            and self.entity_description.component in self.coordinator.data.updated
+        )

--- a/homeassistant/components/kaco_modbus/entity.py
+++ b/homeassistant/components/kaco_modbus/entity.py
@@ -1,0 +1,49 @@
+"""What every KACO entity shares."""
+
+from dataclasses import dataclass
+from typing import override
+
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import KacoDataUpdateCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class KacoEntityDescription(EntityDescription):
+    """Which component on the inverter an entity reads through."""
+
+    component: str  # attribute name on KacoInverter, e.g. 'inverter'
+
+
+class KacoEntity(CoordinatorEntity[KacoDataUpdateCoordinator]):
+    """An entity backed by one component of the inverter.
+
+    Components are polled independently, so an entity is unavailable when its
+    own component failed to read, not when any of them did.
+    """
+
+    _attr_has_entity_name = True
+    entity_description: KacoEntityDescription
+
+    def __init__(
+        self,
+        coordinator: KacoDataUpdateCoordinator,
+        entity_description: KacoEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+
+        info = coordinator.device.info
+        assert info is not None
+        self._attr_unique_id = f"{info.serial_number}_{entity_description.key}"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Whether this entity's own component answered the last poll."""
+        if not super().available:
+            return False
+        return self.entity_description.component in self.coordinator.data.updated

--- a/homeassistant/components/kaco_modbus/manifest.json
+++ b/homeassistant/components/kaco_modbus/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "kaco_modbus",
+  "name": "KACO Modbus",
+  "codeowners": ["@g4bri3lDev"],
+  "config_flow": true,
+  "dependencies": ["modbus"],
+  "documentation": "https://www.home-assistant.io/integrations/kaco_modbus",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "quality_scale": "bronze",
+  "requirements": ["kaco-modbus==1.1.0"]
+}

--- a/homeassistant/components/kaco_modbus/quality_scale.yaml
+++ b/homeassistant/components/kaco_modbus/quality_scale.yaml
@@ -1,0 +1,98 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not register any service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not register any service actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not provide any conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not provide any triggers.
+  entity-event-setup:
+    status: exempt
+    comment: >-
+      local_polling; entities rely solely on CoordinatorEntity's built-in
+      lifecycle, with no manual event subscriptions.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not register any service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: >-
+      Local Modbus TCP; there is no authentication that can expire or be
+      invalidated.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: There is no discovery to carry updated network information.
+  discovery:
+    status: exempt
+    comment: >-
+      The inverter advertises no mDNS service, and its MAC OUI is Microchip's
+      rather than KACO's, so a DHCP match would catch unrelated devices.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: One fixed inverter per config entry; nothing is discovered at runtime.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: >-
+      All three sensors in this initial platform are primary readings that a
+      user adds the integration to get. The follow-up PR adding the full
+      register table is where less popular entities start being disabled.
+  entity-translations: done
+  exception-translations: done
+  icon-translations:
+    status: exempt
+    comment: Entities use device_class-derived icons; no custom icons are needed.
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: One fixed inverter per config entry; nothing to detect as stale.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: This integration communicates over Modbus TCP, not HTTP.
+  strict-typing: done

--- a/homeassistant/components/kaco_modbus/quality_scale.yaml
+++ b/homeassistant/components/kaco_modbus/quality_scale.yaml
@@ -59,8 +59,8 @@ rules:
   discovery:
     status: exempt
     comment: >-
-      The inverter advertises no mDNS service, and its MAC OUI is Microchip's
-      rather than KACO's, so a DHCP match would catch unrelated devices.
+      The inverter advertises no mDNS service, sends no DHCP hostname, and its
+      MAC OUI is Microchip's rather than KACO's.
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo

--- a/homeassistant/components/kaco_modbus/sensor.py
+++ b/homeassistant/components/kaco_modbus/sensor.py
@@ -1,0 +1,102 @@
+"""What the inverter measures."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import override
+
+from kaco_modbus.models import InverterThreePhase
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import KacoConfigEntry
+from .entity import KacoEntity, KacoEntityDescription
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class KacoSensorDescription(SensorEntityDescription, KacoEntityDescription):
+    """A sensor, and where to read its value off the inverter block."""
+
+    value_fn: Callable[[InverterThreePhase], StateType]
+
+
+SENSOR_DESCRIPTIONS: tuple[KacoSensorDescription, ...] = (
+    KacoSensorDescription(
+        key="ac_power",
+        component="inverter",
+        translation_key="ac_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda inverter: inverter.w,
+    ),
+    KacoSensorDescription(
+        key="lifetime_energy",
+        component="inverter",
+        translation_key="lifetime_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        value_fn=lambda inverter: inverter.wh,
+    ),
+    KacoSensorDescription(
+        key="operating_state",
+        component="inverter",
+        translation_key="operating_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "off",
+            "sleeping",
+            "starting",
+            "mppt",
+            "throttled",
+            "shutting_down",
+            "fault",
+            "standby",
+        ],
+        value_fn=lambda inverter: inverter.st,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: KacoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the KACO Modbus sensor platform."""
+    async_add_entities(
+        KacoSensor(entry.runtime_data, description)
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class KacoSensor(KacoEntity, SensorEntity):
+    """A read-only value off one of the inverter's components."""
+
+    entity_description: KacoSensorDescription
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the value this sensor reads from the device."""
+        component = getattr(self.coordinator.device, self.entity_description.component)
+        value = self.entity_description.value_fn(component)
+        # An IntEnum stringifies as the raw number; use the option slug the
+        # ENUM device class and the translations are keyed on.
+        if isinstance(value, IntEnum):
+            return value.name.lower()
+        return value

--- a/homeassistant/components/kaco_modbus/sensor.py
+++ b/homeassistant/components/kaco_modbus/sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import IntEnum
 from typing import override
 
 from kaco_modbus.models import InverterThreePhase
@@ -67,7 +66,9 @@ SENSOR_DESCRIPTIONS: tuple[KacoSensorDescription, ...] = (
             "fault",
             "standby",
         ],
-        value_fn=lambda inverter: inverter.st,
+        value_fn=lambda inverter: (
+            None if inverter.st is None else inverter.st.name.lower()
+        ),
     ),
 )
 
@@ -94,9 +95,4 @@ class KacoSensor(KacoEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return the value this sensor reads from the device."""
         component = getattr(self.coordinator.device, self.entity_description.component)
-        value = self.entity_description.value_fn(component)
-        # An IntEnum stringifies as the raw number; use the option slug the
-        # ENUM device class and the translations are keyed on.
-        if isinstance(value, IntEnum):
-            return value.name.lower()
-        return value
+        return self.entity_description.value_fn(component)

--- a/homeassistant/components/kaco_modbus/strings.json
+++ b/homeassistant/components/kaco_modbus/strings.json
@@ -1,0 +1,64 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "not_a_kaco_inverter": "That address answers, but the device is not a KACO inverter: {error}",
+      "not_a_sunspec_inverter": "That address answers Modbus, but not as a SunSpec inverter: {error}"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "unit_id": "Unit ID"
+        },
+        "data_description": {
+          "host": "The inverter's hostname or IP address.",
+          "port": "The Modbus TCP port. KACO inverters use 502 unless changed.",
+          "unit_id": "Leave at 1 unless the inverter is reached through an RS485-to-TCP gateway, which needs the address configured on that gateway."
+        },
+        "description": "Enter the address of your KACO inverter. Modbus TCP must be enabled on the inverter, under its SunSpec or Modbus protocol settings."
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "ac_power": {
+        "name": "AC power"
+      },
+      "lifetime_energy": {
+        "name": "Total energy produced"
+      },
+      "operating_state": {
+        "name": "Operating state",
+        "state": {
+          "fault": "Fault",
+          "mppt": "Producing",
+          "off": "[%key:common::state::off%]",
+          "shutting_down": "Shutting down",
+          "sleeping": "Asleep",
+          "standby": "[%key:common::state::standby%]",
+          "starting": "Starting up",
+          "throttled": "Throttled"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Failed to reach the inverter: {error}"
+    },
+    "no_component_answered": {
+      "message": "{name} accepted the connection but answered nothing."
+    },
+    "not_a_kaco_inverter": {
+      "message": "The device at this address is not a KACO inverter: {error}"
+    },
+    "sunspec_map_moved": {
+      "message": "The inverter's SunSpec register map moved, so the integration is reloading to find it again: {error}"
+    }
+  }
+}

--- a/homeassistant/components/kaco_modbus/strings.json
+++ b/homeassistant/components/kaco_modbus/strings.json
@@ -5,8 +5,9 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "not_a_kaco_inverter": "That address answers, but the device is not a KACO inverter: {error}",
-      "not_a_sunspec_inverter": "That address answers Modbus, but not as a SunSpec inverter: {error}"
+      "not_a_kaco_inverter": "That address answers, but the device is not a KACO inverter",
+      "not_a_sunspec_inverter": "That address answers Modbus, but not as a SunSpec inverter",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -399,6 +399,7 @@ FLOWS = {
         "jewish_calendar",
         "justnimbus",
         "jvc_projector",
+        "kaco_modbus",
         "kaleidescape",
         "karakeep",
         "keenetic_ndms2",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3582,6 +3582,12 @@
       "config_flow": true,
       "iot_class": "local_polling"
     },
+    "kaco_modbus": {
+      "name": "KACO Modbus",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "kaiser_nienhaus": {
       "name": "Kaiser Nienhaus",
       "integration_type": "virtual",

--- a/mypy.ini
+++ b/mypy.ini
@@ -3058,6 +3058,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.kaco_modbus.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.kaleidescape.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1441,6 +1441,9 @@ jsonpath-python==1.1.6
 # homeassistant.components.justnimbus
 justnimbus==0.7.4
 
+# homeassistant.components.kaco_modbus
+kaco-modbus==1.1.0
+
 # homeassistant.components.kaiterra
 kaiterra-async-client==1.1.0
 

--- a/tests/components/kaco_modbus/__init__.py
+++ b/tests/components/kaco_modbus/__init__.py
@@ -1,7 +1,11 @@
 """Tests for the KACO Modbus integration."""
 
+from kaco_modbus.testing import BASE_ADDRESS
+
 from homeassistant.components.kaco_modbus.const import CONF_UNIT_ID
 from homeassistant.const import CONF_HOST, CONF_PORT
+
+END_OF_CHAIN = 0xFFFF
 
 MOCK_SERIAL = "8.6TL00000000"
 MOCK_MODEL = "blueplanet 8.6 TL3 INT"
@@ -11,3 +15,18 @@ MOCK_USER_INPUT = {
     CONF_PORT: 502,
     CONF_UNIT_ID: 1,
 }
+
+
+def model_registers(image: dict[int, int], model_id: int) -> range:
+    """Return the registers *model_id* occupies in a captured image.
+
+    Walks the SunSpec model chain rather than hard-coding an offset, so a
+    test can make one block unreadable and leave the rest answering.
+    """
+    address = BASE_ADDRESS + 2  # past the "SunS" marker
+    while (found := image[address]) != END_OF_CHAIN:
+        length = image[address + 1]
+        if found == model_id:
+            return range(address, address + 2 + length)
+        address += 2 + length
+    raise KeyError(f"model {model_id} is not in this image")

--- a/tests/components/kaco_modbus/__init__.py
+++ b/tests/components/kaco_modbus/__init__.py
@@ -1,0 +1,13 @@
+"""Tests for the KACO Modbus integration."""
+
+from homeassistant.components.kaco_modbus.const import CONF_UNIT_ID
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+MOCK_SERIAL = "8.6TL00000000"
+MOCK_MODEL = "blueplanet 8.6 TL3 INT"
+
+MOCK_USER_INPUT = {
+    CONF_HOST: "192.168.1.100",
+    CONF_PORT: 502,
+    CONF_UNIT_ID: 1,
+}

--- a/tests/components/kaco_modbus/conftest.py
+++ b/tests/components/kaco_modbus/conftest.py
@@ -1,0 +1,69 @@
+"""Common fixtures for the KACO Modbus tests.
+
+The mock is loaded with a register image captured from a real blueplanet
+8.6 TL3 INT, so everything below the connection is the library's own code
+reading a real SunSpec map rather than a stubbed device.
+"""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+from kaco_modbus.testing import BLUEPLANET_86TL3
+from modbus_connection.mock import MockModbusConnection
+import pytest
+
+from homeassistant.components.kaco_modbus.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_MODEL, MOCK_SERIAL, MOCK_USER_INPUT
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.kaco_modbus.async_setup_entry",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_connection() -> MockModbusConnection:
+    """A fake Modbus TCP connection serving the captured 8.6 TL3 image."""
+    connection = MockModbusConnection()
+    connection.for_unit(1).load_raw({"holding": dict(BLUEPLANET_86TL3)})
+    return connection
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a KACO Modbus config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_SERIAL,
+        data=MOCK_USER_INPUT,
+        title=MOCK_MODEL,
+    )
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MockModbusConnection,
+) -> MockConfigEntry:
+    """Set up the KACO Modbus integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.kaco_modbus.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+            unit_id
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+    return mock_config_entry

--- a/tests/components/kaco_modbus/conftest.py
+++ b/tests/components/kaco_modbus/conftest.py
@@ -2,14 +2,17 @@
 
 The mock is loaded with a register image captured from a real blueplanet
 8.6 TL3 INT, so everything below the connection is the library's own code
-reading a real SunSpec map rather than a stubbed device.
+reading a real SunSpec map rather than a stubbed device. A test that needs a
+different device overrides ``register_image``.
 """
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from collections.abc import AsyncIterator, Generator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from kaco_modbus.testing import BLUEPLANET_86TL3
-from modbus_connection.mock import MockModbusConnection
+from modbus_connection import ModbusTcpParams
+from modbus_connection.mock import MockModbusConnection, MockModbusUnit
 import pytest
 
 from homeassistant.components.kaco_modbus.const import DOMAIN
@@ -32,11 +35,48 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_connection() -> MockModbusConnection:
-    """A fake Modbus TCP connection serving the captured 8.6 TL3 image."""
+def register_image() -> dict[int, int]:
+    """The registers the mock inverter answers with."""
+    return BLUEPLANET_86TL3
+
+
+@pytest.fixture
+def mock_connection(register_image: dict[int, int]) -> MockModbusConnection:
+    """A fake Modbus TCP connection serving the captured register image."""
     connection = MockModbusConnection()
-    connection.for_unit(1).load_raw({"holding": dict(BLUEPLANET_86TL3)})
+    connection.for_unit(1).load_raw({"holding": dict(register_image)})
     return connection
+
+
+@pytest.fixture
+def mock_get_unit(mock_connection: MockModbusConnection) -> Generator[MagicMock]:
+    """Hand the integration a unit on the mock connection."""
+    with patch(
+        "homeassistant.components.kaco_modbus.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+            unit_id
+        ),
+    ) as mock_get_unit:
+        yield mock_get_unit
+
+
+@pytest.fixture
+def mock_temporary_unit(
+    mock_connection: MockModbusConnection,
+) -> Generator[MagicMock]:
+    """Hand the config flow a unit on the mock connection."""
+
+    @asynccontextmanager
+    async def _get_unit(
+        hass: HomeAssistant, params: ModbusTcpParams, unit_id: int
+    ) -> AsyncIterator[MockModbusUnit]:
+        yield mock_connection.for_unit(unit_id)
+
+    with patch(
+        "homeassistant.components.kaco_modbus.config_flow.async_get_temporary_unit",
+        side_effect=_get_unit,
+    ) as mock_temporary_unit:
+        yield mock_temporary_unit
 
 
 @pytest.fixture
@@ -54,16 +94,10 @@ def mock_config_entry() -> MockConfigEntry:
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_connection: MockModbusConnection,
+    mock_get_unit: MagicMock,
 ) -> MockConfigEntry:
     """Set up the KACO Modbus integration for testing."""
     mock_config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.kaco_modbus.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
-            unit_id
-        ),
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
     return mock_config_entry

--- a/tests/components/kaco_modbus/snapshots/test_sensor.ambr
+++ b/tests/components/kaco_modbus/snapshots/test_sensor.ambr
@@ -1,0 +1,192 @@
+# serializer version: 1
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_ac_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_ac_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AC power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'AC power',
+    'platform': 'kaco_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ac_power',
+    'unique_id': '8.6TL00000000_ac_power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_ac_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'blueplanet 8.6 TL3 INT AC power',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_ac_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_operating_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
+        'sleeping',
+        'starting',
+        'mppt',
+        'throttled',
+        'shutting_down',
+        'fault',
+        'standby',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_operating_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Operating state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Operating state',
+    'platform': 'kaco_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'operating_state',
+    'unique_id': '8.6TL00000000_operating_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_operating_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'blueplanet 8.6 TL3 INT Operating state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
+        'sleeping',
+        'starting',
+        'mppt',
+        'throttled',
+        'shutting_down',
+        'fault',
+        'standby',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_operating_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'mppt',
+  })
+# ---
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_total_energy_produced-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_total_energy_produced',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Total energy produced',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total energy produced',
+    'platform': 'kaco_modbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_energy',
+    'unique_id': '8.6TL00000000_lifetime_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.blueplanet_8_6_tl3_int_total_energy_produced-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'blueplanet 8.6 TL3 INT Total energy produced',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.blueplanet_8_6_tl3_int_total_energy_produced',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12187.169',
+  })
+# ---

--- a/tests/components/kaco_modbus/test_config_flow.py
+++ b/tests/components/kaco_modbus/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the KACO Modbus config flow."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, _patch, patch
 
@@ -9,8 +9,8 @@ from modbus_connection import ModbusTcpParams, ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection, MockModbusUnit
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.kaco_modbus.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
@@ -19,50 +19,43 @@ from . import MOCK_MODEL, MOCK_SERIAL, MOCK_USER_INPUT
 
 from tests.common import MockConfigEntry
 
+TARGET = "homeassistant.components.kaco_modbus.config_flow.async_get_temporary_unit"
 
-def _patch_temporary_unit(connection: MockModbusConnection) -> _patch:
-    """Stand in for async_get_temporary_unit, handing out a unit on connection."""
+
+def _serving(image: dict[int, int]) -> _patch:
+    """Patch the temporary unit onto a device answering with *image*."""
+    connection = MockModbusConnection()
+    connection.for_unit(1).load_raw({"holding": dict(image)})
 
     @asynccontextmanager
-    async def _get_temporary_unit(
+    async def _get_unit(
         hass: HomeAssistant, params: ModbusTcpParams, unit_id: int
     ) -> AsyncIterator[MockModbusUnit]:
         yield connection.for_unit(unit_id)
 
-    return patch(
-        "homeassistant.components.kaco_modbus.config_flow.async_get_temporary_unit",
-        side_effect=_get_temporary_unit,
-    )
+    return patch(TARGET, side_effect=_get_unit)
 
 
-def _connection_serving(image: dict[int, int]) -> MockModbusConnection:
-    """A mock connection answering with *image*."""
-    connection = MockModbusConnection()
-    connection.for_unit(1).load_raw({"holding": dict(image)})
-    return connection
+def _raising(error: Exception) -> _patch:
+    """Patch the temporary unit so acquiring it fails."""
+    return patch(TARGET, side_effect=error)
 
 
-async def test_user_step_shows_form(hass: HomeAssistant) -> None:
-    """Test the initial form renders with no errors before any input."""
+@pytest.mark.usefixtures("mock_temporary_unit")
+async def test_user_step_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the form renders and a successful flow creates an entry."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
-
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-
-async def test_user_step_success(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
-    """Test a successful flow creates an entry keyed by serial number."""
-    with _patch_temporary_unit(_connection_serving(BLUEPLANET_86TL3)):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_USER_INPUT
+    )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_MODEL
@@ -72,99 +65,67 @@ async def test_user_step_success(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_step_rejects_another_brand(hass: HomeAssistant) -> None:
-    """Test a SunSpec inverter that is not a KACO is refused.
-
-    Another vendor answers the same models at the same addresses, so without
-    this it would be added and then read on KACO's terms.
-    """
-    foreign = _connection_serving(with_manufacturer(BLUEPLANET_86TL3, "Fronius"))
-
-    with _patch_temporary_unit(foreign):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "not_a_kaco_inverter"}
-
-
-async def test_user_step_rejects_a_non_sunspec_device(hass: HomeAssistant) -> None:
-    """Test something answering Modbus but not SunSpec is refused."""
-    silent = _connection_serving(dict.fromkeys(range(40000, 40010), 0))
-
-    with _patch_temporary_unit(silent):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "not_a_sunspec_inverter"}
-
-
 @pytest.mark.parametrize(
-    "error",
+    ("failure", "expected_error"),
     [
-        ModbusTimeoutError("no answer"),
-        HomeAssistantError("already in use with different link settings"),
+        # Another vendor's SunSpec inverter answers the same models at the
+        # same addresses, so it has to be told apart by its manufacturer.
+        (
+            lambda: _serving(with_manufacturer(BLUEPLANET_86TL3, "Fronius")),
+            "not_a_kaco_inverter",
+        ),
+        (
+            lambda: _serving(dict.fromkeys(range(40000, 40010), 0)),
+            "not_a_sunspec_inverter",
+        ),
+        (lambda: _raising(ModbusTimeoutError("no answer")), "cannot_connect"),
+        # The device is already held on different link settings.
+        (lambda: _raising(HomeAssistantError("in use")), "cannot_connect"),
+        (lambda: _raising(RuntimeError("boom")), "unknown"),
     ],
 )
-async def test_user_step_cannot_connect(hass: HomeAssistant, error: Exception) -> None:
-    """Test an unreachable address, and one held on different link settings."""
-    connection = _connection_serving(BLUEPLANET_86TL3)
-    connection.for_unit(1).fail_requests(error)
-
-    with _patch_temporary_unit(connection):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_user_step_recovers_after_an_error(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
+@pytest.mark.usefixtures("mock_temporary_unit")
+async def test_user_step_errors_then_recovers(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    failure: Callable[[], _patch],
+    expected_error: str,
 ) -> None:
-    """Test the form can be resubmitted once the inverter answers."""
-    connection = _connection_serving(BLUEPLANET_86TL3)
-    connection.for_unit(1).fail_requests(ModbusTimeoutError("no answer"))
+    """Test each failure shows on the form, and the flow still completes."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    with _patch_temporary_unit(connection):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
-        assert result["errors"] == {"base": "cannot_connect"}
-
-        connection.for_unit(1).fail_requests(None)
+    with failure():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], MOCK_USER_INPUT
         )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
+
+    # The healthy device the fixture serves is back once the failure lifts.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_USER_INPUT
+    )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == MOCK_SERIAL
 
 
+@pytest.mark.usefixtures("mock_temporary_unit")
 async def test_user_step_aborts_when_already_configured(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test the same inverter cannot be added twice, even at a new address."""
     mock_config_entry.add_to_hass(hass)
 
-    with _patch_temporary_unit(_connection_serving(BLUEPLANET_86TL3)):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data={**MOCK_USER_INPUT, "host": "192.168.1.101"},
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {**MOCK_USER_INPUT, "host": "192.168.1.101"}
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/kaco_modbus/test_config_flow.py
+++ b/tests/components/kaco_modbus/test_config_flow.py
@@ -1,0 +1,170 @@
+"""Test the KACO Modbus config flow."""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, _patch, patch
+
+from kaco_modbus.testing import BLUEPLANET_86TL3, with_manufacturer
+from modbus_connection import ModbusTcpParams, ModbusTimeoutError
+from modbus_connection.mock import MockModbusConnection, MockModbusUnit
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.kaco_modbus.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+
+from . import MOCK_MODEL, MOCK_SERIAL, MOCK_USER_INPUT
+
+from tests.common import MockConfigEntry
+
+
+def _patch_temporary_unit(connection: MockModbusConnection) -> _patch:
+    """Stand in for async_get_temporary_unit, handing out a unit on connection."""
+
+    @asynccontextmanager
+    async def _get_temporary_unit(
+        hass: HomeAssistant, params: ModbusTcpParams, unit_id: int
+    ) -> AsyncIterator[MockModbusUnit]:
+        yield connection.for_unit(unit_id)
+
+    return patch(
+        "homeassistant.components.kaco_modbus.config_flow.async_get_temporary_unit",
+        side_effect=_get_temporary_unit,
+    )
+
+
+def _connection_serving(image: dict[int, int]) -> MockModbusConnection:
+    """A mock connection answering with *image*."""
+    connection = MockModbusConnection()
+    connection.for_unit(1).load_raw({"holding": dict(image)})
+    return connection
+
+
+async def test_user_step_shows_form(hass: HomeAssistant) -> None:
+    """Test the initial form renders with no errors before any input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+async def test_user_step_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test a successful flow creates an entry keyed by serial number."""
+    with _patch_temporary_unit(_connection_serving(BLUEPLANET_86TL3)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_MODEL
+    assert result["data"] == MOCK_USER_INPUT
+    # The serial survives an address change, which a host or port does not.
+    assert result["result"].unique_id == MOCK_SERIAL
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_step_rejects_another_brand(hass: HomeAssistant) -> None:
+    """Test a SunSpec inverter that is not a KACO is refused.
+
+    Another vendor answers the same models at the same addresses, so without
+    this it would be added and then read on KACO's terms.
+    """
+    foreign = _connection_serving(with_manufacturer(BLUEPLANET_86TL3, "Fronius"))
+
+    with _patch_temporary_unit(foreign):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "not_a_kaco_inverter"}
+
+
+async def test_user_step_rejects_a_non_sunspec_device(hass: HomeAssistant) -> None:
+    """Test something answering Modbus but not SunSpec is refused."""
+    silent = _connection_serving(dict.fromkeys(range(40000, 40010), 0))
+
+    with _patch_temporary_unit(silent):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "not_a_sunspec_inverter"}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ModbusTimeoutError("no answer"),
+        HomeAssistantError("already in use with different link settings"),
+    ],
+)
+async def test_user_step_cannot_connect(hass: HomeAssistant, error: Exception) -> None:
+    """Test an unreachable address, and one held on different link settings."""
+    connection = _connection_serving(BLUEPLANET_86TL3)
+    connection.for_unit(1).fail_requests(error)
+
+    with _patch_temporary_unit(connection):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_step_recovers_after_an_error(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the form can be resubmitted once the inverter answers."""
+    connection = _connection_serving(BLUEPLANET_86TL3)
+    connection.for_unit(1).fail_requests(ModbusTimeoutError("no answer"))
+
+    with _patch_temporary_unit(connection):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        connection.for_unit(1).fail_requests(None)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == MOCK_SERIAL
+
+
+async def test_user_step_aborts_when_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the same inverter cannot be added twice, even at a new address."""
+    mock_config_entry.add_to_hass(hass)
+
+    with _patch_temporary_unit(_connection_serving(BLUEPLANET_86TL3)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={**MOCK_USER_INPUT, "host": "192.168.1.101"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/kaco_modbus/test_init.py
+++ b/tests/components/kaco_modbus/test_init.py
@@ -1,0 +1,133 @@
+"""Test setting the KACO Modbus entry up, and what happens when it fails."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from kaco_modbus import SunSpecMapShiftError
+from kaco_modbus.testing import BLUEPLANET_86TL3, with_manufacturer
+from modbus_connection import ModbusTimeoutError
+from modbus_connection.mock import MockModbusConnection
+
+from homeassistant.components.kaco_modbus.const import DOMAIN
+from homeassistant.components.kaco_modbus.coordinator import (
+    SCAN_INTERVAL,
+    KacoDataUpdateCoordinator,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import MOCK_SERIAL, MOCK_USER_INPUT
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def _patch_get_unit(connection: MockModbusConnection) -> object:
+    """Hand the integration a unit on *connection* instead of a real one."""
+    return patch(
+        "homeassistant.components.kaco_modbus.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: connection.for_unit(unit_id),
+    )
+
+
+async def test_setup_and_unload_entry(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test a config entry sets up and unloads with runtime_data populated."""
+    assert init_integration.state is ConfigEntryState.LOADED
+    assert isinstance(init_integration.runtime_data, KacoDataUpdateCoordinator)
+
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert init_integration.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_device_registry_entry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the inverter is identified by serial, which survives a move."""
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), init_integration.entry_id
+    )
+
+    assert device is not None
+    assert device.manufacturer == "KACO new energy"
+    assert device.model == "blueplanet 8.6 TL3 INT"
+    assert device.sw_version == "V5.53"
+    assert device.serial_number == MOCK_SERIAL
+
+
+async def test_a_silent_inverter_retries_and_recovers(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_connection: MockModbusConnection,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an inverter asleep at setup is retried rather than given up on."""
+    mock_config_entry.add_to_hass(hass)
+    unit = mock_connection.for_unit(1)
+    unit.fail_requests(ModbusTimeoutError("asleep"))
+
+    with _patch_get_unit(mock_connection):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+        unit.fail_requests(None)
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_another_brand_at_the_same_address_fails_permanently(
+    hass: HomeAssistant,
+) -> None:
+    """Test a swapped device is a setup error, not an endless retry.
+
+    Retrying cannot make a Fronius into a KACO, so this must not sit in
+    SETUP_RETRY polling someone else's inverter forever.
+    """
+    connection = MockModbusConnection()
+    connection.for_unit(1).load_raw(
+        {"holding": with_manufacturer(BLUEPLANET_86TL3, "Fronius")}
+    )
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
+    entry.add_to_hass(hass)
+
+    with _patch_get_unit(connection):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_a_moved_sunspec_map_reloads_the_entry(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test a shifted model chain triggers rediscovery.
+
+    Every bound register offset is stale, so polling on would report
+    plausible nonsense rather than fail. SunSpecMapShiftError is not a
+    ModbusError, so it needs handling of its own.
+    """
+    device = init_integration.runtime_data.device
+
+    with (
+        patch.object(
+            device, "async_update_readings", side_effect=SunSpecMapShiftError("moved")
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload") as reload,
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    reload.assert_called_once_with(init_integration.entry_id)

--- a/tests/components/kaco_modbus/test_init.py
+++ b/tests/components/kaco_modbus/test_init.py
@@ -8,35 +8,24 @@ from kaco_modbus import SunSpecMapShiftError
 from kaco_modbus.testing import BLUEPLANET_86TL3, with_manufacturer
 from modbus_connection import ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
+import pytest
 
 from homeassistant.components.kaco_modbus.const import DOMAIN
-from homeassistant.components.kaco_modbus.coordinator import (
-    SCAN_INTERVAL,
-    KacoDataUpdateCoordinator,
-)
+from homeassistant.components.kaco_modbus.coordinator import SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from . import MOCK_SERIAL, MOCK_USER_INPUT
+from . import MOCK_SERIAL
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-
-
-def _patch_get_unit(connection: MockModbusConnection) -> object:
-    """Hand the integration a unit on *connection* instead of a real one."""
-    return patch(
-        "homeassistant.components.kaco_modbus.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: connection.for_unit(unit_id),
-    )
 
 
 async def test_setup_and_unload_entry(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
-    """Test a config entry sets up and unloads with runtime_data populated."""
+    """Test a config entry sets up and unloads."""
     assert init_integration.state is ConfigEntryState.LOADED
-    assert isinstance(init_integration.runtime_data, KacoDataUpdateCoordinator)
 
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     await hass.async_block_till_done()
@@ -61,6 +50,7 @@ async def test_device_registry_entry(
     assert device.serial_number == MOCK_SERIAL
 
 
+@pytest.mark.usefixtures("mock_get_unit")
 async def test_a_silent_inverter_retries_and_recovers(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -72,39 +62,36 @@ async def test_a_silent_inverter_retries_and_recovers(
     unit = mock_connection.for_unit(1)
     unit.fail_requests(ModbusTimeoutError("asleep"))
 
-    with _patch_get_unit(mock_connection):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
-        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
-        unit.fail_requests(None)
-        freezer.tick(timedelta(seconds=30))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
+    unit.fail_requests(None)
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
+@pytest.mark.parametrize(
+    "register_image", [with_manufacturer(BLUEPLANET_86TL3, "Fronius")]
+)
+@pytest.mark.usefixtures("mock_get_unit")
 async def test_another_brand_at_the_same_address_fails_permanently(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test a swapped device is a setup error, not an endless retry.
 
     Retrying cannot make a Fronius into a KACO, so this must not sit in
     SETUP_RETRY polling someone else's inverter forever.
     """
-    connection = MockModbusConnection()
-    connection.for_unit(1).load_raw(
-        {"holding": with_manufacturer(BLUEPLANET_86TL3, "Fronius")}
-    )
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    with _patch_get_unit(connection):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_a_moved_sunspec_map_reloads_the_entry(
@@ -118,11 +105,10 @@ async def test_a_moved_sunspec_map_reloads_the_entry(
     plausible nonsense rather than fail. SunSpecMapShiftError is not a
     ModbusError, so it needs handling of its own.
     """
-    device = init_integration.runtime_data.device
-
     with (
-        patch.object(
-            device, "async_update_readings", side_effect=SunSpecMapShiftError("moved")
+        patch(
+            "homeassistant.components.kaco_modbus.KacoInverter.async_update_readings",
+            side_effect=SunSpecMapShiftError("moved"),
         ),
         patch.object(hass.config_entries, "async_schedule_reload") as reload,
     ):

--- a/tests/components/kaco_modbus/test_sensor.py
+++ b/tests/components/kaco_modbus/test_sensor.py
@@ -1,0 +1,158 @@
+"""Test the KACO Modbus sensor platform."""
+
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from kaco_modbus import KacoInverter
+from kaco_modbus.testing import BLUEPLANET_86TL3_ASLEEP
+from modbus_connection import ModbusTimeoutError
+from modbus_connection.mock import MockModbusConnection
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.kaco_modbus.const import DOMAIN
+from homeassistant.components.kaco_modbus.coordinator import SCAN_INTERVAL
+from homeassistant.components.kaco_modbus.sensor import SENSOR_DESCRIPTIONS
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import MOCK_SERIAL
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+def _entity_id(entity_registry: er.EntityRegistry, key: str) -> str:
+    """Look the entity up by unique id rather than by a guessed slug."""
+    entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_{key}"
+    )
+    assert entity_id is not None, f"{key} was not created"
+    return entity_id
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test all entities match their snapshot."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+def test_sensor_descriptions_read_real_fields() -> None:
+    """Guard SENSOR_DESCRIPTIONS against a component transcription slip.
+
+    Values are resolved by getattr, so a wrong component name would other-
+    wise show up as a permanently empty sensor rather than an error.
+    """
+    device = KacoInverter(MockModbusConnection().for_unit(1))
+    for description in SENSOR_DESCRIPTIONS:
+        assert hasattr(device, description.component), (
+            f"unknown component {description.component!r}"
+        )
+
+
+async def test_sensor_values(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the shipped sensors carry the captured inverter's readings."""
+    assert hass.states.get(_entity_id(entity_registry, "ac_power")).state == "1000"
+    assert (
+        hass.states.get(_entity_id(entity_registry, "operating_state")).state == "mppt"
+    )
+    # Reported in Wh and shown in kWh, so the state is the converted value.
+    energy = hass.states.get(_entity_id(entity_registry, "lifetime_energy"))
+    assert float(energy.state) == pytest.approx(12187.169)
+
+
+async def test_sensors_go_unavailable_when_the_link_drops(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    mock_connection: MockModbusConnection,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test a silent inverter takes its sensors unavailable, then recovers."""
+    power = _entity_id(entity_registry, "ac_power")
+    unit = mock_connection.for_unit(1)
+
+    unit.fail_requests(ModbusTimeoutError("asleep"))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(power).state == STATE_UNAVAILABLE
+
+    # Recovery must not need a reload: every request connects first.
+    unit.fail_requests(None)
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(power).state == "1000"
+
+
+async def test_a_failing_component_does_not_take_out_the_others(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    mock_connection: MockModbusConnection,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test one unreadable block leaves the rest of the entities alone.
+
+    Components are polled separately, so an entity is unavailable when its
+    own component failed, not when any of them did.
+    """
+    coordinator = init_integration.runtime_data
+    # Where the MPPT block landed in this device's discovered model chain.
+    assert coordinator.device.models is not None
+    mppt = coordinator.device.models.first(160)
+    assert mppt is not None
+    unit = mock_connection.for_unit(1)
+
+    for address in range(mppt.address, mppt.address + mppt.length):
+        unit.fail_read(address, ModbusTimeoutError("slow block"))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert coordinator.last_update_success
+    assert "mppt" in coordinator.data.failed
+    assert hass.states.get(_entity_id(entity_registry, "ac_power")).state == "1000"
+
+
+async def test_after_dark_the_inverter_reports_a_true_zero(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a sleeping inverter still reports what it genuinely measures.
+
+    A KACO keeps answering after dark rather than going quiet, so nothing
+    goes unavailable. Producing nothing really is 0 W, and the lifetime
+    total must keep reporting or the Energy dashboard gains a nightly gap.
+    """
+    connection = MockModbusConnection()
+    connection.for_unit(1).load_raw({"holding": dict(BLUEPLANET_86TL3_ASLEEP)})
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.kaco_modbus.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: connection.for_unit(unit_id),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(_entity_id(entity_registry, "ac_power")).state == "0"
+    assert (
+        hass.states.get(_entity_id(entity_registry, "operating_state")).state
+        == "sleeping"
+    )
+    energy = hass.states.get(_entity_id(entity_registry, "lifetime_energy"))
+    assert energy.state != STATE_UNAVAILABLE
+    assert float(energy.state) > 12000

--- a/tests/components/kaco_modbus/test_sensor.py
+++ b/tests/components/kaco_modbus/test_sensor.py
@@ -1,10 +1,9 @@
 """Test the KACO Modbus sensor platform."""
 
-from unittest.mock import patch
-
 from freezegun.api import FrozenDateTimeFactory
 from kaco_modbus import KacoInverter
-from kaco_modbus.testing import BLUEPLANET_86TL3_ASLEEP
+from kaco_modbus.const import INVERTER_MODEL_ID
+from kaco_modbus.testing import BLUEPLANET_86TL3, BLUEPLANET_86TL3_ASLEEP
 from modbus_connection import ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
 import pytest
@@ -14,11 +13,12 @@ from homeassistant.components.kaco_modbus.const import DOMAIN
 from homeassistant.components.kaco_modbus.coordinator import SCAN_INTERVAL
 from homeassistant.components.kaco_modbus.sensor import SENSOR_DESCRIPTIONS
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MOCK_SERIAL
+from . import MOCK_SERIAL, model_registers
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -96,40 +96,39 @@ async def test_sensors_go_unavailable_when_the_link_drops(
     assert hass.states.get(power).state == "1000"
 
 
-async def test_a_failing_component_does_not_take_out_the_others(
+async def test_an_unreadable_block_takes_its_sensors_unavailable(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
     mock_connection: MockModbusConnection,
     init_integration: MockConfigEntry,
 ) -> None:
-    """Test one unreadable block leaves the rest of the entities alone.
+    """Test a partial poll, where one block fails and the others answer.
 
-    Components are polled separately, so an entity is unavailable when its
-    own component failed, not when any of them did.
+    A different path from a dead link: the poll still succeeds, so the entry
+    stays loaded, and it is the per-component check that takes these entities
+    unavailable. That the *other* components are unaffected is not observable
+    until a second component has entities of its own.
     """
-    coordinator = init_integration.runtime_data
-    # Where the MPPT block landed in this device's discovered model chain.
-    assert coordinator.device.models is not None
-    mppt = coordinator.device.models.first(160)
-    assert mppt is not None
-    unit = mock_connection.for_unit(1)
+    power = _entity_id(entity_registry, "ac_power")
+    assert hass.states.get(power).state == "1000"
 
-    for address in range(mppt.address, mppt.address + mppt.length):
+    unit = mock_connection.for_unit(1)
+    for address in model_registers(BLUEPLANET_86TL3, INVERTER_MODEL_ID):
         unit.fail_read(address, ModbusTimeoutError("slow block"))
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert coordinator.last_update_success
-    assert "mppt" in coordinator.data.failed
-    assert hass.states.get(_entity_id(entity_registry, "ac_power")).state == "1000"
+    assert hass.states.get(power).state == STATE_UNAVAILABLE
+    assert init_integration.state is ConfigEntryState.LOADED
 
 
+@pytest.mark.parametrize("register_image", [BLUEPLANET_86TL3_ASLEEP])
 async def test_after_dark_the_inverter_reports_a_true_zero(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test a sleeping inverter still reports what it genuinely measures.
 
@@ -137,17 +136,6 @@ async def test_after_dark_the_inverter_reports_a_true_zero(
     goes unavailable. Producing nothing really is 0 W, and the lifetime
     total must keep reporting or the Energy dashboard gains a nightly gap.
     """
-    connection = MockModbusConnection()
-    connection.for_unit(1).load_raw({"holding": dict(BLUEPLANET_86TL3_ASLEEP)})
-    mock_config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.kaco_modbus.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: connection.for_unit(unit_id),
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
     assert hass.states.get(_entity_id(entity_registry, "ac_power")).state == "0"
     assert (
         hass.states.get(_entity_id(entity_registry, "operating_state")).state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the Kaco Modbus integration (KACO new energy inverters over Modbus TCP, local polling).
It is a port of my [custom integration](https://github.com/g4bri3lDev/kaco-modbus-hass) which I have been running against my own inverters (blueplanet 8.6 TL3 INT) for the last few weeks.

This PR only includes the sensor platform (AC Power, total energy produced and operating state) to keep the PR small.

Dependencies: [kaco-modbus](https://github.com/g4bri3lDev/kaco-modbus)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47745
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
