### PR TITLE
Restore Husqvarna Automower work area sensors and gate by WorkAreaTyp…

### DIFF
--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -14,6 +14,7 @@ from aioautomower.model import (
     MowerModes,
     RestrictedReasons,
     WorkArea,
+    WorkAreaType,
 )
 
 from homeassistant.components.sensor import (
@@ -343,7 +344,7 @@ WORK_AREA_SENSOR_TYPES: tuple[WorkAreaSensorEntityDescription, ...] = (
     WorkAreaSensorEntityDescription(
         key="progress",
         translation_key_fn=_work_area_translation_key,
-        exists_fn=lambda data: data.progress is not None,
+        exists_fn=lambda data: data.type == WorkAreaType.SYSTEMATIC,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=attrgetter("progress"),
@@ -351,7 +352,7 @@ WORK_AREA_SENSOR_TYPES: tuple[WorkAreaSensorEntityDescription, ...] = (
     WorkAreaSensorEntityDescription(
         key="last_time_completed",
         translation_key_fn=_work_area_translation_key,
-        exists_fn=lambda data: data.last_time_completed is not None,
+        exists_fn=lambda data: data.type == WorkAreaType.SYSTEMATIC,
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=attrgetter("last_time_completed"),
     ),

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -470,7 +470,7 @@ async def test_add_and_remove_work_area(
                 last_time_completed=datetime(
                     2024, 10, 1, 11, 11, 0, tzinfo=dt_util.get_default_time_zone()
                 ),
-                type=WorkAreaType.RANDOM,
+                type=WorkAreaType.SYSTEMATIC,
                 use_global_cutting_height=False,
             )
         }

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -10,13 +10,15 @@ from aioautomower.model import (
     MowerModes,
     MowerStates,
     RestrictedReasons,
+    WorkArea,
+    WorkAreaType,
 )
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.husqvarna_automower.coordinator import SCAN_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -142,6 +144,69 @@ async def test_work_area_sensor(
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
+
+
+async def test_work_area_sensor_creation(
+    hass: HomeAssistant,
+    mock_automower_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    values: dict[str, MowerAttributes],
+) -> None:
+    """Test the work area sensor depending on mower pattern."""
+    await setup_integration(hass, mock_config_entry)
+
+    values[TEST_MOWER_ID].work_area_names.append("new systematic work area")
+    values[TEST_MOWER_ID].work_area_dict.update({1: "new systematic work area"})
+    values[TEST_MOWER_ID].work_areas.update(
+        {
+            1: WorkArea(
+                name="new systematic work area",
+                cutting_height=12,
+                enabled=True,
+                type=WorkAreaType.SYSTEMATIC,
+                use_global_cutting_height=False,
+            )
+        }
+    )
+    mock_automower_client.get_status.return_value = values
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get(
+        "sensor.garden_test_mower_1_new_systematic_work_area_progress"
+    )
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get(
+        "sensor.garden_test_mower_1_new_systematic_work_area_last_time_completed"
+    )
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    values[TEST_MOWER_ID].work_area_names.append("new random work area")
+    values[TEST_MOWER_ID].work_area_dict.update({1: "new random work area"})
+    values[TEST_MOWER_ID].work_areas.update(
+        {
+            1: WorkArea(
+                name="new random work area",
+                cutting_height=12,
+                enabled=True,
+                type=WorkAreaType.RANDOM,
+                use_global_cutting_height=False,
+            )
+        }
+    )
+    mock_automower_client.get_status.return_value = values
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.garden_test_mower_1_new_random_work_area_progress")
+    assert state is None
+    state = hass.states.get(
+        "sensor.garden_test_mower_1_new_random_work_area_last_time_completed"
+    )
+    assert state is None
 
 
 async def test_restricted_reason_sensor(

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -185,10 +185,10 @@ async def test_work_area_sensor_creation(
     assert state.state == STATE_UNKNOWN
 
     values[TEST_MOWER_ID].work_area_names.append("new random work area")
-    values[TEST_MOWER_ID].work_area_dict.update({1: "new random work area"})
+    values[TEST_MOWER_ID].work_area_dict.update({2: "new random work area"})
     values[TEST_MOWER_ID].work_areas.update(
         {
-            1: WorkArea(
+            2: WorkArea(
                 name="new random work area",
                 cutting_height=12,
                 enabled=True,

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -154,8 +154,6 @@ async def test_work_area_sensor_creation(
     values: dict[str, MowerAttributes],
 ) -> None:
     """Test the work area sensor depending on mower pattern."""
-    await setup_integration(hass, mock_config_entry)
-
     values[TEST_MOWER_ID].work_area_names.append("new systematic work area")
     values[TEST_MOWER_ID].work_area_dict.update({1: "new systematic work area"})
     values[TEST_MOWER_ID].work_areas.update(
@@ -170,6 +168,7 @@ async def test_work_area_sensor_creation(
         }
     )
     mock_automower_client.get_status.return_value = values
+    await setup_integration(hass, mock_config_entry)
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces #168567 which got stale.
We know these entities got created for systematic work areas. So we can use this instead on relying on `is not None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
