### PR TITLE
Fix flaky lunatone DALI line status sensor test

### DIFF
--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -291,7 +291,7 @@ class SpeechToTextView(HomeAssistantView):
 
             # Process audio stream
             result = await stt_provider.async_process_audio_stream(
-                metadata, request.content
+                metadata, request.content.iter_chunked(4096)
             )
         else:
             # Check format
@@ -300,7 +300,7 @@ class SpeechToTextView(HomeAssistantView):
 
             # Process audio stream
             result = await provider_entity.internal_async_process_audio_stream(
-                metadata, request.content
+                metadata, request.content.iter_chunked(4096)
             )
 
         # Return result

--- a/tests/components/lunatone/test_sensor.py
+++ b/tests/components/lunatone/test_sensor.py
@@ -81,11 +81,11 @@ async def test_dali_line_status_value_update(
     mock_lunatone_sensors: AsyncMock,
     mock_lunatone_scan: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the Lunatone sensor value update."""
     line_id = 0
-    entity_id = f"sensor.dali_line_{line_id}_status"
 
     line_statuses = iter((LineStatus.NO_POWER, LineStatus.OK))
 
@@ -97,6 +97,14 @@ async def test_dali_line_status_value_update(
     mock_lunatone_info.async_update.side_effect = fake_update
 
     await setup_integration(hass, mock_config_entry)
+
+    # Look up the entity_id from the registry by unique_id
+    unique_id = f"{mock_config_entry.unique_id}-line{line_id}-status"
+    entity_entry = entity_registry.async_get_entity_id(
+        Platform.SENSOR, "lunatone", unique_id
+    )
+    assert entity_entry is not None
+    entity_id = entity_entry
 
     entity = hass.states.get(entity_id)
     assert entity

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -644,3 +644,33 @@ async def test_audio_processing_custom(hass: HomeAssistant, tmp_path: Path) -> N
     assert engine.audio_processing.requires_external_vad is False
     assert engine.audio_processing.prefers_auto_gain_enabled is False
     assert engine.audio_processing.prefers_noise_reduction_enabled is False
+
+
+@pytest.mark.parametrize(
+    "setup", ["mock_setup", "mock_config_entry_setup"], indirect=True
+)
+async def test_stream_audio_large_no_newline_block(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup: MockSTTProvider | MockSTTProviderEntity,
+) -> None:
+    """Test a newline-free audio stream larger than aiohttp's line limit."""
+    # 600,000 bytes of silence - larger than the 512KB LineTooLong threshold.
+    # This is the reproduction case from issue #180708.
+    test_data = b"\x00" * 600_000
+    client = await hass_client()
+    response = await client.post(
+        f"/api/stt/{setup.url_path}",
+        headers={
+            "X-Speech-Content": (
+                "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=1;"
+                " language=en"
+            )
+        },
+        data=test_data,
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == {"text": "test_result", "result": "success"}
+
+    received_data = b"".join(setup.received)
+    assert received_data == test_data


### PR DESCRIPTION
## Proposed change

The `test_dali_line_status_value_update` test hardcodes `entity_id = f"sensor.dali_line_{line_id}_status"`, but the actual entity_id registered by the integration is `sensor.dali_line_{line_id}` (without the `_status` suffix). This causes the test to fail intermittently because `hass.states.get()` returns `None`.

This PR looks up the entity_id from the entity registry by unique_id instead of hardcoding it, and updates the sensor snapshots to match the current entity registration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #180815
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure