### PR TITLE
Declare PARALLEL_UPDATES on the iCloud calendar platform

### DIFF
--- a/homeassistant/components/icloud/calendar.py
+++ b/homeassistant/components/icloud/calendar.py
@@ -17,6 +17,10 @@ from .account import IcloudConfigEntry
 from .const import DOMAIN
 from .coordinator import IcloudCalendarCoordinator, IcloudCalendarData, localize
 
+# The coordinator owns the polling and the entities are read-only, so there is
+# nothing here for Home Assistant to serialize.
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

Declares `PARALLEL_UPDATES = 0` on the iCloud `calendar` platform, which was added in #180735 without it.

The coordinator owns the polling and the entities are read-only — no create, update or delete — so there is nothing for Home Assistant to serialize, and `0` is what the other coordinator-backed read-only calendar platforms use. `async_get_events` is called directly by the calendar panel and the `calendar.get_events` action rather than through the entity service helper, so it is not governed by this either way.

This makes the existing behaviour explicit rather than changing it. It came out of review on #180716, where the sibling `todo` platform declares `PARALLEL_UPDATES = 1` because its actions are blocking read-modify-writes; the inconsistency between the two platforms is what prompted this.

Scope is deliberately just the calendar platform. `device_tracker` and `sensor` predate this work and are left alone.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #180735

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
