### PR TITLE
Bump pyHik to 0.4.5

### DIFF
--- a/homeassistant/components/hikvision/manifest.json
+++ b/homeassistant/components/hikvision/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["pyhik"],
-  "requirements": ["pyHik==0.4.4"]
+  "requirements": ["pyHik==0.4.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2026,7 +2026,7 @@ pyElectra==1.2.4
 pyEmby==1.10
 
 # homeassistant.components.hikvision
-pyHik==0.4.4
+pyHik==0.4.5
 
 # homeassistant.components.homee
 pyHomee==1.4.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Bumps pyHik from 0.4.4 to 0.4.5.

Changelog / diff: https://github.com/mezz64/pyHik/compare/0.4.4...0.4.5 — a single change, mezz64/pyHik#129, which makes the event stream thread's reconnect backoff wake on the kill event and checks that event before opening another connection.

In 0.4.4, `disconnect()` sets the kill event and joins the thread with no timeout, but `alert_stream()` only consulted the event while reading a *successful* response — its request-error path slept and retried unconditionally. With the camera unreachable, `disconnect()` never returned.

Verified against a real DS-7608NI-EV2/8P (V3.4.96) with the released 0.4.5 wheel:

| | 0.4.4 | 0.4.5 |
| --- | --- | --- |
| `disconnect()` while streaming | — | 1.4s, thread dead |
| `disconnect()` while device unreachable | never returned (killed at 45s) | 0.001s, thread dead |

This matters for #180873, which awaits `disconnect()` on `EVENT_HOMEASSISTANT_STOP`.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #180873
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
