### PR TITLE
Use JSON fixture helpers in tests (5/6)

### DIFF
--- a/tests/components/nordpool/test_services.py
+++ b/tests/components/nordpool/test_services.py
@@ -1,6 +1,5 @@
 """Test services in Nord Pool."""
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -26,7 +25,7 @@ from homeassistant.const import ATTR_DATE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 TEST_SERVICE_DATA = {
@@ -228,8 +227,8 @@ async def test_service_call_for_price_indices(
 ) -> None:
     """Test get_price_indices_for_date service call."""
 
-    fixture_60 = json.loads(await async_load_fixture(hass, "indices_60.json", DOMAIN))
-    fixture_15 = json.loads(await async_load_fixture(hass, "indices_15.json", DOMAIN))
+    fixture_60 = await async_load_json_object_fixture(hass, "indices_60.json", DOMAIN)
+    fixture_15 = await async_load_json_object_fixture(hass, "indices_15.json", DOMAIN)
 
     aioclient_mock.request(
         "GET",

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -1,7 +1,6 @@
 """Define fixtures for Notion tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, Mock, patch
 
 from aionotion.bridge.models import Bridge
@@ -18,7 +17,7 @@ from homeassistant.components.notion.const import (
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 TEST_USERNAME = "user@host.com"
 TEST_PASSWORD = "password123"
@@ -94,25 +93,25 @@ def config_fixture():
 @pytest.fixture(name="data_bridge", scope="package")
 def data_bridge_fixture():
     """Define bridge data."""
-    return json.loads(load_fixture("bridge_data.json", "notion"))
+    return load_json_object_fixture("bridge_data.json", "notion")
 
 
 @pytest.fixture(name="data_listener", scope="package")
 def data_listener_fixture():
     """Define listener data."""
-    return json.loads(load_fixture("listener_data.json", "notion"))
+    return load_json_object_fixture("listener_data.json", "notion")
 
 
 @pytest.fixture(name="data_sensor", scope="package")
 def data_sensor_fixture():
     """Define sensor data."""
-    return json.loads(load_fixture("sensor_data.json", "notion"))
+    return load_json_object_fixture("sensor_data.json", "notion")
 
 
 @pytest.fixture(name="data_user_preferences", scope="package")
 def data_user_preferences_fixture():
     """Define user preferences data."""
-    return json.loads(load_fixture("user_preferences_data.json", "notion"))
+    return load_json_object_fixture("user_preferences_data.json", "notion")
 
 
 @pytest.fixture(name="get_client")

--- a/tests/components/nut/test_switch.py
+++ b/tests/components/nut/test_switch.py
@@ -1,6 +1,5 @@
 """Test the NUT switch platform."""
 
-import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .util import async_init_integration
 
-from tests.common import async_load_fixture
+from tests.common import async_load_json_object_fixture
 
 
 @pytest.mark.parametrize(
@@ -83,7 +82,7 @@ async def test_switch_pdu_dynamic_outlets(
         list_commands_return_value[command] = command
 
     ups_fixture = f"{model}.json"
-    list_vars = json.loads(await async_load_fixture(hass, ups_fixture, DOMAIN))
+    list_vars = await async_load_json_object_fixture(hass, ups_fixture, DOMAIN)
 
     run_command = AsyncMock()
 

--- a/tests/components/nut/util.py
+++ b/tests/components/nut/util.py
@@ -1,6 +1,5 @@
 """Tests for the nut integration."""
 
-import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 def _get_mock_nutclient(
@@ -61,7 +60,7 @@ async def async_init_integration(
     if ups_fixture is not None:
         ups_fixture = f"{ups_fixture}.json"
         if list_vars is None:
-            list_vars = json.loads(await async_load_fixture(hass, ups_fixture, DOMAIN))
+            list_vars = await async_load_json_object_fixture(hass, ups_fixture, DOMAIN)
 
     mock_pynut = _get_mock_nutclient(
         list_ups=list_ups,

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -1,7 +1,6 @@
 """Define test fixtures for OpenUV."""
 
 from collections.abc import Generator
-import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -20,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 TEST_API_KEY = "abcde12345"
 TEST_ELEVATION = 0
@@ -85,13 +84,13 @@ def config_fixture() -> dict[str, Any]:
 @pytest.fixture(name="data_protection_window", scope="package")
 def data_protection_window_fixture():
     """Define a fixture to return UV protection window data."""
-    return json.loads(load_fixture("protection_window_data.json", "openuv"))
+    return load_json_object_fixture("protection_window_data.json", "openuv")
 
 
 @pytest.fixture(name="data_uv_index", scope="package")
 def data_uv_index_fixture():
     """Define a fixture to return UV index data."""
-    return json.loads(load_fixture("uv_index_data.json", "openuv"))
+    return load_json_object_fixture("uv_index_data.json", "openuv")
 
 
 @pytest.fixture(name="mock_pyopenuv")

--- a/tests/components/p1_monitor/conftest.py
+++ b/tests/components/p1_monitor/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for P1 Monitor integration tests."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from p1monitor import Phases, Settings, SmartMeter, WaterMeter
@@ -10,7 +9,7 @@ from homeassistant.components.p1_monitor.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_array_fixture
 
 
 @pytest.fixture
@@ -34,22 +33,22 @@ def mock_p1monitor():
         client = p1monitor_mock.return_value
         client.smartmeter = AsyncMock(
             return_value=SmartMeter.from_dict(
-                json.loads(load_fixture("p1_monitor/smartmeter.json"))
+                load_json_array_fixture("p1_monitor/smartmeter.json")
             )
         )
         client.phases = AsyncMock(
             return_value=Phases.from_dict(
-                json.loads(load_fixture("p1_monitor/phases.json"))
+                load_json_array_fixture("p1_monitor/phases.json")
             )
         )
         client.settings = AsyncMock(
             return_value=Settings.from_dict(
-                json.loads(load_fixture("p1_monitor/settings.json"))
+                load_json_array_fixture("p1_monitor/settings.json")
             )
         )
         client.watermeter = AsyncMock(
             return_value=WaterMeter.from_dict(
-                json.loads(load_fixture("p1_monitor/watermeter.json"))
+                load_json_array_fixture("p1_monitor/watermeter.json")
             )
         )
         yield client

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Generator
 from contextlib import nullcontext
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from peblar import (
@@ -20,7 +19,7 @@ from homeassistant.components.peblar.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
 
 
 @pytest.fixture
@@ -54,8 +53,8 @@ def mock_peblar(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     and the user configuration.
     """
     overrides = getattr(request, "param", {})
-    system_information = json.loads(load_fixture("system_information.json", DOMAIN))
-    user_configuration = json.loads(load_fixture("user_configuration.json", DOMAIN))
+    system_information = load_json_object_fixture("system_information.json", DOMAIN)
+    user_configuration = load_json_object_fixture("user_configuration.json", DOMAIN)
     for key, value in overrides.items():
         if key in system_information:
             system_information[key] = value

--- a/tests/components/picnic/conftest.py
+++ b/tests/components/picnic/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,7 +12,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 from tests.typing import WebSocketGenerator
 
 ENTITY_ID = "todo.mock_title_shopping_cart"
@@ -44,13 +43,13 @@ def mock_picnic_api():
         client = mock.return_value
         client.session.auth_token = "3q29fpwhulzes"
         client.get_cart.return_value = Cart.from_api(
-            json.loads(load_fixture("picnic/cart.json"))
+            load_json_object_fixture("picnic/cart.json")
         )
         client.get_user.return_value = User.from_api(
-            json.loads(load_fixture("picnic/user.json"))
+            load_json_object_fixture("picnic/user.json")
         )
         client.get_deliveries.return_value = [
-            DeliverySummary.from_api(json.loads(load_fixture("picnic/delivery.json")))
+            DeliverySummary.from_api(load_json_object_fixture("picnic/delivery.json"))
         ]
         client.get_delivery_position.return_value = {}
         yield client

--- a/tests/components/pure_energie/conftest.py
+++ b/tests/components/pure_energie/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for Pure Energie integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gridnet import Device as GridNetDevice, SmartBridge
@@ -11,7 +10,7 @@ from homeassistant.components.pure_energie.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -42,7 +41,7 @@ def mock_pure_energie_config_flow() -> Generator[MagicMock]:
     ) as pure_energie_mock:
         pure_energie = pure_energie_mock.return_value
         pure_energie.device.return_value = GridNetDevice.from_dict(
-            json.loads(load_fixture("device.json", DOMAIN))
+            load_json_object_fixture("device.json", DOMAIN)
         )
         yield pure_energie
 
@@ -56,12 +55,12 @@ def mock_pure_energie():
         pure_energie = pure_energie_mock.return_value
         pure_energie.smartbridge = AsyncMock(
             return_value=SmartBridge.from_dict(
-                json.loads(load_fixture("pure_energie/smartbridge.json"))
+                load_json_object_fixture("pure_energie/smartbridge.json")
             )
         )
         pure_energie.device = AsyncMock(
             return_value=GridNetDevice.from_dict(
-                json.loads(load_fixture("pure_energie/device.json"))
+                load_json_object_fixture("pure_energie/device.json")
             )
         )
         yield pure_energie_mock

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -1,7 +1,6 @@
 """Define test fixtures for RainMachine."""
 
 from collections.abc import AsyncGenerator
-import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -12,7 +11,11 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import (
+    MockConfigEntry,
+    load_json_array_fixture,
+    load_json_object_fixture,
+)
 
 
 @pytest.fixture(name="client")
@@ -90,27 +93,27 @@ def controller_mac_fixture() -> str:
 @pytest.fixture(name="data_api_versions", scope="package")
 def data_api_versions_fixture():
     """Define API version data."""
-    return json.loads(load_fixture("api_versions_data.json", "rainmachine"))
+    return load_json_object_fixture("api_versions_data.json", "rainmachine")
 
 
 @pytest.fixture(name="data_diagnostics_current", scope="package")
 def data_diagnostics_current_fixture():
     """Define current diagnostics data."""
-    return json.loads(load_fixture("diagnostics_current_data.json", "rainmachine"))
+    return load_json_object_fixture("diagnostics_current_data.json", "rainmachine")
 
 
 @pytest.fixture(name="data_machine_firmare_update_status", scope="package")
 def data_machine_firmare_update_status_fixture():
     """Define machine firmware update status data."""
-    return json.loads(
-        load_fixture("machine_firmware_update_status_data.json", "rainmachine")
+    return load_json_object_fixture(
+        "machine_firmware_update_status_data.json", "rainmachine"
     )
 
 
 @pytest.fixture(name="data_programs", scope="package")
 def data_programs_fixture():
     """Define program data."""
-    raw_data = json.loads(load_fixture("programs_data.json", "rainmachine"))
+    raw_data = load_json_array_fixture("programs_data.json", "rainmachine")
     # This replicate the process from `regenmaschine` to convert list to dict
     return {program["uid"]: program for program in raw_data}
 
@@ -118,27 +121,27 @@ def data_programs_fixture():
 @pytest.fixture(name="data_provision_settings", scope="package")
 def data_provision_settings_fixture():
     """Define provisioning settings data."""
-    return json.loads(load_fixture("provision_settings_data.json", "rainmachine"))
+    return load_json_object_fixture("provision_settings_data.json", "rainmachine")
 
 
 @pytest.fixture(name="data_restrictions_current", scope="package")
 def data_restrictions_current_fixture():
     """Define current restrictions settings data."""
-    return json.loads(load_fixture("restrictions_current_data.json", "rainmachine"))
+    return load_json_object_fixture("restrictions_current_data.json", "rainmachine")
 
 
 @pytest.fixture(name="data_restrictions_universal", scope="package")
 def data_restrictions_universal_fixture():
     """Define universal restrictions settings data."""
-    return json.loads(load_fixture("restrictions_universal_data.json", "rainmachine"))
+    return load_json_object_fixture("restrictions_universal_data.json", "rainmachine")
 
 
 @pytest.fixture(name="data_zones", scope="package")
 def data_zones_fixture():
     """Define zone data."""
-    raw_data = json.loads(load_fixture("zones_data.json", "rainmachine"))
+    raw_data = load_json_array_fixture("zones_data.json", "rainmachine")
     # This replicate the process from `regenmaschine` to convert list to dict
-    zone_details = json.loads(load_fixture("zones_details.json", "rainmachine"))
+    zone_details = load_json_array_fixture("zones_details.json", "rainmachine")
 
     zones: dict[int, dict[str, Any]] = {}
     for zone in raw_data:

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for Roku integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +10,7 @@ from homeassistant.components.roku.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 def app_icon_url(*args, **kwargs):
@@ -48,7 +47,7 @@ async def mock_device(
     if hasattr(request, "param") and request.param:
         fixture = request.param
 
-    return RokuDevice(json.loads(await async_load_fixture(hass, fixture)))
+    return RokuDevice(await async_load_json_object_fixture(hass, fixture))
 
 
 @pytest.fixture

--- a/tests/components/sonarr/conftest.py
+++ b/tests/components/sonarr/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for Sonarr integration tests."""
 
 from collections.abc import Generator
-import json
 from unittest.mock import MagicMock, patch
 
 from aiopyarr import (
@@ -33,36 +32,40 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import (
+    MockConfigEntry,
+    load_json_array_fixture,
+    load_json_object_fixture,
+)
 
 
 def sonarr_calendar() -> list[SonarrCalendar]:
     """Generate a response for the calendar method."""
-    results = json.loads(load_fixture("sonarr/calendar.json"))
+    results = load_json_array_fixture("sonarr/calendar.json")
     return [SonarrCalendar(result) for result in results]
 
 
 def sonarr_commands() -> list[Command]:
     """Generate a response for the commands method."""
-    results = json.loads(load_fixture("sonarr/command.json"))
+    results = load_json_array_fixture("sonarr/command.json")
     return [Command(result) for result in results]
 
 
 def sonarr_diskspace() -> list[Diskspace]:
     """Generate a response for the diskspace method."""
-    results = json.loads(load_fixture("sonarr/diskspace.json"))
+    results = load_json_array_fixture("sonarr/diskspace.json")
     return [Diskspace(result) for result in results]
 
 
 def sonarr_queue() -> SonarrQueue:
     """Generate a response for the queue method."""
-    results = json.loads(load_fixture("sonarr/queue.json"))
+    results = load_json_object_fixture("sonarr/queue.json")
     return SonarrQueue(results)
 
 
 def sonarr_queue_season_pack() -> SonarrQueue:
     """Generate a response for the queue method with a season pack."""
-    results = json.loads(load_fixture("sonarr/queue_season_pack.json"))
+    results = load_json_object_fixture("sonarr/queue_season_pack.json")
     return SonarrQueue(results)
 
 
@@ -75,25 +78,25 @@ def mock_sonarr_season_pack(mock_sonarr: MagicMock) -> MagicMock:
 
 def sonarr_series() -> list[SonarrSeries]:
     """Generate a response for the series method."""
-    results = json.loads(load_fixture("sonarr/series.json"))
+    results = load_json_array_fixture("sonarr/series.json")
     return [SonarrSeries(result) for result in results]
 
 
 def sonarr_system_status() -> SystemStatus:
     """Generate a response for the system status method."""
-    result = json.loads(load_fixture("sonarr/system-status.json"))
+    result = load_json_object_fixture("sonarr/system-status.json")
     return SystemStatus(result)
 
 
 def sonarr_wanted() -> SonarrWantedMissing:
     """Generate a response for the wanted method."""
-    results = json.loads(load_fixture("sonarr/wanted-missing.json"))
+    results = load_json_object_fixture("sonarr/wanted-missing.json")
     return SonarrWantedMissing(results)
 
 
 def sonarr_episodes() -> list[SonarrEpisode]:
     """Generate a response for the episodes method."""
-    results = json.loads(load_fixture("sonarr/episodes.json"))
+    results = load_json_array_fixture("sonarr/episodes.json")
     return [SonarrEpisode(result) for result in results]
 
 

--- a/tests/components/sonarr/test_calendar.py
+++ b/tests/components/sonarr/test_calendar.py
@@ -1,7 +1,6 @@
 """The tests for Sonarr calendar platform."""
 
 from datetime import datetime
-import json
 from unittest.mock import MagicMock, patch
 
 from aiopyarr import SonarrCalendar
@@ -17,7 +16,11 @@ from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry, async_load_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_array_fixture,
+    snapshot_platform,
+)
 
 ENTITY_ID = "calendar.sonarr"
 
@@ -112,7 +115,7 @@ async def test_calendar_get_events_without_overview(
 ) -> None:
     """Test that episodes without an overview are handled (real Sonarr omits it)."""
     await hass.config.async_set_time_zone("UTC")
-    raw = json.loads(await async_load_fixture(hass, "calendar.json", "sonarr"))[0]
+    raw = (await async_load_json_array_fixture(hass, "calendar.json", "sonarr"))[0]
     raw.pop("overview")
     mock_sonarr.async_get_calendar.return_value = [SonarrCalendar(raw)]
 

--- a/tests/components/starlink/patchers.py
+++ b/tests/components/starlink/patchers.py
@@ -1,9 +1,8 @@
 """General Starlink patchers."""
 
-import json
 from unittest.mock import patch
 
-from tests.common import load_fixture
+from tests.common import load_json_array_fixture, load_json_object_fixture
 
 SETUP_ENTRY_PATCHER = patch(
     "homeassistant.components.starlink.async_setup_entry", return_value=True
@@ -11,23 +10,23 @@ SETUP_ENTRY_PATCHER = patch(
 
 LOCATION_DATA_SUCCESS_PATCHER = patch(
     "homeassistant.components.starlink.coordinator.location_data",
-    return_value=json.loads(load_fixture("location_data_success.json", "starlink")),
+    return_value=load_json_object_fixture("location_data_success.json", "starlink"),
 )
 
 SLEEP_DATA_SUCCESS_PATCHER = patch(
     "homeassistant.components.starlink.coordinator.get_sleep_config",
-    return_value=json.loads(load_fixture("sleep_data_success.json", "starlink")),
+    return_value=load_json_array_fixture("sleep_data_success.json", "starlink"),
 )
 
 STATUS_DATA_TARGET = "homeassistant.components.starlink.coordinator.status_data"
-STATUS_DATA_FIXTURE = json.loads(load_fixture("status_data_success.json", "starlink"))
+STATUS_DATA_FIXTURE = load_json_array_fixture("status_data_success.json", "starlink")
 STATUS_DATA_SUCCESS_PATCHER = patch(
     STATUS_DATA_TARGET, return_value=STATUS_DATA_FIXTURE
 )
 
 HISTORY_STATS_SUCCESS_PATCHER = patch(
     "homeassistant.components.starlink.coordinator.history_stats",
-    return_value=json.loads(load_fixture("history_stats_success.json", "starlink")),
+    return_value=load_json_array_fixture("history_stats_success.json", "starlink"),
 )
 
 DEVICE_FOUND_PATCHER = patch(


### PR DESCRIPTION
## Breaking change

## Proposed change

Part 5 of 6 splitting up the cleanup of the new `home-assistant-json-fixture`
pylint check (see #180829).

This batch converts 14 test file(s) to use the dedicated JSON fixture
helpers (`load_json_object_fixture` / `load_json_array_fixture` /
`load_json_value_fixture` and their `async_` variants) instead of manually
wrapping a loaded fixture in `json.loads(...)`. Unused `json` / `load_fixture`
imports are removed as a result.

Integrations touched in this batch: nordpool, notion, nut, openuv, p1_monitor, peblar, picnic, pure_energie, rainmachine, roku, sonarr, starlink.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
