### PR TITLE
Do not leak a compiler warning when parsing a template result

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -13,6 +13,7 @@ import re
 import sys
 from types import CodeType
 from typing import TYPE_CHECKING, Any, Literal, Self, overload, override
+import warnings
 import weakref
 
 import jinja2
@@ -270,8 +271,14 @@ def _cached_parse_result(render_result: str) -> Any:
     # not Python literals, so literal_eval compiles and raises for them on
     # every render. Catching here caches that outcome (return the original
     # render) so the recompile only happens once per distinct result.
+    # A result that is not a literal can still make the compiler emit a
+    # SyntaxWarning before literal_eval raises: "5in" is read as a malformed
+    # numeric literal. The template itself rendered fine, so that warning is
+    # noise in the user's log. Suppressing it also keeps this path cheap,
+    # since emitting a warning costs several times more than the parse.
     try:
-        result = literal_eval(render_result)
+        with warnings.catch_warnings(action="ignore", category=SyntaxWarning):
+            result = literal_eval(render_result)
     except ValueError, TypeError, SyntaxError, MemoryError:
         return render_result
     if type(result) in RESULT_WRAPPERS:

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import gc
 from unittest.mock import patch
+import warnings
 
 from freezegun import freeze_time
 import pytest
@@ -933,6 +934,29 @@ async def test_parse_result(hass: HomeAssistant) -> None:
         ("set()", set()),
     ):
         assert render(hass, tpl) == result
+
+
+@pytest.mark.parametrize(
+    "tpl",
+    ["0.5in", "5in", "1and", "-0.5in", "+5in", "3if"],
+)
+async def test_parse_result_does_not_leak_a_compiler_warning(
+    hass: HomeAssistant, tpl: str
+) -> None:
+    """Test a non-literal result does not leak a warning about the parse.
+
+    Parsing a result such as "5in" makes the compiler read a malformed numeric
+    literal and emit a SyntaxWarning before it raises. The template rendered
+    fine and the user never wrote Python, so that warning only adds noise to
+    their log.
+    """
+    template._cached_parse_result.cache_clear()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert render(hass, tpl) == tpl
+
+    assert [w.message for w in caught if issubclass(w.category, SyntaxWarning)] == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

A rendered result that is not a Python literal is still handed to `literal_eval`, and for a result like `0.5in` the compiler reads a malformed numeric literal and emits `SyntaxWarning: invalid decimal literal` before raising. The `SyntaxError` is already caught, but the warning has escaped by then and lands in the user's log for a template that rendered exactly as written. `{{ rain }}in` is the reported case; `-0.5in`, `+5in`, `1and` and `3if` do the same.

Suppressing it also makes that path cheaper, because emitting the warning costs more than the parse. Measured per `literal_eval` call on fresh strings, so every one is a cache miss, on Python 3.14:

| result | before | after |
| --- | --- | --- |
| ordinary string, no warning | 12.98 µs | 14.43 µs |
| `0.5in` | 67.72 µs | 15.37 µs |

An ordinary miss pays 1.45 µs for the context manager; the reported case gets about four times cheaper. The added test fails on five of its six parameters without the change.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179754
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
