### PR TITLE
Bump habluetooth to 6.26.11, bleak-retry-connector to 4.7.0 and bluetooth-data-tools to 1.29.24

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -19,7 +19,7 @@
     "bleak-retry-connector==4.7.0",
     "bluetooth-adapters==2.4.0",
     "bluetooth-auto-recovery==1.6.4",
-    "bluetooth-data-tools==1.29.21",
+    "bluetooth-data-tools==1.29.23",
     "dbus-fast==5.0.22",
     "habluetooth==6.26.11"
   ]

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -19,7 +19,7 @@
     "bleak-retry-connector==4.7.0",
     "bluetooth-adapters==2.4.0",
     "bluetooth-auto-recovery==1.6.4",
-    "bluetooth-data-tools==1.29.23",
+    "bluetooth-data-tools==1.29.24",
     "dbus-fast==5.0.22",
     "habluetooth==6.26.11"
   ]

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.6.4",
     "bluetooth-data-tools==1.29.21",
     "dbus-fast==5.0.22",
-    "habluetooth==6.26.7"
+    "habluetooth==6.26.11"
   ]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -16,7 +16,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==3.0.2",
-    "bleak-retry-connector==4.6.3",
+    "bleak-retry-connector==4.7.0",
     "bluetooth-adapters==2.4.0",
     "bluetooth-auto-recovery==1.6.4",
     "bluetooth-data-tools==1.29.21",

--- a/homeassistant/components/ld2410_ble/manifest.json
+++ b/homeassistant/components/ld2410_ble/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ld2410_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.23", "ld2410-ble==0.1.1"]
+  "requirements": ["bluetooth-data-tools==1.29.24", "ld2410-ble==0.1.1"]
 }

--- a/homeassistant/components/ld2410_ble/manifest.json
+++ b/homeassistant/components/ld2410_ble/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ld2410_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.21", "ld2410-ble==0.1.1"]
+  "requirements": ["bluetooth-data-tools==1.29.23", "ld2410-ble==0.1.1"]
 }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -36,5 +36,5 @@
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.29.23", "led-ble==1.1.11"]
+  "requirements": ["bluetooth-data-tools==1.29.24", "led-ble==1.1.11"]
 }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -36,5 +36,5 @@
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.29.21", "led-ble==1.1.11"]
+  "requirements": ["bluetooth-data-tools==1.29.23", "led-ble==1.1.11"]
 }

--- a/homeassistant/components/private_ble_device/manifest.json
+++ b/homeassistant/components/private_ble_device/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/private_ble_device",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.23"]
+  "requirements": ["bluetooth-data-tools==1.29.24"]
 }

--- a/homeassistant/components/private_ble_device/manifest.json
+++ b/homeassistant/components/private_ble_device/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/private_ble_device",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.29.21"]
+  "requirements": ["bluetooth-data-tools==1.29.23"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ bleak-retry-connector==4.7.0
 bleak==3.0.2
 bluetooth-adapters==2.4.0
 bluetooth-auto-recovery==1.6.4
-bluetooth-data-tools==1.29.23
+bluetooth-data-tools==1.29.24
 cached-ipaddress==1.1.2
 certifi>=2021.5.30
 ciso8601==2.3.3

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ bleak-retry-connector==4.7.0
 bleak==3.0.2
 bluetooth-adapters==2.4.0
 bluetooth-auto-recovery==1.6.4
-bluetooth-data-tools==1.29.21
+bluetooth-data-tools==1.29.23
 cached-ipaddress==1.1.2
 certifi>=2021.5.30
 ciso8601==2.3.3

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -36,7 +36,7 @@ fnv-hash-fast==2.0.3
 gazetteer-matcher==1.1.0
 go2rtc-client==0.4.0
 ha-ffmpeg==3.2.2
-habluetooth==6.26.7
+habluetooth==6.26.11
 hass-nabucasa==2.7.0
 hassil==3.12.0
 home-assistant-bluetooth==2.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ audioop-lts==0.2.2
 av==17.0.1
 awesomeversion==25.8.0
 bcrypt==5.0.0
-bleak-retry-connector==4.6.3
+bleak-retry-connector==4.7.0
 bleak==3.0.2
 bluetooth-adapters==2.4.0
 bluetooth-auto-recovery==1.6.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -706,7 +706,7 @@ bluetooth-auto-recovery==1.6.4
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
 # homeassistant.components.private_ble_device
-bluetooth-data-tools==1.29.21
+bluetooth-data-tools==1.29.23
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -706,7 +706,7 @@ bluetooth-auto-recovery==1.6.4
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
 # homeassistant.components.private_ble_device
-bluetooth-data-tools==1.29.23
+bluetooth-data-tools==1.29.24
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -673,7 +673,7 @@ bizkaibus==0.1.1
 bleak-esphome==4.0.0
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==4.6.3
+bleak-retry-connector==4.7.0
 
 # homeassistant.components.smlight
 bleak-smlight==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1250,7 +1250,7 @@ ha-xthings-cloud==1.0.5
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.26.7
+habluetooth==6.26.11
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps habluetooth from 6.26.7 to 6.26.11 for the bluetooth integration; the new habluetooth requires bleak-retry-connector 4.7.0 and bluetooth-data-tools 1.29.24, so those are bumped too. bluetooth-data-tools is also pinned by ld2410_ble, led_ble and private_ble_device, which are updated to match.

habluetooth release notes: https://github.com/Bluetooth-Devices/habluetooth/releases/tag/v6.26.11
habluetooth changes: https://github.com/Bluetooth-Devices/habluetooth/compare/v6.26.7...v6.26.11

bleak-retry-connector release notes: https://github.com/Bluetooth-Devices/bleak-retry-connector/releases/tag/v4.7.0
bleak-retry-connector changes: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v4.6.3...v4.7.0

bluetooth-data-tools release notes: https://github.com/bdraco/bluetooth-data-tools/releases/tag/v1.29.24
bluetooth-data-tools changes: https://github.com/bdraco/bluetooth-data-tools/compare/v1.29.21...v1.29.24

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
