### PR TITLE
Fix HomeKit cover direction when moved from outside HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -348,7 +348,7 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         if state == CoverState.OPENING:
             if target_position < current_position:
                 self.char_target_position.set_value(100)
-        elif target_position > current_position:
+        elif state == CoverState.CLOSING and target_position > current_position:
             self.char_target_position.set_value(0)
 
     @callback

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -330,6 +330,28 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         self.async_call_service(COVER_DOMAIN, SERVICE_SET_COVER_POSITION, params, value)
 
     @callback
+    def _async_update_target_position_while_moving(
+        self, state: str, current_position: int
+    ) -> None:
+        """Aim the target position at the end of travel while moving.
+
+        The Home app reads the direction of travel from the target position
+        relative to the current one, so a target the cover has already passed
+        makes it report the opposite direction. Only a passed target is
+        replaced: one the cover is still travelling towards, or has just
+        reached, is what HomeKit asked for.
+        """
+        if not self.features & CoverEntityFeature.SET_POSITION:
+            # Tilt-only covers lock the target position to closed.
+            return
+        target_position = self.char_target_position.value
+        if state == CoverState.OPENING:
+            if target_position < current_position:
+                self.char_target_position.set_value(100)
+        elif target_position > current_position:
+            self.char_target_position.set_value(0)
+
+    @callback
     @override
     def async_update_state(self, new_state: State) -> None:
         """Update cover position and tilt after state changed."""
@@ -339,9 +361,11 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         if isinstance(current_position, (float, int)):
             current_position = int(current_position)
             self.char_current_position.set_value(current_position)
-            # Writing target_position on a moving cover
-            # will break the moving state in HK.
-            if new_state.state not in MOVING_STATES:
+            if new_state.state in MOVING_STATES:
+                self._async_update_target_position_while_moving(
+                    new_state.state, current_position
+                )
+            else:
                 self.char_target_position.set_value(current_position)
 
         position_state = _hass_state_to_position_start(new_state.state)

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -228,7 +228,8 @@ async def test_windowcovering_set_cover_position(
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 60
-    assert acc.char_target_position.value == 0
+    # Aimed at the end of travel, not left behind at the starting position.
+    assert acc.char_target_position.value == 100
     assert acc.char_position_state.value == 1
 
     hass.states.async_set(
@@ -241,7 +242,7 @@ async def test_windowcovering_set_cover_position(
     )
     await hass.async_block_till_done()
     assert acc.char_current_position.value == 70
-    assert acc.char_target_position.value == 0
+    assert acc.char_target_position.value == 100
     assert acc.char_position_state.value == 1
 
     hass.states.async_set(
@@ -294,6 +295,109 @@ async def test_windowcovering_set_cover_position(
     assert acc.char_target_position.value == 75
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] == 75
+
+
+async def test_windowcovering_target_position_while_moving(
+    hass: HomeAssistant, hk_driver
+) -> None:
+    """Test the target position while the cover is moving.
+
+    The Home app derives the direction of travel from the target position
+    relative to the current one, so a target left behind the cover makes it
+    report the opposite of what the cover is doing.
+    """
+    entity_id = "cover.window"
+    features = CoverEntityFeature.SET_POSITION
+
+    hass.states.async_set(
+        entity_id, CoverState.CLOSED, {ATTR_SUPPORTED_FEATURES: features}
+    )
+    await hass.async_block_till_done()
+    acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    # Opened from outside HomeKit: the target still points at the start.
+    hass.states.async_set(
+        entity_id,
+        CoverState.OPENING,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 20},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 100
+
+    # Coming to rest hands the target back to the real position.
+    hass.states.async_set(
+        entity_id,
+        CoverState.OPEN,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 40},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 40
+
+    # Closed from outside HomeKit.
+    hass.states.async_set(
+        entity_id,
+        CoverState.CLOSING,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 30},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 0
+
+    # A partial move asked for from HomeKit must survive.
+    async_mock_service(hass, COVER_DOMAIN, "set_cover_position")
+    hass.states.async_set(
+        entity_id,
+        CoverState.CLOSED,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 0},
+    )
+    await hass.async_block_till_done()
+    acc.char_target_position.client_update_value(60)
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 60
+
+    hass.states.async_set(
+        entity_id,
+        CoverState.OPENING,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 30},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 60
+
+    # Still reported as opening on arrival at the requested position: the
+    # target must not jump to the end of travel in that last moment.
+    hass.states.async_set(
+        entity_id,
+        CoverState.OPENING,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 60},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_position.value == 60
+
+
+async def test_windowcovering_tilt_only_target_position_stays_closed(
+    hass: HomeAssistant, hk_driver
+) -> None:
+    """Test that a tilt-only cover keeps its target position locked at closed."""
+    entity_id = "cover.window"
+    features = CoverEntityFeature.OPEN_TILT | CoverEntityFeature.SET_TILT_POSITION
+
+    hass.states.async_set(
+        entity_id, CoverState.CLOSED, {ATTR_SUPPORTED_FEATURES: features}
+    )
+    await hass.async_block_till_done()
+    acc = WindowCovering(hass, hk_driver, "Cover", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        entity_id,
+        CoverState.OPENING,
+        {ATTR_SUPPORTED_FEATURES: features, ATTR_CURRENT_POSITION: 20},
+    )
+    await hass.async_block_till_done()
+    # Capped at 0 for tilt-only covers, so 100 would be out of range.
+    assert acc.char_target_position.value == 0
 
 
 async def test_window_instantiate_set_position(hass: HomeAssistant, hk_driver) -> None:


### PR DESCRIPTION
## Proposed change

Covers moved from outside HomeKit are reported as travelling in the opposite
direction by the Home app: a blind opening from closed shows as closing.

The Home app derives the direction of travel from the target position relative
to the current one, so `CHAR_POSITION_STATE` alone is not enough. Writing the
current position as the target while the cover moves would make it look
stopped, which is why the target used to be left alone entirely while moving.

Leaving it alone has its own failure mode though. When a cover is moved from
outside HomeKit — a wall switch, an automation, a scene — the target is still
the position the cover set off from, so the app reports the exact opposite of
what the cover is doing. This is why it only affects some movements, and never
those started in the Home app itself, where the target is set correctly by the
slider.

This aims the target at the end of travel while the cover is moving, which
fixes the direction while keeping the cover moving in the app. A partial move
requested from HomeKit is left untouched, recognised by its target already
lying ahead in the direction of travel, so "open to 60%" still reads as 60%
while it runs. Reversals mid-travel resolve correctly in both directions for
the same reason.

Only a target the cover has already passed is replaced. One it is still
travelling towards, or has just reached, is what HomeKit asked for and is left
alone — including the moment a partial move arrives at its requested position
while the entity still reports `opening`.

Tilt-only covers are skipped: their target position characteristic is capped
at `PROP_MAX_VALUE: 0`, so aiming at the end of travel would be out of range.

Two notes for review:

- The existing `test_windowcovering_set_cover_position` asserted the old
  behaviour explicitly — a target of `0` while the cover reports `opening` at
  position `60` — so those assertions change with the fix. That is the
  behaviour being corrected, not an unrelated test break.
- `Characteristic.set_value` only assigns and notifies; the setter callback is
  reached solely through `client_update_value` from the Home app. Writing the
  target here therefore cannot loop back into `set_cover_position`. The
  existing non-moving branch already relies on this.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #162595
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
