### PR TITLE
Use JSON fixture helpers in tests

### DIFF
--- a/tests/components/dexcom/__init__.py
+++ b/tests/components/dexcom/__init__.py
@@ -1,6 +1,5 @@
 """Tests for the Dexcom integration."""
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -10,7 +9,7 @@ from homeassistant.components.dexcom.const import CONF_SERVER, DOMAIN, SERVER_US
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 CONFIG = {
     CONF_USERNAME: "test_username",
@@ -18,7 +17,7 @@ CONFIG = {
     CONF_SERVER: SERVER_US,
 }
 
-GLUCOSE_READING = GlucoseReading(json.loads(load_fixture("data.json", "dexcom")))
+GLUCOSE_READING = GlucoseReading(load_json_object_fixture("data.json", "dexcom"))
 TEST_ACCOUNT_ID = "99999999-9999-9999-9999-999999999999"
 TEST_SESSION_ID = "55555555-5555-5555-5555-555555555555"
 

--- a/tests/components/monarch_money/conftest.py
+++ b/tests/components/monarch_money/conftest.py
@@ -1,7 +1,6 @@
 """Common fixtures for the Monarch Money tests."""
 
 from collections.abc import Generator
-import json
 from typing import Any
 from unittest.mock import AsyncMock, PropertyMock, patch
 
@@ -15,7 +14,7 @@ from typedmonarchmoney.models import (
 from homeassistant.components.monarch_money.const import DOMAIN
 from homeassistant.const import CONF_TOKEN
 
-from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -48,12 +47,12 @@ def mock_config_api() -> Generator[AsyncMock]:
         acc["id"]: MonarchAccount(acc) for acc in account_json["accounts"]
     }
 
-    cashflow_json: dict[str, Any] = json.loads(
-        load_fixture("get_cashflow_summary.json", DOMAIN)
+    cashflow_json: dict[str, Any] = load_json_object_fixture(
+        "get_cashflow_summary.json", DOMAIN
     )
     cashflow_summary = MonarchCashflowSummary(cashflow_json)
     subscription_details = MonarchSubscription(
-        json.loads(load_fixture("get_subscription_details.json", DOMAIN))
+        load_json_object_fixture("get_subscription_details.json", DOMAIN)
     )
 
     with (

--- a/tests/components/tplink/test_diagnostics.py
+++ b/tests/components/tplink/test_diagnostics.py
@@ -1,7 +1,5 @@
 """Tests for the diagnostics data provided by the TP-Link integration."""
 
-import json
-
 from kasa import Device
 import pytest
 
@@ -10,7 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from . import _mocked_device, initialize_config_entry_for_device
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -41,7 +39,7 @@ async def test_diagnostics(
     expected_oui: str | None,
 ) -> None:
     """Test diagnostics for config entry."""
-    diagnostics_data = json.loads(await async_load_fixture(hass, fixture_file, DOMAIN))
+    diagnostics_data = await async_load_json_object_fixture(hass, fixture_file, DOMAIN)
 
     mocked_dev.internal_state = diagnostics_data["device_last_response"]
 

--- a/tests/components/yandex_transport/test_sensor.py
+++ b/tests/components/yandex_transport/test_sensor.py
@@ -1,6 +1,5 @@
 """Tests for the yandex transport platform."""
 
-import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -12,11 +11,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import assert_setup_component, load_fixture
+from tests.common import assert_setup_component, load_json_object_fixture
 
-BUS_REPLY = json.loads(load_fixture("bus_reply.json", "yandex_transport"))
-SUBURBAN_TRAIN_REPLY = json.loads(
-    load_fixture("suburban_reply.json", "yandex_transport")
+BUS_REPLY = load_json_object_fixture("bus_reply.json", "yandex_transport")
+SUBURBAN_TRAIN_REPLY = load_json_object_fixture(
+    "suburban_reply.json", "yandex_transport"
 )
 
 


### PR DESCRIPTION
## Breaking change

## Proposed change

Part 1 of 6 splitting up the cleanup of the new `home-assistant-json-fixture`
pylint check (see #180829).

This batch converts 4 test file(s) to use the dedicated JSON fixture
helpers (`load_json_object_fixture` / `load_json_array_fixture` /
`load_json_value_fixture` and their `async_` variants) instead of manually
wrapping a loaded fixture in `json.loads(...)`. Unused `json` / `load_fixture`
imports are removed as a result.

Integrations touched in this batch: dexcom, monarch_money, tplink, yandex_transport.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
