### PR TITLE
Bump solaredge-web to 0.4.0

### DIFF
--- a/homeassistant/components/solaredge/manifest.json
+++ b/homeassistant/components/solaredge/manifest.json
@@ -14,5 +14,5 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "loggers": ["aiosolaredge", "solaredge_web"],
-  "requirements": ["aiosolaredge==1.0.2", "solaredge-web==0.3.1"]
+  "requirements": ["aiosolaredge==1.0.2", "solaredge-web==0.4.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3117,7 +3117,7 @@ sofar-modbus==0.6.0
 solaredge-local==0.2.3
 
 # homeassistant.components.solaredge
-solaredge-web==0.3.1
+solaredge-web==0.4.0
 
 # homeassistant.components.solaredge_modbus
 solaredged==0.2.3


### PR DESCRIPTION
## Proposed change

Bumps `solaredge-web` from 0.3.1 to 0.4.0.

The main driver is [Solarlibs/solaredge-web#13](https://github.com/Solarlibs/solaredge-web/issues/13): on some sites the SolarEdge `optimizers-compact` playback endpoint answers HTTP 200 with a header-only payload. The library decoded that into hourly slots with no values, so `SolarEdgeModulesCoordinator` wrote **0 Wh statistics for every piece of equipment, every hour, with nothing logged** — it looked like a correctly configured integration attached to panels that produce nothing. 0.4.0 detects that case, warns, and falls back to the verbose `optimizers` endpoint, which returns the real measurements for those sites.

Two other fixes are directly visible in this integration:

- **Wrong credentials now surface as `invalid_auth` instead of `cannot_connect`.** A bad password makes SolarEdge re-serve the login page with HTTP 200, and the library raised a bare `ClientError`. `config_flow._async_check_web_login` only maps `ClientResponseError` with status 401/403 to `invalid_auth`, so users were told the integration could not connect, with no hint the password was wrong. The library now raises `ClientResponseError` with status 401. It still subclasses `ClientError`, so no change is needed here — the existing branch simply starts firing.
- **One coordinator refresh no longer runs three OAuth flows.** SolarEdge stopped setting the `SolarEdge_SSO-1.4` cookie the library looked for, so its one-hour session reuse never triggered and the cached layout was discarded on each attempt. Measured against a live site, a single refresh went from 3 authorize + 3 token + 3 auth-exchange + 2 layout requests down to 1 of each.

Additionally, the library now drains the authorize and token-exchange response bodies, which matters here because the integration uses the shared `async_get_clientsession` — those connections were previously held until garbage collection.

There are no API changes: `SolarEdgeWeb.__init__`, `async_login`, `async_get_equipment`, `async_get_energy_data` and the `EnergyData` fields all keep identical signatures, so no integration code changes are required.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Library changelog and diff:

- Release notes: https://github.com/Solarlibs/solaredge-web/releases/tag/v0.4.0
- Full diff v0.3.1...v0.4.0: https://github.com/Solarlibs/solaredge-web/compare/v0.3.1...v0.4.0

The 0.4.0 changes were verified against a live SolarEdge site: the fallback path was exercised by blanking the compact payload and produced the same window, the same 31 devices, and daily totals within 0.03% of the compact path.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
