### PR TITLE
Attribute the deprecated via_device report to the config entry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2306,6 +2306,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 core_behavior=ReportBehavior.ERROR,
                 core_integration_behavior=ReportBehavior.ERROR,
                 breaks_in_ha_version=version,
+                integration_domain=config_entry.domain,
             )
         if (
             config_subentry_id is not UNDEFINED

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4566,23 +4566,10 @@ async def test_async_get_device_deprecated(
     ],
 )
 @pytest.mark.parametrize(
-    ("integration_frame_path", "expectation", "expected_log"),
+    ("built_in", "expectation"),
     [
-        pytest.param(
-            "homeassistant/test_core", pytest.raises(RuntimeError), 0, id="core"
-        ),
-        pytest.param(
-            "homeassistant/components/test_integration",
-            pytest.raises(RuntimeError),
-            1,
-            id="core integration",
-        ),
-        pytest.param(
-            "custom_components/test_integration",
-            nullcontext(),
-            1,
-            id="custom integration",
-        ),
+        pytest.param(True, pytest.raises(RuntimeError), id="core integration"),
+        pytest.param(False, nullcontext(), id="custom integration"),
     ],
 )
 @pytest.mark.usefixtures("mock_integration_frame")
@@ -4593,14 +4580,18 @@ async def test_async_get_or_create_deprecated_parameters(
     parameter: str,
     value: Any,
     advice: str,
+    built_in: bool,
     expectation: AbstractContextManager,
-    expected_log: int,
 ) -> None:
     """Test passing deprecated parameters to async_get_or_create.
 
-    They log for custom integrations and raise for core and core integrations.
+    They log for custom integrations and raise for core integrations. The report is
+    attributed to the config entry which owns the device, not to the caller on the
+    stack: `mock_integration_frame` puts a core integration on the stack here, and a
+    custom integration's config entry must still only log.
     """
-    config_entry = MockConfigEntry()
+    mock_integration(hass, MockModule("test_integration"), built_in=built_in)
+    config_entry = MockConfigEntry(domain="test_integration")
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
@@ -4617,7 +4608,56 @@ async def test_async_get_or_create_deprecated_parameters(
             **{parameter: value},
         )
 
-    assert caplog.text.count(what) == expected_log
+    assert caplog.text.count(what) == 1
+
+
+@pytest.mark.parametrize(
+    ("built_in", "expectation"),
+    [
+        pytest.param(True, pytest.raises(RuntimeError), id="core integration"),
+        pytest.param(False, nullcontext(), id="custom integration"),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_async_get_or_create_deprecated_parameters_without_integration_frame(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    built_in: bool,
+    expectation: AbstractContextManager,
+) -> None:
+    """Test the deprecation report when no integration frame is on the stack.
+
+    Device info reaches the registry from `entity_platform`, so the integration which
+    set `via_device` is not on the stack when entities are added from a task. The
+    report must still be attributed to it, instead of falling back to `core_behavior`
+    and raising at a custom integration.
+    """
+    mock_integration(hass, MockModule("test_integration"), built_in=built_in)
+    config_entry = MockConfigEntry(domain="test_integration")
+    config_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("some_domain", "via_id")}
+    )
+
+    what = (
+        "calls `device_registry.async_get_or_create` with a deprecated "
+        "`via_device` parameter; use `via_device_id` instead"
+    )
+    with (
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+        patch.object(
+            frame, "get_integration_frame", side_effect=frame.MissingIntegrationFrame
+        ),
+        expectation,
+    ):
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("some_domain", "some_id")},
+            via_device=("some_domain", "via_id"),
+        )
+
+    assert caplog.text.count(what) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

`async_get_or_create` reports the deprecated `DeviceInfo` parameters with `core_behavior=ReportBehavior.ERROR` and `core_integration_behavior=ReportBehavior.ERROR`, leaving `custom_integration_behavior` at its `LOG` default. It is the only `report_usage` call in that function that escalates to `ERROR`, and the only one that does not pass `integration_domain`.

Because it does not, `report_usage` has to identify the caller by walking the stack — and for the `DeviceInfo` path that does not work. The integration only *builds* a dict; the registry call happens later, from `entity_platform._async_add_entity`. When entities are added from a task, no frame of the integration is left on the stack, `get_integration_frame()` raises `MissingIntegrationFrame`, and `_report_usage_no_integration` applies `core_behavior` — so a **custom** integration gets `RuntimeError` where the deprecation is meant to only warn until 2027.8.

This passes the domain of the config entry that owns the device being created, which is by definition the integration responsible for the `DeviceInfo`. Attribution then no longer depends on the call path, matching the approach taken in #139819 and, a few lines below in this same function, in #180628.

Reported in #180469 (huawei_solar), and hit by frigate and tado_ce as well. #180628 added `integration_domain` to the config-subentry notice ~180 lines below, which was already `ReportBehavior.LOG` and could not raise either way; the escalating call was left unchanged, so the reported crash still reproduces.

Verified against 2026.9.0b4 (sha-identical to the tag and to current `dev`) on a live Home Assistant Container install: a custom integration whose platforms call `async_add_entities` inside their own `async_setup_entry` keeps its frame on the stack and correctly logs

```
WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration
'luxtronik2' calls `device_registry.async_get_or_create` with a deprecated `via_device`
parameter; use `via_device_id` instead ... This will stop working in Home Assistant 2027.8.0
```

while integrations that add entities from a task raise instead. The behaviour is currently accidental, depending only on where the call originates.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Fixes the crash reported in #180469

### One open question, on the existing test

`test_async_get_or_create_deprecated_parameters` covers `via_device` and asserts that a custom integration logs rather than raises — the exact behaviour that is broken in practice. It passes today only because `mock_integration_frame` injects a synthetic frame; the real-world case, where no frame of the integration is on the stack, is not covered anywhere.

With this change, core-vs-custom comes from the config entry's integration rather than from the mocked frame, so that parametrization no longer selects the behaviour under test: `MockConfigEntry`'s domain does not resolve through `async_get_issue_integration`, so `report_usage` would fall back to `core_behavior`. The test would need to register a mock integration for the entry's domain and parametrize on `built_in` instead.

I have deliberately not pushed that, because it changes what the test models and I would rather follow your preference on it — happy to add it in whichever shape you want, including a regression test for the no-frame case. Flagging it up front so the CI result is not a surprise.

## Checklist

- [x] The code change is tested and works locally — verified on a live 2026.9.0b4 install as described above
- [ ] The core test suite was run locally — I was not able to run it in this environment; relying on CI
- [x] There is no commented out code in this PR
- [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
