### PR TITLE
Use JSON fixture helpers in tests (4/6)

### DIFF
--- a/tests/components/laundrify/conftest.py
+++ b/tests/components/laundrify/conftest.py
@@ -1,6 +1,5 @@
 """Configure py.test."""
 
-import json
 from unittest.mock import AsyncMock, patch
 
 from laundrify_aio import LaundrifyAPI, LaundrifyDevice
@@ -12,7 +11,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import VALID_ACCESS_TOKEN, VALID_ACCOUNT_ID
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_array_fixture
 from tests.typing import ClientSessionGenerator
 
 
@@ -20,7 +19,7 @@ from tests.typing import ClientSessionGenerator
 def laundrify_sensor_fixture() -> LaundrifyDevice:
     """Return a default Laundrify power sensor mock."""
     # Load test data from machines.json
-    machine_data = json.loads(load_fixture("laundrify/machines.json"))[0]
+    machine_data = load_json_array_fixture("laundrify/machines.json")[0]
 
     mock_device = AsyncMock(spec=LaundrifyDevice)
     mock_device.id = machine_data["id"]
@@ -70,7 +69,7 @@ def laundrify_api_fixture(hass_client: ClientSessionGenerator):
             "laundrify_aio.LaundrifyAPI.get_machines",
             return_value=[
                 LaundrifyDevice(machine, LaundrifyAPI)
-                for machine in json.loads(load_fixture("laundrify/machines.json"))
+                for machine in load_json_array_fixture("laundrify/machines.json")
             ],
         ),
     ):

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -1,6 +1,5 @@
 """Test configuration and mocks for LCN component."""
 
-import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -17,7 +16,7 @@ from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_ENTITIES, CONF_
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 LATEST_CONFIG_ENTRY_VERSION = (LcnFlowHandler.VERSION, LcnFlowHandler.MINOR_VERSION)
 
@@ -75,7 +74,7 @@ def create_config_entry(
 ) -> MockConfigEntry:
     """Set up config entries with configuration data."""
     fixture_filename = f"lcn/config_entry_{name}.json"
-    entry_data = json.loads(load_fixture(fixture_filename))
+    entry_data = load_json_object_fixture(fixture_filename)
     for device in entry_data[CONF_DEVICES]:
         device[CONF_ADDRESS] = tuple(device[CONF_ADDRESS])
     for entity in entry_data[CONF_ENTITIES]:

--- a/tests/components/lektrico/conftest.py
+++ b/tests/components/lektrico/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator
 from ipaddress import ip_address
-import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,7 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 MOCKED_DEVICE_IP_ADDRESS = "192.168.100.10"
 MOCKED_DEVICE_SERIAL_NUMBER = "500006"
@@ -58,11 +57,11 @@ def mock_device() -> Generator[AsyncMock]:
     ):
         device = mock_device.return_value
 
-        device.device_config.return_value = json.loads(
-            load_fixture("get_config.json", DOMAIN)
+        device.device_config.return_value = load_json_object_fixture(
+            "get_config.json", DOMAIN
         )
-        device.device_info.return_value = json.loads(
-            load_fixture("get_info.json", DOMAIN)
+        device.device_info.return_value = load_json_object_fixture(
+            "get_info.json", DOMAIN
         )
 
         yield device

--- a/tests/components/loqed/conftest.py
+++ b/tests/components/loqed/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import AsyncGenerator, Callable
 from contextlib import contextmanager
-import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -14,7 +13,11 @@ from homeassistant.const import CONF_API_TOKEN, CONF_NAME, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_array_fixture,
+    async_load_json_object_fixture,
+)
 
 type PatchLockCreationFlow = Callable[[dict[str, Any], loqed.Lock, str], Any]
 
@@ -23,8 +26,9 @@ type PatchLockCreationFlow = Callable[[dict[str, Any], loqed.Lock, str], Any]
 async def config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
     """Mock config entry."""
 
-    config = await async_load_fixture(hass, "integration_config.json", DOMAIN)
-    json_config = json.loads(config)
+    json_config = await async_load_json_object_fixture(
+        hass, "integration_config.json", DOMAIN
+    )
     return MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -46,11 +50,12 @@ async def config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
 async def cloud_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
     """Mock config entry."""
 
-    config = await async_load_fixture(hass, "integration_config.json", DOMAIN)
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    json_config = await async_load_json_object_fixture(
+        hass, "integration_config.json", DOMAIN
     )
-    json_config = json.loads(config)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
+    )
     return MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -72,8 +77,8 @@ async def cloud_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
 @pytest.fixture(name="lock")
 async def lock_fixture(hass: HomeAssistant) -> loqed.Lock:
     """Set up a mock implementation of a Lock."""
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
 
     mock_lock = Mock(spec=loqed.Lock, id="Foo", last_key_id=2)
@@ -92,7 +97,7 @@ async def integration_fixture(
     config: dict[str, Any] = {DOMAIN: {CONF_API_TOKEN: ""}}
     config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     with (
         patch("loqedAPI.loqed.LoqedAPI.async_get_lock", return_value=lock),

--- a/tests/components/loqed/test_config_flow.py
+++ b/tests/components/loqed/test_config_flow.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from ipaddress import ip_address
-import json
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -16,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 TEST_API_TOKEN = "eyadiuyfasiuasf"
@@ -35,7 +34,7 @@ zeroconf_data = ZeroconfServiceInfo(
 
 async def _async_init_zeroconf_flow(hass: HomeAssistant) -> dict[str, Any]:
     """Initialize a zeroconf flow and return the form result."""
-    lock_result = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_result = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     with patch(
         "loqedAPI.loqed.LoqedAPI.async_get_lock_details",
@@ -65,7 +64,7 @@ async def test_create_entry_zeroconf(
     patch_lock_creation_flow: Callable[[dict[str, Any], loqed.Lock, str], Any],
 ) -> None:
     """Test we get can create a lock via zeroconf."""
-    lock_result = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_result = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     with patch(
         "loqedAPI.loqed.LoqedAPI.async_get_lock_details",
@@ -82,8 +81,8 @@ async def test_create_entry_zeroconf(
 
     mock_lock = Mock(spec=loqed.Lock, id="Foo")
     webhook_id = "Webhook_ID"
-    all_locks_response = json.loads(
-        await async_load_fixture(hass, "get_all_locks.json", DOMAIN)
+    all_locks_response = await async_load_json_object_fixture(
+        hass, "get_all_locks.json", DOMAIN
     )
 
     with patch_lock_creation_flow(all_locks_response, mock_lock, webhook_id):
@@ -122,8 +121,8 @@ async def test_create_entry_user(
 
     mock_lock = Mock(spec=loqed.Lock, id="Foo")
     webhook_id = TEST_WEBHOOK_ID
-    all_locks_response = json.loads(
-        await async_load_fixture(hass, "get_all_locks.json", DOMAIN)
+    all_locks_response = await async_load_json_object_fixture(
+        hass, "get_all_locks.json", DOMAIN
     )
     found_lock = all_locks_response["data"][0]
 
@@ -160,8 +159,8 @@ async def test_create_entry_user_with_pick_lock(
 
     mock_lock = Mock(spec=loqed.Lock, id="Foo")
     webhook_id = TEST_WEBHOOK_ID
-    all_locks_response = json.loads(
-        await async_load_fixture(hass, "get_all_locks.json", DOMAIN)
+    all_locks_response = await async_load_json_object_fixture(
+        hass, "get_all_locks.json", DOMAIN
     )
     second_lock = all_locks_response["data"][0].copy()
     second_lock["id"] = "Bar"
@@ -242,8 +241,8 @@ async def test_recover_after_cannot_connect(
 
     mock_lock = Mock(spec=loqed.Lock, id="Foo")
     webhook_id = TEST_WEBHOOK_ID
-    all_locks_response = json.loads(
-        await async_load_fixture(hass, "get_all_locks.json", DOMAIN)
+    all_locks_response = await async_load_json_object_fixture(
+        hass, "get_all_locks.json", DOMAIN
     )
     found_lock = all_locks_response["data"][0]
 
@@ -342,8 +341,8 @@ async def test_cannot_connect_when_lock_not_reachable(
     """Test we handle a situation where the lock is not reachable."""
     result = await _async_init_user_flow(hass)
 
-    all_locks_response = json.loads(
-        await async_load_fixture(hass, "get_all_locks.json", DOMAIN)
+    all_locks_response = await async_load_json_object_fixture(
+        hass, "get_all_locks.json", DOMAIN
     )
 
     with (

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -1,7 +1,6 @@
 """Tests the init part of the Loqed integration."""
 
 from datetime import timedelta
-import json
 from typing import Any
 from unittest.mock import AsyncMock, call, patch
 
@@ -22,6 +21,7 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_fixture,
+    async_load_json_array_fixture,
     async_load_json_object_fixture,
 )
 from tests.typing import ClientSessionGenerator
@@ -36,8 +36,8 @@ async def test_webhook_accepts_valid_message(
     """Test webhook called with valid message."""
     await async_setup_component(hass, "http", {"http": {}})
     client = await hass_client_no_auth()
-    processed_message = json.loads(
-        await async_load_fixture(hass, "lock_going_to_nightlock.json", DOMAIN)
+    processed_message = await async_load_json_object_fixture(
+        hass, "lock_going_to_nightlock.json", DOMAIN
     )
     lock.receiveWebhook = AsyncMock(return_value=processed_message)
 
@@ -58,9 +58,9 @@ async def test_setup_webhook_in_bridge(
     config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
     lock.getWebhooks = AsyncMock(side_effect=[[], webhooks_fixture])
 
@@ -89,8 +89,8 @@ async def test_webhook_prefers_internal_url(
 
     lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
     webhooks_fixture[0]["url"] = f"{hass.config.internal_url}/api/webhook/Webhook_id"
 
@@ -230,9 +230,9 @@ async def test_setup_retry_after_bridge_webhook_failure(
     """
     config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
     lock.getWebhooks = AsyncMock(
         side_effect=[ConfigEntryNotReady, webhooks_fixture, webhooks_fixture]
@@ -264,9 +264,9 @@ async def test_setup_cloudhook_in_bridge(
     config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
     lock.getWebhooks = AsyncMock(side_effect=[[], webhooks_fixture])
 
@@ -294,14 +294,14 @@ async def test_setup_cloudhook_from_entry_in_bridge(
     hass: HomeAssistant, cloud_config_entry: MockConfigEntry, lock: loqed.Lock
 ) -> None:
     """Test webhook setup in loqed bridge."""
-    webhooks_fixture = json.loads(
-        await async_load_fixture(hass, "get_all_webhooks.json", DOMAIN)
+    webhooks_fixture = await async_load_json_array_fixture(
+        hass, "get_all_webhooks.json", DOMAIN
     )
 
     config: dict[str, Any] = {DOMAIN: {}}
     cloud_config_entry.add_to_hass(hass)
 
-    lock_status = json.loads(await async_load_fixture(hass, "status_ok.json", DOMAIN))
+    lock_status = await async_load_json_object_fixture(hass, "status_ok.json", DOMAIN)
 
     lock.getWebhooks = AsyncMock(side_effect=[[], webhooks_fixture])
 

--- a/tests/components/matter/test_diagnostics.py
+++ b/tests/components/matter/test_diagnostics.py
@@ -1,6 +1,5 @@
 """Test the Matter diagnostics platform."""
 
-import json
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -18,7 +17,7 @@ from homeassistant.components.matter.diagnostics import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
@@ -29,19 +28,19 @@ from tests.typing import ClientSessionGenerator
 @pytest.fixture(name="config_entry_diagnostics")
 def config_entry_diagnostics_fixture() -> dict[str, Any]:
     """Fixture for config entry diagnostics."""
-    return json.loads(load_fixture("config_entry_diagnostics.json", DOMAIN))
+    return load_json_object_fixture("config_entry_diagnostics.json", DOMAIN)
 
 
 @pytest.fixture(name="config_entry_diagnostics_redacted")
 def config_entry_diagnostics_redacted_fixture() -> dict[str, Any]:
     """Fixture for redacted config entry diagnostics."""
-    return json.loads(load_fixture("config_entry_diagnostics_redacted.json", DOMAIN))
+    return load_json_object_fixture("config_entry_diagnostics_redacted.json", DOMAIN)
 
 
 @pytest.fixture(name="device_diagnostics")
 def device_diagnostics_fixture() -> dict[str, Any]:
     """Fixture for device diagnostics."""
-    return json.loads(load_fixture("nodes/device_diagnostics.json", DOMAIN))
+    return load_json_object_fixture("nodes/device_diagnostics.json", DOMAIN)
 
 
 async def test_matter_attribute_redact(device_diagnostics: dict[str, Any]) -> None:

--- a/tests/components/metoffice/test_config_flow.py
+++ b/tests/components/metoffice/test_config_flow.py
@@ -22,7 +22,7 @@ from .const import (
     TEST_SITE_NAME_WAVERTREE,
 )
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_form(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
@@ -31,7 +31,7 @@ async def test_form(hass: HomeAssistant, requests_mock: requests_mock.Mocker) ->
     hass.config.longitude = TEST_LONGITUDE_WAVERTREE
 
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
     requests_mock.get(
         "https://data.hub.api.metoffice.gov.uk/sitespecific/v0/point/daily",
@@ -72,7 +72,7 @@ async def test_form_already_configured(
     hass.config.longitude = TEST_LONGITUDE_WAVERTREE
 
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
     requests_mock.get(
         "https://data.hub.api.metoffice.gov.uk/sitespecific/v0/point/daily",
@@ -156,7 +156,7 @@ async def test_reauth_flow(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test handling authentication errors and reauth flow."""
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     requests_mock.get(

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -13,7 +13,11 @@ from homeassistant.util import utcnow
 
 from .const import METOFFICE_CONFIG_WAVERTREE
 
-from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_json_object_fixture,
+)
 
 
 @pytest.mark.freeze_time(datetime.datetime(2024, 11, 23, 12, tzinfo=datetime.UTC))
@@ -23,7 +27,7 @@ async def test_reauth_on_auth_error(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test handling authentication errors and reauth flow."""
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     requests_mock.get(

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -24,7 +24,11 @@ from .const import (
     WAVERTREE_SENSOR_RESULTS,
 )
 
-from tests.common import MockConfigEntry, async_load_fixture, get_sensor_display_state
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    get_sensor_display_state,
+)
 
 
 @pytest.mark.freeze_time(datetime.datetime(2024, 11, 23, 12, tzinfo=datetime.UTC))
@@ -37,7 +41,7 @@ async def test_one_sensor_site_running(
 ) -> None:
     """Test the Met Office sensor platform."""
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
 
@@ -89,7 +93,7 @@ async def test_two_sensor_sites_running(
     """Test we handle two sets of sensors running for two different sites."""
 
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
     kingslynn_hourly = json.dumps(mock_json["kingslynn_hourly"])
@@ -182,7 +186,7 @@ async def test_legacy_entities_are_removed(
     old_unique_id: str,
 ) -> None:
     """Test the expected entities are deleted."""
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
 

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -29,7 +29,11 @@ from .const import (
     WAVERTREE_SENSOR_RESULTS,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_json_object_fixture,
+)
 from tests.typing import WebSocketGenerator
 
 
@@ -48,7 +52,7 @@ async def wavertree_data(
 ) -> dict[str, _Matcher]:
     """Mock data for the Wavertree location."""
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     wavertree_hourly = json.dumps(mock_json["wavertree_hourly"])
     wavertree_daily = json.dumps(mock_json["wavertree_daily"])
 
@@ -196,7 +200,7 @@ async def test_two_weather_sites_running(
     """Test we handle two different weather sites both running."""
 
     # all metoffice test data encapsulated in here
-    mock_json = json.loads(await async_load_fixture(hass, "metoffice.json", DOMAIN))
+    mock_json = await async_load_json_object_fixture(hass, "metoffice.json", DOMAIN)
     kingslynn_hourly = json.dumps(mock_json["kingslynn_hourly"])
     kingslynn_daily = json.dumps(mock_json["kingslynn_daily"])
 

--- a/tests/components/modern_forms/__init__.py
+++ b/tests/components/modern_forms/__init__.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable, Coroutine
 from functools import partial
-import json
 from typing import Any
 
 from aiomodernforms.const import COMMAND_QUERY_STATIC_DATA
@@ -12,11 +11,7 @@ from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 
-from tests.common import (
-    MockConfigEntry,
-    async_load_fixture,
-    async_load_json_object_fixture,
-)
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
 
 
@@ -31,7 +26,7 @@ async def modern_forms_call_mock(
     return AiohttpClientMockResponse(
         method=method,
         url=url,
-        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
+        json=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     )
 
 
@@ -46,7 +41,7 @@ async def modern_forms_no_light_call_mock(
     return AiohttpClientMockResponse(
         method=method,
         url=url,
-        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
+        json=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     )
 
 
@@ -61,7 +56,7 @@ async def modern_forms_timers_set_mock(
     return AiohttpClientMockResponse(
         method=method,
         url=url,
-        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
+        json=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     )
 
 
@@ -76,7 +71,7 @@ async def modern_forms_breeze_call_mock(
     return AiohttpClientMockResponse(
         method=method,
         url=url,
-        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
+        json=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     )
 
 
@@ -91,7 +86,7 @@ async def modern_forms_breeze_active_call_mock(
     return AiohttpClientMockResponse(
         method=method,
         url=url,
-        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
+        json=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     )
 
 

--- a/tests/components/mysensors/conftest.py
+++ b/tests/components/mysensors/conftest.py
@@ -198,9 +198,8 @@ def gateway_fixture(
 
 def load_nodes_state(fixture_path: str) -> dict:
     """Load mysensors nodes fixture."""
-    return json.loads(
-        load_fixture(fixture_path, integration=DOMAIN), cls=MySensorsJSONDecoder
-    )
+    fixture = load_fixture(fixture_path, integration=DOMAIN)
+    return json.loads(fixture, cls=MySensorsJSONDecoder)
 
 
 def update_gateway_nodes(

--- a/tests/components/netatmo/common.py
+++ b/tests/components/netatmo/common.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.aiohttp import MockRequest
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
 HOME_ID = "91763b24c43d3e344f424e8b"
@@ -78,12 +78,12 @@ async def fake_post_request(hass: HomeAssistant, *args: Any, **kwargs: Any):
 
     elif endpoint == "homestatus":
         home_id = kwargs.get("params", {}).get("home_id")
-        payload = json.loads(
-            await async_load_fixture(hass, f"{endpoint}_{home_id}.json", DOMAIN)
+        payload = await async_load_json_object_fixture(
+            hass, f"{endpoint}_{home_id}.json", DOMAIN
         )
 
     else:
-        payload = json.loads(await async_load_fixture(hass, f"{endpoint}.json", DOMAIN))
+        payload = await async_load_json_object_fixture(hass, f"{endpoint}.json", DOMAIN)
 
     # Apply test-specific modifications to the payload
     if "msg_callback" in kwargs:


### PR DESCRIPTION
## Breaking change

## Proposed change

Part 4 of 6 splitting up the cleanup of the new `home-assistant-json-fixture`
pylint check (see #180829).

This batch converts 14 test file(s) to use the dedicated JSON fixture
helpers (`load_json_object_fixture` / `load_json_array_fixture` /
`load_json_value_fixture` and their `async_` variants) instead of manually
wrapping a loaded fixture in `json.loads(...)`. Unused `json` / `load_fixture`
imports are removed as a result.

Integrations touched in this batch: laundrify, lcn, lektrico, loqed, matter, metoffice, modern_forms, mysensors, netatmo.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
