### PR TITLE
Bump lyngdorf to 2.1.0

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.11.0"],
+  "requirements": ["lyngdorf==2.1.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1562,7 +1562,7 @@ lw12==0.9.2
 lxml==6.1.2
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.11.0
+lyngdorf==2.1.0
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0


### PR DESCRIPTION
## Proposed change

Bump lyngdorf from 1.11.0 to 2.1.0.

2.1.0 removes the 1.x compatibility layer, which the integration no longer uses,
and replaces the last blocking socket call with an asyncio datagram endpoint, so
the library now has no executor use at all.

No code changes: the platform migrations landed separately and the integration
already runs entirely on the 2.0 API.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Release notes: https://github.com/fishloa/lyngdorf/releases/tag/v2.1.0
Diff: https://github.com/fishloa/lyngdorf/compare/v1.11.0...v2.1.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
