### PR TITLE
Add explicit device creation for DALI lines of lunatone

### DIFF
--- a/homeassistant/components/lunatone/__init__.py
+++ b/homeassistant/components/lunatone/__init__.py
@@ -100,7 +100,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: LunatoneConfigEntry) -> 
 
     device_registry = dr.async_get(hass)
 
-    # Create main device that holds most device information
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.unique_id)},
@@ -116,7 +115,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: LunatoneConfigEntry) -> 
         ),
     )
 
-    # Create a device for every connected DALI line
     for line_id, line_info in info_api.data.lines.items():
         line_unique_id = f"{entry.unique_id}-line{line_id}"
 

--- a/homeassistant/components/lunatone/__init__.py
+++ b/homeassistant/components/lunatone/__init__.py
@@ -99,6 +99,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LunatoneConfigEntry) -> 
     assert entry.unique_id
 
     device_registry = dr.async_get(hass)
+
+    # Create main device that holds most device information
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.unique_id)},
@@ -113,6 +115,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: LunatoneConfigEntry) -> 
             f"{coordinator_info.data.device.article_number}{coordinator_info.data.article_suffix}"
         ),
     )
+
+    # Create a device for every connected DALI line
+    for line_id, line_info in info_api.data.lines.items():
+        line_unique_id = f"{entry.unique_id}-line{line_id}"
+
+        extra_info: dict = {}
+        if line_info.device.serial != info_api.data.device.serial:
+            extra_info.update(
+                serial_number=str(line_info.device.serial),
+                hw_version=line_info.device.pcb,
+                model_id=(
+                    f"{line_info.device.article_number}{line_info.device.article_info}"
+                ),
+            )
+
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, line_unique_id)},
+            name=f"DALI Line {line_id}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass, (DOMAIN, entry.unique_id), config_entry_id=entry.entry_id
+            ),
+            **extra_info,
+        )
 
     devices_api = Devices(auth_api, info_api.data.version)
     coordinator_devices = LunatoneDevicesDataUpdateCoordinator(hass, entry, devices_api)

--- a/homeassistant/components/lunatone/light.py
+++ b/homeassistant/components/lunatone/light.py
@@ -250,30 +250,9 @@ class LunatoneLineBroadcastLight(
         self._coordinator_info = coordinator_info
         self._broadcast = broadcast
 
-        line = broadcast.line
-
-        self._attr_unique_id = f"{config_entry_unique_id}-line{line}"
-
-        line_device = self._coordinator_info.data.lines[str(line)].device
-        extra_info: dict = {}
-        if line_device.serial != self._coordinator_info.data.device.serial:
-            extra_info.update(
-                serial_number=str(line_device.serial),
-                hw_version=line_device.pcb,
-                model_id=f"{line_device.article_number}{line_device.article_info}",
-            )
-
-        assert self.unique_id
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
-            name=f"DALI Line {line}",
-            via_device_id=dr.async_get_device_id_by_identifier(
-                self.coordinator.hass,
-                (DOMAIN, config_entry_unique_id),
-                config_entry_id=self.coordinator.config_entry.entry_id,
-            ),
-            **extra_info,
-        )
+        line_unique_id = f"{config_entry_unique_id}-line{broadcast.line}"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, line_unique_id)})
+        self._attr_unique_id = line_unique_id
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/tests/components/lunatone/test_init.py
+++ b/tests/components/lunatone/test_init.py
@@ -47,6 +47,13 @@ async def test_load_unload_config_entry(
     assert device_entry.configuration_url == BASE_URL
     assert device_entry.model == PRODUCT_NAME
 
+    for line_id in mock_lunatone_info.data.lines:
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{mock_config_entry.unique_id}-line{line_id}"),
+            mock_config_entry.entry_id,
+        )
+        assert device_entry is not None
+
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/lunatone/test_light.py
+++ b/tests/components/lunatone/test_light.py
@@ -256,23 +256,6 @@ async def test_line_broadcast_available_status(
     assert state.state == "unavailable"
 
 
-async def test_line_broadcast_line_present(
-    hass: HomeAssistant,
-    mock_lunatone_info: AsyncMock,
-    mock_lunatone_devices: AsyncMock,
-    mock_lunatone_sensors: AsyncMock,
-    mock_lunatone_scan: AsyncMock,
-    mock_lunatone_dali_broadcast: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test if the broadcast light line is present."""
-    mock_lunatone_dali_broadcast.line = None
-
-    await setup_integration(hass, mock_config_entry)
-
-    assert not hass.states.async_entity_ids("light")
-
-
 @pytest.mark.parametrize(
     "color_temp_kelvin",
     [10000, 5000, 1000],


### PR DESCRIPTION
Moves the creation of DALI line devices from individual entities to the main integration setup.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add explicit device creation for DALI lines.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180815
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
