### PR TITLE
Add AC buttons to LG Infrared

### DIFF
--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -124,9 +124,13 @@ AC_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     LgIrButtonEntityDescription(
         key="eco", translation_key="eco", command_code=LGACCode.ECO
     ),
-    # A separate boost from JET, offered on LG India units.
+    # A separate boost from JET, only offered on LG India units, so it is
+    # disabled by default.
     LgIrButtonEntityDescription(
-        key="viraat", translation_key="viraat", command_code=LGACCode.VIRAAT
+        key="viraat",
+        translation_key="viraat",
+        command_code=LGACCode.VIRAAT,
+        entity_registry_enabled_default=False,
     ),
     LgIrButtonEntityDescription(
         key="ai_convertible",

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -3,11 +3,13 @@
 from dataclasses import dataclass
 from typing import override
 
+from infrared_protocols.codes.lg.ac import LGACCode
 from infrared_protocols.codes.lg.tv import LGTVCode
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.components.infrared import InfraredEmitterConsumerEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -21,7 +23,7 @@ PARALLEL_UPDATES = 1
 class LgIrButtonEntityDescription(ButtonEntityDescription):
     """Describes LG IR button entity."""
 
-    command_code: LGTVCode
+    command_code: LGTVCode | LGACCode
 
 
 TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
@@ -114,6 +116,66 @@ TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     ),
 )
 
+# One-shot AC actions with no discrete on/off code, so each is a momentary button.
+AC_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
+    LgIrButtonEntityDescription(
+        key="jet", translation_key="jet", command_code=LGACCode.JET
+    ),
+    LgIrButtonEntityDescription(
+        key="eco", translation_key="eco", command_code=LGACCode.ECO
+    ),
+    # A separate boost from JET, offered on LG India units.
+    LgIrButtonEntityDescription(
+        key="viraat", translation_key="viraat", command_code=LGACCode.VIRAAT
+    ),
+    LgIrButtonEntityDescription(
+        key="ai_convertible",
+        translation_key="ai_convertible",
+        command_code=LGACCode.AI_CONVERTIBLE,
+    ),
+    LgIrButtonEntityDescription(
+        key="light",
+        translation_key="light",
+        command_code=LGACCode.LIGHT_TOGGLE,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LgIrButtonEntityDescription(
+        key="wifi",
+        translation_key="wifi",
+        command_code=LGACCode.WIFI_TOGGLE,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LgIrButtonEntityDescription(
+        key="audio",
+        translation_key="audio",
+        command_code=LGACCode.AUDIO_TOGGLE,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LgIrButtonEntityDescription(
+        key="diagnose",
+        translation_key="diagnose",
+        command_code=LGACCode.DIAGNOSE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Only flips between auto-swing and off; the climate swing dropdown supersedes it,
+    # so it is kept for older units but disabled by default.
+    LgIrButtonEntityDescription(
+        key="swing_v_toggle",
+        translation_key="swing_v_toggle",
+        command_code=LGACCode.SWING_V_TOGGLE,
+        entity_registry_enabled_default=False,
+    ),
+)
+
+_DEVICE_BUTTONS: dict[LGDeviceType, tuple[LgIrButtonEntityDescription, ...]] = {
+    LGDeviceType.TV: TV_BUTTON_DESCRIPTIONS,
+    LGDeviceType.AC: AC_BUTTON_DESCRIPTIONS,
+}
+_DEVICE_NAMES: dict[LGDeviceType, str] = {
+    LGDeviceType.TV: "LG TV",
+    LGDeviceType.AC: "LG AC",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -125,11 +187,11 @@ async def async_setup_entry(
         return
 
     device_type = entry.data[CONF_DEVICE_TYPE]
-    if device_type == LGDeviceType.TV:
-        async_add_entities(
-            LgIrButton(entry, infrared_entity_id, description)
-            for description in TV_BUTTON_DESCRIPTIONS
-        )
+    device_name = _DEVICE_NAMES[device_type]
+    async_add_entities(
+        LgIrButton(entry, infrared_entity_id, description, device_name)
+        for description in _DEVICE_BUTTONS[device_type]
+    )
 
 
 class LgIrButton(LgIrEntity, InfraredEmitterConsumerEntity, ButtonEntity):
@@ -142,9 +204,12 @@ class LgIrButton(LgIrEntity, InfraredEmitterConsumerEntity, ButtonEntity):
         entry: ConfigEntry,
         infrared_entity_id: str,
         description: LgIrButtonEntityDescription,
+        device_name: str,
     ) -> None:
         """Initialize LG IR button."""
-        super().__init__(entry, unique_id_suffix=description.key)
+        super().__init__(
+            entry, unique_id_suffix=description.key, device_name=device_name
+        )
         self._infrared_emitter_entity_id = infrared_entity_id
         self.entity_description = description
 

--- a/homeassistant/components/lg_infrared/icons.json
+++ b/homeassistant/components/lg_infrared/icons.json
@@ -1,11 +1,23 @@
 {
   "entity": {
     "button": {
+      "ai_convertible": {
+        "default": "mdi:brain"
+      },
+      "audio": {
+        "default": "mdi:volume-high"
+      },
       "back": {
         "default": "mdi:keyboard-backspace"
       },
+      "diagnose": {
+        "default": "mdi:stethoscope"
+      },
       "down": {
         "default": "mdi:arrow-down"
+      },
+      "eco": {
+        "default": "mdi:leaf"
       },
       "exit": {
         "default": "mdi:exit-to-app"
@@ -34,8 +46,14 @@
       "input": {
         "default": "mdi:import"
       },
+      "jet": {
+        "default": "mdi:fan-chevron-up"
+      },
       "left": {
         "default": "mdi:arrow-left"
+      },
+      "light": {
+        "default": "mdi:led-on"
       },
       "menu": {
         "default": "mdi:menu"
@@ -85,8 +103,17 @@
       "right": {
         "default": "mdi:arrow-right"
       },
+      "swing_v_toggle": {
+        "default": "mdi:arrow-up-down"
+      },
       "up": {
         "default": "mdi:arrow-up"
+      },
+      "viraat": {
+        "default": "mdi:rocket-launch"
+      },
+      "wifi": {
+        "default": "mdi:wifi"
       }
     }
   }

--- a/homeassistant/components/lg_infrared/quality_scale.yaml
+++ b/homeassistant/components/lg_infrared/quality_scale.yaml
@@ -84,10 +84,7 @@ rules:
       Each config entry creates a single device.
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default:
-    status: exempt
-    comment: |
-      No entities should be disabled by default.
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations:
     status: exempt

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -47,11 +47,23 @@
   },
   "entity": {
     "button": {
+      "ai_convertible": {
+        "name": "AI mode"
+      },
+      "audio": {
+        "name": "Beep"
+      },
       "back": {
         "name": "[%key:common::entity::button::back::name%]"
       },
+      "diagnose": {
+        "name": "Diagnose"
+      },
       "down": {
         "name": "[%key:common::entity::button::down::name%]"
+      },
+      "eco": {
+        "name": "Eco"
       },
       "exit": {
         "name": "[%key:common::entity::button::exit::name%]"
@@ -80,8 +92,14 @@
       "input": {
         "name": "[%key:common::entity::button::input::name%]"
       },
+      "jet": {
+        "name": "Jet"
+      },
       "left": {
         "name": "[%key:common::entity::button::left::name%]"
+      },
+      "light": {
+        "name": "Light"
       },
       "menu": {
         "name": "[%key:common::entity::button::menu::name%]"
@@ -131,8 +149,17 @@
       "right": {
         "name": "[%key:common::entity::button::right::name%]"
       },
+      "swing_v_toggle": {
+        "name": "Vertical swing toggle"
+      },
       "up": {
         "name": "[%key:common::entity::button::up::name%]"
+      },
+      "viraat": {
+        "name": "Viraat"
+      },
+      "wifi": {
+        "name": "Wi-Fi"
       }
     },
     "climate": {

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -51,7 +51,7 @@
         "name": "AI mode"
       },
       "audio": {
-        "name": "Beep"
+        "name": "Toggle beep"
       },
       "back": {
         "name": "[%key:common::entity::button::back::name%]"
@@ -63,7 +63,7 @@
         "name": "[%key:common::entity::button::down::name%]"
       },
       "eco": {
-        "name": "Eco"
+        "name": "Eco mode"
       },
       "exit": {
         "name": "[%key:common::entity::button::exit::name%]"
@@ -93,13 +93,13 @@
         "name": "[%key:common::entity::button::input::name%]"
       },
       "jet": {
-        "name": "Jet"
+        "name": "Jet mode"
       },
       "left": {
         "name": "[%key:common::entity::button::left::name%]"
       },
       "light": {
-        "name": "Light"
+        "name": "Toggle light"
       },
       "menu": {
         "name": "[%key:common::entity::button::menu::name%]"
@@ -150,16 +150,16 @@
         "name": "[%key:common::entity::button::right::name%]"
       },
       "swing_v_toggle": {
-        "name": "Vertical swing toggle"
+        "name": "Toggle vertical swing"
       },
       "up": {
         "name": "[%key:common::entity::button::up::name%]"
       },
       "viraat": {
-        "name": "Viraat"
+        "name": "Viraat mode"
       },
       "wifi": {
-        "name": "Wi-Fi"
+        "name": "Start Wi-Fi pairing"
       }
     },
     "climate": {

--- a/tests/components/lg_infrared/snapshots/test_button.ambr
+++ b/tests/components/lg_infrared/snapshots/test_button.ambr
@@ -1,4 +1,454 @@
 # serializer version: 1
+# name: test_ac_entities[ac][button.lg_ac_ai_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_ai_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AI mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AI mode',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ai_convertible',
+    'unique_id': '01JTEST0000000000000000000_ai_convertible',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_ai_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC AI mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_ai_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_beep-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.lg_ac_beep',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Beep',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Beep',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio',
+    'unique_id': '01JTEST0000000000000000000_audio',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_beep-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Beep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_beep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_diagnose-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.lg_ac_diagnose',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Diagnose',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Diagnose',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'diagnose',
+    'unique_id': '01JTEST0000000000000000000_diagnose',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_diagnose-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Diagnose',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_diagnose',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_eco-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_eco',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Eco',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Eco',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'eco',
+    'unique_id': '01JTEST0000000000000000000_eco',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_eco-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Eco',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_eco',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_jet-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_jet',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Jet',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Jet',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'jet',
+    'unique_id': '01JTEST0000000000000000000_jet',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_jet-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Jet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_jet',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.lg_ac_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light',
+    'unique_id': '01JTEST0000000000000000000_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Light',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_vertical_swing_toggle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_vertical_swing_toggle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vertical swing toggle',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vertical swing toggle',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'swing_v_toggle',
+    'unique_id': '01JTEST0000000000000000000_swing_v_toggle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_vertical_swing_toggle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Vertical swing toggle',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_vertical_swing_toggle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_viraat-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_viraat',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Viraat',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Viraat',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'viraat',
+    'unique_id': '01JTEST0000000000000000000_viraat',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_viraat-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Viraat',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_viraat',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_wi_fi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.lg_ac_wi_fi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi',
+    'unique_id': '01JTEST0000000000000000000_wifi',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ac_entities[ac][button.lg_ac_wi_fi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Wi-Fi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_wi_fi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_entities[button.lg_tv_back-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/lg_infrared/snapshots/test_button.ambr
+++ b/tests/components/lg_infrared/snapshots/test_button.ambr
@@ -49,56 +49,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[ac][button.lg_ac_beep-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'button',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.lg_ac_beep',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Beep',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Beep',
-    'platform': 'lg_infrared',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'audio',
-    'unique_id': '01JTEST0000000000000000000_audio',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_beep-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Beep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.lg_ac_beep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_entities[ac][button.lg_ac_diagnose-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -149,7 +99,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[ac][button.lg_ac_eco-entry]
+# name: test_entities[ac][button.lg_ac_eco_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -163,7 +113,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': None,
-    'entity_id': 'button.lg_ac_eco',
+    'entity_id': 'button.lg_ac_eco_mode',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -171,12 +121,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Eco',
+    'object_id_base': 'Eco mode',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Eco',
+    'original_name': 'Eco mode',
     'platform': 'lg_infrared',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -186,20 +136,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[ac][button.lg_ac_eco-state]
+# name: test_entities[ac][button.lg_ac_eco_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Eco',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Eco mode',
     }),
     'context': <ANY>,
-    'entity_id': 'button.lg_ac_eco',
+    'entity_id': 'button.lg_ac_eco_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_entities[ac][button.lg_ac_jet-entry]
+# name: test_entities[ac][button.lg_ac_jet_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -213,7 +163,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': None,
-    'entity_id': 'button.lg_ac_jet',
+    'entity_id': 'button.lg_ac_jet_mode',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -221,12 +171,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Jet',
+    'object_id_base': 'Jet mode',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Jet',
+    'original_name': 'Jet mode',
     'platform': 'lg_infrared',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -236,20 +186,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[ac][button.lg_ac_jet-state]
+# name: test_entities[ac][button.lg_ac_jet_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Jet',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Jet mode',
     }),
     'context': <ANY>,
-    'entity_id': 'button.lg_ac_jet',
+    'entity_id': 'button.lg_ac_jet_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_entities[ac][button.lg_ac_light-entry]
+# name: test_entities[ac][button.lg_ac_start_wi_fi_pairing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -263,7 +213,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.lg_ac_light',
+    'entity_id': 'button.lg_ac_start_wi_fi_pairing',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -271,162 +221,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Light',
+    'object_id_base': 'Start Wi-Fi pairing',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
-    'platform': 'lg_infrared',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'light',
-    'unique_id': '01JTEST0000000000000000000_light',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_light-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Light',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.lg_ac_light',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_vertical_swing_toggle-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'button',
-    'entity_category': None,
-    'entity_id': 'button.lg_ac_vertical_swing_toggle',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Vertical swing toggle',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Vertical swing toggle',
-    'platform': 'lg_infrared',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'swing_v_toggle',
-    'unique_id': '01JTEST0000000000000000000_swing_v_toggle',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_vertical_swing_toggle-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Vertical swing toggle',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.lg_ac_vertical_swing_toggle',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_viraat-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'button',
-    'entity_category': None,
-    'entity_id': 'button.lg_ac_viraat',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Viraat',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Viraat',
-    'platform': 'lg_infrared',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'viraat',
-    'unique_id': '01JTEST0000000000000000000_viraat',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_viraat-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Viraat',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.lg_ac_viraat',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_entities[ac][button.lg_ac_wi_fi-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'button',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.lg_ac_wi_fi',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Wi-Fi',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Wi-Fi',
+    'original_name': 'Start Wi-Fi pairing',
     'platform': 'lg_infrared',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -436,13 +236,213 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[ac][button.lg_ac_wi_fi-state]
+# name: test_entities[ac][button.lg_ac_start_wi_fi_pairing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Wi-Fi',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Start Wi-Fi pairing',
     }),
     'context': <ANY>,
-    'entity_id': 'button.lg_ac_wi_fi',
+    'entity_id': 'button.lg_ac_start_wi_fi_pairing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_beep-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.lg_ac_toggle_beep',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Toggle beep',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Toggle beep',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio',
+    'unique_id': '01JTEST0000000000000000000_audio',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_beep-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Toggle beep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_toggle_beep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.lg_ac_toggle_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Toggle light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Toggle light',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light',
+    'unique_id': '01JTEST0000000000000000000_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Toggle light',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_toggle_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_vertical_swing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_toggle_vertical_swing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Toggle vertical swing',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Toggle vertical swing',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'swing_v_toggle',
+    'unique_id': '01JTEST0000000000000000000_swing_v_toggle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_toggle_vertical_swing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Toggle vertical swing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_toggle_vertical_swing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_viraat_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.lg_ac_viraat_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Viraat mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Viraat mode',
+    'platform': 'lg_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'viraat',
+    'unique_id': '01JTEST0000000000000000000_viraat',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[ac][button.lg_ac_viraat_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Viraat mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.lg_ac_viraat_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/lg_infrared/snapshots/test_button.ambr
+++ b/tests/components/lg_infrared/snapshots/test_button.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_ac_entities[ac][button.lg_ac_ai_mode-entry]
+# name: test_entities[ac][button.lg_ac_ai_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -36,7 +36,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_ai_mode-state]
+# name: test_entities[ac][button.lg_ac_ai_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC AI mode',
@@ -49,7 +49,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_beep-entry]
+# name: test_entities[ac][button.lg_ac_beep-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -86,7 +86,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_beep-state]
+# name: test_entities[ac][button.lg_ac_beep-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Beep',
@@ -99,7 +99,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_diagnose-entry]
+# name: test_entities[ac][button.lg_ac_diagnose-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -136,7 +136,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_diagnose-state]
+# name: test_entities[ac][button.lg_ac_diagnose-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Diagnose',
@@ -149,7 +149,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_eco-entry]
+# name: test_entities[ac][button.lg_ac_eco-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -186,7 +186,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_eco-state]
+# name: test_entities[ac][button.lg_ac_eco-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Eco',
@@ -199,7 +199,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_jet-entry]
+# name: test_entities[ac][button.lg_ac_jet-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -236,7 +236,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_jet-state]
+# name: test_entities[ac][button.lg_ac_jet-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Jet',
@@ -249,7 +249,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_light-entry]
+# name: test_entities[ac][button.lg_ac_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -286,7 +286,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_light-state]
+# name: test_entities[ac][button.lg_ac_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Light',
@@ -299,7 +299,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_vertical_swing_toggle-entry]
+# name: test_entities[ac][button.lg_ac_vertical_swing_toggle-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -336,7 +336,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_vertical_swing_toggle-state]
+# name: test_entities[ac][button.lg_ac_vertical_swing_toggle-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Vertical swing toggle',
@@ -349,7 +349,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_viraat-entry]
+# name: test_entities[ac][button.lg_ac_viraat-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -386,7 +386,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_viraat-state]
+# name: test_entities[ac][button.lg_ac_viraat-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Viraat',
@@ -399,7 +399,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_wi_fi-entry]
+# name: test_entities[ac][button.lg_ac_wi_fi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -436,7 +436,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_ac_entities[ac][button.lg_ac_wi_fi-state]
+# name: test_entities[ac][button.lg_ac_wi_fi-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG AC Wi-Fi',
@@ -449,7 +449,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_back-entry]
+# name: test_entities[tv][button.lg_tv_back-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -486,7 +486,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_back-state]
+# name: test_entities[tv][button.lg_tv_back-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Back',
@@ -499,7 +499,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_down-entry]
+# name: test_entities[tv][button.lg_tv_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -536,7 +536,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_down-state]
+# name: test_entities[tv][button.lg_tv_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Down',
@@ -549,7 +549,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_exit-entry]
+# name: test_entities[tv][button.lg_tv_exit-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -586,7 +586,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_exit-state]
+# name: test_entities[tv][button.lg_tv_exit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Exit',
@@ -599,7 +599,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_guide-entry]
+# name: test_entities[tv][button.lg_tv_guide-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -636,7 +636,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_guide-state]
+# name: test_entities[tv][button.lg_tv_guide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Guide',
@@ -649,7 +649,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_1-entry]
+# name: test_entities[tv][button.lg_tv_hdmi_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -686,7 +686,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_1-state]
+# name: test_entities[tv][button.lg_tv_hdmi_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV HDMI 1',
@@ -699,7 +699,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_2-entry]
+# name: test_entities[tv][button.lg_tv_hdmi_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -736,7 +736,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_2-state]
+# name: test_entities[tv][button.lg_tv_hdmi_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV HDMI 2',
@@ -749,7 +749,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_3-entry]
+# name: test_entities[tv][button.lg_tv_hdmi_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -786,7 +786,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_3-state]
+# name: test_entities[tv][button.lg_tv_hdmi_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV HDMI 3',
@@ -799,7 +799,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_4-entry]
+# name: test_entities[tv][button.lg_tv_hdmi_4-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -836,7 +836,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_hdmi_4-state]
+# name: test_entities[tv][button.lg_tv_hdmi_4-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV HDMI 4',
@@ -849,7 +849,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_home-entry]
+# name: test_entities[tv][button.lg_tv_home-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -886,7 +886,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_home-state]
+# name: test_entities[tv][button.lg_tv_home-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Home',
@@ -899,7 +899,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_info-entry]
+# name: test_entities[tv][button.lg_tv_info-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -936,7 +936,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_info-state]
+# name: test_entities[tv][button.lg_tv_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Info',
@@ -949,7 +949,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_input-entry]
+# name: test_entities[tv][button.lg_tv_input-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -986,7 +986,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_input-state]
+# name: test_entities[tv][button.lg_tv_input-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Input',
@@ -999,7 +999,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_left-entry]
+# name: test_entities[tv][button.lg_tv_left-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1036,7 +1036,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_left-state]
+# name: test_entities[tv][button.lg_tv_left-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Left',
@@ -1049,7 +1049,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_menu-entry]
+# name: test_entities[tv][button.lg_tv_menu-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1086,7 +1086,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_menu-state]
+# name: test_entities[tv][button.lg_tv_menu-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Menu',
@@ -1099,7 +1099,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_0-entry]
+# name: test_entities[tv][button.lg_tv_number_0-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1136,7 +1136,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_0-state]
+# name: test_entities[tv][button.lg_tv_number_0-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 0',
@@ -1149,7 +1149,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_1-entry]
+# name: test_entities[tv][button.lg_tv_number_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1186,7 +1186,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_1-state]
+# name: test_entities[tv][button.lg_tv_number_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 1',
@@ -1199,7 +1199,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_2-entry]
+# name: test_entities[tv][button.lg_tv_number_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1236,7 +1236,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_2-state]
+# name: test_entities[tv][button.lg_tv_number_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 2',
@@ -1249,7 +1249,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_3-entry]
+# name: test_entities[tv][button.lg_tv_number_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1286,7 +1286,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_3-state]
+# name: test_entities[tv][button.lg_tv_number_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 3',
@@ -1299,7 +1299,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_4-entry]
+# name: test_entities[tv][button.lg_tv_number_4-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1336,7 +1336,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_4-state]
+# name: test_entities[tv][button.lg_tv_number_4-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 4',
@@ -1349,7 +1349,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_5-entry]
+# name: test_entities[tv][button.lg_tv_number_5-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1386,7 +1386,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_5-state]
+# name: test_entities[tv][button.lg_tv_number_5-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 5',
@@ -1399,7 +1399,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_6-entry]
+# name: test_entities[tv][button.lg_tv_number_6-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1436,7 +1436,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_6-state]
+# name: test_entities[tv][button.lg_tv_number_6-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 6',
@@ -1449,7 +1449,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_7-entry]
+# name: test_entities[tv][button.lg_tv_number_7-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1486,7 +1486,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_7-state]
+# name: test_entities[tv][button.lg_tv_number_7-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 7',
@@ -1499,7 +1499,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_8-entry]
+# name: test_entities[tv][button.lg_tv_number_8-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1536,7 +1536,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_8-state]
+# name: test_entities[tv][button.lg_tv_number_8-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 8',
@@ -1549,7 +1549,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_number_9-entry]
+# name: test_entities[tv][button.lg_tv_number_9-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1586,7 +1586,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_number_9-state]
+# name: test_entities[tv][button.lg_tv_number_9-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Number 9',
@@ -1599,7 +1599,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_ok-entry]
+# name: test_entities[tv][button.lg_tv_ok-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1636,7 +1636,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_ok-state]
+# name: test_entities[tv][button.lg_tv_ok-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV OK',
@@ -1649,7 +1649,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_power-entry]
+# name: test_entities[tv][button.lg_tv_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1686,7 +1686,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_power-state]
+# name: test_entities[tv][button.lg_tv_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Power',
@@ -1699,7 +1699,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_power_off-entry]
+# name: test_entities[tv][button.lg_tv_power_off-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1736,7 +1736,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_power_off-state]
+# name: test_entities[tv][button.lg_tv_power_off-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Power off',
@@ -1749,7 +1749,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_power_on-entry]
+# name: test_entities[tv][button.lg_tv_power_on-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1786,7 +1786,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_power_on-state]
+# name: test_entities[tv][button.lg_tv_power_on-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Power on',
@@ -1799,7 +1799,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_right-entry]
+# name: test_entities[tv][button.lg_tv_right-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1836,7 +1836,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_right-state]
+# name: test_entities[tv][button.lg_tv_right-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Right',
@@ -1849,7 +1849,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_entities[button.lg_tv_up-entry]
+# name: test_entities[tv][button.lg_tv_up-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1886,7 +1886,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_entities[button.lg_tv_up-state]
+# name: test_entities[tv][button.lg_tv_up-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'LG TV Up',

--- a/tests/components/lg_infrared/test_button.py
+++ b/tests/components/lg_infrared/test_button.py
@@ -113,15 +113,15 @@ async def test_button_availability_follows_ir_entity(
 @pytest.mark.parametrize(
     ("entity_id", "expected_code"),
     [
-        ("button.lg_ac_jet", LGACCode.JET),
-        ("button.lg_ac_eco", LGACCode.ECO),
-        ("button.lg_ac_viraat", LGACCode.VIRAAT),
+        ("button.lg_ac_jet_mode", LGACCode.JET),
+        ("button.lg_ac_eco_mode", LGACCode.ECO),
+        ("button.lg_ac_viraat_mode", LGACCode.VIRAAT),
         ("button.lg_ac_ai_mode", LGACCode.AI_CONVERTIBLE),
-        ("button.lg_ac_light", LGACCode.LIGHT_TOGGLE),
-        ("button.lg_ac_wi_fi", LGACCode.WIFI_TOGGLE),
-        ("button.lg_ac_beep", LGACCode.AUDIO_TOGGLE),
+        ("button.lg_ac_toggle_light", LGACCode.LIGHT_TOGGLE),
+        ("button.lg_ac_start_wi_fi_pairing", LGACCode.WIFI_TOGGLE),
+        ("button.lg_ac_toggle_beep", LGACCode.AUDIO_TOGGLE),
         ("button.lg_ac_diagnose", LGACCode.DIAGNOSE),
-        ("button.lg_ac_vertical_swing_toggle", LGACCode.SWING_V_TOGGLE),
+        ("button.lg_ac_toggle_vertical_swing", LGACCode.SWING_V_TOGGLE),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")

--- a/tests/components/lg_infrared/test_button.py
+++ b/tests/components/lg_infrared/test_button.py
@@ -153,18 +153,19 @@ async def test_ac_button_press_sends_correct_code(
 
 
 @pytest.mark.parametrize("device_type", [LGDeviceType.AC])
+@pytest.mark.parametrize("key", ["swing_v_toggle", "viraat"])
 @pytest.mark.usefixtures("init_integration")
-async def test_swing_v_toggle_disabled_by_default(
+async def test_ac_buttons_disabled_by_default(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
+    key: str,
 ) -> None:
-    """Test the legacy vertical-swing toggle is registered but disabled by default."""
+    """Test the buttons only some units support are registered but disabled."""
     entity_id = entity_registry.async_get_entity_id(
-        BUTTON_DOMAIN, "lg_infrared", f"{mock_config_entry.entry_id}_swing_v_toggle"
+        BUTTON_DOMAIN, "lg_infrared", f"{mock_config_entry.entry_id}_{key}"
     )
     assert entity_id is not None
     entry = entity_registry.async_get(entity_id)
     assert entry is not None
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-    assert entry.unique_id.endswith("_swing_v_toggle")

--- a/tests/components/lg_infrared/test_button.py
+++ b/tests/components/lg_infrared/test_button.py
@@ -1,10 +1,12 @@
 """Tests for the LG Infrared button platform."""
 
+from infrared_protocols.codes.lg.ac import LGACCode
 from infrared_protocols.codes.lg.tv import LGTVCode
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.lg_infrared.const import LGDeviceType
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -104,3 +106,65 @@ async def test_button_availability_follows_ir_entity(
     """Test button becomes unavailable when IR entity is unavailable."""
     entity_id = "button.lg_tv_power_on"
     await assert_availability_follows_source_entity(hass, entity_id, EMITTER_ENTITY_ID)
+
+
+@pytest.mark.parametrize("device_type", [LGDeviceType.AC])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_ac_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test all AC button entities are created with correct attributes."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("device_type", [LGDeviceType.AC])
+@pytest.mark.parametrize(
+    ("entity_id", "expected_code"),
+    [
+        ("button.lg_ac_jet", LGACCode.JET),
+        ("button.lg_ac_eco", LGACCode.ECO),
+        ("button.lg_ac_viraat", LGACCode.VIRAAT),
+        ("button.lg_ac_ai_mode", LGACCode.AI_CONVERTIBLE),
+        ("button.lg_ac_light", LGACCode.LIGHT_TOGGLE),
+        ("button.lg_ac_wi_fi", LGACCode.WIFI_TOGGLE),
+        ("button.lg_ac_beep", LGACCode.AUDIO_TOGGLE),
+        ("button.lg_ac_diagnose", LGACCode.DIAGNOSE),
+        ("button.lg_ac_vertical_swing_toggle", LGACCode.SWING_V_TOGGLE),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_ac_button_press_sends_correct_code(
+    hass: HomeAssistant,
+    mock_infrared_emitter_entity: MockInfraredEmitterEntity,
+    entity_id: str,
+    expected_code: LGACCode,
+) -> None:
+    """Test pressing an AC button sends the matching fixed IR code."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+
+    assert len(mock_infrared_emitter_entity.send_command_calls) == 1
+    timings = mock_infrared_emitter_entity.send_command_calls[0].get_raw_timings()
+    assert timings == expected_code.to_command().get_raw_timings()
+
+
+@pytest.mark.parametrize("device_type", [LGDeviceType.AC])
+@pytest.mark.usefixtures("init_integration")
+async def test_swing_v_toggle_disabled_by_default(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the legacy vertical-swing toggle is registered but disabled by default."""
+    entity_id = entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, "lg_infrared", f"{mock_config_entry.entry_id}_swing_v_toggle"
+    )
+    assert entity_id is not None
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert entry.unique_id.endswith("_swing_v_toggle")

--- a/tests/components/lg_infrared/test_button.py
+++ b/tests/components/lg_infrared/test_button.py
@@ -23,7 +23,8 @@ def platforms() -> list[Platform]:
     return [Platform.BUTTON]
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize("device_type", [LGDeviceType.TV, LGDeviceType.AC])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -106,18 +107,6 @@ async def test_button_availability_follows_ir_entity(
     """Test button becomes unavailable when IR entity is unavailable."""
     entity_id = "button.lg_tv_power_on"
     await assert_availability_follows_source_entity(hass, entity_id, EMITTER_ENTITY_ID)
-
-
-@pytest.mark.parametrize("device_type", [LGDeviceType.AC])
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_ac_entities(
-    hass: HomeAssistant,
-    snapshot: SnapshotAssertion,
-    entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test all AC button entities are created with correct attributes."""
-    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 @pytest.mark.parametrize("device_type", [LGDeviceType.AC])


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the AC buttons to the existing `button` platform: Jet, Eco, Viraat, AI mode, Light, Wi-Fi, Beep, Diagnose and a legacy vertical swing toggle.

These are one-shot AC actions with no discrete on/off code, so each is a momentary button. Viraat is only offered on LG India models and the vertical swing toggle is superseded by the climate swing control, so both are disabled by default.

Split from the original combined change at @joostlek's request, one pull request per platform. The sibling PRs are #177191 (climate swing modes), #180842 (AC buttons), #180843 (switch platform) and #180844 (select platform); each has its own documentation PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47766
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
