### PR TITLE
Added sleep timer for air purifier to LG ThinQ.

### DIFF
--- a/homeassistant/components/lg_thinq/number.py
+++ b/homeassistant/components/lg_thinq/number.py
@@ -101,6 +101,9 @@ DEVICE_TYPE_NUMBER_MAP: dict[DeviceType, tuple[NumberEntityDescription, ...]] = 
         TIMER_NUMBER_DESC[ThinQProperty.RELATIVE_HOUR_TO_STOP],
         TIMER_NUMBER_DESC[ThinQProperty.SLEEP_TIMER_RELATIVE_HOUR_TO_STOP],
     ),
+    DeviceType.AIR_PURIFIER: (
+        TIMER_NUMBER_DESC[ThinQProperty.SLEEP_TIMER_RELATIVE_HOUR_TO_STOP],
+    ),
     DeviceType.AIR_PURIFIER_FAN: (
         NUMBER_DESC[ThinQProperty.WIND_TEMPERATURE],
         TIMER_NUMBER_DESC[ThinQProperty.SLEEP_TIMER_RELATIVE_HOUR_TO_STOP],

--- a/tests/components/lg_thinq/conftest.py
+++ b/tests/components/lg_thinq/conftest.py
@@ -117,9 +117,10 @@ def mock_thinq_mqtt_client() -> Generator[None]:
         "air_conditioner",
         "air_conditioner1",
         "air_conditioner2",
-        "washer",
+        "air_purifier",
         "dehumidifier",
         "kimchi_refrigerator",
+        "washer",
     ]
 )
 def device_fixture(request: pytest.FixtureRequest) -> Generator[str]:

--- a/tests/components/lg_thinq/fixtures/air_purifier/device.json
+++ b/tests/components/lg_thinq/fixtures/air_purifier/device.json
@@ -1,0 +1,9 @@
+{
+  "deviceId": "MW2-5E747ABC-6542-4DEF-AA89-4EC4353B2E90",
+  "deviceInfo": {
+    "deviceType": "DEVICE_AIR_PURIFIER",
+    "modelName": "AIR_910604_WW",
+    "alias": "Test air purifier",
+    "reportable": true
+  }
+}

--- a/tests/components/lg_thinq/fixtures/air_purifier/energy_profile.json
+++ b/tests/components/lg_thinq/fixtures/air_purifier/energy_profile.json
@@ -1,0 +1,4 @@
+{
+  "resultCode": "0000",
+  "result": {}
+}

--- a/tests/components/lg_thinq/fixtures/air_purifier/profile.json
+++ b/tests/components/lg_thinq/fixtures/air_purifier/profile.json
@@ -1,0 +1,20 @@
+{
+  "property": {
+    "operation": {
+      "airPurifierOperationMode": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["POWER_ON", "POWER_OFF"],
+          "w": ["POWER_ON", "POWER_OFF"]
+        }
+      }
+    },
+    "sleepTimer": {
+      "relativeHourToStop": {
+        "mode": ["r", "w"],
+        "type": "number"
+      }
+    }
+  }
+}

--- a/tests/components/lg_thinq/fixtures/air_purifier/status.json
+++ b/tests/components/lg_thinq/fixtures/air_purifier/status.json
@@ -1,0 +1,8 @@
+{
+  "operation": {
+    "airPurifierOperationMode": "POWER_ON"
+  },
+  "sleepTimer": {
+    "relativeHourToStop": 4
+  }
+}

--- a/tests/components/lg_thinq/snapshots/test_number.ambr
+++ b/tests/components/lg_thinq/snapshots/test_number.ambr
@@ -179,3 +179,63 @@
     'state': '0',
   })
 # ---
+# name: test_number_entities[air_purifier][number.test_air_purifier_sleep_timer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100.0,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0.0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.test_air_purifier_sleep_timer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Sleep timer',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sleep timer',
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <Property.SLEEP_TIMER_RELATIVE_HOUR_TO_STOP: 'sleep_timer_relative_hour_to_stop'>,
+    'unique_id': 'MW2-5E747ABC-6542-4DEF-AA89-4EC4353B2E90_sleep_timer_relative_hour_to_stop',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_number_entities[air_purifier][number.test_air_purifier_sleep_timer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test air purifier Sleep timer',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 100.0,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0.0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.BOX: 'box'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1.0,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.test_air_purifier_sleep_timer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4',
+  })
+# ---

--- a/tests/components/lg_thinq/test_number.py
+++ b/tests/components/lg_thinq/test_number.py
@@ -15,7 +15,9 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.parametrize("device_fixture", ["air_conditioner", "washer"])
+@pytest.mark.parametrize(
+    "device_fixture", ["air_conditioner", "air_purifier", "washer"]
+)
 async def test_number_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added sleep timer for air purifier to LG ThinQ.
That feature was supported on the server side but was missing from the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180706
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
