### PR TITLE
Add a reconfigure flow to the Sofar integration

### DIFF
--- a/homeassistant/components/sofar/config_flow.py
+++ b/homeassistant/components/sofar/config_flow.py
@@ -127,7 +127,7 @@ class SofarConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, reconfigure_entry.data
+                STEP_USER_DATA_SCHEMA, user_input or reconfigure_entry.data
             ),
             errors=errors,
             description_placeholders=description_placeholders,

--- a/homeassistant/components/sofar/config_flow.py
+++ b/homeassistant/components/sofar/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.modbus import async_get_temporary_unit
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -41,6 +42,17 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def _async_probe(
+    hass: HomeAssistant, host: str, port: int, unit_id: int
+) -> SofarInverter:
+    """Connect to the inverter and read its identity, or raise."""
+    params = ModbusTcpParams(host=host, port=port)
+    async with async_get_temporary_unit(hass, params, unit_id) as unit:
+        device = SofarInverter(unit)
+        await device.async_update()
+    return device
+
+
 class SofarConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a Sofar config flow."""
 
@@ -54,15 +66,13 @@ class SofarConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
-            params = ModbusTcpParams(
-                host=user_input[CONF_HOST], port=user_input[CONF_PORT]
-            )
             try:
-                async with async_get_temporary_unit(
-                    self.hass, params, user_input[CONF_UNIT_ID]
-                ) as unit:
-                    device = SofarInverter(unit)
-                    await device.async_update()
+                device = await _async_probe(
+                    self.hass,
+                    user_input[CONF_HOST],
+                    user_input[CONF_PORT],
+                    user_input[CONF_UNIT_ID],
+                )
             except (ModbusError, HomeAssistantError) as err:
                 errors["base"] = "cannot_connect"
                 description_placeholders["error"] = str(err)
@@ -81,6 +91,44 @@ class SofarConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle updating an existing entry's connection details."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                device = await _async_probe(
+                    self.hass,
+                    user_input[CONF_HOST],
+                    user_input[CONF_PORT],
+                    user_input[CONF_UNIT_ID],
+                )
+            except (ModbusError, HomeAssistantError) as err:
+                errors["base"] = "cannot_connect"
+                description_placeholders["error"] = str(err)
+            else:
+                assert device.serial_number is not None
+                if not device.inverter_type:
+                    errors["base"] = "unrecognized_inverter"
+                else:
+                    await self.async_set_unique_id(device.serial_number)
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry, data_updates=user_input
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, reconfigure_entry.data
+            ),
             errors=errors,
             description_placeholders=description_placeholders,
         )

--- a/homeassistant/components/sofar/quality_scale.yaml
+++ b/homeassistant/components/sofar/quality_scale.yaml
@@ -70,7 +70,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices: todo
 

--- a/homeassistant/components/sofar/strings.json
+++ b/homeassistant/components/sofar/strings.json
@@ -1,13 +1,27 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "Please reconfigure the same inverter you originally set up."
     },
     "error": {
       "cannot_connect": "Failed to connect: {error}",
       "unrecognized_inverter": "The device answered, but its serial number doesn't match a known Sofar model."
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "unit_id": "Modbus unit ID"
+        },
+        "data_description": {
+          "host": "[%key:component::sofar::config::step::user::data_description::host%]",
+          "port": "[%key:component::sofar::config::step::user::data_description::port%]",
+          "unit_id": "[%key:component::sofar::config::step::user::data_description::unit_id%]"
+        }
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/tests/components/sofar/test_config_flow.py
+++ b/tests/components/sofar/test_config_flow.py
@@ -275,7 +275,7 @@ async def test_reconfigure_errors(
     expected_error: str,
     expected_placeholders: dict[str, str],
 ) -> None:
-    """Test the reconfigure step reports the right error, per failure."""
+    """Test the reconfigure step reports the right error and recovers."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
     result = await entry.start_reconfigure_flow(hass)
@@ -293,3 +293,15 @@ async def test_reconfigure_errors(
     assert result["errors"] == {"base": expected_error}
     assert result["description_placeholders"] == expected_placeholders
     assert entry.data == MOCK_USER_INPUT
+
+    working_conn = MockModbusConnection()
+    seed_pv_inverter(working_conn.for_unit(1))
+
+    with _patch_temporary_unit(working_conn):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _NEW_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == _NEW_USER_INPUT

--- a/tests/components/sofar/test_config_flow.py
+++ b/tests/components/sofar/test_config_flow.py
@@ -10,6 +10,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.sofar.const import DEFAULT_NAME, DOMAIN
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
@@ -202,3 +203,93 @@ async def test_user_step_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+_NEW_USER_INPUT = {**MOCK_USER_INPUT, CONF_HOST: "192.168.1.200"}
+
+
+async def test_reconfigure_updates_the_entry(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test reconfigure updates the entry and reloads it."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
+    entry.add_to_hass(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_conn = MockModbusConnection()
+    seed_pv_inverter(mock_conn.for_unit(1))
+
+    with _patch_temporary_unit(mock_conn):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _NEW_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == _NEW_USER_INPUT
+
+
+async def test_reconfigure_rejects_a_different_serial(hass: HomeAssistant) -> None:
+    """Test reconfigure aborts if the inverter's serial doesn't match."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
+    entry.add_to_hass(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_conn = MockModbusConnection()
+    seed_pv_inverter(mock_conn.for_unit(1), serial=_UNMODELED_SERIAL)
+
+    with _patch_temporary_unit(mock_conn):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _NEW_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+    assert entry.data == MOCK_USER_INPUT
+
+
+@pytest.mark.parametrize(
+    ("seed", "expected_error", "expected_placeholders"),
+    [
+        pytest.param(
+            _seed_unreachable,
+            "cannot_connect",
+            {"error": "stuck"},
+            id="cannot_connect",
+        ),
+        pytest.param(
+            _seed_unrecognized,
+            "unrecognized_inverter",
+            {},
+            id="unrecognized_inverter",
+        ),
+    ],
+)
+async def test_reconfigure_errors(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    seed: Callable[[MockModbusUnit], None],
+    expected_error: str,
+    expected_placeholders: dict[str, str],
+) -> None:
+    """Test the reconfigure step reports the right error, per failure."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_SERIAL, data=MOCK_USER_INPUT)
+    entry.add_to_hass(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_conn = MockModbusConnection()
+    seed(mock_conn.for_unit(1))
+
+    with _patch_temporary_unit(mock_conn):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _NEW_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": expected_error}
+    assert result["description_placeholders"] == expected_placeholders
+    assert entry.data == MOCK_USER_INPUT

--- a/tests/components/sofar/test_config_flow.py
+++ b/tests/components/sofar/test_config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import MOCK_MODEL, MOCK_SERIAL, MOCK_USER_INPUT, seed_pv_inverter
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 # A recognized prefix with no model in sofar-modbus's own table.
 _UNMODELED_SERIAL = "SA1XXES100XX"
@@ -293,6 +293,11 @@ async def test_reconfigure_errors(
     assert result["errors"] == {"base": expected_error}
     assert result["description_placeholders"] == expected_placeholders
     assert entry.data == MOCK_USER_INPUT
+    # The retry starts from what was typed, not from the stored entry.
+    assert (
+        get_schema_suggested_value(result["data_schema"].schema, CONF_HOST)
+        == _NEW_USER_INPUT[CONF_HOST]
+    )
 
     working_conn = MockModbusConnection()
     seed_pv_inverter(working_conn.for_unit(1))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a reconfigure flow, so an inverter that moves to a new address (DHCP lease change,
replaced Modbus TCP bridge) can be pointed at without deleting and re-adding the entry
and losing its history and entity customizations.

The probe is now shared between the user and reconfigure steps. Reconfiguring re-reads
the serial number and aborts on a mismatch, so an entry can't be silently repointed at a
different inverter.

Marks `reconfiguration-flow` as done in the quality scale.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47756
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
