### PR TITLE
Stop reporting max_volume in Lyngdorf diagnostics

### DIFF
--- a/homeassistant/components/lyngdorf/diagnostics.py
+++ b/homeassistant/components/lyngdorf/diagnostics.py
@@ -73,7 +73,6 @@ async def async_get_config_entry_diagnostics(
         "model": receiver.model.name,
         "power_on": receiver.power_on,
         "volume": volume.value if volume is not None else None,
-        "max_volume": receiver.max_volume,
         "mute_enabled": receiver.muted,
         "source": receiver.source,
         "available_sources": receiver.sources,

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -115,7 +115,6 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     # Diagnostics reports the whole receiver, so every property it reads
     # needs a value here; an unset one is a mock the response cannot encode.
     receiver.model = LyngdorfModel.MP_60
-    receiver.max_volume = 0.0
     receiver.room_perfect_position = "Focus 1"
     receiver.available_room_perfect_positions = ["Global", "Focus 1"]
     receiver.room_perfect_positions = ["Global", "Focus 1"]

--- a/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
+++ b/tests/components/lyngdorf/snapshots/test_diagnostics.ambr
@@ -90,7 +90,6 @@
       ]),
       'connected': True,
       'lipsync': 50.0,
-      'max_volume': 0.0,
       'model': 'MP_60',
       'mute_enabled': False,
       'power_on': False,


### PR DESCRIPTION
## Proposed change

`max_volume` is the device's user-set volume ceiling. It only ever appeared in a
diagnostics download, where it is not useful, so it is removed rather than
carried forward.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The 1.11.0 bump this builds on merged in #180528.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
