### PR TITLE
Use JSON fixture helpers in tests (2/6)

### DIFF
--- a/tests/components/abode/test_lock.py
+++ b/tests/components/abode/test_lock.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_array_fixture
 
 DEVICE_ID = "lock.test_lock"
 
@@ -75,7 +75,7 @@ async def test_retrofit_lock_discovered(
     hass: HomeAssistant, requests_mock: Mocker
 ) -> None:
     """Test retrofit locks are discovered as lock entities."""
-    devices = json.loads(await async_load_fixture(hass, "devices.json", "abode"))
+    devices = await async_load_json_array_fixture(hass, "devices.json", "abode")
     for device in devices:
         if device["type_tag"] == "device_type.door_lock":
             device["type_tag"] = "device_type.retrofit_lock"

--- a/tests/components/actron_air/conftest.py
+++ b/tests/components/actron_air/conftest.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from actron_neo_api.models.auth import ActronAirDeviceCode, ActronAirUserInfo
@@ -17,7 +16,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -105,7 +104,7 @@ def mock_actron_api(mock_actron_api_class: MagicMock) -> Generator[AsyncMock]:
 
         # Build status from fixture JSON
         status = ActronAirStatus.model_validate(
-            json.loads(load_fixture("status.json", DOMAIN))
+            load_json_object_fixture("status.json", DOMAIN)
         )
         status.set_api(api)
 

--- a/tests/components/altruist/conftest.py
+++ b/tests/components/altruist/conftest.py
@@ -1,7 +1,6 @@
 """Altruist tests configuration."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, Mock, patch
 
 from altruistclient import AltruistDeviceModel, AltruistError
@@ -10,7 +9,7 @@ import pytest
 from homeassistant.components.altruist.const import DOMAIN
 from homeassistant.const import CONF_HOST
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_array_fixture
 
 
 @pytest.fixture
@@ -61,11 +60,11 @@ def mock_altruist_client(mock_altruist_device: Mock) -> Generator[AsyncMock]:
         mock_instance = AsyncMock()
         mock_instance.device = mock_altruist_device
         mock_instance.device_id = mock_altruist_device.id
-        mock_instance.sensor_names = json.loads(
-            load_fixture("sensor_names.json", DOMAIN)
+        mock_instance.sensor_names = load_json_array_fixture(
+            "sensor_names.json", DOMAIN
         )
-        mock_instance.fetch_data.return_value = json.loads(
-            load_fixture("real_data.json", DOMAIN)
+        mock_instance.fetch_data.return_value = load_json_array_fixture(
+            "real_data.json", DOMAIN
         )
 
         mock_client_class.from_ip_address = AsyncMock(return_value=mock_instance)

--- a/tests/components/awair/conftest.py
+++ b/tests/components/awair/conftest.py
@@ -1,73 +1,71 @@
 """Fixtures for testing Awair integration."""
 
-import json
-
 import pytest
 
-from tests.common import load_fixture
+from tests.common import load_json_object_fixture
 
 
 @pytest.fixture(name="cloud_devices", scope="package")
 def cloud_devices_fixture():
     """Fixture representing devices returned by Awair Cloud API."""
-    return json.loads(load_fixture("awair/cloud_devices.json"))
+    return load_json_object_fixture("awair/cloud_devices.json")
 
 
 @pytest.fixture(name="local_devices", scope="package")
 def local_devices_fixture():
     """Fixture representing devices returned by Awair local API."""
-    return json.loads(load_fixture("awair/local_devices.json"))
+    return load_json_object_fixture("awair/local_devices.json")
 
 
 @pytest.fixture(name="gen1_data", scope="package")
 def gen1_data_fixture():
     """Fixture representing data returned from Gen1 Awair device."""
-    return json.loads(load_fixture("awair/awair.json"))
+    return load_json_object_fixture("awair/awair.json")
 
 
 @pytest.fixture(name="gen2_data", scope="package")
 def gen2_data_fixture():
     """Fixture representing data returned from Gen2 Awair device."""
-    return json.loads(load_fixture("awair/awair-r2.json"))
+    return load_json_object_fixture("awair/awair-r2.json")
 
 
 @pytest.fixture(name="glow_data", scope="package")
 def glow_data_fixture():
     """Fixture representing data returned from Awair glow device."""
-    return json.loads(load_fixture("awair/glow.json"))
+    return load_json_object_fixture("awair/glow.json")
 
 
 @pytest.fixture(name="mint_data", scope="package")
 def mint_data_fixture():
     """Fixture representing data returned from Awair mint device."""
-    return json.loads(load_fixture("awair/mint.json"))
+    return load_json_object_fixture("awair/mint.json")
 
 
 @pytest.fixture(name="no_devices", scope="package")
 def no_devicess_fixture():
     """Fixture representing when no devices are found in Awair's cloud API."""
-    return json.loads(load_fixture("awair/no_devices.json"))
+    return load_json_object_fixture("awair/no_devices.json")
 
 
 @pytest.fixture(name="awair_offline", scope="package")
 def awair_offline_fixture():
     """Fixture representing when Awair devices are offline."""
-    return json.loads(load_fixture("awair/awair-offline.json"))
+    return load_json_object_fixture("awair/awair-offline.json")
 
 
 @pytest.fixture(name="omni_data", scope="package")
 def omni_data_fixture():
     """Fixture representing data returned from Awair omni device."""
-    return json.loads(load_fixture("awair/omni.json"))
+    return load_json_object_fixture("awair/omni.json")
 
 
 @pytest.fixture(name="user", scope="package")
 def user_fixture():
     """Fixture representing the User object returned from Awair's Cloud API."""
-    return json.loads(load_fixture("awair/user.json"))
+    return load_json_object_fixture("awair/user.json")
 
 
 @pytest.fixture(name="local_data", scope="package")
 def local_data_fixture():
     """Fixture representing data returned from Awair local device."""
-    return json.loads(load_fixture("awair/awair-local.json"))
+    return load_json_object_fixture("awair/awair-local.json")

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -28,7 +28,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
-from homeassistant.util.json import json_loads
 
 from . import (
     FakeRemoteScanner as FakeScanner,
@@ -39,7 +38,11 @@ from . import (
     patch_bluetooth_time,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_json_object_fixture,
+)
 
 
 @pytest.mark.parametrize("name_2", [None, "w"])
@@ -304,8 +307,10 @@ async def test_restore_history_remote_adapter(
 ) -> None:
     """Test we can restore history for a remote adapter."""
 
-    data = hass_storage[storage.REMOTE_SCANNER_STORAGE_KEY] = json_loads(
-        await async_load_fixture(hass, "bluetooth.remote_scanners", bluetooth.DOMAIN)
+    data = hass_storage[
+        storage.REMOTE_SCANNER_STORAGE_KEY
+    ] = await async_load_json_object_fixture(
+        hass, "bluetooth.remote_scanners", bluetooth.DOMAIN
     )
     now = time.time()
     timestamps = data["data"]["atom-bluetooth-proxy-ceaac4"][

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -44,7 +44,6 @@ from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utcnow
-from homeassistant.util.json import json_loads
 
 from . import (
     HCI0_SOURCE_ADDRESS,
@@ -66,7 +65,7 @@ from tests.common import (
     MockModule,
     async_call_logger_set_level,
     async_fire_time_changed,
-    async_load_fixture,
+    async_load_json_object_fixture,
     mock_integration,
 )
 
@@ -466,8 +465,10 @@ async def test_restore_history_from_dbus_and_remote_adapters(
     """Test we can restore history from dbus along with remote adapters."""
     address = "AA:BB:CC:CC:CC:FF"
 
-    data = hass_storage[storage.REMOTE_SCANNER_STORAGE_KEY] = json_loads(
-        await async_load_fixture(hass, "bluetooth.remote_scanners", bluetooth.DOMAIN)
+    data = hass_storage[
+        storage.REMOTE_SCANNER_STORAGE_KEY
+    ] = await async_load_json_object_fixture(
+        hass, "bluetooth.remote_scanners", bluetooth.DOMAIN
     )
     now = time.time()
     timestamps = data["data"]["atom-bluetooth-proxy-ceaac4"][
@@ -508,10 +509,10 @@ async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
     """Test history restore when remote adapters data is corrupted."""
     address = "AA:BB:CC:CC:CC:FF"
 
-    data = hass_storage[storage.REMOTE_SCANNER_STORAGE_KEY] = json_loads(
-        await async_load_fixture(
-            hass, "bluetooth.remote_scanners.corrupt", bluetooth.DOMAIN
-        )
+    data = hass_storage[
+        storage.REMOTE_SCANNER_STORAGE_KEY
+    ] = await async_load_json_object_fixture(
+        hass, "bluetooth.remote_scanners.corrupt", bluetooth.DOMAIN
     )
     now = time.time()
     timestamps = data["data"]["atom-bluetooth-proxy-ceaac4"][

--- a/tests/components/control4/conftest.py
+++ b/tests/components/control4/conftest.py
@@ -1,7 +1,6 @@
 """Common fixtures for the Control4 tests."""
 
 from collections.abc import AsyncGenerator, Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,7 +8,11 @@ import pytest
 from homeassistant.components.control4.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import (
+    MockConfigEntry,
+    load_json_array_fixture,
+    load_json_object_fixture,
+)
 
 MOCK_HOST = "192.168.1.100"
 MOCK_USERNAME = "test-username"
@@ -83,10 +86,10 @@ def mock_c4_director() -> Generator[MagicMock]:
         ),
     ):
         mock_director = mock_director_class.return_value
-        all_items = json.loads(load_fixture("director_all_items.json", DOMAIN))
+        all_items = load_json_array_fixture("director_all_items.json", DOMAIN)
         mock_director.get_all_item_info = AsyncMock(return_value=all_items)
         mock_director.get_ui_configuration = AsyncMock(
-            return_value=json.loads(load_fixture("ui_configuration.json", DOMAIN))
+            return_value=load_json_object_fixture("ui_configuration.json", DOMAIN)
         )
         mock_director.get_item_variables = AsyncMock(return_value=[])
         yield mock_director

--- a/tests/components/devialet/test_diagnostics.py
+++ b/tests/components/devialet/test_diagnostics.py
@@ -1,13 +1,11 @@
 """Test the Devialet diagnostics."""
 
-import json
-
 from homeassistant.components.devialet.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
@@ -23,19 +21,19 @@ async def test_diagnostics(
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == {
         "is_available": True,
-        "general_info": json.loads(
-            await async_load_fixture(hass, "general_info.json", DOMAIN)
+        "general_info": await async_load_json_object_fixture(
+            hass, "general_info.json", DOMAIN
         ),
-        "sources": json.loads(await async_load_fixture(hass, "sources.json", DOMAIN)),
-        "source_state": json.loads(
-            await async_load_fixture(hass, "source_state.json", DOMAIN)
+        "sources": await async_load_json_object_fixture(hass, "sources.json", DOMAIN),
+        "source_state": await async_load_json_object_fixture(
+            hass, "source_state.json", DOMAIN
         ),
-        "volume": json.loads(await async_load_fixture(hass, "volume.json", DOMAIN)),
-        "night_mode": json.loads(
-            await async_load_fixture(hass, "night_mode.json", DOMAIN)
+        "volume": await async_load_json_object_fixture(hass, "volume.json", DOMAIN),
+        "night_mode": await async_load_json_object_fixture(
+            hass, "night_mode.json", DOMAIN
         ),
-        "equalizer": json.loads(
-            await async_load_fixture(hass, "equalizer.json", DOMAIN)
+        "equalizer": await async_load_json_object_fixture(
+            hass, "equalizer.json", DOMAIN
         ),
         "source_list": [
             "Airplay",

--- a/tests/components/elmax/conftest.py
+++ b/tests/components/elmax/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator
 from datetime import timedelta
-import json
 from unittest.mock import AsyncMock, patch
 
 from elmax_api.constants import (
@@ -27,7 +26,7 @@ from . import (
     MOCK_PANEL_PIN,
 )
 
-from tests.common import load_fixture
+from tests.common import load_fixture, load_json_array_fixture, load_json_object_fixture
 
 TOKEN_SIGNING_KEY = "elmax-test-token-signing-key-0123"
 
@@ -44,13 +43,13 @@ def httpx_mock_cloud_fixture() -> Generator[respx.MockRouter]:
         # Mock Login POST.
         login_route = respx_mock.post(f"/{ENDPOINT_LOGIN}", name="login")
         login_route.return_value = Response(
-            200, json=json.loads(load_fixture("cloud/login.json", "elmax"))
+            200, json=load_json_object_fixture("cloud/login.json", "elmax")
         )
 
         # Mock Device list GET.
         list_devices_route = respx_mock.get(f"/{ENDPOINT_DEVICES}", name="list_devices")
         list_devices_route.return_value = Response(
-            200, json=json.loads(load_fixture("cloud/list_devices.json", "elmax"))
+            200, json=load_json_array_fixture("cloud/list_devices.json", "elmax")
         )
 
         # Mock Panel GET.
@@ -58,7 +57,7 @@ def httpx_mock_cloud_fixture() -> Generator[respx.MockRouter]:
             f"/{ENDPOINT_DISCOVERY}/{MOCK_PANEL_ID}/{MOCK_PANEL_PIN}", name="get_panel"
         )
         get_panel_route.return_value = Response(
-            200, json=json.loads(load_fixture("cloud/get_panel.json", "elmax"))
+            200, json=load_json_object_fixture("cloud/get_panel.json", "elmax")
         )
 
         yield respx_mock
@@ -77,7 +76,7 @@ def httpx_mock_direct_fixture(base_uri: str) -> Generator[respx.MockRouter]:
         # Mock Login POST.
         login_route = respx_mock.post(f"/api/v2/{ENDPOINT_LOGIN}", name="login")
 
-        login_json = json.loads(load_fixture("direct/login.json", "elmax"))
+        login_json = load_json_object_fixture("direct/login.json", "elmax")
         decoded_jwt = jwt.decode_complete(
             login_json["token"].split(" ")[1],
             algorithms="HS256",
@@ -96,7 +95,8 @@ def httpx_mock_direct_fixture(base_uri: str) -> Generator[respx.MockRouter]:
             f"/api/v2/{ENDPOINT_DISCOVERY}", name="discovery_panel"
         )
         list_devices_route.return_value = Response(
-            200, json=json.loads(load_fixture("direct/discovery_panel.json", "elmax"))
+            200,
+            json=load_json_object_fixture("direct/discovery_panel.json", "elmax"),
         )
 
         yield respx_mock

--- a/tests/components/environment_canada/conftest.py
+++ b/tests/components/environment_canada/conftest.py
@@ -41,7 +41,5 @@ def ec_data():
             weather["metadata"] = MetaData(**t)
         return weather
 
-    return json.loads(
-        load_fixture("environment_canada/current_conditions_data.json"),
-        object_hook=data_hook,
-    )
+    fixture = load_fixture("environment_canada/current_conditions_data.json")
+    return json.loads(fixture, object_hook=data_hook)

--- a/tests/components/fully_kiosk/conftest.py
+++ b/tests/components/fully_kiosk/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for the Fully Kiosk Browser integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,7 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -69,11 +68,11 @@ def mock_fully_kiosk() -> Generator[MagicMock]:
         autospec=True,
     ) as client_mock:
         client = client_mock.return_value
-        client.getDeviceInfo.return_value = json.loads(
-            load_fixture("deviceinfo.json", DOMAIN)
+        client.getDeviceInfo.return_value = load_json_object_fixture(
+            "deviceinfo.json", DOMAIN
         )
-        client.getSettings.return_value = json.loads(
-            load_fixture("listsettings.json", DOMAIN)
+        client.getSettings.return_value = load_json_object_fixture(
+            "listsettings.json", DOMAIN
         )
         yield client
 

--- a/tests/components/fully_kiosk/test_init.py
+++ b/tests/components/fully_kiosk/test_init.py
@@ -1,6 +1,5 @@
 """Tests for the Fully Kiosk Browser integration."""
 
-import json
 from unittest.mock import MagicMock, patch
 
 from fullykiosk import FullyKioskError
@@ -19,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_load_unload_config_entry(
@@ -73,11 +72,11 @@ async def _load_config(
         autospec=True,
     ) as client_mock:
         client = client_mock.return_value
-        client.getDeviceInfo.return_value = json.loads(
-            await async_load_fixture(hass, device_info_fixture, DOMAIN)
+        client.getDeviceInfo.return_value = await async_load_json_object_fixture(
+            hass, device_info_fixture, DOMAIN
         )
-        client.getSettings.return_value = json.loads(
-            await async_load_fixture(hass, "listsettings.json", DOMAIN)
+        client.getSettings.return_value = await async_load_json_object_fixture(
+            hass, "listsettings.json", DOMAIN
         )
 
         config_entry.add_to_hass(hass)

--- a/tests/components/google_air_quality/test_services.py
+++ b/tests/components/google_air_quality/test_services.py
@@ -1,7 +1,6 @@
 """Test services for Google Air Quality."""
 
 from datetime import timedelta
-import json
 from unittest.mock import AsyncMock
 
 from google_air_quality_api.model import AirQualityForecastData
@@ -18,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -36,7 +35,7 @@ async def test_get_forecast_service(
     assert device is not None
 
     forecast = AirQualityForecastData.from_dict(
-        json.loads(await async_load_fixture(hass, "air_quality_forecast.json", DOMAIN))
+        await async_load_json_object_fixture(hass, "air_quality_forecast.json", DOMAIN)
     )
     mock_api.async_get_forecast.return_value = forecast
 

--- a/tests/components/google_assistant/test_data_redaction.py
+++ b/tests/components/google_assistant/test_data_redaction.py
@@ -1,15 +1,13 @@
 """Test data redaction helpers."""
 
-import json
-
 from homeassistant.components.google_assistant.data_redaction import async_redact_msg
 
-from tests.common import load_fixture
+from tests.common import load_json_array_fixture
 
 
 def test_redact_msg() -> None:
     """Test async_redact_msg."""
-    messages = json.loads(load_fixture("data_redaction.json", "google_assistant"))
+    messages = load_json_array_fixture("data_redaction.json", "google_assistant")
     agent_user_id = "333dee20-1234-1234-1234-2225a0d70d4c"
     for item in messages:
         assert async_redact_msg(item["raw"], agent_user_id) == item["redacted"]


### PR DESCRIPTION
## Breaking change

## Proposed change

Part 2 of 6 splitting up the cleanup of the new `home-assistant-json-fixture`
pylint check (see #180829).

This batch converts 14 test file(s) to use the dedicated JSON fixture
helpers (`load_json_object_fixture` / `load_json_array_fixture` /
`load_json_value_fixture` and their `async_` variants) instead of manually
wrapping a loaded fixture in `json.loads(...)`. Unused `json` / `load_fixture`
imports are removed as a result.

Integrations touched in this batch: abode, actron_air, altruist, awair, bluetooth, control4, devialet, elmax, environment_canada, fully_kiosk, google_air_quality, google_assistant.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
