### PR TITLE
Add KNX entity suggestions generated from project data semantics

### DIFF
--- a/homeassistant/components/knx/storage/dpa.py
+++ b/homeassistant/components/knx/storage/dpa.py
@@ -1,0 +1,80 @@
+"""KNX Information Model semantics constants.
+
+Functional block (FB) and datapoint application (DPA) identifiers
+as defined by the KNX Information Model (KIM) and parsed from
+ETS project semantics by xknxproject.
+https://buildwithknxiot.knx.org/public-projects/knx-iot-docs/kim/functionalblock-overview/
+
+These are used to generate entity suggestions from project data in the
+frontend - no validation is done against them.
+"""
+
+from typing import Final
+
+from homeassistant.const import Platform
+
+# FB 417 Light Switching Actuator Basic
+DPA_417_INFO_ON_OFF: Final = "417.51"  # output
+DPA_417_SWITCH_ON_OFF: Final = "417.52"  # input
+
+# FB 418 Light Dimming Actuator Basic
+DPA_418_INFO_ON_OFF: Final = "418.51"  # output
+DPA_418_ACTUAL_DIMMING_VALUE: Final = "418.52"  # output
+DPA_418_SWITCH_ON_OFF: Final = "418.62"  # input
+DPA_418_ABS_SETVALUE_CONTROL: Final = "418.70"  # input
+
+# FB 422 Colour Actuator xyY
+DPA_422_INFO_ON_OFF: Final = "422.51"  # output
+DPA_422_ACTUAL_DIMMING_VALUE: Final = "422.52"  # output
+DPA_422_CURRENT_COLOUR_XYY: Final = "422.56"  # output
+DPA_422_SWITCH_ON_OFF: Final = "422.62"  # input
+DPA_422_ABS_SETVALUE_CONTROL: Final = "422.70"  # input
+DPA_422_COLOUR_SET_XYY: Final = "422.76"  # input
+
+# FB 423 Colour Actuator RGB(W)
+DPA_423_COMBINED_SWITCH_ON_OFF: Final = "423.51"  # input
+DPA_423_COLOUR_SET_RGB: Final = "423.52"  # input
+DPA_423_COLOUR_SET_RGBW: Final = "423.54"  # input
+DPA_423_SWITCH_ON_OFF_RED: Final = "423.56"  # input
+DPA_423_ABS_SETVALUE_CONTROL_RED: Final = "423.58"  # input
+DPA_423_SWITCH_ON_OFF_GREEN: Final = "423.59"  # input
+DPA_423_ABS_SETVALUE_CONTROL_GREEN: Final = "423.61"  # input
+DPA_423_SWITCH_ON_OFF_BLUE: Final = "423.62"  # input
+DPA_423_ABS_SETVALUE_CONTROL_BLUE: Final = "423.64"  # input
+DPA_423_SWITCH_ON_OFF_WHITE: Final = "423.65"  # input
+DPA_423_ABS_SETVALUE_CONTROL_WHITE: Final = "423.67"  # input
+DPA_423_COMBINED_INFO_ON_OFF: Final = "423.80"  # output
+DPA_423_CURRENT_COLOUR_RGB: Final = "423.81"  # output
+DPA_423_CURRENT_COLOUR_RGBW: Final = "423.82"  # output
+DPA_423_ACTUAL_DIMMING_VALUE_RED: Final = "423.83"  # output
+DPA_423_ACTUAL_DIMMING_VALUE_GREEN: Final = "423.84"  # output
+DPA_423_ACTUAL_DIMMING_VALUE_BLUE: Final = "423.85"  # output
+DPA_423_ACTUAL_DIMMING_VALUE_WHITE: Final = "423.86"  # output
+
+# FB 427 Colour Temperature Actuator
+DPA_427_INFO_ON_OFF: Final = "427.51"  # output
+DPA_427_ACTUAL_DIMMING_VALUE: Final = "427.52"  # output
+DPA_427_SWITCH_ON_OFF: Final = "427.62"  # input
+DPA_427_ABS_SETVALUE_CONTROL: Final = "427.70"  # input
+DPA_427_CURRENT_COLOUR_TEMPERATURE: Final = "427.75"  # output
+DPA_427_ABS_COLOUR_TEMPERATURE_CONTROL: Final = "427.81"  # input
+
+# FB 800 Sunblind Actuator Basic
+DPA_800_CURRENT_ABS_POS_SLATS_PERCENT: Final = "800.56"  # output
+DPA_800_DEDICATED_STOP: Final = "800.70"  # input
+DPA_800_SET_ABS_POS_BLINDS_PERCENT: Final = "800.71"  # input
+DPA_800_SET_ABS_POS_SLATS_PERCENT: Final = "800.72"  # input
+DPA_800_MOVE_UP_DOWN: Final = "800.81"  # input
+DPA_800_STOP_STEP_UP_DOWN: Final = "800.82"  # input
+DPA_800_CURRENT_ABS_POS_BLINDS_PERCENT: Final = "800.85"  # output
+
+# Maps functional block numbers to platforms suitable to represent them.
+# The first platform in the list is used as default suggestion.
+FUNCTIONAL_BLOCK_PLATFORMS: Final[dict[str, list[Platform]]] = {
+    "417": [Platform.LIGHT, Platform.SWITCH],
+    "418": [Platform.LIGHT],
+    "422": [Platform.LIGHT],
+    "423": [Platform.LIGHT],
+    "427": [Platform.LIGHT],
+    "800": [Platform.COVER],
+}

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -130,6 +130,51 @@ from .const import (
     CONF_SPEED,
     CONF_TARGET_TEMPERATURE,
 )
+from .dpa import (
+    DPA_417_INFO_ON_OFF,
+    DPA_417_SWITCH_ON_OFF,
+    DPA_418_ABS_SETVALUE_CONTROL,
+    DPA_418_ACTUAL_DIMMING_VALUE,
+    DPA_418_INFO_ON_OFF,
+    DPA_418_SWITCH_ON_OFF,
+    DPA_422_ABS_SETVALUE_CONTROL,
+    DPA_422_ACTUAL_DIMMING_VALUE,
+    DPA_422_COLOUR_SET_XYY,
+    DPA_422_CURRENT_COLOUR_XYY,
+    DPA_422_INFO_ON_OFF,
+    DPA_422_SWITCH_ON_OFF,
+    DPA_423_ABS_SETVALUE_CONTROL_BLUE,
+    DPA_423_ABS_SETVALUE_CONTROL_GREEN,
+    DPA_423_ABS_SETVALUE_CONTROL_RED,
+    DPA_423_ABS_SETVALUE_CONTROL_WHITE,
+    DPA_423_ACTUAL_DIMMING_VALUE_BLUE,
+    DPA_423_ACTUAL_DIMMING_VALUE_GREEN,
+    DPA_423_ACTUAL_DIMMING_VALUE_RED,
+    DPA_423_ACTUAL_DIMMING_VALUE_WHITE,
+    DPA_423_COLOUR_SET_RGB,
+    DPA_423_COLOUR_SET_RGBW,
+    DPA_423_COMBINED_INFO_ON_OFF,
+    DPA_423_COMBINED_SWITCH_ON_OFF,
+    DPA_423_CURRENT_COLOUR_RGB,
+    DPA_423_CURRENT_COLOUR_RGBW,
+    DPA_423_SWITCH_ON_OFF_BLUE,
+    DPA_423_SWITCH_ON_OFF_GREEN,
+    DPA_423_SWITCH_ON_OFF_RED,
+    DPA_423_SWITCH_ON_OFF_WHITE,
+    DPA_427_ABS_COLOUR_TEMPERATURE_CONTROL,
+    DPA_427_ABS_SETVALUE_CONTROL,
+    DPA_427_ACTUAL_DIMMING_VALUE,
+    DPA_427_CURRENT_COLOUR_TEMPERATURE,
+    DPA_427_INFO_ON_OFF,
+    DPA_427_SWITCH_ON_OFF,
+    DPA_800_CURRENT_ABS_POS_BLINDS_PERCENT,
+    DPA_800_CURRENT_ABS_POS_SLATS_PERCENT,
+    DPA_800_DEDICATED_STOP,
+    DPA_800_MOVE_UP_DOWN,
+    DPA_800_SET_ABS_POS_BLINDS_PERCENT,
+    DPA_800_SET_ABS_POS_SLATS_PERCENT,
+    DPA_800_STOP_STEP_UP_DOWN,
+)
 from .knx_selector import (
     AllSerializeFirst,
     GASelector,
@@ -243,20 +288,34 @@ BUTTON_KNX_SCHEMA = AllSerializeFirst(
 COVER_KNX_SCHEMA = AllSerializeFirst(
     probatio.Schema(
         {
-            probatio.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
+            probatio.Optional(CONF_GA_UP_DOWN): GASelector(
+                state=False, valid_dpt="1", dpa_write=[DPA_800_MOVE_UP_DOWN]
+            ),
             probatio.Optional(CoverConf.INVERT_UPDOWN): selector.BooleanSelector(),
-            probatio.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
-            probatio.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
+            probatio.Optional(CONF_GA_STOP): GASelector(
+                state=False, valid_dpt="1", dpa_write=[DPA_800_DEDICATED_STOP]
+            ),
+            probatio.Optional(CONF_GA_STEP): GASelector(
+                state=False, valid_dpt="1", dpa_write=[DPA_800_STOP_STEP_UP_DOWN]
+            ),
             "section_position_control": KNXSectionFlat(collapsible=True),
             probatio.Optional(CONF_GA_POSITION_SET): GASelector(
-                state=False, valid_dpt="5.001"
+                state=False,
+                valid_dpt="5.001",
+                dpa_write=[DPA_800_SET_ABS_POS_BLINDS_PERCENT],
             ),
             probatio.Optional(CONF_GA_POSITION_STATE): GASelector(
-                write=False, valid_dpt="5.001"
+                write=False,
+                valid_dpt="5.001",
+                dpa_state=[DPA_800_CURRENT_ABS_POS_BLINDS_PERCENT],
             ),
             probatio.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
-            probatio.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
+            probatio.Optional(CONF_GA_ANGLE): GASelector(
+                valid_dpt="5.001",
+                dpa_write=[DPA_800_SET_ABS_POS_SLATS_PERCENT],
+                dpa_state=[DPA_800_CURRENT_ABS_POS_SLATS_PERCENT],
+            ),
             probatio.Optional(CoverConf.INVERT_ANGLE): selector.BooleanSelector(),
             "section_travel_time": KNXSectionFlat(),
             probatio.Required(
@@ -398,14 +457,43 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
     probatio.Schema(
         {
             probatio.Optional(CONF_GA_SWITCH): GASelector(
-                write_required=True, valid_dpt="1"
+                write_required=True,
+                valid_dpt="1",
+                dpa_write=[
+                    DPA_417_SWITCH_ON_OFF,
+                    DPA_418_SWITCH_ON_OFF,
+                    DPA_422_SWITCH_ON_OFF,
+                    DPA_423_COMBINED_SWITCH_ON_OFF,
+                    DPA_427_SWITCH_ON_OFF,
+                ],
+                dpa_state=[
+                    DPA_417_INFO_ON_OFF,
+                    DPA_418_INFO_ON_OFF,
+                    DPA_422_INFO_ON_OFF,
+                    DPA_423_COMBINED_INFO_ON_OFF,
+                    DPA_427_INFO_ON_OFF,
+                ],
             ),
             probatio.Optional(CONF_GA_BRIGHTNESS): GASelector(
-                write_required=True, valid_dpt="5.001"
+                write_required=True,
+                valid_dpt="5.001",
+                dpa_write=[
+                    DPA_418_ABS_SETVALUE_CONTROL,
+                    DPA_422_ABS_SETVALUE_CONTROL,
+                    DPA_427_ABS_SETVALUE_CONTROL,
+                ],
+                dpa_state=[
+                    DPA_418_ACTUAL_DIMMING_VALUE,
+                    DPA_422_ACTUAL_DIMMING_VALUE,
+                    DPA_427_ACTUAL_DIMMING_VALUE,
+                ],
             ),
             "section_color_temp": KNXSectionFlat(collapsible=True),
             probatio.Optional(CONF_GA_COLOR_TEMP): GASelector(
-                write_required=True, dpt=ColorTempModes
+                write_required=True,
+                dpt=ColorTempModes,
+                dpa_write=[DPA_427_ABS_COLOUR_TEMPERATURE_CONTROL],
+                dpa_state=[DPA_427_CURRENT_COLOUR_TEMPERATURE],
             ),
             probatio.Required(CONF_COLOR_TEMP_MIN, default=2700): AllSerializeFirst(
                 selector.NumberSelector(
@@ -428,7 +516,18 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                     translation_key="single_address",
                     schema={
                         probatio.Optional(CONF_GA_COLOR): GASelector(
-                            write_required=True, dpt=LightColorMode
+                            write_required=True,
+                            dpt=LightColorMode,
+                            dpa_write=[
+                                DPA_422_COLOUR_SET_XYY,
+                                DPA_423_COLOUR_SET_RGB,
+                                DPA_423_COLOUR_SET_RGBW,
+                            ],
+                            dpa_state=[
+                                DPA_422_CURRENT_COLOUR_XYY,
+                                DPA_423_CURRENT_COLOUR_RGB,
+                                DPA_423_CURRENT_COLOUR_RGBW,
+                            ],
                         )
                     },
                 ),
@@ -436,28 +535,48 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                     translation_key="individual_addresses",
                     schema={
                         probatio.Optional(CONF_GA_RED_SWITCH): GASelector(
-                            write_required=False, valid_dpt="1"
+                            write_required=False,
+                            valid_dpt="1",
+                            dpa_write=[DPA_423_SWITCH_ON_OFF_RED],
                         ),
                         probatio.Required(CONF_GA_RED_BRIGHTNESS): GASelector(
-                            write_required=True, valid_dpt="5.001"
+                            write_required=True,
+                            valid_dpt="5.001",
+                            dpa_write=[DPA_423_ABS_SETVALUE_CONTROL_RED],
+                            dpa_state=[DPA_423_ACTUAL_DIMMING_VALUE_RED],
                         ),
                         probatio.Optional(CONF_GA_GREEN_SWITCH): GASelector(
-                            write_required=False, valid_dpt="1"
+                            write_required=False,
+                            valid_dpt="1",
+                            dpa_write=[DPA_423_SWITCH_ON_OFF_GREEN],
                         ),
                         probatio.Required(CONF_GA_GREEN_BRIGHTNESS): GASelector(
-                            write_required=True, valid_dpt="5.001"
+                            write_required=True,
+                            valid_dpt="5.001",
+                            dpa_write=[DPA_423_ABS_SETVALUE_CONTROL_GREEN],
+                            dpa_state=[DPA_423_ACTUAL_DIMMING_VALUE_GREEN],
                         ),
                         probatio.Optional(CONF_GA_BLUE_SWITCH): GASelector(
-                            write_required=False, valid_dpt="1"
+                            write_required=False,
+                            valid_dpt="1",
+                            dpa_write=[DPA_423_SWITCH_ON_OFF_BLUE],
                         ),
                         probatio.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
-                            write_required=True, valid_dpt="5.001"
+                            write_required=True,
+                            valid_dpt="5.001",
+                            dpa_write=[DPA_423_ABS_SETVALUE_CONTROL_BLUE],
+                            dpa_state=[DPA_423_ACTUAL_DIMMING_VALUE_BLUE],
                         ),
                         probatio.Optional(CONF_GA_WHITE_SWITCH): GASelector(
-                            write_required=False, valid_dpt="1"
+                            write_required=False,
+                            valid_dpt="1",
+                            dpa_write=[DPA_423_SWITCH_ON_OFF_WHITE],
                         ),
                         probatio.Optional(CONF_GA_WHITE_BRIGHTNESS): GASelector(
-                            write_required=True, valid_dpt="5.001"
+                            write_required=True,
+                            valid_dpt="5.001",
+                            dpa_write=[DPA_423_ABS_SETVALUE_CONTROL_WHITE],
+                            dpa_state=[DPA_423_ACTUAL_DIMMING_VALUE_WHITE],
                         ),
                     },
                 ),
@@ -728,7 +847,10 @@ SELECT_KNX_SCHEMA = AllSerializeFirst(
 SWITCH_KNX_SCHEMA = probatio.Schema(
     {
         probatio.Required(CONF_GA_SWITCH): GASelector(
-            write_required=True, valid_dpt="1"
+            write_required=True,
+            valid_dpt="1",
+            dpa_write=[DPA_417_SWITCH_ON_OFF],
+            dpa_state=[DPA_417_INFO_ON_OFF],
         ),
         probatio.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
         probatio.Optional(

--- a/homeassistant/components/knx/storage/entity_suggestions/__init__.py
+++ b/homeassistant/components/knx/storage/entity_suggestions/__init__.py
@@ -6,11 +6,14 @@ from homeassistant.core import HomeAssistant
 
 from .base import SuggestionProvider
 from .const import EntitySuggestion, EntitySuggestionsResult, SuggestionFilter
+from .functional_blocks import FunctionalBlockSuggestionProvider
 
 if TYPE_CHECKING:
     from ...knx_module import KNXModule
 
-SUGGESTION_PROVIDERS: list[type[SuggestionProvider]] = []
+SUGGESTION_PROVIDERS: list[type[SuggestionProvider]] = [
+    FunctionalBlockSuggestionProvider,
+]
 
 
 def _matches(suggestion: EntitySuggestion, suggestion_filter: SuggestionFilter) -> bool:

--- a/homeassistant/components/knx/storage/entity_suggestions/__init__.py
+++ b/homeassistant/components/knx/storage/entity_suggestions/__init__.py
@@ -1,0 +1,52 @@
+"""Entity suggestions from KNX data sources."""
+
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant
+
+from .base import SuggestionProvider
+from .const import EntitySuggestion, EntitySuggestionsResult, SuggestionFilter
+
+if TYPE_CHECKING:
+    from ...knx_module import KNXModule
+
+SUGGESTION_PROVIDERS: list[type[SuggestionProvider]] = []
+
+
+def _matches(suggestion: EntitySuggestion, suggestion_filter: SuggestionFilter) -> bool:
+    """Check a suggestion against a filter."""
+    if (
+        suggestion_filter.platform is not None
+        and suggestion_filter.platform not in suggestion["suggestions"]
+    ):
+        return False
+    if (
+        suggestion_filter.group_id is not None
+        and suggestion_filter.group_id != suggestion["group_id"]
+    ):
+        return False
+    return suggestion_filter.include_configured or not suggestion["existing_entity_ids"]
+
+
+async def async_get_entity_suggestions(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    suggestion_filter: SuggestionFilter | None = None,
+) -> EntitySuggestionsResult:
+    """Generate entity suggestions from all providers.
+
+    Providers generate everything they know about; filtering is applied here so
+    it behaves the same for every source. Results are not windowed - a caller
+    that has to bound its response applies its own limit.
+    """
+    suggestion_filter = suggestion_filter or SuggestionFilter()
+    result = EntitySuggestionsResult(suggestions=[], providers={})
+    for provider_class in SUGGESTION_PROVIDERS:
+        provider = provider_class()
+        provider_result = await provider.async_get_suggestions(hass, knx)
+        for suggestion in provider_result["suggestions"]:
+            suggestion["id"] = f"{provider.provider_id}_{suggestion['id']}"
+            if _matches(suggestion, suggestion_filter):
+                result["suggestions"].append(suggestion)
+        result["providers"][provider.provider_id] = provider_result["hints"]
+    return result

--- a/homeassistant/components/knx/storage/entity_suggestions/base.py
+++ b/homeassistant/components/knx/storage/entity_suggestions/base.py
@@ -1,0 +1,28 @@
+"""Base class for KNX entity suggestion providers."""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+from homeassistant.core import HomeAssistant
+
+from .const import ProviderResult
+
+if TYPE_CHECKING:
+    from ...knx_module import KNXModule
+
+
+class SuggestionProvider(ABC):
+    """Generate entity suggestions from a specific data source.
+
+    Providers gather their data sources themselves (eg. project data
+    or existing entity configurations) and report source specific
+    information for empty result hints in `ProviderResult["hints"]`.
+    """
+
+    provider_id: ClassVar[str]
+
+    @abstractmethod
+    async def async_get_suggestions(
+        self, hass: HomeAssistant, knx: KNXModule
+    ) -> ProviderResult:
+        """Generate entity suggestions."""

--- a/homeassistant/components/knx/storage/entity_suggestions/const.py
+++ b/homeassistant/components/knx/storage/entity_suggestions/const.py
@@ -1,0 +1,101 @@
+"""Types for KNX entity suggestions."""
+
+from dataclasses import dataclass, field
+from typing import Any, TypedDict
+
+
+@dataclass(frozen=True)
+class SuggestionFilter:
+    """Narrow down which entity suggestions are returned.
+
+    Generating every suggestion of a large project is cheap, but sending them
+    all is not - a caller that only wants the covers of one device shouldn't
+    have to receive the whole installation. Field metadata descriptions follow
+    the convention of the library `*.mcp` input dataclasses, so a parameter
+    schema can be derived from this class.
+    """
+
+    platform: str | None = field(
+        default=None,
+        metadata={
+            "description": (
+                'Only suggestions that can be created as this platform, e.g. "light".'
+            )
+        },
+    )
+    group_id: str | None = field(
+        default=None,
+        metadata={
+            "description": (
+                "Only suggestions of this group - for suggestions from project data "
+                'the individual address of the device, e.g. "1.1.5".'
+            )
+        },
+    )
+    include_configured: bool = field(
+        default=True,
+        metadata={
+            "description": (
+                "Include suggestions whose group addresses are already used by an "
+                "existing entity."
+            )
+        },
+    )
+
+
+class SuggestedGroupAddress(TypedDict):
+    """A group address used by a suggested entity configuration."""
+
+    address: str
+    name: str
+
+
+class PlatformSuggestion(TypedDict):
+    """Suggested entity configuration for one platform."""
+
+    # `knx` options of EntityData
+    knx: dict[str, Any]
+    # group addresses used in `knx` - for duplicate detection and display
+    matched_group_addresses: list[SuggestedGroupAddress]
+    # informative: DPAs of the source that were not assigned to a config key
+    unmatched_dpas: list[str]
+
+
+class EntitySuggestion(TypedDict):
+    """A suggested entity, possibly representable by multiple platforms."""
+
+    # unique id - prefixed with the providers id by the orchestrator
+    id: str
+    # provider id this suggestion originates from
+    source: str
+    suggested_name: str
+    # group suggestions belong to, eg. a device; `group_id` is stable, `group_name`
+    # is for display - callers compose their own title from both
+    group_id: str
+    group_name: str
+    # additional info for the suggestion, eg. a channel name
+    secondary_info: str
+    # platforms able to represent this suggestion - first item is the default
+    platform_options: list[str]
+    # key: platform
+    suggestions: dict[str, PlatformSuggestion]
+    # entities already using one of the matched group addresses
+    existing_entity_ids: list[str]
+    # provider specific details about where the suggestion comes from
+    metadata: dict[str, Any]
+
+
+class ProviderResult(TypedDict):
+    """Result of a single suggestion provider."""
+
+    suggestions: list[EntitySuggestion]
+    # provider specific information, eg. for empty-state hints
+    hints: dict[str, Any]
+
+
+class EntitySuggestionsResult(TypedDict):
+    """Combined result of all suggestion providers."""
+
+    suggestions: list[EntitySuggestion]
+    # key: provider id
+    providers: dict[str, dict[str, Any]]

--- a/homeassistant/components/knx/storage/entity_suggestions/functional_blocks.py
+++ b/homeassistant/components/knx/storage/entity_suggestions/functional_blocks.py
@@ -1,0 +1,445 @@
+"""Entity suggestions from KNX Information Model semantics of project data.
+
+Matches functional block (FB) and datapoint application (DPA) semantics
+parsed from ETS project data by xknxproject against DPA annotations of
+the entity store schemas defined in `entity_store_schema.py`.
+"""
+
+from collections import Counter
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import cache
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
+
+from awesomeversion import AwesomeVersion
+import probatio
+from xknx.typing import DPTMainSubDict
+from xknxproject.models import (
+    Channel as ProjectChannel,
+    CommunicationObject,
+    DPTType,
+    KNXProject,
+)
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from ...const import DOMAIN
+from ..const import CONF_DPT, CONF_GA_PASSIVE, CONF_GA_WRITE
+from ..dpa import FUNCTIONAL_BLOCK_PLATFORMS
+from ..entity_store_schema import KNX_SCHEMA_FOR_PLATFORM
+from ..knx_selector import GASelector, GroupSelect, GroupSelectSchema, KNXSection
+from ..util import dpt_string_to_dict
+from .base import SuggestionProvider
+from .const import (
+    EntitySuggestion,
+    PlatformSuggestion,
+    ProviderResult,
+    SuggestedGroupAddress,
+)
+
+if TYPE_CHECKING:
+    from ...knx_module import KNXModule
+
+# first xknxproject version parsing KNX Information Model semantics
+MIN_SEMANTICS_PARSER_VERSION = AwesomeVersion("3.9.0")
+
+type GaSlot = Literal["write", "state"]
+# config path of a group select and index of one of its options
+type GroupSelectOptionRef = tuple[tuple[str, ...], int]
+
+
+@dataclass(frozen=True)
+class DpaSlotTarget:
+    """A `write` or `state` key of a GASelector a DPA can be assigned to."""
+
+    # config path to the group address selector, eg. ("color", "ga_color")
+    path: tuple[str, ...]
+    slot: GaSlot
+    selector: GASelector
+    # set when the selector is inside a group select option
+    group_select: GroupSelectOptionRef | None = None
+
+
+@dataclass
+class _SlotAssignment:
+    """Group address config assigned to one config key."""
+
+    ga_schema: dict[str, Any]
+    group_select: GroupSelectOptionRef | None
+    # DPAs assigned to this config key
+    dpas: list[str] = field(default_factory=list)
+    # group addresses used by this config key (including passive)
+    group_addresses: set[str] = field(default_factory=set)
+
+
+def _iter_ga_selectors(
+    validator: Any,
+    path: tuple[str, ...],
+    group_select: GroupSelectOptionRef | None,
+) -> Iterator[tuple[tuple[str, ...], GASelector, GroupSelectOptionRef | None]]:
+    """Yield GASelectors of a schema with their config path and group select scope."""
+    if isinstance(validator, probatio.All):
+        # AllSerializeFirst: only the first validator holds the UI schema
+        yield from _iter_ga_selectors(validator.validators[0], path, group_select)
+        return
+    if isinstance(validator, probatio.Schema) and isinstance(validator.schema, dict):
+        for marker, value in validator.schema.items():
+            key_path = (*path, str(marker))
+            if isinstance(value, GASelector):
+                yield (key_path, value, group_select)
+            elif isinstance(value, GroupSelect):
+                # group select options nest config under the group selects key
+                # and are mutually exclusive alternatives
+                assert isinstance(value.schema, GroupSelectSchema)
+                for index, option in enumerate(value.schema.validators):
+                    yield from _iter_ga_selectors(
+                        option.schema, key_path, (key_path, index)
+                    )
+            elif isinstance(value, KNXSection):
+                yield from _iter_ga_selectors(value.schema, key_path, group_select)
+
+
+@cache
+def _collect_dpa_index(platform: Platform) -> dict[str, DpaSlotTarget]:
+    """Map DPA ids (eg. "417.52") to their target key in a platform schema.
+
+    First occurrence of a DPA wins.
+    """
+    index: dict[str, DpaSlotTarget] = {}
+    for path, selector, group_select in _iter_ga_selectors(
+        KNX_SCHEMA_FOR_PLATFORM[platform], (), None
+    ):
+        slot_dpas: dict[GaSlot, Iterable[str] | None] = {
+            "write": selector.dpa_write,
+            "state": selector.dpa_state,
+        }
+        for slot, dpas in slot_dpas.items():
+            for dpa in dpas or ():
+                index.setdefault(
+                    dpa,
+                    DpaSlotTarget(
+                        path=path,
+                        slot=slot,
+                        selector=selector,
+                        group_select=group_select,
+                    ),
+                )
+    return index
+
+
+def _selector_dpt_enum(selector: GASelector) -> type[Enum] | None:
+    """Return the selectors dpt enum, if it uses one."""
+    if isinstance(selector.dpt, type) and issubclass(selector.dpt, Enum):
+        return selector.dpt
+    return None
+
+
+def _dpt_matches(ga_dpt: DPTType | None, valid_dpt: DPTMainSubDict) -> bool:
+    """Check whether a group address DPT matches a valid DPT (sub None matches any)."""
+    return (
+        ga_dpt is not None
+        and ga_dpt["main"] == valid_dpt["main"]
+        and (valid_dpt["sub"] is None or ga_dpt["sub"] == valid_dpt["sub"])
+    )
+
+
+def _ga_dpt_valid_for_selector(ga_dpt: DPTType | None, selector: GASelector) -> bool:
+    """Check whether a group addresses DPT is accepted by a GASelector."""
+    if selector.valid_dpt is not None:
+        return any(
+            _dpt_matches(ga_dpt, dpt_string_to_dict(dpt)) for dpt in selector.valid_dpt
+        )
+    if (dpt_enum := _selector_dpt_enum(selector)) is not None:
+        return any(
+            _dpt_matches(ga_dpt, dpt_string_to_dict(item.value)) for item in dpt_enum
+        )
+    # dpt-class lists or no restriction: don't reject based on project DPT
+    return True
+
+
+def _dpt_select_value(ga_dpt: DPTType | None, selector: GASelector) -> str | None:
+    """Value for the `dpt` config key of dpt-enum selectors matching a group addresses DPT."""
+    if (dpt_enum := _selector_dpt_enum(selector)) is None:
+        return None
+    return next(
+        (
+            str(item.value)
+            for item in dpt_enum
+            if _dpt_matches(ga_dpt, dpt_string_to_dict(item.value))
+        ),
+        None,
+    )
+
+
+def _try_assign_dpa(
+    project: KNXProject,
+    dpa: str,
+    com_object: CommunicationObject,
+    target: DpaSlotTarget,
+    assignments: dict[tuple[str, ...], _SlotAssignment],
+) -> bool:
+    """Assign a com objects group addresses to the config key targeted by a DPA.
+
+    The first linked group address fills the targeted `write` or `state` key,
+    additional links become `passive` addresses.
+    Returns False if the DPA can not be assigned.
+    """
+    ga_links = [
+        ga
+        for ga in com_object["group_address_links"]
+        if ga in project["group_addresses"]
+    ]
+    if not ga_links:
+        return False
+    primary_ga = ga_links[0]
+    ga_dpt = project["group_addresses"][primary_ga]["dpt"]
+    if not _ga_dpt_valid_for_selector(ga_dpt, target.selector):
+        return False
+    assignment = assignments.get(target.path)
+    if assignment is not None and target.slot in assignment.ga_schema:
+        # slot already assigned by another com object - first wins
+        return False
+    if assignment is None:
+        assignment = _SlotAssignment(ga_schema={}, group_select=target.group_select)
+        assignments[target.path] = assignment
+
+    assignment.ga_schema[target.slot] = primary_ga
+    if (dpt_value := _dpt_select_value(ga_dpt, target.selector)) is not None:
+        assignment.ga_schema[CONF_DPT] = dpt_value
+    assignment.dpas.append(dpa)
+    assignment.group_addresses.add(primary_ga)
+    if target.selector.passive and len(ga_links) > 1:
+        passive: list[str] = assignment.ga_schema.setdefault(CONF_GA_PASSIVE, [])
+        passive.extend(ga for ga in ga_links[1:] if ga not in passive)
+        assignment.group_addresses.update(ga_links[1:])
+    return True
+
+
+def _resolve_group_select_options(
+    assignments: dict[tuple[str, ...], _SlotAssignment],
+    unmatched_dpas: set[str],
+) -> None:
+    """Drop assignments of all but the first matched group select option.
+
+    Group select options are mutually exclusive alternatives, but a device may
+    provide com objects matching multiple options (eg. combined and individual
+    colour addresses). Option order marks preference (eg. combined colour
+    addresses before individual ones).
+    """
+    # group select path -> option index -> assignment paths
+    group_selects: dict[tuple[str, ...], dict[int, list[tuple[str, ...]]]] = {}
+    for path, assignment in assignments.items():
+        if assignment.group_select is None:
+            continue
+        gs_path, option = assignment.group_select
+        group_selects.setdefault(gs_path, {}).setdefault(option, []).append(path)
+    for options in group_selects.values():
+        if len(options) <= 1:
+            continue
+        winning_option = min(options)
+        for option, paths in options.items():
+            if option == winning_option:
+                continue
+            for path in paths:
+                unmatched_dpas.update(assignments[path].dpas)
+                del assignments[path]
+
+
+def _set_nested_value(
+    config: dict[str, Any], path: tuple[str, ...], value: Any
+) -> None:
+    """Set a value in a nested config dict, creating intermediate dicts."""
+    for key in path[:-1]:
+        config = config.setdefault(key, {})
+    config[path[-1]] = value
+
+
+def _build_platform_suggestion(
+    project: KNXProject,
+    channel: ProjectChannel,
+    dpa_index: dict[str, DpaSlotTarget],
+) -> PlatformSuggestion | None:
+    """Build the suggested `knx` config for one channel and platform schema."""
+    assignments: dict[tuple[str, ...], _SlotAssignment] = {}
+    unmatched_dpas: set[str] = set()
+
+    for com_object_id in channel["communication_object_ids"]:
+        # com objects without group address links are not included in the project data
+        if (com_object := project["communication_objects"].get(com_object_id)) is None:
+            continue
+        for dpa in com_object["dpas"] or ():
+            target = dpa_index.get(dpa)
+            if target is None or not _try_assign_dpa(
+                project, dpa, com_object, target, assignments
+            ):
+                unmatched_dpas.add(dpa)
+
+    _resolve_group_select_options(assignments, unmatched_dpas)
+
+    # a config without any write address can never validate for actuator platforms
+    if not any(CONF_GA_WRITE in a.ga_schema for a in assignments.values()):
+        return None
+
+    knx_config: dict[str, Any] = {}
+    matched_group_addresses: set[str] = set()
+    for path, assignment in assignments.items():
+        _set_nested_value(knx_config, path, assignment.ga_schema)
+        matched_group_addresses.update(assignment.group_addresses)
+    return PlatformSuggestion(
+        knx=knx_config,
+        # names carry the semantics a channel name often lacks
+        matched_group_addresses=[
+            SuggestedGroupAddress(
+                address=address, name=project["group_addresses"][address]["name"]
+            )
+            for address in sorted(matched_group_addresses)
+        ],
+        unmatched_dpas=sorted(unmatched_dpas),
+    )
+
+
+class FunctionalBlockSuggestionProvider(SuggestionProvider):
+    """Suggest entities from functional block semantics of imported project data."""
+
+    # marks suggestions of this provider for the frontend
+    provider_id: ClassVar[str] = "fb"
+
+    @override
+    async def async_get_suggestions(
+        self, hass: HomeAssistant, knx: KNXModule
+    ) -> ProviderResult:
+        """Generate entity suggestions from project data."""
+        project = await knx.project.get_knxproject()
+        if project is None:
+            return ProviderResult(suggestions=[], hints={"state": "no_project"})
+
+        parser_version = project["info"]["xknxproject_version"]
+        if AwesomeVersion(parser_version) < MIN_SEMANTICS_PARSER_VERSION:
+            return ProviderResult(
+                suggestions=[],
+                hints={"state": "outdated_parser", "parser_version": parser_version},
+            )
+        functional_blocks_found = {
+            fb
+            for device in project["devices"].values()
+            for channel in device["channels"].values()
+            for fb in channel["functional_blocks"] or ()
+        }
+        if not functional_blocks_found:
+            return ProviderResult(suggestions=[], hints={"state": "no_semantics"})
+
+        return ProviderResult(
+            suggestions=self._build_suggestions(hass, knx, project),
+            hints={
+                "state": "ok",
+                "functional_blocks_found": sorted(functional_blocks_found),
+            },
+        )
+
+    def _build_suggestions(
+        self, hass: HomeAssistant, knx: KNXModule, project: KNXProject
+    ) -> list[EntitySuggestion]:
+        """Build suggestions for all channels with supported functional blocks."""
+        candidates = [
+            candidate
+            for device_address, device in project["devices"].items()
+            for channel_id, channel in device["channels"].items()
+            if (
+                candidate := self._build_channel_suggestion(
+                    project, device_address, channel_id, channel
+                )
+            )
+            is not None
+        ]
+        self._add_existing_entity_ids(hass, knx, candidates)
+        self._disambiguate_names(project, candidates)
+        return candidates
+
+    def _build_channel_suggestion(
+        self,
+        project: KNXProject,
+        device_address: str,
+        channel_id: str,
+        channel: ProjectChannel,
+    ) -> EntitySuggestion | None:
+        """Build the suggestion for one channel, if it has supported functional blocks."""
+        functional_blocks = [
+            fb
+            for fb in channel["functional_blocks"] or ()
+            if fb in FUNCTIONAL_BLOCK_PLATFORMS
+        ]
+        # platforms able to represent the channels functional blocks - ordered, deduplicated
+        platform_options = dict.fromkeys(
+            platform
+            for fb in functional_blocks
+            for platform in FUNCTIONAL_BLOCK_PLATFORMS[fb]
+        )
+        suggestions = {
+            platform.value: suggestion
+            for platform in platform_options
+            if (
+                suggestion := _build_platform_suggestion(
+                    project, channel, _collect_dpa_index(platform)
+                )
+            )
+            is not None
+        }
+        if not suggestions:
+            return None
+        device = project["devices"][device_address]
+        return EntitySuggestion(
+            # channel ids are only unique within a device
+            id=f"{device_address}_{channel_id}",
+            source=self.provider_id,
+            suggested_name=channel["name"] or device["name"],
+            group_id=device_address,
+            group_name=device["name"],
+            secondary_info=channel["name"],
+            platform_options=list(suggestions),
+            suggestions=suggestions,
+            existing_entity_ids=[],
+            metadata={"functional_blocks": functional_blocks},
+        )
+
+    def _add_existing_entity_ids(
+        self, hass: HomeAssistant, knx: KNXModule, candidates: list[EntitySuggestion]
+    ) -> None:
+        """Add entities already using one of the suggested group addresses."""
+        entity_registry = er.async_get(hass)
+        ga_entities = {
+            str(ga): identifiers
+            for ga, identifiers in knx.group_address_entities.items()
+        }
+        for candidate in candidates:
+            candidate["existing_entity_ids"] = sorted(
+                {
+                    entity_id
+                    for suggestion in candidate["suggestions"].values()
+                    for ga in suggestion["matched_group_addresses"]
+                    for identifier in ga_entities.get(ga["address"], ())
+                    if (
+                        entity_id := entity_registry.async_get_entity_id(
+                            identifier.platform, DOMAIN, identifier.unique_id
+                        )
+                    )
+                    is not None
+                }
+            )
+
+    def _disambiguate_names(
+        self, project: KNXProject, candidates: list[EntitySuggestion]
+    ) -> None:
+        """Prefix names used multiple times with their device name."""
+        name_counts = Counter(candidate["suggested_name"] for candidate in candidates)
+        for candidate in candidates:
+            if (
+                name_counts[candidate["suggested_name"]] > 1
+                and candidate["secondary_info"]
+            ):
+                device = project["devices"][candidate["group_id"]]
+                candidate["suggested_name"] = (
+                    f"{device['name']} {candidate['secondary_info']}"
+                )

--- a/homeassistant/components/knx/storage/knx_selector.py
+++ b/homeassistant/components/knx/storage/knx_selector.py
@@ -180,6 +180,9 @@ class GASelector(KNXSelectorBase):
 
     `dpt_required` optional dpt only apply to dpt-class lists, enums are always required.
     `valid_dpt` is used in frontend to filter dropdown menu - no validation is done.
+    `dpa_write` / `dpa_state` are KNX Information Model datapoint application
+    identifiers used by entity suggestion providers to assign addresses from
+    project data to that key - no validation is done and they are not serialized.
     """
 
     selector_type = "knx_group_address"
@@ -194,8 +197,14 @@ class GASelector(KNXSelectorBase):
         dpt: type[Enum] | list[HaDptClass] | None = None,
         dpt_required: bool = True,
         valid_dpt: str | Iterable[str] | None = None,
+        dpa_write: Iterable[str] | None = None,
+        dpa_state: Iterable[str] | None = None,
     ) -> None:
         """Initialize the group address selector."""
+        if dpa_write is not None and not write:
+            raise ValueError("`dpa_write` requires `write` to be allowed")
+        if dpa_state is not None and not state:
+            raise ValueError("`dpa_state` requires `state` to be allowed")
         self.write = write
         self.state = state
         self.passive = passive
@@ -204,6 +213,8 @@ class GASelector(KNXSelectorBase):
         self.dpt = dpt
         self.dpt_required = dpt_required
         self.valid_dpt = (valid_dpt,) if isinstance(valid_dpt, str) else valid_dpt
+        self.dpa_write = dpa_write
+        self.dpa_state = dpa_state
 
         self.schema = self.build_schema()
 

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -50,6 +50,8 @@ from .storage.entity_store_validation import (
     EntityStoreValidationSuccess,
     validate_entity_data,
 )
+from .storage.entity_suggestions import async_get_entity_suggestions
+from .storage.entity_suggestions.const import SuggestionFilter
 from .storage.expose_controller import validate_expose_data
 from .storage.serialize import get_serialized_schema
 from .storage.time_server import validate_time_server_data
@@ -71,6 +73,7 @@ async def register_panel(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_query_telegrams)
     websocket_api.async_register_command(hass, ws_subscribe_telegram)
     websocket_api.async_register_command(hass, ws_get_knx_project)
+    websocket_api.async_register_command(hass, ws_get_entity_suggestions)
     websocket_api.async_register_command(hass, ws_validate_entity)
     websocket_api.async_register_command(hass, ws_create_entity)
     websocket_api.async_register_command(hass, ws_update_entity)
@@ -252,6 +255,36 @@ async def ws_get_knx_project(
         msg["id"],
         knxproject,
     )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/get_entity_suggestions",
+        vol.Optional("platform"): vol.In(SUPPORTED_PLATFORMS_UI),
+        vol.Optional("group_id"): str,
+        vol.Optional("include_configured", default=True): bool,
+    }
+)
+@websocket_api.async_response
+@provide_knx
+async def ws_get_entity_suggestions(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Handle get entity suggestions."""
+    result = await async_get_entity_suggestions(
+        hass,
+        knx,
+        SuggestionFilter(
+            platform=msg.get("platform"),
+            group_id=msg.get("group_id"),
+            include_configured=msg["include_configured"],
+        ),
+    )
+    connection.send_result(msg["id"], result)
 
 
 @websocket_api.require_admin

--- a/tests/components/knx/test_dpa.py
+++ b/tests/components/knx/test_dpa.py
@@ -1,0 +1,39 @@
+"""Test KNX Information Model semantics constants."""
+
+from homeassistant.components.knx.const import SUPPORTED_PLATFORMS_UI
+from homeassistant.components.knx.storage.dpa import FUNCTIONAL_BLOCK_PLATFORMS
+from homeassistant.components.knx.storage.entity_suggestions.functional_blocks import (
+    _collect_dpa_index,
+)
+
+
+def test_functional_block_platform_map() -> None:
+    """Test FUNCTIONAL_BLOCK_PLATFORMS mapping consistency with schema annotations."""
+    dpas_of_platform = {
+        platform: set(_collect_dpa_index(platform))
+        for platform in SUPPORTED_PLATFORMS_UI
+    }
+    for functional_block, platforms in FUNCTIONAL_BLOCK_PLATFORMS.items():
+        for platform in platforms:
+            assert platform in SUPPORTED_PLATFORMS_UI
+            # every mapped platform shall have at least one DPA
+            # annotation of that functional block in its schema
+            assert any(
+                dpa.startswith(f"{functional_block}.")
+                for dpa in dpas_of_platform[platform]
+            ), f"No DPA of FB {functional_block} in {platform} schema"
+
+    # every DPA annotation shall have its functional block
+    # registered in FUNCTIONAL_BLOCK_PLATFORMS for that platform
+    for platform, dpas in dpas_of_platform.items():
+        for dpa in dpas:
+            functional_block = dpa.split(".")[0]
+            assert platform in FUNCTIONAL_BLOCK_PLATFORMS.get(functional_block, []), (
+                f"DPA {dpa} in {platform} schema but FB {functional_block}"
+                " not mapped to that platform in FUNCTIONAL_BLOCK_PLATFORMS"
+            )
+    # DPA format sanity check: "<fb>.<datapoint>" - both numeric
+    for dpas in dpas_of_platform.values():
+        for dpa in dpas:
+            fb_part, dpa_part = dpa.split(".")
+            assert fb_part.isdigit() and dpa_part.isdigit()

--- a/tests/components/knx/test_entity_suggestions.py
+++ b/tests/components/knx/test_entity_suggestions.py
@@ -1,0 +1,155 @@
+"""Test the KNX entity suggestion API."""
+
+from typing import Any, override
+from unittest.mock import patch
+
+from homeassistant.components.knx.storage.entity_suggestions.base import (
+    SuggestionProvider,
+)
+from homeassistant.components.knx.storage.entity_suggestions.const import (
+    EntitySuggestion,
+    PlatformSuggestion,
+    ProviderResult,
+    SuggestedGroupAddress,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import KNXTestKit
+
+from tests.typing import WebSocketGenerator
+
+
+def _suggestion(
+    suggestion_id: str,
+    platform: Platform,
+    group_id: str = "1.1.1",
+    existing_entity_ids: list[str] | None = None,
+) -> EntitySuggestion:
+    """Build a suggestion as a provider would return it - id not yet prefixed."""
+    return EntitySuggestion(
+        id=suggestion_id,
+        source=_StubProvider.provider_id,
+        suggested_name=f"Entity {suggestion_id}",
+        group_id=group_id,
+        group_name="Device",
+        secondary_info="Channel",
+        platform_options=[platform.value],
+        suggestions={
+            platform.value: PlatformSuggestion(
+                knx={"ga_switch": {"write": "1/2/3"}},
+                matched_group_addresses=[
+                    SuggestedGroupAddress(address="1/2/3", name="GA 1/2/3")
+                ],
+                unmatched_dpas=[],
+            )
+        },
+        existing_entity_ids=existing_entity_ids or [],
+        metadata={},
+    )
+
+
+class _StubProvider(SuggestionProvider):
+    """Provider returning a fixed set of suggestions."""
+
+    provider_id = "stub"
+
+    @override
+    async def async_get_suggestions(
+        self, hass: HomeAssistant, knx: Any
+    ) -> ProviderResult:
+        """Return suggestions covering every filterable property."""
+        return ProviderResult(
+            suggestions=[
+                _suggestion("light", Platform.LIGHT),
+                _suggestion("cover", Platform.COVER, group_id="1.1.2"),
+                _suggestion(
+                    "configured", Platform.LIGHT, existing_entity_ids=["light.existing"]
+                ),
+            ],
+            hints={"state": "ok"},
+        )
+
+
+async def _get_suggestions(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, **filters: Any
+) -> dict:
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "knx/get_entity_suggestions"} | filters)
+    res = await client.receive_json()
+    assert res["success"], res
+    return res["result"]
+
+
+async def test_ws_get_entity_suggestions(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test suggestions of a provider are returned with their hints."""
+    await knx.setup_integration()
+    with patch(
+        "homeassistant.components.knx.storage.entity_suggestions.SUGGESTION_PROVIDERS",
+        [_StubProvider],
+    ):
+        result = await _get_suggestions(hass, hass_ws_client)
+
+    # ids are prefixed with the provider id so they stay unique across providers
+    assert [suggestion["id"] for suggestion in result["suggestions"]] == [
+        "stub_light",
+        "stub_cover",
+        "stub_configured",
+    ]
+    assert result["providers"] == {"stub": {"state": "ok"}}
+
+
+async def test_ws_get_entity_suggestions_without_providers(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test an empty result when no provider generates suggestions."""
+    await knx.setup_integration()
+    with patch(
+        "homeassistant.components.knx.storage.entity_suggestions.SUGGESTION_PROVIDERS",
+        [],
+    ):
+        result = await _get_suggestions(hass, hass_ws_client)
+
+    assert result == {"suggestions": [], "providers": {}}
+
+
+async def test_ws_get_entity_suggestions_filtered(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test narrowing down suggestions."""
+    await knx.setup_integration()
+    with patch(
+        "homeassistant.components.knx.storage.entity_suggestions.SUGGESTION_PROVIDERS",
+        [_StubProvider],
+    ):
+        by_platform = await _get_suggestions(
+            hass, hass_ws_client, platform=Platform.COVER
+        )
+        by_group = await _get_suggestions(hass, hass_ws_client, group_id="1.1.1")
+        unconfigured = await _get_suggestions(
+            hass, hass_ws_client, include_configured=False
+        )
+
+    assert [suggestion["id"] for suggestion in by_platform["suggestions"]] == [
+        "stub_cover"
+    ]
+    # hints are reported no matter how narrow the filter is
+    assert by_platform["providers"] == {"stub": {"state": "ok"}}
+
+    assert [suggestion["id"] for suggestion in by_group["suggestions"]] == [
+        "stub_light",
+        "stub_configured",
+    ]
+    # suggestions whose group addresses are already used are dropped
+    assert [suggestion["id"] for suggestion in unconfigured["suggestions"]] == [
+        "stub_light",
+        "stub_cover",
+    ]

--- a/tests/components/knx/test_entity_suggestions_functional_blocks.py
+++ b/tests/components/knx/test_entity_suggestions_functional_blocks.py
@@ -1,0 +1,466 @@
+"""Test KNX entity suggestions generated from functional block semantics."""
+
+from typing import Any
+
+from homeassistant.components.knx.project import STORAGE_KEY as KNX_PROJECT_STORAGE_KEY
+from homeassistant.components.knx.storage.entity_suggestions.functional_blocks import (
+    _build_platform_suggestion,
+    _collect_dpa_index,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import KNXTestKit
+
+from tests.typing import WebSocketGenerator
+
+DPT_SWITCH = {"main": 1, "sub": 1}
+DPT_PERCENT = {"main": 5, "sub": 1}
+DPT_COLOR_TEMP_ABS = {"main": 7, "sub": 600}
+DPT_COLOR_RGB = {"main": 232, "sub": 600}
+
+
+def _channel(name: str, fbs: list[str] | None, com_object_ids: list[str]) -> dict:
+    return {
+        "identifier": name,
+        "name": name,
+        "communication_object_ids": com_object_ids,
+        "functional_blocks": fbs,
+    }
+
+
+def _com_object(dpas: list[str] | None, ga_links: list[str]) -> dict:
+    return {"dpas": dpas, "group_address_links": ga_links}
+
+
+def _group_address(address: str, dpt: dict | None) -> dict:
+    return {"name": f"GA {address}", "address": address, "description": "", "dpt": dpt}
+
+
+TEST_PROJECT_INFO = {
+    "xknxproject_version": "3.9.0",
+    "group_address_style": "ThreeLevel",
+}
+
+TEST_PROJECT: dict[str, Any] = {
+    "info": TEST_PROJECT_INFO,
+    "group_addresses": {
+        "1/0/1": _group_address("1/0/1", DPT_SWITCH),
+        "1/0/2": _group_address("1/0/2", DPT_SWITCH),
+        "1/0/3": _group_address("1/0/3", DPT_SWITCH),
+        "1/0/4": _group_address("1/0/4", DPT_SWITCH),
+        "1/0/5": _group_address("1/0/5", DPT_PERCENT),  # wrong DPT for a switch GA
+        "2/0/1": _group_address("2/0/1", DPT_SWITCH),
+        "2/0/2": _group_address("2/0/2", DPT_SWITCH),
+        "2/0/3": _group_address("2/0/3", DPT_PERCENT),
+        "2/0/4": _group_address("2/0/4", DPT_PERCENT),
+        "2/0/5": _group_address("2/0/5", DPT_PERCENT),
+        "2/0/6": _group_address("2/0/6", DPT_PERCENT),
+        "2/0/7": _group_address("2/0/7", DPT_SWITCH),
+        "5/0/1": _group_address("5/0/1", DPT_SWITCH),
+        "5/0/2": _group_address("5/0/2", DPT_SWITCH),
+        "5/0/3": _group_address("5/0/3", DPT_PERCENT),
+        "5/0/4": _group_address("5/0/4", DPT_PERCENT),
+        "5/0/5": _group_address("5/0/5", DPT_COLOR_TEMP_ABS),
+        "5/0/6": _group_address("5/0/6", DPT_COLOR_TEMP_ABS),
+        "6/0/1": _group_address("6/0/1", DPT_SWITCH),
+        "6/0/2": _group_address("6/0/2", DPT_SWITCH),
+        "6/0/3": _group_address("6/0/3", DPT_COLOR_RGB),
+        "6/0/4": _group_address("6/0/4", DPT_COLOR_RGB),
+        "6/1/1": _group_address("6/1/1", DPT_PERCENT),
+        "6/1/2": _group_address("6/1/2", DPT_PERCENT),
+        "6/1/3": _group_address("6/1/3", DPT_PERCENT),
+        "6/1/4": _group_address("6/1/4", DPT_PERCENT),
+        "6/1/5": _group_address("6/1/5", DPT_PERCENT),
+        "6/1/6": _group_address("6/1/6", DPT_PERCENT),
+    },
+    "devices": {
+        "1.1.1": {
+            "name": "Schaltaktor",
+            "channels": {
+                # channel ids are only unique within a device - colliding on purpose
+                "CH-1": _channel(
+                    "Ausgang 1", ["417"], ["co-1", "co-2", "co-4", "co-missing"]
+                ),
+                "CH-2": _channel("Ausgang 2", ["417"], ["co-3"]),
+                "CH-3": _channel("Unsupported FB", ["999"], []),
+                "CH-4": _channel("No semantics", None, ["co-1"]),
+            },
+        },
+        "1.1.2": {
+            "name": "Jalousieaktor",
+            "channels": {
+                "CH-1": _channel(
+                    "Jalousie 1",
+                    ["800"],
+                    ["co-10", "co-11", "co-12", "co-13", "co-14", "co-15", "co-16"],
+                ),
+            },
+        },
+        "1.1.3": {
+            "name": "Schaltaktor 2",
+            "channels": {
+                # same channel name as 1.1.1 CH-1 - names get device name prefixed
+                "CH-1": _channel("Ausgang 1", ["417"], ["co-20"]),
+                # write GA has non-matching DPT - no valid suggestion
+                "CH-2": _channel("Wrong DPT", ["417"], ["co-21"]),
+            },
+        },
+        "1.2.1": {
+            "name": "TW Aktor",
+            "channels": {
+                "CH-1": _channel(
+                    "Tunable White",
+                    ["427"],
+                    ["co-50", "co-51", "co-52", "co-53", "co-54", "co-55"],
+                ),
+            },
+        },
+        "1.2.2": {
+            "name": "RGB Aktor",
+            "channels": {
+                # com objects for combined AND individual colour addresses
+                "CH-1": _channel(
+                    "RGB",
+                    ["423"],
+                    [
+                        "co-60",
+                        "co-61",
+                        "co-62",
+                        "co-63",
+                        "co-70",
+                        "co-71",
+                        "co-72",
+                        "co-73",
+                        "co-74",
+                        "co-75",
+                    ],
+                ),
+            },
+        },
+    },
+    "communication_objects": {
+        "co-1": _com_object(["417.52"], ["1/0/1", "1/0/2"]),
+        "co-2": _com_object(["417.51"], ["1/0/3"]),
+        "co-3": _com_object(["417.52"], ["1/0/4"]),
+        "co-4": _com_object(["417.69"], ["1/0/4"]),  # no config key for this DPA
+        "co-10": _com_object(["800.81"], ["2/0/1"]),
+        "co-11": _com_object(["800.82"], ["2/0/2"]),
+        "co-12": _com_object(["800.71"], ["2/0/3"]),
+        "co-13": _com_object(["800.85"], ["2/0/4"]),
+        "co-14": _com_object(["800.72"], ["2/0/5"]),
+        "co-15": _com_object(["800.56"], ["2/0/6"]),
+        "co-16": _com_object(["800.75", "800.51"], ["2/0/7"]),
+        "co-20": _com_object(["417.52"], ["1/0/1"]),
+        "co-21": _com_object(["417.52"], ["1/0/5"]),
+        "co-50": _com_object(["427.62"], ["5/0/1"]),
+        "co-51": _com_object(["427.51"], ["5/0/2"]),
+        "co-52": _com_object(["427.70"], ["5/0/3"]),
+        "co-53": _com_object(["427.52"], ["5/0/4"]),
+        "co-54": _com_object(["427.81"], ["5/0/5"]),
+        "co-55": _com_object(["427.75"], ["5/0/6"]),
+        "co-60": _com_object(["423.51"], ["6/0/1"]),
+        "co-61": _com_object(["423.80"], ["6/0/2"]),
+        "co-62": _com_object(["423.52"], ["6/0/3"]),
+        "co-63": _com_object(["423.81"], ["6/0/4"]),
+        "co-70": _com_object(["423.58"], ["6/1/1"]),
+        "co-71": _com_object(["423.83"], ["6/1/2"]),
+        "co-72": _com_object(["423.61"], ["6/1/3"]),
+        "co-73": _com_object(["423.84"], ["6/1/4"]),
+        "co-74": _com_object(["423.64"], ["6/1/5"]),
+        "co-75": _com_object(["423.85"], ["6/1/6"]),
+    },
+}
+
+
+def _test_channel(device: str, channel: str) -> dict:
+    return TEST_PROJECT["devices"][device]["channels"][channel]
+
+
+def test_collect_dpa_index() -> None:
+    """Test DPA index generation from entity store schemas."""
+    light_index = _collect_dpa_index(Platform.LIGHT)
+    target = light_index["417.52"]
+    assert target.path == ("ga_switch",)
+    assert target.slot == "write"
+    assert target.group_select is None
+
+    target = light_index["418.51"]
+    assert target.path == ("ga_switch",)
+    assert target.slot == "state"
+
+    # group select options are tracked with their option index
+    target = light_index["423.52"]
+    assert target.path == ("color", "ga_color")
+    assert target.slot == "write"
+    assert target.group_select == (("color",), 0)
+
+    target = light_index["423.84"]
+    assert target.path == ("color", "ga_green_brightness")
+    assert target.slot == "state"
+    assert target.group_select == (("color",), 1)
+
+    assert "999.99" not in light_index
+
+
+def test_switch_and_light_suggestion() -> None:
+    """Test FB 417 suggestions with state, passive and unmatched DPAs."""
+    channel = _test_channel("1.1.1", "CH-1")
+    for platform in (Platform.LIGHT, Platform.SWITCH):
+        suggestion = _build_platform_suggestion(
+            TEST_PROJECT, channel, _collect_dpa_index(platform)
+        )
+        assert suggestion is not None
+        assert suggestion["knx"] == {
+            "ga_switch": {"write": "1/0/1", "state": "1/0/3", "passive": ["1/0/2"]}
+        }
+        # missing com objects are skipped; DPAs without config key are reported
+        assert suggestion["unmatched_dpas"] == ["417.69"]
+        # group addresses carry their project name
+        assert suggestion["matched_group_addresses"] == [
+            {"address": "1/0/1", "name": "GA 1/0/1"},
+            {"address": "1/0/2", "name": "GA 1/0/2"},
+            {"address": "1/0/3", "name": "GA 1/0/3"},
+        ]
+
+
+def test_cover_suggestion() -> None:
+    """Test FB 800 suggestion."""
+    channel = _test_channel("1.1.2", "CH-1")
+    suggestion = _build_platform_suggestion(
+        TEST_PROJECT, channel, _collect_dpa_index(Platform.COVER)
+    )
+    assert suggestion is not None
+    assert suggestion["knx"] == {
+        "ga_up_down": {"write": "2/0/1"},
+        "ga_step": {"write": "2/0/2"},
+        "ga_position_set": {"write": "2/0/3"},
+        "ga_position_state": {"state": "2/0/4"},
+        "ga_angle": {"write": "2/0/5", "state": "2/0/6"},
+    }
+    assert suggestion["unmatched_dpas"] == ["800.51", "800.75"]
+
+
+def test_invalid_dpt_dropped() -> None:
+    """Test that a write GA with non-matching DPT yields no suggestion."""
+    channel = _test_channel("1.1.3", "CH-2")
+    assert (
+        _build_platform_suggestion(
+            TEST_PROJECT, channel, _collect_dpa_index(Platform.SWITCH)
+        )
+        is None
+    )
+
+
+def test_tunable_white_suggestion() -> None:
+    """Test FB 427 suggestion with `dpt` derived from the group address."""
+    channel = _test_channel("1.2.1", "CH-1")
+    suggestion = _build_platform_suggestion(
+        TEST_PROJECT, channel, _collect_dpa_index(Platform.LIGHT)
+    )
+    assert suggestion is not None
+    assert suggestion["knx"] == {
+        "ga_switch": {"write": "5/0/1", "state": "5/0/2"},
+        "ga_brightness": {"write": "5/0/3", "state": "5/0/4"},
+        "ga_color_temp": {"write": "5/0/5", "state": "5/0/6", "dpt": "7.600"},
+    }
+
+
+def test_combined_color_preferred() -> None:
+    """Test that the first matched group select option wins."""
+    channel = _test_channel("1.2.2", "CH-1")
+    suggestion = _build_platform_suggestion(
+        TEST_PROJECT, channel, _collect_dpa_index(Platform.LIGHT)
+    )
+    assert suggestion is not None
+    assert suggestion["knx"] == {
+        "ga_switch": {"write": "6/0/1", "state": "6/0/2"},
+        "color": {"ga_color": {"write": "6/0/3", "state": "6/0/4", "dpt": "232.600"}},
+    }
+    # individual colour DPAs were dropped in favor of the combined option
+    assert suggestion["unmatched_dpas"] == [
+        "423.58",
+        "423.61",
+        "423.64",
+        "423.83",
+        "423.84",
+        "423.85",
+    ]
+    assert "6/1/1" not in [
+        ga["address"] for ga in suggestion["matched_group_addresses"]
+    ]
+
+
+def test_individual_color_without_combined() -> None:
+    """Test individual colour addresses are used when no combined com objects exist."""
+    channel = _channel(
+        "RGB einzeln",
+        ["423"],
+        ["co-60", "co-61", "co-70", "co-71", "co-72", "co-73", "co-74", "co-75"],
+    )
+    suggestion = _build_platform_suggestion(
+        TEST_PROJECT, channel, _collect_dpa_index(Platform.LIGHT)
+    )
+    assert suggestion is not None
+    assert suggestion["knx"] == {
+        "ga_switch": {"write": "6/0/1", "state": "6/0/2"},
+        "color": {
+            "ga_red_brightness": {"write": "6/1/1", "state": "6/1/2"},
+            "ga_green_brightness": {"write": "6/1/3", "state": "6/1/4"},
+            "ga_blue_brightness": {"write": "6/1/5", "state": "6/1/6"},
+        },
+    }
+
+
+async def _get_suggestions(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, **filters: Any
+) -> dict:
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "knx/get_entity_suggestions"} | filters,
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    return res["result"]
+
+
+async def test_ws_get_entity_suggestions(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the knx/get_entity_suggestions command."""
+    hass_storage[KNX_PROJECT_STORAGE_KEY] = {"version": 1, "data": TEST_PROJECT}
+    await knx.setup_integration()
+    result = await _get_suggestions(hass, hass_ws_client)
+
+    assert result["providers"]["fb"] == {
+        "state": "ok",
+        "functional_blocks_found": ["417", "423", "427", "800", "999"],
+    }
+    suggestions = {suggestion["id"]: suggestion for suggestion in result["suggestions"]}
+    assert sorted(suggestions) == [
+        "fb_1.1.1_CH-1",
+        "fb_1.1.1_CH-2",
+        "fb_1.1.2_CH-1",
+        "fb_1.1.3_CH-1",
+        "fb_1.2.1_CH-1",
+        "fb_1.2.2_CH-1",
+    ]
+
+    switch_actuator = suggestions["fb_1.1.1_CH-1"]
+    assert switch_actuator["source"] == "fb"
+    assert switch_actuator["group_id"] == "1.1.1"
+    assert switch_actuator["group_name"] == "Schaltaktor"
+    assert switch_actuator["metadata"] == {"functional_blocks": ["417"]}
+    assert switch_actuator["secondary_info"] == "Ausgang 1"
+    # light is the default for FB 417
+    assert switch_actuator["platform_options"] == ["light", "switch"]
+    assert (
+        switch_actuator["suggestions"]["light"]["knx"]["ga_switch"]["write"] == "1/0/1"
+    )
+    assert switch_actuator["existing_entity_ids"] == []
+
+    # ambiguous channel names get the device name prefixed
+    assert switch_actuator["suggested_name"] == "Schaltaktor Ausgang 1"
+    assert suggestions["fb_1.1.3_CH-1"]["suggested_name"] == ("Schaltaktor 2 Ausgang 1")
+    assert suggestions["fb_1.1.1_CH-2"]["suggested_name"] == "Ausgang 2"
+
+    assert suggestions["fb_1.1.2_CH-1"]["platform_options"] == ["cover"]
+
+
+async def test_ws_get_entity_suggestions_duplicates(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test that entities using suggested group addresses are reported."""
+    hass_storage[KNX_PROJECT_STORAGE_KEY] = {"version": 1, "data": TEST_PROJECT}
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/create_entity",
+            "platform": Platform.SWITCH,
+            "data": {
+                "entity": {
+                    "name": "Existing",
+                    "device_info": None,
+                    "entity_category": None,
+                },
+                "knx": {"ga_switch": {"write": "1/0/4"}},
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    entity_id = res["result"]["entity_id"]
+
+    result = await _get_suggestions(hass, hass_ws_client)
+    suggestions = {suggestion["id"]: suggestion for suggestion in result["suggestions"]}
+    assert suggestions["fb_1.1.1_CH-2"]["existing_entity_ids"] == [entity_id]
+    assert suggestions["fb_1.1.2_CH-1"]["existing_entity_ids"] == []
+
+
+async def test_ws_get_entity_suggestions_no_project(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test suggestions without project data."""
+    await knx.setup_integration()
+    result = await _get_suggestions(hass, hass_ws_client)
+    assert result["suggestions"] == []
+    assert result["providers"]["fb"] == {"state": "no_project"}
+
+
+async def test_ws_get_entity_suggestions_outdated_parser(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test suggestions for a project imported with an old parser version."""
+    hass_storage[KNX_PROJECT_STORAGE_KEY] = {
+        "version": 1,
+        "data": {
+            **TEST_PROJECT,
+            "info": {**TEST_PROJECT_INFO, "xknxproject_version": "3.8.0"},
+        },
+    }
+    await knx.setup_integration()
+    result = await _get_suggestions(hass, hass_ws_client)
+    assert result["suggestions"] == []
+    assert result["providers"]["fb"] == {
+        "state": "outdated_parser",
+        "parser_version": "3.8.0",
+    }
+
+
+async def test_ws_get_entity_suggestions_no_semantics(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test suggestions for a project without semantics information."""
+    hass_storage[KNX_PROJECT_STORAGE_KEY] = {
+        "version": 1,
+        "data": {
+            "info": TEST_PROJECT_INFO,
+            "group_addresses": {},
+            "devices": {
+                "1.1.1": {
+                    "name": "Aktor",
+                    "channels": {"CH-1": _channel("Ausgang", None, [])},
+                }
+            },
+            "communication_objects": {},
+        },
+    }
+    await knx.setup_integration()
+    result = await _get_suggestions(hass, hass_ws_client)
+    assert result["suggestions"] == []
+    assert result["providers"]["fb"] == {"state": "no_semantics"}

--- a/tests/components/knx/test_knx_selectors.py
+++ b/tests/components/knx/test_knx_selectors.py
@@ -180,6 +180,19 @@ def test_ga_selector_invalid(
         selector(data)
 
 
+@pytest.mark.parametrize(
+    "selector_config",
+    [
+        {"write": False, "dpa_write": ["417.52"]},
+        {"state": False, "dpa_state": ["417.51"]},
+    ],
+)
+def test_ga_selector_invalid_dpa_config(selector_config: dict[str, Any]) -> None:
+    """Test GASelector raising on DPAs annotated for disallowed keys."""
+    with pytest.raises(ValueError):
+        GASelector(**selector_config)
+
+
 def test_sync_state_selector() -> None:
     """Test SyncStateSelector."""
     selector = SyncStateSelector()
@@ -220,6 +233,18 @@ def test_sync_state_selector() -> None:
                     "state": False,
                     "passive": False,
                     "validDPTs": [{"main": 5, "sub": 1}],
+                },
+            },
+        ),
+        (
+            # dpa_write/dpa_state are not serialized
+            GASelector(dpa_write=["417.52"], dpa_state=["417.51"]),
+            {
+                "type": "knx_group_address",
+                "options": {
+                    "write": {"required": False},
+                    "state": {"required": False},
+                    "passive": True,
                 },
             },
         ),


### PR DESCRIPTION
## Proposed change

Adds an entity suggestion API to the KNX integration and a first provider that generates ready-made entity configurations from the imported ETS project.

Since xknxproject 3.9.0 the parser exposes KNX Information Model semantics of ETS projects: functional block (FB) references on device channels (`knx:fb.417`) and datapoint application (DPA) references on group objects (`knx:dpa.417.52`). These identify what a channel *is* (eg. a light switching actuator) and what each of its group objects *does* (eg. "SwitchOnOff" vs. "InfoOnOff"), which is exactly the information needed to fill an entity configuration.

**How it works**

- `GASelector` gets two new optional arguments, `dpa_write` and `dpa_state`, annotating which DPAs belong to that config key. They live next to `valid_dpt` in `entity_store_schema.py`, are not validated and not serialized to the frontend - the entity store schemas stay the single source of truth for what a platform accepts.
- A new `storage/entity_suggestions` package walks the platform schemas, indexes those annotations and matches them against the channels of the imported project. The result is a complete `knx` config per suggestion, ready to be passed to `knx/create_entity`.
- The new `knx/get_entity_suggestions` websocket command serves them to the panel.

The API is provider based: `SuggestionProvider` subclasses register in `SUGGESTION_PROVIDERS` and the response format carries nothing provider specific at its top level, so further sources (eg. suggestions derived from already configured entities) only need a new class. The first provider is `"fb"` (functional blocks).

**Covered functional blocks** (v1): FB 417 (light switching actuator) → `light` or `switch`, FB 418 (dimming actuator), FB 422/423 (colour actuators xyY and RGB(W)), FB 427 (colour temperature actuator) → `light`, FB 800 (sunblind actuator) → `cover`. Adding more is a table entry in `storage/dpa.py` plus annotations in the schema.

**Matching rules** worth pointing out for review:
- The first group address linked to a group object fills the `write` / `state` key, further links become `passive` addresses.
- Group addresses whose DPT doesn't fit the selector are rejected, so a mismatched project can't produce an invalid config.
- Group select options are mutually exclusive alternatives - devices often offer combined *and* individual colour objects. The first matching option in schema order wins (combined colour addresses before individual ones); dropped DPAs are reported in `unmatched_dpas`.
- Entities already using one of the matched group addresses are reported in `existing_entity_ids`, so the panel can flag duplicates.

Suggestions are generated, never applied - creating an entity still goes through the regular `knx/validate_entity` and `knx/create_entity` path.

`async_get_entity_suggestions` takes a `SuggestionFilter` (platform, group, whether to include already configured ones), applied in the orchestrator so it behaves the same for every provider; the websocket command exposes it as optional parameters. The filter is a dataclass carrying its parameter descriptions in `field` metadata, following the convention of the library `*.mcp` input dataclasses, so #178029's `_schema_from_dataclass` can derive a tool schema from it as-is. Results are deliberately not windowed - like `get_last_values` there, a caller that has to bound its response applies its own limit. Suggestions carry structured data rather than formatted strings (`group_id` + `group_name`, matched group addresses with their project names, a provider specific `metadata` block), so a consumer composes its own presentation.

The change is split into two commits that can be reviewed - and if preferred, merged - independently:

1. **Add KNX entity configuration suggestion API** - the provider interface, the central filtering and the websocket command. Stands on its own; a further source only needs a new class in `SUGGESTION_PROVIDERS`.
2. **Add KNX entity suggestions from functional block semantics** - the first provider, the `dpa_write` / `dpa_state` annotations and the functional block to platform table.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to frontend pull request: https://github.com/XKNX/knx-frontend/pull/448
- This PR is related to issue: #178029 (the entity suggestions are meant to become a tool of that KNX LLM API in a follow-up)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
