### PR TITLE
Use JSON fixture helpers in tests (3/6)

### DIFF
--- a/tests/components/here_travel_time/conftest.py
+++ b/tests/components/here_travel_time/conftest.py
@@ -1,20 +1,19 @@
 """Fixtures for HERE Travel Time tests."""
 
-import json
 from unittest.mock import patch
 
 import pytest
 
-from tests.common import load_fixture
+from tests.common import load_json_object_fixture
 
-RESPONSE = json.loads(load_fixture("here_travel_time/car_response.json"))
-TRANSIT_RESPONSE = json.loads(
-    load_fixture("here_travel_time/transit_route_response.json")
+RESPONSE = load_json_object_fixture("here_travel_time/car_response.json")
+TRANSIT_RESPONSE = load_json_object_fixture(
+    "here_travel_time/transit_route_response.json"
 )
-NO_ATTRIBUTION_TRANSIT_RESPONSE = json.loads(
-    load_fixture("here_travel_time/no_attribution_transit_route_response.json")
+NO_ATTRIBUTION_TRANSIT_RESPONSE = load_json_object_fixture(
+    "here_travel_time/no_attribution_transit_route_response.json"
 )
-BIKE_RESPONSE = json.loads(load_fixture("here_travel_time/bike_response.json"))
+BIKE_RESPONSE = load_json_object_fixture("here_travel_time/bike_response.json")
 
 
 @pytest.fixture(name="valid_response")

--- a/tests/components/hko/conftest.py
+++ b/tests/components/hko/conftest.py
@@ -1,11 +1,10 @@
 """Configure py.test."""
 
-import json
 from unittest.mock import patch
 
 import pytest
 
-from tests.common import load_fixture
+from tests.common import load_json_object_fixture
 
 
 @pytest.fixture(name="hko_config_flow_connect", autouse=True)
@@ -13,6 +12,6 @@ def hko_config_flow_connect():
     """Mock valid config flow setup."""
     with patch(
         "homeassistant.components.hko.config_flow.HKO.weather",
-        return_value=json.loads(load_fixture("hko/rhrread.json")),
+        return_value=load_json_object_fixture("hko/rhrread.json"),
     ):
         yield

--- a/tests/components/homekit/test_iidmanager.py
+++ b/tests/components/homekit/test_iidmanager.py
@@ -9,10 +9,9 @@ from homeassistant.components.homekit.iidmanager import (
     get_iid_storage_filename_for_entry_id,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util.json import json_loads
 from homeassistant.util.uuid import random_uuid_hex
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_iid_generation_and_restore(
@@ -108,8 +107,8 @@ async def test_iid_migration_to_v2(
     hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test iid storage migration."""
-    v1_iids = json_loads(await async_load_fixture(hass, "iids_v1", DOMAIN))
-    v2_iids = json_loads(await async_load_fixture(hass, "iids_v2", DOMAIN))
+    v1_iids = await async_load_json_object_fixture(hass, "iids_v1", DOMAIN)
+    v2_iids = await async_load_json_object_fixture(hass, "iids_v2", DOMAIN)
     hass_storage["homekit.v1.iids"] = v1_iids
     hass_storage["homekit.v2.iids"] = v2_iids
 
@@ -132,11 +131,11 @@ async def test_iid_migration_to_v2_with_underscore(
     hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test iid storage migration with underscore."""
-    v1_iids = json_loads(
-        await async_load_fixture(hass, "iids_v1_with_underscore", DOMAIN)
+    v1_iids = await async_load_json_object_fixture(
+        hass, "iids_v1_with_underscore", DOMAIN
     )
-    v2_iids = json_loads(
-        await async_load_fixture(hass, "iids_v2_with_underscore", DOMAIN)
+    v2_iids = await async_load_json_object_fixture(
+        hass, "iids_v2_with_underscore", DOMAIN
     )
     hass_storage["homekit.v1_with_underscore.iids"] = v1_iids
     hass_storage["homekit.v2_with_underscore.iids"] = v2_iids

--- a/tests/components/homevolt/conftest.py
+++ b/tests/components/homevolt/conftest.py
@@ -1,7 +1,6 @@
 """Common fixtures for the Homevolt tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homevolt import DeviceMetadata, Sensor
@@ -11,7 +10,7 @@ from homeassistant.components.homevolt.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 DEVICE_IDENTIFIER = "ems_40580137858664"
 
@@ -60,7 +59,7 @@ def mock_homevolt_client() -> Generator[MagicMock]:
         client.unique_id = "40580137858664"
 
         # Load sensor data from fixture and convert to Sensor objects
-        sensors_data = json.loads(load_fixture("sensors.json", DOMAIN))
+        sensors_data = load_json_object_fixture("sensors.json", DOMAIN)
         client.sensors = {
             key: Sensor(
                 value=value,
@@ -71,7 +70,7 @@ def mock_homevolt_client() -> Generator[MagicMock]:
         }
 
         # Load device metadata from fixture and convert to DeviceMetadata objects
-        metadata_data = json.loads(load_fixture("device_metadata.json", DOMAIN))
+        metadata_data = load_json_object_fixture("device_metadata.json", DOMAIN)
         client.device_metadata = {
             key: DeviceMetadata(
                 name=metadata["name"],
@@ -81,7 +80,7 @@ def mock_homevolt_client() -> Generator[MagicMock]:
         }
 
         # Load schedule data from fixture
-        client.current_schedule = json.loads(load_fixture("schedule.json", DOMAIN))
+        client.current_schedule = load_json_object_fixture("schedule.json", DOMAIN)
 
         # Switch (local mode) support
         client.local_mode_enabled = False

--- a/tests/components/hortimax/conftest.py
+++ b/tests/components/hortimax/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
-import json
 from unittest.mock import AsyncMock, patch
 
 from aiohortos import Device, Organisation, Readout, TokenPair
@@ -11,7 +10,7 @@ import pytest
 from homeassistant.components.hortimax.const import DOMAIN
 from homeassistant.const import CONF_API_KEY
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_array_fixture
 
 API_KEY = "test-api-key"
 DEVICE = "HOR00000000.000"
@@ -23,7 +22,7 @@ def load_readouts() -> list[Readout]:
     """Return the fixture readouts, parsed the way the library parses them."""
     return [
         readout
-        for raw in json.loads(load_fixture("readouts.json", DOMAIN))
+        for raw in load_json_array_fixture("readouts.json", DOMAIN)
         if (readout := Readout.from_api(raw)) is not None
     ]
 

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the HVV Departures config flow."""
 
-import json
 from unittest.mock import MagicMock, patch
 
 from aiohttp import ClientConnectorError
@@ -18,16 +17,16 @@ from homeassistant.const import CONF_HOST, CONF_OFFSET, CONF_PASSWORD, CONF_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
-FIXTURE_INIT = json.loads(load_fixture("hvv_departures/init.json"))
-FIXTURE_CHECK_NAME = json.loads(load_fixture("hvv_departures/check_name.json"))
-FIXTURE_STATION_INFORMATION = json.loads(
-    load_fixture("hvv_departures/station_information.json")
+FIXTURE_INIT = load_json_object_fixture("hvv_departures/init.json")
+FIXTURE_CHECK_NAME = load_json_object_fixture("hvv_departures/check_name.json")
+FIXTURE_STATION_INFORMATION = load_json_object_fixture(
+    "hvv_departures/station_information.json"
 )
-FIXTURE_CONFIG_ENTRY = json.loads(load_fixture("hvv_departures/config_entry.json"))
-FIXTURE_OPTIONS = json.loads(load_fixture("hvv_departures/options.json"))
-FIXTURE_DEPARTURE_LIST = json.loads(load_fixture("hvv_departures/departure_list.json"))
+FIXTURE_CONFIG_ENTRY = load_json_object_fixture("hvv_departures/config_entry.json")
+FIXTURE_OPTIONS = load_json_object_fixture("hvv_departures/options.json")
+FIXTURE_DEPARTURE_LIST = load_json_object_fixture("hvv_departures/departure_list.json")
 
 
 async def test_user_flow(hass: HomeAssistant) -> None:

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -1,7 +1,6 @@
 """Test the Insteon All-Link Database APIs."""
 
 import asyncio
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -26,14 +25,14 @@ from homeassistant.core import HomeAssistant
 from .const import MOCK_USER_INPUT_PLM
 from .mock_devices import MockDevices
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
 @pytest.fixture(name="aldb_data", scope="module")
 def aldb_data_fixture():
     """Load the controller state fixture data."""
-    return json.loads(load_fixture("insteon/aldb_data.json"))
+    return load_json_object_fixture("insteon/aldb_data.json")
 
 
 async def _setup(

--- a/tests/components/insteon/test_api_config.py
+++ b/tests/components/insteon/test_api_config.py
@@ -1,7 +1,6 @@
 """Test the Insteon APIs for configuring the integration."""
 
 import asyncio
-import json
 from unittest.mock import patch
 
 from homeassistant.components import insteon
@@ -25,7 +24,7 @@ from .mock_connection import mock_failed_connection, mock_successful_connection
 from .mock_devices import MockDevices
 from .mock_setup import async_mock_setup
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_object_fixture
 from tests.typing import WebSocketGenerator
 
 
@@ -405,7 +404,7 @@ async def test_get_broken_links(
     ws_client, _, _, _ = await async_mock_setup(hass, hass_ws_client)
     devices = MockDevices()
     await devices.async_load()
-    aldb_data = json.loads(await async_load_fixture(hass, "aldb_data.json", DOMAIN))
+    aldb_data = await async_load_json_object_fixture(hass, "aldb_data.json", DOMAIN)
     devices.fill_aldb("33.33.33", aldb_data)
     await asyncio.sleep(1)
     with patch.object(insteon.api.config, "devices", devices):

--- a/tests/components/insteon/test_api_properties.py
+++ b/tests/components/insteon/test_api_properties.py
@@ -1,6 +1,5 @@
 """Test the Insteon properties APIs."""
 
-import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -26,20 +25,20 @@ from homeassistant.core import HomeAssistant
 
 from .mock_devices import MockDevices
 
-from tests.common import load_fixture
+from tests.common import load_json_object_fixture
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
 @pytest.fixture(name="kpl_properties_data", scope="module")
 def kpl_properties_data_fixture():
     """Load the controller state fixture data."""
-    return json.loads(load_fixture("insteon/kpl_properties.json"))
+    return load_json_object_fixture("insteon/kpl_properties.json")
 
 
 @pytest.fixture(name="iolinc_properties_data", scope="module")
 def iolinc_properties_data_fixture():
     """Load the controller state fixture data."""
-    return json.loads(load_fixture("insteon/iolinc_properties.json"))
+    return load_json_object_fixture("insteon/iolinc_properties.json")
 
 
 async def _setup(

--- a/tests/components/iometer/test_binary_sensor.py
+++ b/tests/components/iometer/test_binary_sensor.py
@@ -14,7 +14,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import get_status_callback, setup_platform
 
-from tests.common import MockConfigEntry, async_load_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -47,7 +51,7 @@ async def test_connection_status_sensors(
         == STATE_ON
     )
 
-    status_data = json.loads(await async_load_fixture(hass, "status.json", DOMAIN))
+    status_data = await async_load_json_object_fixture(hass, "status.json", DOMAIN)
     status_data["device"]["core"]["connectionStatus"] = "disconnected"
     get_status_callback(mock_iometer_client)(Status.from_json(json.dumps(status_data)))
     await hass.async_block_till_done()
@@ -76,7 +80,7 @@ async def test_attachment_status_sensors(
         == STATE_ON
     )
 
-    status_data = json.loads(await async_load_fixture(hass, "status.json", DOMAIN))
+    status_data = await async_load_json_object_fixture(hass, "status.json", DOMAIN)
     status_data["device"]["core"]["attachmentStatus"] = "detached"
     get_status_callback(mock_iometer_client)(Status.from_json(json.dumps(status_data)))
     await hass.async_block_till_done()
@@ -105,7 +109,7 @@ async def test_attachment_status_sensors_unknown(
         == STATE_ON
     )
 
-    status_data = json.loads(await async_load_fixture(hass, "status.json", DOMAIN))
+    status_data = await async_load_json_object_fixture(hass, "status.json", DOMAIN)
     del status_data["device"]["core"]["attachmentStatus"]
     get_status_callback(mock_iometer_client)(Status.from_json(json.dumps(status_data)))
     await hass.async_block_till_done()

--- a/tests/components/iometer/test_init.py
+++ b/tests/components/iometer/test_init.py
@@ -28,7 +28,7 @@ from . import (
     setup_platform,
 )
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_new_firmware_version(
@@ -47,7 +47,7 @@ async def test_new_firmware_version(
     assert device_entry is not None
     assert device_entry.sw_version == "build-58/build-65"
 
-    status_data = json.loads(await async_load_fixture(hass, "status.json", DOMAIN))
+    status_data = await async_load_json_object_fixture(hass, "status.json", DOMAIN)
     status_data["device"]["core"]["version"] = "build-62"
     status_data["device"]["bridge"]["version"] = "build-69"
     get_status_callback(mock_iometer_client)(Status.from_json(json.dumps(status_data)))

--- a/tests/components/ipp/conftest.py
+++ b/tests/components/ipp/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for IPP integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyipp import Printer
@@ -17,7 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.fixture
@@ -57,7 +56,7 @@ async def mock_printer(
     if hasattr(request, "param") and request.param:
         fixture = request.param
 
-    return Printer.from_dict(json.loads(await async_load_fixture(hass, fixture)))
+    return Printer.from_dict(await async_load_json_object_fixture(hass, fixture))
 
 
 @pytest.fixture

--- a/tests/components/irm_kmi/conftest.py
+++ b/tests/components/irm_kmi/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for the IRM KMI integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import MagicMock, patch
 
 from irm_kmi_api import IrmKmiApiError
@@ -15,7 +14,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
 )
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -77,7 +76,7 @@ def mock_irm_kmi_api(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked IrmKmi api client."""
     fixture: str = "forecast.json"
 
-    forecast = json.loads(load_fixture(fixture, "irm_kmi"))
+    forecast = load_json_object_fixture(fixture, "irm_kmi")
     with patch(
         "homeassistant.components.irm_kmi.IrmKmiApiClientHa", autospec=True
     ) as irm_kmi_api_mock:
@@ -90,7 +89,7 @@ def mock_irm_kmi_api(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 def mock_irm_kmi_api_nl():
     """Mock get_forecasts_coord() to return a Netherlands forecast."""
     fixture: str = "forecast_nl.json"
-    forecast = json.loads(load_fixture(fixture, "irm_kmi"))
+    forecast = load_json_object_fixture(fixture, "irm_kmi")
     with patch(
         "homeassistant.components.irm_kmi.coordinator.IrmKmiApiClientHa.get_forecasts_coord",
         return_value=forecast,
@@ -102,7 +101,7 @@ def mock_irm_kmi_api_nl():
 def mock_irm_kmi_api_high_low_temp():
     """Mock get_forecasts_coord() to return high_low_temp forecast."""
     fixture: str = "high_low_temp.json"
-    forecast = json.loads(load_fixture(fixture, "irm_kmi"))
+    forecast = load_json_object_fixture(fixture, "irm_kmi")
     with patch(
         "homeassistant.components.irm_kmi.coordinator.IrmKmiApiClientHa.get_forecasts_coord",
         return_value=forecast,

--- a/tests/components/jellyfin/__init__.py
+++ b/tests/components/jellyfin/__init__.py
@@ -1,16 +1,15 @@
 """Tests for the jellyfin integration."""
 
-import json
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from tests.common import load_fixture
+from tests.common import load_json_value_fixture
 
 
 def load_json_fixture(filename: str) -> Any:
     """Load JSON fixture on-demand."""
-    return json.loads(load_fixture(f"jellyfin/{filename}"))
+    return load_json_value_fixture(f"jellyfin/{filename}")
 
 
 async def async_load_json_fixture(hass: HomeAssistant, filename: str) -> Any:


### PR DESCRIPTION
## Breaking change

## Proposed change

Part 3 of 6 splitting up the cleanup of the new `home-assistant-json-fixture`
pylint check (see #180829).

This batch converts 14 test file(s) to use the dedicated JSON fixture
helpers (`load_json_object_fixture` / `load_json_array_fixture` /
`load_json_value_fixture` and their `async_` variants) instead of manually
wrapping a loaded fixture in `json.loads(...)`. Unused `json` / `load_fixture`
imports are removed as a result.

Integrations touched in this batch: here_travel_time, hko, homekit, homevolt, hortimax, hvv_departures, insteon, iometer, ipp, irm_kmi, jellyfin.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
