### PR TITLE
Continue the conversation when a local intent sets a reprompt

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -521,7 +521,12 @@ class DefaultAgent(ConversationEntity):
         )
 
         return ConversationResult(
-            response=response, conversation_id=chat_log.conversation_id
+            response=response,
+            conversation_id=chat_log.conversation_id,
+            # A reprompt is a follow-up question, so the satellite has to keep
+            # listening for the answer. Conversation agents backed by an LLM
+            # already get this from `chat_log.continue_conversation`.
+            continue_conversation=bool(response.reprompt),
         )
 
     async def _async_process_intent_result(

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -84,6 +84,50 @@ class OrderBeerIntentHandler(intent.IntentHandler):
         return response
 
 
+@pytest.mark.parametrize(
+    ("reprompt", "expected"),
+    [("Which one?", True), (None, False)],
+)
+async def test_reprompt_continues_the_conversation(
+    hass: HomeAssistant,
+    init_components: None,
+    reprompt: str | None,
+    expected: bool,
+) -> None:
+    """Test a reprompt keeps the satellite listening for the answer.
+
+    `intent_script` exposes a `reprompt:` option that sets this on the response,
+    which is a follow-up question. Without this the user has to say the wake
+    word again before answering, since only agents backed by an LLM reach
+    `chat_log.continue_conversation`.
+    """
+
+    class RepromptingIntentHandler(intent.IntentHandler):
+        """Handle OrderBeer, optionally with a reprompt."""
+
+        intent_type = "OrderBeer"
+
+        async def async_handle(
+            self, intent_obj: intent.Intent
+        ) -> intent.IntentResponse:
+            """Return speech response."""
+            response = intent_obj.create_response()
+            response.async_set_speech("You ordered a stout")
+            if reprompt is not None:
+                response.async_set_reprompt(reprompt)
+            return response
+
+    # Reuse the custom sentences in the test config to reach the default agent.
+    intent.async_register(hass, RepromptingIntentHandler())
+
+    result = await conversation.async_converse(
+        hass, "I'd like to order a stout, please", None, Context(), language="en"
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.continue_conversation is expected
+
+
 @pytest.fixture
 async def init_components(hass: HomeAssistant) -> None:
     """Initialize relevant components with empty configs."""


### PR DESCRIPTION
## Proposed change

`intent_script` accepts a `reprompt:` block and sets it on the response through `IntentResponse.async_set_reprompt()`, but nothing ever reads it back. `default_agent` builds its `ConversationResult` without `continue_conversation`, which defaults to `False`, so a locally handled intent that asks a follow-up question never gets the answer: the satellite is back to waiting for the wake word by the time the user replies. Only agents backed by an LLM continue, through `chat_log.continue_conversation` in `conversation/util.py`.

This does the same thing for the default agent, from the reprompt the intent already set. The added test covers both directions and fails on its reprompt parameter without the change.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179617
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
