### PR TITLE
Pick up SolarEdge Modbus meters and batteries wired in or out later

### DIFF
--- a/homeassistant/components/solaredge_modbus/__init__.py
+++ b/homeassistant/components/solaredge_modbus/__init__.py
@@ -145,6 +145,7 @@ async def async_setup_entry(
         settings=settings,
         device_info=device_info,
         inverter_device_id=inverter.id,
+        attachments=_attachment_identities(solaredge),
     )
 
     if silent := solaredge.unresponsive_blocks & {
@@ -175,20 +176,41 @@ async def async_setup_entry(
     return True
 
 
+def _attachment_identities(solaredge: SolarEdge) -> frozenset[str]:
+    """Return what the meters and batteries attached right now are known by."""
+    return frozenset(
+        [
+            *(
+                f"meter_{attachment_identity(meter, index)}"
+                for index, meter in enumerate(solaredge.meters, 1)
+            ),
+            *(
+                f"battery_{attachment_identity(battery, index)}"
+                for index, battery in enumerate(solaredge.batteries, 1)
+            ),
+        ]
+    )
+
+
 async def _async_reload_when_attachments_change(
     hass: HomeAssistant,
     entry: SolarEdgeModbusConfigEntry,
     unit: ModbusUnit,
     _now: datetime,
 ) -> None:
-    """Reload the entry when the hardware wired to the inverter changed.
+    """Reload the entry when the hardware wired to the inverter changed."""
+    solaredge = entry.runtime_data.solaredge
 
-    Probing again is what tells a meter or battery apart from one that was
-    never there, and the entry is built around what that probe found, so the
-    honest way to pick up a change is to load it again. This is rare hardware
-    work, usually done with the power off, which is why looking now and then
-    and reloading is enough.
-    """
+    # Swapping one meter for another leaves the count alone, but the polls have
+    # been reading the new one's serial number since it was wired in.
+    if _attachment_identities(solaredge) != entry.runtime_data.attachments:
+        LOGGER.info(
+            "%s: what is attached changed, reloading to pick that up",
+            entry.title,
+        )
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+        return
+
     try:
         probed = await SolarEdge.async_probe(unit)
     except SolarEdgeError as err:
@@ -197,7 +219,6 @@ async def _async_reload_when_attachments_change(
         LOGGER.debug("%s: could not probe for attached hardware: %s", entry.title, err)
         return
 
-    solaredge = entry.runtime_data.solaredge
     for name, found, known in (
         (SUBSYSTEM_METERS, len(probed.meters), len(solaredge.meters)),
         (SUBSYSTEM_BATTERIES, len(probed.batteries), len(solaredge.batteries)),

--- a/homeassistant/components/solaredge_modbus/__init__.py
+++ b/homeassistant/components/solaredge_modbus/__init__.py
@@ -7,8 +7,11 @@ the ``solaredged`` library.
 """
 
 from collections.abc import Set as AbstractSet
+from datetime import datetime
+from functools import partial
 from typing import TYPE_CHECKING
 
+from modbus_connection import ModbusUnit
 from solaredged import SolarEdge, SolarEdgeConnectionError, SolarEdgeError
 
 from homeassistant.components.modbus import async_get_unit
@@ -20,8 +23,10 @@ from homeassistant.exceptions import (
     HomeAssistantError,
 )
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
+    ATTACHMENT_SCAN_INTERVAL,
     CONF_UNIT_ID,
     DOMAIN,
     LOGGER,
@@ -157,7 +162,63 @@ async def async_setup_entry(
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # What is wired to the inverter is read while setting up, so a meter or
+    # battery added or removed later needs the entry to load again to be seen.
+    entry.async_on_unload(
+        async_track_time_interval(
+            hass,
+            partial(_async_reload_when_attachments_change, hass, entry, unit),
+            ATTACHMENT_SCAN_INTERVAL,
+        )
+    )
+
     return True
+
+
+async def _async_reload_when_attachments_change(
+    hass: HomeAssistant,
+    entry: SolarEdgeModbusConfigEntry,
+    unit: ModbusUnit,
+    _now: datetime,
+) -> None:
+    """Reload the entry when the hardware wired to the inverter changed.
+
+    Probing again is what tells a meter or battery apart from one that was
+    never there, and the entry is built around what that probe found, so the
+    honest way to pick up a change is to load it again. This is rare hardware
+    work, usually done with the power off, which is why looking now and then
+    and reloading is enough.
+    """
+    try:
+        probed = await SolarEdge.async_probe(unit)
+    except SolarEdgeError as err:
+        # Nothing to conclude from a probe that did not finish; the coordinators
+        # report an inverter that stopped answering.
+        LOGGER.debug("%s: could not probe for attached hardware: %s", entry.title, err)
+        return
+
+    solaredge = entry.runtime_data.solaredge
+    for name, found, known in (
+        (SUBSYSTEM_METERS, len(probed.meters), len(solaredge.meters)),
+        (SUBSYSTEM_BATTERIES, len(probed.batteries), len(solaredge.batteries)),
+    ):
+        if found == known:
+            continue
+        # A block that stayed silent is taken for absent, which is not the same
+        # as the inverter saying it is gone, and reloading on that would drop a
+        # device over one timeout.
+        if found < known and name in probed.unresponsive_blocks:
+            continue
+
+        LOGGER.info(
+            "%s: %s went from %s to %s, reloading to pick that up",
+            entry.title,
+            name,
+            known,
+            found,
+        )
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+        return
 
 
 def _async_remove_stale_devices(

--- a/homeassistant/components/solaredge_modbus/const.py
+++ b/homeassistant/components/solaredge_modbus/const.py
@@ -39,3 +39,7 @@ SCAN_INTERVAL: Final = timedelta(seconds=10)
 # The control blocks hold what the site was told to do; they only move when
 # something writes them, so they do not need a live measurement's cadence.
 SETTINGS_SCAN_INTERVAL: Final = timedelta(minutes=5)
+
+# Meters and batteries are wired to an inverter by hand, usually with the power
+# off, so looking for a change now and then is often enough.
+ATTACHMENT_SCAN_INTERVAL: Final = timedelta(minutes=15)

--- a/homeassistant/components/solaredge_modbus/coordinator.py
+++ b/homeassistant/components/solaredge_modbus/coordinator.py
@@ -169,6 +169,9 @@ class SolarEdgeModbusRuntimeData:
     settings: SolarEdgeModbusDataUpdateCoordinator
     device_info: DeviceInfo
     inverter_device_id: str
+    # What was attached when this entry was built, to notice a swap: a meter
+    # replaced by another one leaves the count alone.
+    attachments: frozenset[str]
 
     # The export mode and its flags share one register, which the library
     # changes by taking its cached value, flipping bits and writing it back.

--- a/homeassistant/components/solaredge_modbus/quality_scale.yaml
+++ b/homeassistant/components/solaredge_modbus/quality_scale.yaml
@@ -61,7 +61,7 @@ rules:
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
-  dynamic-devices: todo
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -72,7 +72,7 @@ rules:
   repair-issues:
     status: exempt
     comment: No repairable issues are raised.
-  stale-devices: todo
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/tests/components/solaredge_modbus/test_init.py
+++ b/tests/components/solaredge_modbus/test_init.py
@@ -7,11 +7,12 @@ from freezegun.api import FrozenDateTimeFactory
 from modbus_connection import (
     IllegalDataAddressError,
     ModbusTimeoutError,
+    ModbusUnit,
     ServerDeviceFailureError,
 )
 from modbus_connection.mock import MockModbusConnection, MockModbusUnit
 import pytest
-from solaredged import SolarEdgeConnectionError
+from solaredged import SolarEdge, SolarEdgeConnectionError
 
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -58,6 +59,9 @@ METER_MODEL_REGISTER = 40188
 
 # An address inside the pooled storage and export control read.
 SITE_CONTROL_REGISTER = 57348
+
+# Where the first meter's serial number lives.
+METER_SERIAL_REGISTER = 40171
 
 EXPORT_LIMITATION_ENTITY = "select.solaredge_se10000h_export_limitation"
 EXTERNAL_PRODUCTION_ENTITY = "switch.solaredge_se10000h_external_production"
@@ -623,11 +627,26 @@ async def test_concurrent_control_writes_keep_both_changes(
 
 async def _tick_attachment_check(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
-) -> None:
-    """Let the check for changed hardware run, and any reload it starts."""
-    freezer.tick(ATTACHMENT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+) -> int:
+    """Let the check for changed hardware run, and report what it cost.
+
+    Setting up probes the device, so a check that reloads the entry probes
+    twice: once to look, once to build the entry again.
+    """
+    probes = 0
+    probe = SolarEdge.async_probe
+
+    async def counting_probe(unit: ModbusUnit) -> SolarEdge:
+        nonlocal probes
+        probes += 1
+        return await probe(unit)
+
+    with patch.object(SolarEdge, "async_probe", counting_probe):
+        freezer.tick(ATTACHMENT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    return probes
 
 
 async def test_meter_added_later_is_picked_up(
@@ -696,6 +715,49 @@ async def test_battery_removed_later_is_dropped(
     )
 
 
+async def test_replaced_meter_is_picked_up(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """Another meter in the same place is another device, while running too.
+
+    Swapping one meter for another leaves the count alone, so what gives it
+    away is the serial number the polls have been reading all along.
+    """
+    await _setup(hass, mock_config_entry)
+
+    replacement = "7E9C55A6"
+    padded = replacement.ljust(32, "\0").encode()
+    mock_modbus_unit.holding.update(
+        {
+            METER_SERIAL_REGISTER + index: (padded[index * 2] << 8)
+            | padded[index * 2 + 1]
+            for index in range(16)
+        }
+    )
+
+    # The swap is seen without probing, so the only probe here is the reload's.
+    assert await _tick_attachment_check(hass, freezer) == 1
+
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{SERIAL_NUMBER}_meter_{METER_SERIAL_NUMBER}"),
+            mock_config_entry.entry_id,
+        )
+        is None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{SERIAL_NUMBER}_meter_{replacement}"),
+            mock_config_entry.entry_id,
+        )
+        is not None
+    )
+
+
 async def test_silent_attachment_does_not_trigger_a_reload(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -713,7 +775,7 @@ async def test_silent_attachment_does_not_trigger_a_reload(
     meter = (DOMAIN, f"{SERIAL_NUMBER}_meter_{METER_SERIAL_NUMBER}")
     mock_modbus_unit.fail_read(METER_MODEL_REGISTER, ModbusTimeoutError("timed out"))
 
-    await _tick_attachment_check(hass, freezer)
+    assert await _tick_attachment_check(hass, freezer) == 1
 
     assert (
         device_registry.async_get_device_by_identifier(
@@ -733,7 +795,7 @@ async def test_unchanged_attachments_leave_the_entry_alone(
 
     coordinator = mock_config_entry.runtime_data.readings
 
-    await _tick_attachment_check(hass, freezer)
+    assert await _tick_attachment_check(hass, freezer) == 1
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     # A reload would have built new coordinators.
@@ -756,7 +818,7 @@ async def test_a_dead_probe_leaves_the_entry_where_it_is(
     coordinator = mock_config_entry.runtime_data.readings
     mock_modbus_unit.fail_requests(ModbusTimeoutError("link died"))
 
-    await _tick_attachment_check(hass, freezer)
+    assert await _tick_attachment_check(hass, freezer) == 1
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_config_entry.runtime_data.readings is coordinator

--- a/tests/components/solaredge_modbus/test_init.py
+++ b/tests/components/solaredge_modbus/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.solaredge_modbus.const import (
+    ATTACHMENT_SCAN_INTERVAL,
     DOMAIN,
     SCAN_INTERVAL,
     SETTINGS_SCAN_INTERVAL,
@@ -618,6 +619,147 @@ async def test_concurrent_control_writes_keep_both_changes(
     state = hass.states.get(EXTERNAL_PRODUCTION_ENTITY)
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def _tick_attachment_check(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Let the check for changed hardware run, and any reload it starts."""
+    freezer.tick(ATTACHMENT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_meter_added_later_is_picked_up(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """A meter wired to a running installation appears without being asked.
+
+    What is attached is read while the entry is set up, so the entry loads
+    again once a probe finds something that was not there before.
+    """
+    mock_modbus_unit.fail_read(METER_MODEL_REGISTER, IllegalDataAddressError())
+    await _setup(hass, mock_config_entry)
+
+    meter = (DOMAIN, f"{SERIAL_NUMBER}_meter_{METER_SERIAL_NUMBER}")
+    assert (
+        device_registry.async_get_device_by_identifier(
+            meter, mock_config_entry.entry_id
+        )
+        is None
+    )
+
+    # The meter is wired in and answers from now on.
+    mock_modbus_unit.fail_read(METER_MODEL_REGISTER, None)
+
+    await _tick_attachment_check(hass, freezer)
+
+    assert (
+        device_registry.async_get_device_by_identifier(
+            meter, mock_config_entry.entry_id
+        )
+        is not None
+    )
+
+
+async def test_battery_removed_later_is_dropped(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """A battery taken out of a running installation stops being a device."""
+    await _setup(hass, mock_config_entry)
+
+    battery = (DOMAIN, f"{SERIAL_NUMBER}_battery_{BATTERY_SERIAL_NUMBERS[0]}")
+    assert (
+        device_registry.async_get_device_by_identifier(
+            battery, mock_config_entry.entry_id
+        )
+        is not None
+    )
+
+    mock_modbus_unit.fail_read(BATTERY_RATED_ENERGY, IllegalDataAddressError())
+
+    await _tick_attachment_check(hass, freezer)
+
+    assert (
+        device_registry.async_get_device_by_identifier(
+            battery, mock_config_entry.entry_id
+        )
+        is None
+    )
+
+
+async def test_silent_attachment_does_not_trigger_a_reload(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """A meter that did not answer the probe is not a meter that was removed.
+
+    Silence is taken for absence while probing, so reloading on it would drop a
+    device, and its history, over a single timeout.
+    """
+    await _setup(hass, mock_config_entry)
+
+    meter = (DOMAIN, f"{SERIAL_NUMBER}_meter_{METER_SERIAL_NUMBER}")
+    mock_modbus_unit.fail_read(METER_MODEL_REGISTER, ModbusTimeoutError("timed out"))
+
+    await _tick_attachment_check(hass, freezer)
+
+    assert (
+        device_registry.async_get_device_by_identifier(
+            meter, mock_config_entry.entry_id
+        )
+        is not None
+    )
+
+
+async def test_unchanged_attachments_leave_the_entry_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Nothing changed means nothing happens, however often it is checked."""
+    await _setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.readings
+
+    await _tick_attachment_check(hass, freezer)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    # A reload would have built new coordinators.
+    assert mock_config_entry.runtime_data.readings is coordinator
+
+
+async def test_a_dead_probe_leaves_the_entry_where_it_is(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_modbus_unit: MockModbusUnit,
+) -> None:
+    """An inverter that stops answering says nothing about what is wired to it.
+
+    The coordinators already report an inverter gone quiet; reloading on top of
+    that would only take the entry down with it.
+    """
+    await _setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.readings
+    mock_modbus_unit.fail_requests(ModbusTimeoutError("link died"))
+
+    await _tick_attachment_check(hass, freezer)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.runtime_data.readings is coordinator
 
 
 async def test_setup_retry_when_device_unresponsive(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

What is wired to a SolarEdge inverter is read while the entry is set up, since counting meters and batteries is part of probing the device. So a meter added to a running installation stayed invisible, and one taken out kept its device, until someone reloaded the entry by hand. That is what `dynamic-devices` and `stale-devices` were marked `todo` for; this closes both.

The inverter is probed again every quarter of an hour, and a count that moved reloads the entry.

Reloading is the honest answer rather than a shortcut. The entry is built around what the probe found: which sub-systems are polled, which devices exist, which entities each platform creates. Rebuilding that piecemeal while it runs would be a second, weaker copy of what setting up already does. And this is hardware that changes with a screwdriver, usually with the power off, so looking now and then and starting over costs nothing anyone will notice.

Two things it deliberately does not do:

- **Silence is not proof.** The library takes a block that does not answer for absent, which is what keeps the rest of a device usable. Reloading on that would drop a meter, and its history, over a single timeout, so only the inverter refusing a block counts as gone.
- **A failed probe changes nothing.** An inverter that stopped answering is already reported by the coordinators; a reload on top would only take the entry down with it.

Documentation: home-assistant/home-assistant.io#47679 already tells people a reload is needed for this, and I will send a follow-up that says it now happens by itself.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
