### PR TITLE
Correctly display sn and mac in Midea device page

### DIFF
--- a/homeassistant/components/midea/__init__.py
+++ b/homeassistant/components/midea/__init__.py
@@ -57,6 +57,8 @@ def _create_device(data: Mapping[str, Any], ip_address: str) -> MideaDevice | No
         data[CONF_MODEL],
         data[CONF_SUBTYPE],
         "",
+        data.get(CONF_MAC, None),
+        data.get(CONF_SN, None),
     )
 
 

--- a/tests/components/midea/test_init.py
+++ b/tests/components/midea/test_init.py
@@ -229,9 +229,24 @@ async def test_migrate_entry_drops_empty_mac_connection(
         patch(
             "homeassistant.components.midea.device_selector",
             return_value=DummyDevice(DeviceType.AC),
-        ),
+        ) as device_selector,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
+        device_selector.assert_called_once_with(
+            entry.data[CONF_NAME],
+            entry.data[CONF_DEVICE_ID],
+            entry.data[CONF_TYPE],
+            TEST_IP_ADDRESS,
+            entry.data[CONF_PORT],
+            entry.data[CONF_TOKEN],
+            entry.data[CONF_KEY],
+            ProtocolVersion(entry.data[CONF_PROTOCOL]),
+            entry.data[CONF_MODEL],
+            entry.data[CONF_SUBTYPE],
+            "",
+            entry.data.get(CONF_MAC, None),
+            entry.data.get(CONF_SN, None),
+        )
 
     assert entry.state is ConfigEntryState.LOADED
     device_entry = device_registry.async_get_device_by_identifier(
@@ -250,9 +265,24 @@ async def test_migrate_entry_without_discovery_result(hass: HomeAssistant) -> No
         patch(
             "homeassistant.components.midea.device_selector",
             return_value=DummyDevice(DeviceType.AC),
-        ),
+        ) as device_selector,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
+        device_selector.assert_called_once_with(
+            entry.data[CONF_NAME],
+            entry.data[CONF_DEVICE_ID],
+            entry.data[CONF_TYPE],
+            TEST_IP_ADDRESS,
+            entry.data[CONF_PORT],
+            entry.data[CONF_TOKEN],
+            entry.data[CONF_KEY],
+            ProtocolVersion(entry.data[CONF_PROTOCOL]),
+            entry.data[CONF_MODEL],
+            entry.data[CONF_SUBTYPE],
+            "",
+            None,
+            None,
+        )
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.minor_version == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing attribute to device creation to correctly display the device SN and MAC Address

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
