### PR TITLE
Stop the Hikvision event stream on Home Assistant shutdown

### DIFF
--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -15,9 +15,10 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SSL,
     CONF_USERNAME,
+    EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
@@ -141,6 +142,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
 
     # Start the event stream
     await hass.async_add_executor_job(camera.start_stream)
+
+    async def _async_stop_stream(event: Event) -> None:
+        await hass.async_add_executor_job(camera.disconnect)
+
+    # pyHik's stream thread is non-daemonic and publishes straight into hass, so
+    # it has to be joined before the event loop closes.
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_stream)
+    )
 
     # Register the main device before platforms that use via_device
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -147,7 +147,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
         await hass.async_add_executor_job(camera.disconnect)
 
     # pyHik's stream thread is non-daemonic and publishes straight into hass, so
-    # it has to be joined before the event loop closes.
+    # it has to be joined before the event loop closes. Starting it yields, so
+    # the stop event may already have been fired by the time we get here, and
+    # listening for it now would never hear it.
+    if hass.is_stopping:
+        await hass.async_add_executor_job(camera.disconnect)
+        raise ConfigEntryNotReady("Home Assistant is stopping")
+
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_stream)
     )

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_SSL
+from homeassistant.const import CONF_SSL, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -37,6 +37,20 @@ async def test_setup_and_unload_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_hikcamera.return_value.disconnect.assert_called_once()
+
+
+async def test_stream_stopped_on_shutdown(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hikcamera: MagicMock,
+) -> None:
+    """Test the event stream thread is joined before the event loop closes."""
+    await setup_integration(hass, mock_config_entry)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
     mock_hikcamera.return_value.disconnect.assert_called_once()
 
 

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -9,7 +9,7 @@ import requests
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_SSL, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 
 from . import setup_integration
 from .conftest import TEST_HOST, TEST_PASSWORD, TEST_PORT, TEST_USERNAME
@@ -51,6 +51,22 @@ async def test_stream_stopped_on_shutdown(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
 
+    mock_hikcamera.return_value.disconnect.assert_called_once()
+
+
+async def test_stream_stopped_when_shutdown_starts_during_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hikcamera: MagicMock,
+) -> None:
+    """Test the stream is stopped when shutdown begins while setting up."""
+    hass.set_state(CoreState.stopping)
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_hikcamera.return_value.disconnect.assert_called_once()
 
 


### PR DESCRIPTION
## Breaking change

<!-- not a breaking change -->

## Proposed change

pyHik runs the Hikvision alert stream in a **non-daemonic** thread that calls `schedule_update_ha_state()` on every event it receives. Nothing ever stopped that thread at shutdown: Home Assistant does not unload config entries when it stops, so `async_unload_entry` — the only place `camera.disconnect()` was called — never ran.

The thread therefore outlives the event loop, and the next event it publishes lands in `hass.loop.call_soon_threadsafe()` after the loop is closed:

```
RuntimeError: Event loop is closed
  File "pyhik/hikvision.py", line 380, in _do_update_callback
    callback(msg)
  File "homeassistant/components/hikvision/binary_sensor.py", line 336, in _update_callback
    self.schedule_update_ha_state()
  File "homeassistant/helpers/entity.py", line 1320, in schedule_update_ha_state
    self.hass.loop.call_soon_threadsafe(...)
```

This registers an `EVENT_HOMEASSISTANT_STOP` listener that runs `camera.disconnect()` in the executor, which sets pyHik's kill event and joins the thread before the loop closes. It is registered with `entry.async_on_unload`, so the unload path is unchanged and the disconnect never happens twice.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #180702
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
