### PR TITLE
Add Besen status and configuration entities

### DIFF
--- a/homeassistant/components/besen/const.py
+++ b/homeassistant/components/besen/const.py
@@ -7,4 +7,9 @@ from homeassistant.const import Platform
 DOMAIN: Final = "besen"
 NAME: Final = "Besen"
 
-PLATFORMS: Final = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: Final = [
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/besen/const.py
+++ b/homeassistant/components/besen/const.py
@@ -7,4 +7,4 @@ from homeassistant.const import Platform
 DOMAIN: Final = "besen"
 NAME: Final = "Besen"
 
-PLATFORMS: Final = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: Final = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]

--- a/homeassistant/components/besen/coordinator.py
+++ b/homeassistant/components/besen/coordinator.py
@@ -90,6 +90,11 @@ class BesenCoordinator(DataUpdateCoordinator[BesenData]):
 
         await self._async_run_command(self.client.async_stop_charging())
 
+    async def async_set_charge_amps(self, amps: int) -> None:
+        """Set the charging current."""
+
+        await self._async_run_command(self.client.async_set_charge_amps(amps))
+
     async def _async_run_command(self, command: Awaitable[None]) -> None:
         """Run a charger command and translate command failures."""
 

--- a/homeassistant/components/besen/coordinator.py
+++ b/homeassistant/components/besen/coordinator.py
@@ -95,6 +95,21 @@ class BesenCoordinator(DataUpdateCoordinator[BesenData]):
 
         await self._async_run_command(self.client.async_set_charge_amps(amps))
 
+    async def async_set_lcd_brightness(self, brightness: int) -> None:
+        """Set the LCD brightness."""
+
+        await self._async_run_command(self.client.async_set_lcd_brightness(brightness))
+
+    async def async_set_language(self, language: str) -> None:
+        """Set the charger language."""
+
+        await self._async_run_command(self.client.async_set_language(language))
+
+    async def async_set_temperature_unit(self, unit: str) -> None:
+        """Set the charger temperature unit."""
+
+        await self._async_run_command(self.client.async_set_temperature_unit(unit))
+
     async def _async_run_command(self, command: Awaitable[None]) -> None:
         """Run a charger command and translate command failures."""
 

--- a/homeassistant/components/besen/manifest.json
+++ b/homeassistant/components/besen/manifest.json
@@ -14,5 +14,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["besen==0.4.0"]
+  "requirements": ["besen==0.4.1"]
 }

--- a/homeassistant/components/besen/number.py
+++ b/homeassistant/components/besen/number.py
@@ -1,11 +1,19 @@
 """Number platform for Besen."""
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import override
 
 from besen.const import FALLBACK_MAX_CHARGE_AMPS, MIN_CHARGE_AMPS
+from besen.models import BesenData
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
-from homeassistant.const import EntityCategory, UnitOfElectricCurrent
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -16,6 +24,47 @@ from .entity import BesenEntity
 PARALLEL_UPDATES = 0
 
 
+@dataclass(frozen=True, kw_only=True)
+class BesenNumberEntityDescription(NumberEntityDescription):
+    """Describe a Besen number entity."""
+
+    value_fn: Callable[[BesenData], float | None]
+    set_fn: Callable[[BesenCoordinator, float], Awaitable[None]]
+    max_fn: Callable[[BesenData], float]
+
+
+NUMBER_DESCRIPTIONS: tuple[BesenNumberEntityDescription, ...] = (
+    BesenNumberEntityDescription(
+        key="charging_current",
+        translation_key="charging_current",
+        device_class=NumberDeviceClass.CURRENT,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_min_value=MIN_CHARGE_AMPS,
+        native_step=1,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        value_fn=lambda data: data.config.charge_amps,
+        set_fn=lambda coordinator, value: coordinator.async_set_charge_amps(int(value)),
+        max_fn=lambda data: data.info.output_max_amps or FALLBACK_MAX_CHARGE_AMPS,
+    ),
+    BesenNumberEntityDescription(
+        key="lcd_brightness",
+        translation_key="lcd_brightness",
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        mode=NumberMode.SLIDER,
+        native_min_value=1,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda data: data.config.lcd_brightness,
+        set_fn=lambda coordinator, value: coordinator.async_set_lcd_brightness(
+            int(value)
+        ),
+        max_fn=lambda data: 100,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: BesenConfigEntry,
@@ -23,40 +72,43 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Besen number platform."""
 
-    async_add_entities([BesenChargingCurrentNumber(entry.runtime_data)])
+    async_add_entities(
+        BesenNumber(entry.runtime_data, description)
+        for description in NUMBER_DESCRIPTIONS
+    )
 
 
-class BesenChargingCurrentNumber(BesenEntity, NumberEntity):
-    """Charging current control."""
+class BesenNumber(BesenEntity, NumberEntity):
+    """Representation of a Besen number."""
 
-    _attr_device_class = NumberDeviceClass.CURRENT
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_mode = NumberMode.BOX
-    _attr_native_min_value = MIN_CHARGE_AMPS
-    _attr_native_step = 1
-    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    entity_description: BesenNumberEntityDescription
 
-    def __init__(self, coordinator: BesenCoordinator) -> None:
-        """Initialize the charging current control."""
+    def __init__(
+        self,
+        coordinator: BesenCoordinator,
+        description: BesenNumberEntityDescription,
+    ) -> None:
+        """Initialize a Besen number."""
 
-        super().__init__(coordinator, "charging_current")
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
 
     @property
     @override
     def native_max_value(self) -> float:
-        """Return the maximum charging current."""
+        """Return the maximum value."""
 
-        return self.coordinator.data.info.output_max_amps or FALLBACK_MAX_CHARGE_AMPS
+        return self.entity_description.max_fn(self.coordinator.data)
 
     @property
     @override
     def native_value(self) -> float | None:
-        """Return the configured charging current."""
+        """Return the configured value."""
 
-        return self.coordinator.data.config.charge_amps
+        return self.entity_description.value_fn(self.coordinator.data)
 
     @override
     async def async_set_native_value(self, value: float) -> None:
-        """Set the charging current."""
+        """Set the value."""
 
-        await self.coordinator.async_set_charge_amps(int(value))
+        await self.entity_description.set_fn(self.coordinator, value)

--- a/homeassistant/components/besen/number.py
+++ b/homeassistant/components/besen/number.py
@@ -1,0 +1,62 @@
+"""Number platform for Besen."""
+
+from typing import override
+
+from besen.const import FALLBACK_MAX_CHARGE_AMPS, MIN_CHARGE_AMPS
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.const import EntityCategory, UnitOfElectricCurrent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import BesenConfigEntry
+from .coordinator import BesenCoordinator
+from .entity import BesenEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: BesenConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Besen number platform."""
+
+    async_add_entities([BesenChargingCurrentNumber(entry.runtime_data)])
+
+
+class BesenChargingCurrentNumber(BesenEntity, NumberEntity):
+    """Charging current control."""
+
+    _attr_device_class = NumberDeviceClass.CURRENT
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+    _attr_native_min_value = MIN_CHARGE_AMPS
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+
+    def __init__(self, coordinator: BesenCoordinator) -> None:
+        """Initialize the charging current control."""
+
+        super().__init__(coordinator, "charging_current")
+
+    @property
+    @override
+    def native_max_value(self) -> float:
+        """Return the maximum charging current."""
+
+        return self.coordinator.data.info.output_max_amps or FALLBACK_MAX_CHARGE_AMPS
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the configured charging current."""
+
+        return self.coordinator.data.config.charge_amps
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the charging current."""
+
+        await self.coordinator.async_set_charge_amps(int(value))

--- a/homeassistant/components/besen/select.py
+++ b/homeassistant/components/besen/select.py
@@ -1,0 +1,128 @@
+"""Select platform for Besen."""
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Final, override
+
+from besen.models import BesenData
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import BesenConfigEntry
+from .coordinator import BesenCoordinator
+from .entity import BesenEntity
+
+PARALLEL_UPDATES = 0
+
+LANGUAGE_OPTIONS: Final = {
+    "english": "English",
+    "italian": "Italiano",
+    "german": "Deutsch",
+    "french": "Fran\u00e7ais",
+    "spanish": "Espa\u00f1ol",
+    "hebrew": "\u05e2\u05d1\u05e8\u05d9\u05ea",
+    "polish": "Polski",
+    "chinese": "\u4e2d\u6587",
+}
+LANGUAGE_VALUES: Final = {value: key for key, value in LANGUAGE_OPTIONS.items()}
+
+TEMPERATURE_UNIT_OPTIONS: Final = {
+    "celsius": "Celsius",
+    "fahrenheit": "Fahrenheit",
+}
+TEMPERATURE_UNIT_VALUES: Final = {
+    value: key for key, value in TEMPERATURE_UNIT_OPTIONS.items()
+}
+
+
+def _option_value(value: str | None, options: Mapping[str, str]) -> str | None:
+    """Return a Home Assistant option for a charger value."""
+
+    return options.get(value) if value is not None else None
+
+
+@dataclass(frozen=True, kw_only=True)
+class BesenSelectEntityDescription(SelectEntityDescription):
+    """Describe a Besen select entity."""
+
+    current_option_fn: Callable[[BesenData], str | None]
+    option_values: dict[str, str]
+    select_option_fn: Callable[[BesenCoordinator, str], Awaitable[None]]
+
+
+SELECT_DESCRIPTIONS: tuple[BesenSelectEntityDescription, ...] = (
+    BesenSelectEntityDescription(
+        key="language",
+        translation_key="language",
+        entity_category=EntityCategory.CONFIG,
+        options=list(LANGUAGE_OPTIONS),
+        current_option_fn=lambda data: _option_value(
+            data.config.language, LANGUAGE_VALUES
+        ),
+        option_values=LANGUAGE_OPTIONS,
+        select_option_fn=lambda coordinator, option: coordinator.async_set_language(
+            option
+        ),
+    ),
+    BesenSelectEntityDescription(
+        key="temperature_unit",
+        translation_key="temperature_unit",
+        entity_category=EntityCategory.CONFIG,
+        options=list(TEMPERATURE_UNIT_OPTIONS),
+        current_option_fn=lambda data: _option_value(
+            data.config.temperature_unit, TEMPERATURE_UNIT_VALUES
+        ),
+        option_values=TEMPERATURE_UNIT_OPTIONS,
+        select_option_fn=lambda coordinator, option: (
+            coordinator.async_set_temperature_unit(option)
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: BesenConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Besen select platform."""
+
+    async_add_entities(
+        BesenSelect(entry.runtime_data, description)
+        for description in SELECT_DESCRIPTIONS
+    )
+
+
+class BesenSelect(BesenEntity, SelectEntity):
+    """Representation of a Besen select."""
+
+    entity_description: BesenSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: BesenCoordinator,
+        description: BesenSelectEntityDescription,
+    ) -> None:
+        """Initialize a Besen select."""
+
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the current option."""
+
+        return self.entity_description.current_option_fn(self.coordinator.data)
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Set the selected option."""
+
+        await self.entity_description.select_option_fn(
+            self.coordinator,
+            self.entity_description.option_values[option],
+        )

--- a/homeassistant/components/besen/sensor.py
+++ b/homeassistant/components/besen/sensor.py
@@ -1,8 +1,8 @@
 """Sensor platform for Besen."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import override
+from typing import Final, override
 
 from besen.models import BesenData
 
@@ -30,16 +30,170 @@ from .entity import BesenEntity
 
 PARALLEL_UPDATES = 0
 
+ERROR_STATES: Final = {
+    "Relay Stick Error": "relay_stick_error",
+    "OFFLINE": "offline",
+    "CC Error": "cc_error",
+    "CP Error": "cp_error",
+    "Emergency Stop": "emergency_stop",
+    "Over Temperature": "over_temperature",
+    "Unknown": "unknown",
+    "Leakage Protection": "leakage_protection",
+    "Short Circuit": "short_circuit",
+    "Over Current": "over_current",
+    "Ungrounded": "ungrounded",
+    "Over Voltage": "over_voltage",
+    "Low Voltage": "low_voltage",
+    "Input Power Error": "input_power_error",
+    "DLB Over Current - Mains overload": "dlb_over_current",
+    "Diode Short Circuit": "diode_short_circuit",
+    "RTC Failure": "rtc_failure",
+    "Flash Memory Failure": "flash_memory_failure",
+    "EEPROM Failure": "eeprom_failure",
+    "Metering Module Failure": "metering_module_failure",
+    "No Error": "no_error",
+}
+
+CHARGING_STATES: Final = {
+    "Start": "start",
+    "Finish Charging": "finish_charging",
+    "Waiting": "waiting",
+    "Finished": "finished",
+    "Cancel": "canceled",
+    "Connect": "connect",
+    "Fault": "fault",
+}
+
+CHARGING_MESSAGES: Final = {
+    "EV is connected, please press start": "ev_connected_press_start",
+    "Charging": "charging",
+    "Charging has started, waiting for EV.": "waiting_for_ev",
+    "Charging completed": "charging_completed",
+    "Charging reservation.": "charging_reservation",
+    "The plug is not connected, please start charging after connecting.": (
+        "plug_not_connected"
+    ),
+    "See Error State": "see_error_state",
+    "Wait for the swipe to start": "waiting_for_swipe",
+    "Wait for the button to activate": "waiting_for_button",
+}
+
+PLUG_STATES: Final = {
+    "Unknown 0": "unknown_0",
+    "Disconnected": "disconnected",
+    "Connected Unlocked": "connected_unlocked",
+    "Unknown 1": "unknown_1",
+    "Connected Locked": "connected_locked",
+    "Unknown 2": "unknown_2",
+    "Unknown 3": "unknown_3",
+    "Unknown 4": "unknown_4",
+    "Unknown 5": "unknown_5",
+}
+
+OUTPUT_STATES: Final = {
+    "Unknown 0": "unknown_0",
+    "Charging": "charging",
+    "Idle": "idle",
+    "Unknown 1": "unknown_1",
+    "Unknown 2": "unknown_2",
+    "Unknown 3": "unknown_3",
+    "Unknown 4": "unknown_4",
+    "Unknown 5": "unknown_5",
+    "Unknown 6": "unknown_6",
+}
+
+CURRENT_STATES: Final = {
+    "Fault": "fault",
+    "Charging Fault 1": "charging_fault_1",
+    "Charging Fault 2": "charging_fault_2",
+    "Unknown 1": "unknown_1",
+    "Unknown 2": "unknown_2",
+    "Unknown 3": "unknown_3",
+    "Unknown 4": "unknown_4",
+    "Unknown 5": "unknown_5",
+    "Unknown 6": "unknown_6",
+    "Waiting for swipe": "waiting_for_swipe",
+    "Waiting for button": "waiting_for_button",
+    "Not Connected": "not_connected",
+    "Ready to charge": "ready_to_charge",
+    "Charging": "charging",
+    "Completed": "completed",
+    "Unknown 7": "unknown_7",
+    "Completed Full Charge": "completed_full_charge",
+    "Unknown 8": "unknown_8",
+    "Unknown 9": "unknown_9",
+    "Charging Reservation": "charging_reservation",
+    "Unknown 10": "unknown_10",
+}
+
+
+def _enum_state(value: str | None, states: Mapping[str, str]) -> str | None:
+    """Return the stable Home Assistant value for a charger state."""
+
+    return states.get(value) if value is not None else None
+
 
 @dataclass(frozen=True, kw_only=True)
 class BesenSensorEntityDescription(SensorEntityDescription):
     """Describe a Besen sensor entity."""
 
-    value_fn: Callable[[BesenData], float | int | None]
+    value_fn: Callable[[BesenData], StateType]
     three_phase_only: bool = False
 
 
 SENSOR_DESCRIPTIONS: tuple[BesenSensorEntityDescription, ...] = (
+    BesenSensorEntityDescription(
+        key="charging_status",
+        translation_key="charging_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=list(CHARGING_STATES.values()),
+        value_fn=lambda data: _enum_state(data.charge.charging_status, CHARGING_STATES),
+    ),
+    BesenSensorEntityDescription(
+        key="charging_message",
+        translation_key="charging_message",
+        device_class=SensorDeviceClass.ENUM,
+        options=list(CHARGING_MESSAGES.values()),
+        value_fn=lambda data: _enum_state(
+            data.charge.charging_status_description, CHARGING_MESSAGES
+        ),
+    ),
+    BesenSensorEntityDescription(
+        key="error_state",
+        translation_key="error_state",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        options=list(ERROR_STATES.values()),
+        value_fn=lambda data: _enum_state(data.charge.error_details, ERROR_STATES),
+    ),
+    BesenSensorEntityDescription(
+        key="plug_state",
+        translation_key="plug_state",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        options=list(PLUG_STATES.values()),
+        value_fn=lambda data: _enum_state(data.charge.plug_state, PLUG_STATES),
+    ),
+    BesenSensorEntityDescription(
+        key="output_state",
+        translation_key="output_state",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        options=list(OUTPUT_STATES.values()),
+        value_fn=lambda data: _enum_state(data.charge.output_state, OUTPUT_STATES),
+    ),
+    BesenSensorEntityDescription(
+        key="current_state",
+        translation_key="current_state",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        options=list(CURRENT_STATES.values()),
+        value_fn=lambda data: _enum_state(data.charge.current_state, CURRENT_STATES),
+    ),
     BesenSensorEntityDescription(
         key="charging_power",
         translation_key="charging_power",

--- a/homeassistant/components/besen/strings.json
+++ b/homeassistant/components/besen/strings.json
@@ -39,10 +39,111 @@
   },
   "entity": {
     "number": {
-      "charging_current": { "name": "Charging current" }
+      "charging_current": { "name": "Charging current" },
+      "lcd_brightness": { "name": "LCD brightness" }
+    },
+    "select": {
+      "language": {
+        "name": "Language",
+        "state": {
+          "chinese": "\u4e2d\u6587",
+          "english": "English",
+          "french": "Fran\u00e7ais",
+          "german": "Deutsch",
+          "hebrew": "\u05e2\u05d1\u05e8\u05d9\u05ea",
+          "italian": "Italiano",
+          "polish": "Polski",
+          "spanish": "Espa\u00f1ol"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      }
     },
     "sensor": {
+      "charging_message": {
+        "name": "Charging message",
+        "state": {
+          "charging": "[%key:common::state::charging%]",
+          "charging_completed": "Charging completed",
+          "charging_reservation": "Charging reservation",
+          "ev_connected_press_start": "EV is connected, press start",
+          "plug_not_connected": "The plug is not connected. Connect it before starting charging.",
+          "see_error_state": "See error state",
+          "waiting_for_button": "Waiting for the button to activate",
+          "waiting_for_ev": "Charging started, waiting for the EV",
+          "waiting_for_swipe": "Waiting for a card swipe"
+        }
+      },
       "charging_power": { "name": "Charging power" },
+      "charging_status": {
+        "name": "Charging status",
+        "state": {
+          "canceled": "Canceled",
+          "connect": "Connect",
+          "fault": "[%key:common::state::fault%]",
+          "finish_charging": "Finish charging",
+          "finished": "Finished",
+          "start": "Start",
+          "waiting": "Waiting"
+        }
+      },
+      "current_state": {
+        "name": "Current state",
+        "state": {
+          "charging": "[%key:common::state::charging%]",
+          "charging_fault_1": "Charging fault 1",
+          "charging_fault_2": "Charging fault 2",
+          "charging_reservation": "Charging reservation",
+          "completed": "Completed",
+          "completed_full_charge": "Completed, fully charged",
+          "fault": "[%key:common::state::fault%]",
+          "not_connected": "Not connected",
+          "ready_to_charge": "Ready to charge",
+          "unknown_1": "Unknown 1",
+          "unknown_10": "Unknown 10",
+          "unknown_2": "Unknown 2",
+          "unknown_3": "Unknown 3",
+          "unknown_4": "Unknown 4",
+          "unknown_5": "Unknown 5",
+          "unknown_6": "Unknown 6",
+          "unknown_7": "Unknown 7",
+          "unknown_8": "Unknown 8",
+          "unknown_9": "Unknown 9",
+          "waiting_for_button": "Waiting for button",
+          "waiting_for_swipe": "Waiting for card swipe"
+        }
+      },
+      "error_state": {
+        "name": "Error state",
+        "state": {
+          "cc_error": "CC error",
+          "cp_error": "CP error",
+          "diode_short_circuit": "Diode short circuit",
+          "dlb_over_current": "DLB overcurrent, mains overload",
+          "eeprom_failure": "EEPROM failure",
+          "emergency_stop": "Emergency stop",
+          "flash_memory_failure": "Flash memory failure",
+          "input_power_error": "Input power error",
+          "leakage_protection": "Leakage protection",
+          "low_voltage": "Low voltage",
+          "metering_module_failure": "Metering module failure",
+          "no_error": "No error",
+          "offline": "Offline",
+          "over_current": "Overcurrent",
+          "over_temperature": "Overtemperature",
+          "over_voltage": "Overvoltage",
+          "relay_stick_error": "Relay stick error",
+          "rtc_failure": "RTC failure",
+          "short_circuit": "Short circuit",
+          "ungrounded": "Ungrounded",
+          "unknown": "Unknown"
+        }
+      },
       "external_temperature": { "name": "External temperature" },
       "internal_temperature": { "name": "Internal temperature" },
       "l1_current": { "name": "L1 current" },
@@ -51,6 +152,34 @@
       "l2_voltage": { "name": "L2 voltage" },
       "l3_current": { "name": "L3 current" },
       "l3_voltage": { "name": "L3 voltage" },
+      "output_state": {
+        "name": "Output state",
+        "state": {
+          "charging": "[%key:common::state::charging%]",
+          "idle": "[%key:common::state::idle%]",
+          "unknown_0": "Unknown 0",
+          "unknown_1": "Unknown 1",
+          "unknown_2": "Unknown 2",
+          "unknown_3": "Unknown 3",
+          "unknown_4": "Unknown 4",
+          "unknown_5": "Unknown 5",
+          "unknown_6": "Unknown 6"
+        }
+      },
+      "plug_state": {
+        "name": "Plug state",
+        "state": {
+          "connected_locked": "Connected, locked",
+          "connected_unlocked": "Connected, unlocked",
+          "disconnected": "[%key:common::state::disconnected%]",
+          "unknown_0": "Unknown 0",
+          "unknown_1": "Unknown 1",
+          "unknown_2": "Unknown 2",
+          "unknown_3": "Unknown 3",
+          "unknown_4": "Unknown 4",
+          "unknown_5": "Unknown 5"
+        }
+      },
       "session_energy": { "name": "Session energy" },
       "total_energy": { "name": "Total energy" }
     },

--- a/homeassistant/components/besen/strings.json
+++ b/homeassistant/components/besen/strings.json
@@ -38,6 +38,9 @@
     }
   },
   "entity": {
+    "number": {
+      "charging_current": { "name": "Charging current" }
+    },
     "sensor": {
       "charging_power": { "name": "Charging power" },
       "external_temperature": { "name": "External temperature" },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -661,7 +661,7 @@ batinfo==0.4.2
 beautifulsoup4==4.13.3
 
 # homeassistant.components.besen
-besen==0.4.0
+besen==0.4.1
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/tests/components/besen/conftest.py
+++ b/tests/components/besen/conftest.py
@@ -50,6 +50,8 @@ FAKE_SERVICE_INFO = BluetoothServiceInfoBleak(
 def charger_state(
     *,
     charger_status: bool | None = True,
+    charge_amps: int | None = 16,
+    output_max_amps: int | None = 32,
     available: bool = True,
     authenticated: bool = True,
     phases: int = 1,
@@ -66,8 +68,13 @@ def charger_state(
             model="BS20",
             hardware_version="HW1",
             software_version="SW1",
+            output_max_amps=output_max_amps,
         ),
-        config=ChargerConfig(device_name="Garage", rssi=-55),
+        config=ChargerConfig(
+            charge_amps=charge_amps,
+            device_name="Garage",
+            rssi=-55,
+        ),
         charge=(
             charge
             if charge is not None
@@ -100,6 +107,7 @@ def _configure_client_mock(client: Mock) -> None:
     client.async_stop = AsyncMock()
     client.async_start_charging = AsyncMock()
     client.async_stop_charging = AsyncMock()
+    client.async_set_charge_amps = AsyncMock()
     client.add_listener.return_value = Mock()
 
 
@@ -157,8 +165,12 @@ def mock_besen_client() -> Generator[Mock]:
         async def async_stop_charging() -> None:
             publish_besen_state(client, charger_state(charger_status=False))
 
+        async def async_set_charge_amps(amps: int) -> None:
+            publish_besen_state(client, charger_state(charge_amps=amps))
+
         client.async_start_charging.side_effect = async_start_charging
         client.async_stop_charging.side_effect = async_stop_charging
+        client.async_set_charge_amps.side_effect = async_set_charge_amps
         yield client
 
 

--- a/tests/components/besen/conftest.py
+++ b/tests/components/besen/conftest.py
@@ -51,6 +51,9 @@ def charger_state(
     *,
     charger_status: bool | None = True,
     charge_amps: int | None = 16,
+    lcd_brightness: int | None = 50,
+    language: str | None = "English",
+    temperature_unit: str | None = "Celsius",
     output_max_amps: int | None = 32,
     available: bool = True,
     authenticated: bool = True,
@@ -72,6 +75,9 @@ def charger_state(
         ),
         config=ChargerConfig(
             charge_amps=charge_amps,
+            lcd_brightness=lcd_brightness,
+            language=language,
+            temperature_unit=temperature_unit,
             device_name="Garage",
             rssi=-55,
         ),
@@ -80,6 +86,12 @@ def charger_state(
             if charge is not None
             else ChargeStatus(
                 charger_status=charger_status,
+                error_details="No Error",
+                charging_status="Start",
+                charging_status_description="EV is connected, please press start",
+                plug_state="Connected Locked",
+                output_state="Charging",
+                current_state="Charging",
                 power=3500,
                 total_energy=12.3,
                 session_energy=1.2,
@@ -108,6 +120,9 @@ def _configure_client_mock(client: Mock) -> None:
     client.async_start_charging = AsyncMock()
     client.async_stop_charging = AsyncMock()
     client.async_set_charge_amps = AsyncMock()
+    client.async_set_lcd_brightness = AsyncMock()
+    client.async_set_language = AsyncMock()
+    client.async_set_temperature_unit = AsyncMock()
     client.add_listener.return_value = Mock()
 
 
@@ -168,9 +183,21 @@ def mock_besen_client() -> Generator[Mock]:
         async def async_set_charge_amps(amps: int) -> None:
             publish_besen_state(client, charger_state(charge_amps=amps))
 
+        async def async_set_lcd_brightness(brightness: int) -> None:
+            publish_besen_state(client, charger_state(lcd_brightness=brightness))
+
+        async def async_set_language(language: str) -> None:
+            publish_besen_state(client, charger_state(language=language))
+
+        async def async_set_temperature_unit(unit: str) -> None:
+            publish_besen_state(client, charger_state(temperature_unit=unit))
+
         client.async_start_charging.side_effect = async_start_charging
         client.async_stop_charging.side_effect = async_stop_charging
         client.async_set_charge_amps.side_effect = async_set_charge_amps
+        client.async_set_lcd_brightness.side_effect = async_set_lcd_brightness
+        client.async_set_language.side_effect = async_set_language
+        client.async_set_temperature_unit.side_effect = async_set_temperature_unit
         yield client
 
 

--- a/tests/components/besen/snapshots/test_number.ambr
+++ b/tests/components/besen/snapshots/test_number.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_number_state[number.garage_charging_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 32,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 6,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.garage_charging_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging current',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Charging current',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_current',
+    'unique_id': 'AA:BB_charging_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_number_state[number.garage_charging_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Charging current',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 32,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 6,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.garage_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16',
+  })
+# ---

--- a/tests/components/besen/snapshots/test_number.ambr
+++ b/tests/components/besen/snapshots/test_number.ambr
@@ -60,3 +60,63 @@
     'state': '16',
   })
 # ---
+# name: test_number_state[number.garage_lcd_brightness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.SLIDER: 'slider'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.garage_lcd_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'LCD brightness',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'LCD brightness',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lcd_brightness',
+    'unique_id': 'AA:BB_lcd_brightness',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_number_state[number.garage_lcd_brightness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage LCD brightness',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.SLIDER: 'slider'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.garage_lcd_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---

--- a/tests/components/besen/snapshots/test_select.ambr
+++ b/tests/components/besen/snapshots/test_select.ambr
@@ -1,0 +1,131 @@
+# serializer version: 1
+# name: test_select_state[select.garage_language-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'english',
+        'italian',
+        'german',
+        'french',
+        'spanish',
+        'hebrew',
+        'polish',
+        'chinese',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garage_language',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Language',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Language',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'language',
+    'unique_id': 'AA:BB_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_state[select.garage_language-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Language',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'english',
+        'italian',
+        'german',
+        'french',
+        'spanish',
+        'hebrew',
+        'polish',
+        'chinese',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garage_language',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'english',
+  })
+# ---
+# name: test_select_state[select.garage_temperature_unit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'celsius',
+        'fahrenheit',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garage_temperature_unit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature unit',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature unit',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature_unit',
+    'unique_id': 'AA:BB_temperature_unit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_state[select.garage_temperature_unit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Temperature unit',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'celsius',
+        'fahrenheit',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garage_temperature_unit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'celsius',
+  })
+# ---

--- a/tests/components/besen/snapshots/test_sensor.ambr
+++ b/tests/components/besen/snapshots/test_sensor.ambr
@@ -1,4 +1,78 @@
 # serializer version: 1
+# name: test_sensor_state[single_phase][sensor.garage_charging_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'ev_connected_press_start',
+        'charging',
+        'waiting_for_ev',
+        'charging_completed',
+        'charging_reservation',
+        'plug_not_connected',
+        'see_error_state',
+        'waiting_for_swipe',
+        'waiting_for_button',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_charging_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging message',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charging message',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_message',
+    'unique_id': 'AA:BB_charging_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_charging_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Charging message',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'ev_connected_press_start',
+        'charging',
+        'waiting_for_ev',
+        'charging_completed',
+        'charging_reservation',
+        'plug_not_connected',
+        'see_error_state',
+        'waiting_for_swipe',
+        'waiting_for_button',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_charging_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'ev_connected_press_start',
+  })
+# ---
 # name: test_sensor_state[single_phase][sensor.garage_charging_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -55,6 +129,272 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3500',
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_charging_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'start',
+        'finish_charging',
+        'waiting',
+        'finished',
+        'canceled',
+        'connect',
+        'fault',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_charging_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charging status',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_status',
+    'unique_id': 'AA:BB_charging_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_charging_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Charging status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'start',
+        'finish_charging',
+        'waiting',
+        'finished',
+        'canceled',
+        'connect',
+        'fault',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'start',
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_current_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'fault',
+        'charging_fault_1',
+        'charging_fault_2',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+        'waiting_for_swipe',
+        'waiting_for_button',
+        'not_connected',
+        'ready_to_charge',
+        'charging',
+        'completed',
+        'unknown_7',
+        'completed_full_charge',
+        'unknown_8',
+        'unknown_9',
+        'charging_reservation',
+        'unknown_10',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_current_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Current state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_state',
+    'unique_id': 'AA:BB_current_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_current_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'fault',
+        'charging_fault_1',
+        'charging_fault_2',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+        'waiting_for_swipe',
+        'waiting_for_button',
+        'not_connected',
+        'ready_to_charge',
+        'charging',
+        'completed',
+        'unknown_7',
+        'completed_full_charge',
+        'unknown_8',
+        'unknown_9',
+        'charging_reservation',
+        'unknown_10',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'relay_stick_error',
+        'offline',
+        'cc_error',
+        'cp_error',
+        'emergency_stop',
+        'over_temperature',
+        'unknown',
+        'leakage_protection',
+        'short_circuit',
+        'over_current',
+        'ungrounded',
+        'over_voltage',
+        'low_voltage',
+        'input_power_error',
+        'dlb_over_current',
+        'diode_short_circuit',
+        'rtc_failure',
+        'flash_memory_failure',
+        'eeprom_failure',
+        'metering_module_failure',
+        'no_error',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Error state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Error state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'error_state',
+    'unique_id': 'AA:BB_error_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Error state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'relay_stick_error',
+        'offline',
+        'cc_error',
+        'cp_error',
+        'emergency_stop',
+        'over_temperature',
+        'unknown',
+        'leakage_protection',
+        'short_circuit',
+        'over_current',
+        'ungrounded',
+        'over_voltage',
+        'low_voltage',
+        'input_power_error',
+        'dlb_over_current',
+        'diode_short_circuit',
+        'rtc_failure',
+        'flash_memory_failure',
+        'eeprom_failure',
+        'metering_module_failure',
+        'no_error',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_error_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'no_error',
   })
 # ---
 # name: test_sensor_state[single_phase][sensor.garage_external_temperature-entry]
@@ -289,6 +629,154 @@
     'state': '230.0',
   })
 # ---
+# name: test_sensor_state[single_phase][sensor.garage_output_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'charging',
+        'idle',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_output_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Output state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Output state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'output_state',
+    'unique_id': 'AA:BB_output_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_output_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Output state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'charging',
+        'idle',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_output_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_plug_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'disconnected',
+        'connected_unlocked',
+        'unknown_1',
+        'connected_locked',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_plug_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Plug state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Plug state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'plug_state',
+    'unique_id': 'AA:BB_plug_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[single_phase][sensor.garage_plug_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Plug state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'disconnected',
+        'connected_unlocked',
+        'unknown_1',
+        'connected_locked',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_plug_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'connected_locked',
+  })
+# ---
 # name: test_sensor_state[single_phase][sensor.garage_session_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -405,6 +893,80 @@
     'state': '12.3',
   })
 # ---
+# name: test_sensor_state[three_phase][sensor.garage_charging_message-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'ev_connected_press_start',
+        'charging',
+        'waiting_for_ev',
+        'charging_completed',
+        'charging_reservation',
+        'plug_not_connected',
+        'see_error_state',
+        'waiting_for_swipe',
+        'waiting_for_button',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_charging_message',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging message',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charging message',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_message',
+    'unique_id': 'AA:BB_charging_message',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_charging_message-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Charging message',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'ev_connected_press_start',
+        'charging',
+        'waiting_for_ev',
+        'charging_completed',
+        'charging_reservation',
+        'plug_not_connected',
+        'see_error_state',
+        'waiting_for_swipe',
+        'waiting_for_button',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_charging_message',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'ev_connected_press_start',
+  })
+# ---
 # name: test_sensor_state[three_phase][sensor.garage_charging_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -461,6 +1023,272 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '3500',
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_charging_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'start',
+        'finish_charging',
+        'waiting',
+        'finished',
+        'canceled',
+        'connect',
+        'fault',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_charging_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charging status',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_status',
+    'unique_id': 'AA:BB_charging_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_charging_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Charging status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'start',
+        'finish_charging',
+        'waiting',
+        'finished',
+        'canceled',
+        'connect',
+        'fault',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'start',
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_current_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'fault',
+        'charging_fault_1',
+        'charging_fault_2',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+        'waiting_for_swipe',
+        'waiting_for_button',
+        'not_connected',
+        'ready_to_charge',
+        'charging',
+        'completed',
+        'unknown_7',
+        'completed_full_charge',
+        'unknown_8',
+        'unknown_9',
+        'charging_reservation',
+        'unknown_10',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_current_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Current state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_state',
+    'unique_id': 'AA:BB_current_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_current_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'fault',
+        'charging_fault_1',
+        'charging_fault_2',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+        'waiting_for_swipe',
+        'waiting_for_button',
+        'not_connected',
+        'ready_to_charge',
+        'charging',
+        'completed',
+        'unknown_7',
+        'completed_full_charge',
+        'unknown_8',
+        'unknown_9',
+        'charging_reservation',
+        'unknown_10',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'relay_stick_error',
+        'offline',
+        'cc_error',
+        'cp_error',
+        'emergency_stop',
+        'over_temperature',
+        'unknown',
+        'leakage_protection',
+        'short_circuit',
+        'over_current',
+        'ungrounded',
+        'over_voltage',
+        'low_voltage',
+        'input_power_error',
+        'dlb_over_current',
+        'diode_short_circuit',
+        'rtc_failure',
+        'flash_memory_failure',
+        'eeprom_failure',
+        'metering_module_failure',
+        'no_error',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Error state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Error state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'error_state',
+    'unique_id': 'AA:BB_error_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Error state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'relay_stick_error',
+        'offline',
+        'cc_error',
+        'cp_error',
+        'emergency_stop',
+        'over_temperature',
+        'unknown',
+        'leakage_protection',
+        'short_circuit',
+        'over_current',
+        'ungrounded',
+        'over_voltage',
+        'low_voltage',
+        'input_power_error',
+        'dlb_over_current',
+        'diode_short_circuit',
+        'rtc_failure',
+        'flash_memory_failure',
+        'eeprom_failure',
+        'metering_module_failure',
+        'no_error',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_error_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'no_error',
   })
 # ---
 # name: test_sensor_state[three_phase][sensor.garage_external_temperature-entry]
@@ -925,6 +1753,154 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '232.0',
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_output_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'charging',
+        'idle',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_output_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Output state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Output state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'output_state',
+    'unique_id': 'AA:BB_output_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_output_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Output state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'charging',
+        'idle',
+        'unknown_1',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+        'unknown_6',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_output_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_plug_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'disconnected',
+        'connected_unlocked',
+        'unknown_1',
+        'connected_locked',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_plug_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Plug state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Plug state',
+    'platform': 'besen',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'plug_state',
+    'unique_id': 'AA:BB_plug_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[three_phase][sensor.garage_plug_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Plug state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'unknown_0',
+        'disconnected',
+        'connected_unlocked',
+        'unknown_1',
+        'connected_locked',
+        'unknown_2',
+        'unknown_3',
+        'unknown_4',
+        'unknown_5',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_plug_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'connected_locked',
   })
 # ---
 # name: test_sensor_state[three_phase][sensor.garage_session_energy-entry]

--- a/tests/components/besen/test_number.py
+++ b/tests/components/besen/test_number.py
@@ -1,0 +1,207 @@
+"""Tests for the Besen number platform."""
+
+from unittest.mock import AsyncMock, Mock
+
+from besen.const import FALLBACK_MAX_CHARGE_AMPS
+from besen.exceptions import CommandFailed
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.besen.const import DOMAIN
+from homeassistant.components.number import (
+    ATTR_MAX,
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
+
+from . import publish_besen_state
+from .conftest import charger_state, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "number.garage_charging_current"
+
+
+async def test_number_state(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test number entity state and registry data."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+    mock_besen_client.async_start.assert_awaited_once()
+
+
+async def test_number_updates_from_client(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test number state updates from client push data."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    publish_besen_state(mock_besen_client, charger_state(charge_amps=20))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "20"
+
+
+async def test_number_updates_on_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test number state updates when the coordinator refreshes."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    mock_besen_client.state = charger_state(charge_amps=20)
+    await async_update_entity(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "20"
+
+
+@pytest.mark.parametrize(
+    ("available", "authenticated"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_number_unavailable_from_client_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+    available: bool,
+    authenticated: bool,
+) -> None:
+    """Test number availability follows client availability and authentication."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    publish_besen_state(
+        mock_besen_client,
+        charger_state(available=available, authenticated=authenticated),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_number_unknown_without_reported_current(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test the number is unknown before the charger reports its current."""
+
+    mock_besen_client.state = charger_state(charge_amps=None)
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("output_max_amps", "expected_max"),
+    [
+        (16, 16),
+        (None, FALLBACK_MAX_CHARGE_AMPS),
+    ],
+)
+async def test_number_maximum(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+    output_max_amps: int | None,
+    expected_max: int,
+) -> None:
+    """Test the maximum uses charger information with a safe fallback."""
+
+    mock_besen_client.state = charger_state(
+        charge_amps=16,
+        output_max_amps=output_max_amps,
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes[ATTR_MAX] == expected_max
+
+
+async def test_number_set_value(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test setting the charging current calls the client and updates state."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_VALUE: 20},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_besen_client.async_set_charge_amps.assert_awaited_once_with(20)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "20"
+
+
+async def test_number_command_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test command failures are translated to Home Assistant errors."""
+
+    mock_besen_client.async_set_charge_amps = AsyncMock(
+        side_effect=CommandFailed("failed")
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_VALUE: 20},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "command_failed"
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "16"

--- a/tests/components/besen/test_number.py
+++ b/tests/components/besen/test_number.py
@@ -209,9 +209,9 @@ async def test_number_command_failure(
     assert state.state == "16"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_lcd_brightness_set_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:
@@ -233,9 +233,9 @@ async def test_lcd_brightness_set_value(
     assert state.state == "75"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_lcd_brightness_unknown_without_reported_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:
@@ -250,9 +250,9 @@ async def test_lcd_brightness_unknown_without_reported_value(
     assert state.state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_lcd_brightness_command_failure(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:

--- a/tests/components/besen/test_number.py
+++ b/tests/components/besen/test_number.py
@@ -30,9 +30,11 @@ from .conftest import charger_state, setup_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
 
-ENTITY_ID = "number.garage_charging_current"
+CHARGING_CURRENT_ENTITY_ID = "number.garage_charging_current"
+LCD_BRIGHTNESS_ENTITY_ID = "number.garage_lcd_brightness"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_state(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -60,7 +62,7 @@ async def test_number_updates_from_client(
     publish_besen_state(mock_besen_client, charger_state(charge_amps=20))
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == "20"
 
@@ -75,10 +77,10 @@ async def test_number_updates_on_refresh(
     await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
 
     mock_besen_client.state = charger_state(charge_amps=20)
-    await async_update_entity(hass, ENTITY_ID)
+    await async_update_entity(hass, CHARGING_CURRENT_ENTITY_ID)
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == "20"
 
@@ -107,7 +109,7 @@ async def test_number_unavailable_from_client_state(
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -123,7 +125,7 @@ async def test_number_unknown_without_reported_current(
 
     await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -151,7 +153,7 @@ async def test_number_maximum(
 
     await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.attributes[ATTR_MAX] == expected_max
 
@@ -168,13 +170,13 @@ async def test_number_set_value(
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_VALUE: 20},
+        {ATTR_ENTITY_ID: CHARGING_CURRENT_ENTITY_ID, ATTR_VALUE: 20},
         blocking=True,
     )
     await hass.async_block_till_done()
 
     mock_besen_client.async_set_charge_amps.assert_awaited_once_with(20)
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == "20"
 
@@ -196,12 +198,82 @@ async def test_number_command_failure(
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
-            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_VALUE: 20},
+            {ATTR_ENTITY_ID: CHARGING_CURRENT_ENTITY_ID, ATTR_VALUE: 20},
             blocking=True,
         )
 
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == "command_failed"
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(CHARGING_CURRENT_ENTITY_ID)
     assert state is not None
     assert state.state == "16"
+
+
+async def test_lcd_brightness_set_value(
+    hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test setting the LCD brightness calls the client and updates state."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: LCD_BRIGHTNESS_ENTITY_ID, ATTR_VALUE: 75},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_besen_client.async_set_lcd_brightness.assert_awaited_once_with(75)
+    state = hass.states.get(LCD_BRIGHTNESS_ENTITY_ID)
+    assert state is not None
+    assert state.state == "75"
+
+
+async def test_lcd_brightness_unknown_without_reported_value(
+    hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test LCD brightness is unknown before the charger reports it."""
+
+    mock_besen_client.state = charger_state(lcd_brightness=None)
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    state = hass.states.get(LCD_BRIGHTNESS_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_lcd_brightness_command_failure(
+    hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test LCD brightness command failures are translated."""
+
+    mock_besen_client.async_set_lcd_brightness = AsyncMock(
+        side_effect=CommandFailed("failed")
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: LCD_BRIGHTNESS_ENTITY_ID, ATTR_VALUE: 75},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "command_failed"
+    state = hass.states.get(LCD_BRIGHTNESS_ENTITY_ID)
+    assert state is not None
+    assert state.state == "50"

--- a/tests/components/besen/test_select.py
+++ b/tests/components/besen/test_select.py
@@ -1,0 +1,198 @@
+"""Tests for the Besen select platform."""
+
+from unittest.mock import AsyncMock, Mock
+
+from besen.exceptions import CommandFailed
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.besen.const import DOMAIN
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_OPTION,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import publish_besen_state
+from .conftest import charger_state, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+LANGUAGE_ENTITY_ID = "select.garage_language"
+TEMPERATURE_UNIT_ENTITY_ID = "select.garage_temperature_unit"
+
+
+async def test_select_state(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test select entity states and registry data."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+    mock_besen_client.async_start.assert_awaited_once()
+
+
+async def test_select_updates_from_client(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test select states update from client push data."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    publish_besen_state(
+        mock_besen_client,
+        charger_state(language="Deutsch", temperature_unit="Fahrenheit"),
+    )
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(LANGUAGE_ENTITY_ID)) is not None
+    assert state.state == "german"
+    assert (state := hass.states.get(TEMPERATURE_UNIT_ENTITY_ID)) is not None
+    assert state.state == "fahrenheit"
+
+
+@pytest.mark.parametrize(
+    ("available", "authenticated"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_select_unavailable_from_client_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+    available: bool,
+    authenticated: bool,
+) -> None:
+    """Test select availability follows client state."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    publish_besen_state(
+        mock_besen_client,
+        charger_state(available=available, authenticated=authenticated),
+    )
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(LANGUAGE_ENTITY_ID)) is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_select_unknown_for_unreported_or_unsupported_values(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test unreported and unsupported values are unknown."""
+
+    mock_besen_client.state = charger_state(
+        language="Klingon",
+        temperature_unit=None,
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    assert (state := hass.states.get(LANGUAGE_ENTITY_ID)) is not None
+    assert state.state == STATE_UNKNOWN
+    assert (state := hass.states.get(TEMPERATURE_UNIT_ENTITY_ID)) is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "option", "method", "wire_value"),
+    [
+        (LANGUAGE_ENTITY_ID, "english", "async_set_language", "English"),
+        (LANGUAGE_ENTITY_ID, "italian", "async_set_language", "Italiano"),
+        (LANGUAGE_ENTITY_ID, "german", "async_set_language", "Deutsch"),
+        (LANGUAGE_ENTITY_ID, "french", "async_set_language", "Fran\u00e7ais"),
+        (LANGUAGE_ENTITY_ID, "spanish", "async_set_language", "Espa\u00f1ol"),
+        (
+            LANGUAGE_ENTITY_ID,
+            "hebrew",
+            "async_set_language",
+            "\u05e2\u05d1\u05e8\u05d9\u05ea",
+        ),
+        (LANGUAGE_ENTITY_ID, "polish", "async_set_language", "Polski"),
+        (LANGUAGE_ENTITY_ID, "chinese", "async_set_language", "\u4e2d\u6587"),
+        (
+            TEMPERATURE_UNIT_ENTITY_ID,
+            "celsius",
+            "async_set_temperature_unit",
+            "Celsius",
+        ),
+        (
+            TEMPERATURE_UNIT_ENTITY_ID,
+            "fahrenheit",
+            "async_set_temperature_unit",
+            "Fahrenheit",
+        ),
+    ],
+)
+async def test_select_option(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+    entity_id: str,
+    option: str,
+    method: str,
+    wire_value: str,
+) -> None:
+    """Test selecting an option sends its protocol value and updates state."""
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    getattr(mock_besen_client, method).assert_awaited_once_with(wire_value)
+    assert (state := hass.states.get(entity_id)) is not None
+    assert state.state == option
+
+
+async def test_select_command_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test select command failures are translated."""
+
+    mock_besen_client.async_set_language = AsyncMock(
+        side_effect=CommandFailed("failed")
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: LANGUAGE_ENTITY_ID, ATTR_OPTION: "german"},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "command_failed"
+    assert (state := hass.states.get(LANGUAGE_ENTITY_ID)) is not None
+    assert state.state == "english"

--- a/tests/components/besen/test_sensor.py
+++ b/tests/components/besen/test_sensor.py
@@ -2,10 +2,26 @@
 
 from unittest.mock import Mock
 
+from besen.const import (
+    CHARGING_STATUS,
+    CHARGING_STATUS_DESCRIPTIONS,
+    CURRENT_STATE,
+    ERRORS,
+    OUTPUT_STATE,
+    PLUG_STATE,
+)
 from besen.models import ChargeStatus
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.besen.sensor import (
+    CHARGING_MESSAGES,
+    CHARGING_STATES,
+    CURRENT_STATES,
+    ERROR_STATES,
+    OUTPUT_STATES,
+    PLUG_STATES,
+)
 from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -21,6 +37,8 @@ from .conftest import charger_state, setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 POWER_ENTITY_ID = "sensor.garage_charging_power"
+CHARGING_STATUS_ENTITY_ID = "sensor.garage_charging_status"
+CHARGING_MESSAGE_ENTITY_ID = "sensor.garage_charging_message"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -44,6 +62,7 @@ async def test_sensor_state(
 
 async def test_sensor_updates_from_client(
     hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:
@@ -55,6 +74,12 @@ async def test_sensor_updates_from_client(
         mock_besen_client,
         charger_state(
             charge=ChargeStatus(
+                error_details="Emergency Stop",
+                charging_status="Fault",
+                charging_status_description="See Error State",
+                plug_state="Disconnected",
+                output_state="Idle",
+                current_state="Ready to charge",
                 power=7200,
                 total_energy=123.45,
                 session_energy=4.56,
@@ -72,6 +97,18 @@ async def test_sensor_updates_from_client(
     assert state.state == "4.56"
     assert (state := hass.states.get("sensor.garage_internal_temperature")) is not None
     assert state.state == "26.5"
+    assert (state := hass.states.get(CHARGING_STATUS_ENTITY_ID)) is not None
+    assert state.state == "fault"
+    assert (state := hass.states.get(CHARGING_MESSAGE_ENTITY_ID)) is not None
+    assert state.state == "see_error_state"
+    assert (state := hass.states.get("sensor.garage_error_state")) is not None
+    assert state.state == "emergency_stop"
+    assert (state := hass.states.get("sensor.garage_plug_state")) is not None
+    assert state.state == "disconnected"
+    assert (state := hass.states.get("sensor.garage_output_state")) is not None
+    assert state.state == "idle"
+    assert (state := hass.states.get("sensor.garage_current_state")) is not None
+    assert state.state == "ready_to_charge"
 
 
 async def test_sensor_unknown_value(
@@ -88,6 +125,43 @@ async def test_sensor_unknown_value(
 
     assert (state := hass.states.get(POWER_ENTITY_ID)) is not None
     assert state.state == STATE_UNKNOWN
+    assert (state := hass.states.get(CHARGING_STATUS_ENTITY_ID)) is not None
+    assert state.state == STATE_UNKNOWN
+    assert (state := hass.states.get(CHARGING_MESSAGE_ENTITY_ID)) is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_enum_sensors_unknown_for_unsupported_values(
+    hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
+    mock_config_entry: MockConfigEntry,
+    mock_besen_client: Mock,
+) -> None:
+    """Test unsupported protocol values are exposed as unknown."""
+
+    mock_besen_client.state = charger_state(
+        charge=ChargeStatus(
+            error_details="Unexpected",
+            charging_status="Unexpected",
+            charging_status_description="Unexpected",
+            plug_state="Unexpected",
+            output_state="Unexpected",
+            current_state="Unexpected",
+        )
+    )
+
+    await setup_integration(hass, mock_config_entry, [Platform.SENSOR])
+
+    for entity_id in (
+        CHARGING_STATUS_ENTITY_ID,
+        CHARGING_MESSAGE_ENTITY_ID,
+        "sensor.garage_error_state",
+        "sensor.garage_plug_state",
+        "sensor.garage_output_state",
+        "sensor.garage_current_state",
+    ):
+        assert (state := hass.states.get(entity_id)) is not None
+        assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(
@@ -139,12 +213,16 @@ async def test_diagnostic_sensors_disabled_by_default(
     }
     assert set(diagnostic_entries) == {
         f"{mock_besen_client.address}_external_temperature",
+        f"{mock_besen_client.address}_error_state",
+        f"{mock_besen_client.address}_current_state",
         f"{mock_besen_client.address}_l1_current",
         f"{mock_besen_client.address}_l1_voltage",
         f"{mock_besen_client.address}_l2_current",
         f"{mock_besen_client.address}_l2_voltage",
         f"{mock_besen_client.address}_l3_current",
         f"{mock_besen_client.address}_l3_voltage",
+        f"{mock_besen_client.address}_output_state",
+        f"{mock_besen_client.address}_plug_state",
     }
     for entry in diagnostic_entries.values():
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
@@ -178,3 +256,14 @@ async def test_three_phase_sensor_filtering(
         f"{mock_besen_client.address}_l3_current",
     }
     assert three_phase_unique_ids.issubset(unique_ids) is expected
+
+
+def test_enum_sensor_options_cover_library_states() -> None:
+    """Test every library state has a stable Home Assistant option."""
+
+    assert set(ERROR_STATES) == set(ERRORS.values())
+    assert set(CHARGING_STATES) == set(CHARGING_STATUS.values())
+    assert set(CHARGING_MESSAGES) == set(CHARGING_STATUS_DESCRIPTIONS.values())
+    assert set(PLUG_STATES) == set(PLUG_STATE)
+    assert set(OUTPUT_STATES) == set(OUTPUT_STATE)
+    assert set(CURRENT_STATES) == set(CURRENT_STATE)

--- a/tests/components/besen/test_sensor.py
+++ b/tests/components/besen/test_sensor.py
@@ -60,9 +60,9 @@ async def test_sensor_state(
     mock_besen_client.async_start.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_updates_from_client(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:
@@ -131,9 +131,9 @@ async def test_sensor_unknown_value(
     assert state.state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_enum_sensors_unknown_for_unsupported_values(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_config_entry: MockConfigEntry,
     mock_besen_client: Mock,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This combined draft has been superseded and split after review feedback.

**The current Besen pull request that is ready for review is #180617.**

The follow-up work is now separated into these draft pull requests:

- Dependency update: #180886
- Sensor platform: #180887
- Select platform: #180888

The LCD brightness number entity will be opened separately after #180617 is merged so its diff does not repeat the charging-current number changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47760 and https://github.com/home-assistant/home-assistant.io/pull/47761
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
