### PR TITLE
Stop SwitchBot Meter Pro CO2 connecting during platform setup

### DIFF
--- a/homeassistant/components/switchbot/entity.py
+++ b/homeassistant/components/switchbot/entity.py
@@ -4,18 +4,21 @@ from collections.abc import Callable, Coroutine, Mapping
 import logging
 from typing import Any, Concatenate, override
 
+from bleak.exc import BleakError
 import switchbot
 from switchbot import Switchbot, SwitchbotDevice, SwitchbotOperationError
 
+from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
 )
 from homeassistant.const import ATTR_CONNECTIONS
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.start import async_at_started
 
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import SwitchbotDataUpdateCoordinator
@@ -94,6 +97,58 @@ class SwitchbotEntity(
         Only used by the generic entity update service.
         """
         await self._device.update()
+
+
+class SwitchbotConnectionPolledEntity(SwitchbotEntity):
+    """Entity whose value has to be read from the device over a connection.
+
+    Reading needs an active connection, which is slow and frequently
+    impossible while Home Assistant is still starting up and competing for the
+    Bluetooth adapter, so the first read is deferred until startup is over.
+    """
+
+    _attr_should_poll = True
+    _attr_entity_registry_enabled_default = False
+
+    async def _async_read_value(self) -> None:
+        """Read the value from the device into the entity attributes."""
+        raise NotImplementedError
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks and read the value once startup is over."""
+        await super().async_added_to_hass()
+        self.async_on_remove(async_at_started(self.hass, self._async_hass_started))
+
+    @callback
+    def _async_hass_started(self, _hass: HomeAssistant) -> None:
+        """Read the value now that startup is no longer in the way."""
+        # A background task so a stuck connect is cancelled when the entry
+        # unloads instead of holding up shutdown.
+        self.coordinator.config_entry.async_create_background_task(
+            self.hass,
+            self.async_update_ha_state(force_refresh=True),
+            f"switchbot read {self.entity_id}",
+        )
+
+    @override
+    async def async_update(self) -> None:
+        """Read the value from the device."""
+        if not bluetooth.async_ble_device_from_address(
+            self.hass, self._address, connectable=True
+        ):
+            _LOGGER.debug("No connectable path to %s, skipping update", self._address)
+            return
+        try:
+            await self._async_read_value()
+        except SwitchbotOperationError, BleakError:
+            _LOGGER.debug(
+                "Failed to read %s from %s",
+                self.entity_id,
+                self._address,
+                exc_info=True,
+            )
+            return
 
 
 def exception_handler[_EntityT: SwitchbotEntity, **_P](

--- a/homeassistant/components/switchbot/number.py
+++ b/homeassistant/components/switchbot/number.py
@@ -7,7 +7,6 @@ import logging
 from typing import override
 
 import switchbot
-from switchbot import SwitchbotOperationError
 from switchbot.devices.meter_pro import MAX_TIME_OFFSET
 
 from homeassistant.components.number import (
@@ -20,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
-from .entity import SwitchbotEntity, exception_handler
+from .entity import SwitchbotConnectionPolledEntity, SwitchbotEntity, exception_handler
 
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(days=7)
@@ -38,9 +37,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     if isinstance(coordinator.device, switchbot.SwitchbotMeterProCO2):
-        async_add_entities(
-            [SwitchBotMeterProCO2DisplayTimeOffsetNumber(coordinator)], True
-        )
+        async_add_entities([SwitchBotMeterProCO2DisplayTimeOffsetNumber(coordinator)])
     elif isinstance(coordinator.device, switchbot.SwitchbotStandingFan):
         async_add_entities(
             SwitchBotStandingFanOscillationAngleNumber(coordinator, desc)
@@ -48,7 +45,9 @@ async def async_setup_entry(
         )
 
 
-class SwitchBotMeterProCO2DisplayTimeOffsetNumber(SwitchbotEntity, NumberEntity):
+class SwitchBotMeterProCO2DisplayTimeOffsetNumber(
+    SwitchbotConnectionPolledEntity, NumberEntity
+):
     """Number entity to set the time offset for Meter Pro CO2 devices."""
 
     _device: switchbot.SwitchbotMeterProCO2
@@ -59,8 +58,6 @@ class SwitchBotMeterProCO2DisplayTimeOffsetNumber(SwitchbotEntity, NumberEntity)
     _attr_native_max_value = _MAX_TIME_OFFSET_MINUTES
     _attr_native_step = 1.0
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
-    _attr_should_poll = True
-    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
         """Initialize the number entity."""
@@ -79,15 +76,9 @@ class SwitchBotMeterProCO2DisplayTimeOffsetNumber(SwitchbotEntity, NumberEntity)
         self.async_write_ha_state()
 
     @override
-    async def async_update(self) -> None:
+    async def _async_read_value(self) -> None:
         """Fetch the latest time offset from the device."""
-        try:
-            offset_seconds = await self._device.get_time_offset()
-        except SwitchbotOperationError:
-            _LOGGER.debug(
-                "Failed to update time offset for %s", self._address, exc_info=True
-            )
-            return
+        offset_seconds = await self._device.get_time_offset()
         self._attr_native_value = round(offset_seconds / _SECONDS_IN_MINUTE)
 
 

--- a/homeassistant/components/switchbot/select.py
+++ b/homeassistant/components/switchbot/select.py
@@ -5,7 +5,7 @@ import logging
 from typing import override
 
 import switchbot
-from switchbot import NightLightState, SwitchbotOperationError
+from switchbot import NightLightState
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.const import EntityCategory
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
-from .entity import SwitchbotEntity, exception_handler
+from .entity import SwitchbotConnectionPolledEntity, SwitchbotEntity, exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
@@ -33,16 +33,16 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     if isinstance(coordinator.device, switchbot.SwitchbotMeterProCO2):
-        async_add_entities([SwitchBotMeterProCO2TimeFormatSelect(coordinator)], True)
+        async_add_entities([SwitchBotMeterProCO2TimeFormatSelect(coordinator)])
     elif isinstance(coordinator.device, switchbot.SwitchbotStandingFan):
         async_add_entities([SwitchBotStandingFanNightLightSelect(coordinator)])
 
 
-class SwitchBotMeterProCO2TimeFormatSelect(SwitchbotEntity, SelectEntity):
+class SwitchBotMeterProCO2TimeFormatSelect(
+    SwitchbotConnectionPolledEntity, SelectEntity
+):
     """Select entity to set time display format on Meter Pro CO2."""
 
-    _attr_should_poll = True
-    _attr_entity_registry_enabled_default = False
     _device: switchbot.SwitchbotMeterProCO2
     _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = "time_format"
@@ -64,15 +64,9 @@ class SwitchBotMeterProCO2TimeFormatSelect(SwitchbotEntity, SelectEntity):
         self.async_write_ha_state()
 
     @override
-    async def async_update(self) -> None:
+    async def _async_read_value(self) -> None:
         """Fetch the latest time format from the device."""
-        try:
-            device_time = await self._device.get_datetime()
-        except SwitchbotOperationError:
-            _LOGGER.debug(
-                "Failed to update time format for %s", self._address, exc_info=True
-            )
-            return
+        device_time = await self._device.get_datetime()
         self._attr_current_option = (
             TIME_FORMAT_12H if device_time["12h_mode"] else TIME_FORMAT_24H
         )

--- a/tests/components/switchbot/test_number.py
+++ b/tests/components/switchbot/test_number.py
@@ -3,22 +3,38 @@
 from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
+from bleak_retry_connector import BleakConnectionError
 import pytest
 
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 
-from . import DOMAIN, STANDING_FAN_SERVICE_INFO, WOMETERTHPC_SERVICE_INFO
+from . import (
+    DOMAIN,
+    STANDING_FAN_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
+)
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    inject_bluetooth_service_info_bleak,
+)
+
+TIME_OFFSET_ENTITY_ID = "number.test_name_display_time_offset"
 
 
 @pytest.mark.parametrize(
@@ -50,11 +66,104 @@ async def test_meter_pro_co2_display_time_offset_initial_state(
         return_value=offset_seconds_on_device,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-        state = hass.states.get("number.test_name_display_time_offset")
+        state = hass.states.get(TIME_OFFSET_ENTITY_ID)
         assert state is not None
         assert float(state.state) == expected_state
+
+
+async def test_meter_pro_co2_display_time_offset_disabled_by_default(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+) -> None:
+    """Test the offset entity does not connect while it is disabled."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_time_offset = AsyncMock(return_value=60)
+    with patch("switchbot.SwitchbotMeterProCO2.get_time_offset", mock_get_time_offset):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_get_time_offset.assert_not_awaited()
+    assert hass.states.get(TIME_OFFSET_ENTITY_ID) is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_meter_pro_co2_display_time_offset_waits_for_start(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+) -> None:
+    """Test the offset is only read once Home Assistant has started."""
+    hass.set_state(CoreState.not_running)
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_time_offset = AsyncMock(return_value=60)
+    with patch("switchbot.SwitchbotMeterProCO2.get_time_offset", mock_get_time_offset):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        # Setting up the platform must not reach out over Bluetooth.
+        mock_get_time_offset.assert_not_awaited()
+        assert hass.states.get(TIME_OFFSET_ENTITY_ID).state == STATE_UNKNOWN
+
+        hass.set_state(CoreState.running)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert mock_get_time_offset.await_count
+        assert hass.states.get(TIME_OFFSET_ENTITY_ID).state == "1"
+
+
+@pytest.mark.parametrize(
+    ("service_info", "side_effect", "expected_await_count"),
+    [
+        pytest.param(
+            WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
+            None,
+            0,
+            id="no_connectable_path",
+        ),
+        pytest.param(
+            WOMETERTHPC_SERVICE_INFO,
+            BleakConnectionError("no connectable Bluetooth adapters"),
+            1,
+            id="connection_fails",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_meter_pro_co2_display_time_offset_unreachable(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
+    service_info: BluetoothServiceInfoBleak,
+    side_effect: Exception | None,
+    expected_await_count: int,
+) -> None:
+    """Test an unreachable device leaves the entity added and unknown."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info_bleak(hass, service_info)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_time_offset = AsyncMock(return_value=60, side_effect=side_effect)
+    with patch("switchbot.SwitchbotMeterProCO2.get_time_offset", mock_get_time_offset):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert mock_get_time_offset.await_count == expected_await_count
+    assert hass.states.get(TIME_OFFSET_ENTITY_ID).state == STATE_UNKNOWN
+    assert "Error on device update" not in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -95,13 +204,13 @@ async def test_meter_pro_co2_set_display_time_offset(
         ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {
-                ATTR_ENTITY_ID: "number.test_name_display_time_offset",
+                ATTR_ENTITY_ID: TIME_OFFSET_ENTITY_ID,
                 ATTR_VALUE: time_offset,
             },
             blocking=True,
@@ -109,7 +218,7 @@ async def test_meter_pro_co2_set_display_time_offset(
 
         mock_set_time_offset.assert_awaited_once_with(expected_seconds_on_device)
 
-        state = hass.states.get("number.test_name_display_time_offset")
+        state = hass.states.get(TIME_OFFSET_ENTITY_ID)
         assert state is not None
         assert float(state.state) == time_offset
 
@@ -148,7 +257,7 @@ async def test_set_display_time_offset_out_of_range(
         ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         with pytest.raises(
             ServiceValidationError,
@@ -162,7 +271,7 @@ async def test_set_display_time_offset_out_of_range(
                 NUMBER_DOMAIN,
                 SERVICE_SET_VALUE,
                 {
-                    ATTR_ENTITY_ID: "number.test_name_display_time_offset",
+                    ATTR_ENTITY_ID: TIME_OFFSET_ENTITY_ID,
                     ATTR_VALUE: value,
                 },
                 blocking=True,

--- a/tests/components/switchbot/test_select.py
+++ b/tests/components/switchbot/test_select.py
@@ -3,22 +3,47 @@
 from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
+from bleak_retry_connector import BleakConnectionError
 import pytest
 from switchbot import NightLightState
 
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import DOMAIN, STANDING_FAN_SERVICE_INFO, WOMETERTHPC_SERVICE_INFO
+from . import (
+    DOMAIN,
+    STANDING_FAN_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
+)
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    inject_bluetooth_service_info_bleak,
+)
+
+TIME_FORMAT_ENTITY_ID = "select.test_name_time_format"
+DEVICE_DATETIME_24H = {
+    "12h_mode": False,
+    "year": 2025,
+    "month": 1,
+    "day": 9,
+    "hour": 12,
+    "minute": 0,
+    "second": 0,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,11 +80,106 @@ async def test_time_format_select_initial_state(
         },
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-        state = hass.states.get("select.test_name_time_format")
+        state = hass.states.get(TIME_FORMAT_ENTITY_ID)
         assert state is not None
         assert state.state == expected_state
+
+
+async def test_time_format_select_disabled_by_default(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+) -> None:
+    """Test the time format entity does not connect while it is disabled."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_datetime = AsyncMock(return_value=DEVICE_DATETIME_24H)
+    with patch("switchbot.SwitchbotMeterProCO2.get_datetime", mock_get_datetime):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_get_datetime.assert_not_awaited()
+    assert hass.states.get(TIME_FORMAT_ENTITY_ID) is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_time_format_select_waits_for_start(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+) -> None:
+    """Test the time format is only read once Home Assistant has started."""
+    hass.set_state(CoreState.not_running)
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_datetime = AsyncMock(return_value=DEVICE_DATETIME_24H)
+    with patch("switchbot.SwitchbotMeterProCO2.get_datetime", mock_get_datetime):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        # Setting up the platform must not reach out over Bluetooth.
+        mock_get_datetime.assert_not_awaited()
+        assert hass.states.get(TIME_FORMAT_ENTITY_ID).state == STATE_UNKNOWN
+
+        hass.set_state(CoreState.running)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert mock_get_datetime.await_count
+        assert hass.states.get(TIME_FORMAT_ENTITY_ID).state == "24h"
+
+
+@pytest.mark.parametrize(
+    ("service_info", "side_effect", "expected_await_count"),
+    [
+        pytest.param(
+            WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
+            None,
+            0,
+            id="no_connectable_path",
+        ),
+        pytest.param(
+            WOMETERTHPC_SERVICE_INFO,
+            BleakConnectionError("no connectable Bluetooth adapters"),
+            1,
+            id="connection_fails",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_time_format_select_unreachable(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
+    service_info: BluetoothServiceInfoBleak,
+    side_effect: Exception | None,
+    expected_await_count: int,
+) -> None:
+    """Test an unreachable device leaves the entity added and unknown."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info_bleak(hass, service_info)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_datetime = AsyncMock(
+        return_value=DEVICE_DATETIME_24H, side_effect=side_effect
+    )
+    with patch("switchbot.SwitchbotMeterProCO2.get_datetime", mock_get_datetime):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert mock_get_datetime.await_count == expected_await_count
+    assert hass.states.get(TIME_FORMAT_ENTITY_ID).state == STATE_UNKNOWN
+    assert "Error on device update" not in caplog.text
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -107,13 +227,13 @@ async def test_set_time_format(
         ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
-                ATTR_ENTITY_ID: "select.test_name_time_format",
+                ATTR_ENTITY_ID: TIME_FORMAT_ENTITY_ID,
                 ATTR_OPTION: expected_state,
             },
             blocking=True,
@@ -121,7 +241,7 @@ async def test_set_time_format(
 
         mock_set_time_display_format.assert_awaited_once_with(origin_mode)
 
-        state = hass.states.get("select.test_name_time_format")
+        state = hass.states.get(TIME_FORMAT_ENTITY_ID)
         assert state is not None
         assert state.state == expected_state
 


### PR DESCRIPTION
## Breaking change


## Proposed change

The SwitchBot Meter Pro CO2 number and select entities are added with `update_before_add=True`:

```python
async_add_entities([SwitchBotMeterProCO2DisplayTimeOffsetNumber(coordinator)], True)
```

That makes `EntityPlatform._async_add_entity_impl` await `async_device_update()` before the entity is registered, which for these entities means a full BLE connect and GATT round-trip. It runs inside `async_forward_entry_setups`, so a slow or failing connect blocks config entry setup and therefore Home Assistant startup. As the comment in `entity_platform.py` says, it also runs for entities that are disabled in the registry — and both of these are `_attr_entity_registry_enabled_default = False`, so most users pay the cost for entities they never had.

When the meter does not accept the connection the read is expensive. `establish_connection` allows `MAX_CONNECT_ATTEMPTS = 4` attempts of `BLEAK_TIMEOUT = 20.0 s`, and pySwitchbot's `_send_command_locked_with_retry` wraps that in another `retry_count + 1 = 4` outer attempts. Against a real device a single read was measured at **101 seconds**, with the select entity serialised behind the number entity on the device's `_operation_lock`. Reporters see startup stall for minutes with two meters.

Neither `BleakNotFoundError` nor `BleakConnectionError` is a `SwitchbotOperationError`, so the existing `except SwitchbotOperationError` did not catch them: the entity was aborted and never added, and the platform logged `Error on device update!`.

The shared behaviour moves into a new `SwitchbotConnectionPolledEntity` base in `entity.py`; both platforms now just declare how to read their value. The base:

- adds the entities without `update_before_add`, so **platform setup never opens a Bluetooth connection**;
- defers the first read to `async_at_started`, so it only happens for entities that are actually enabled, and after startup has stopped competing for the adapter;
- skips the read when no connectable path currently exists, reusing the check the coordinator already makes in `_needs_poll`;
- catches `BleakError` alongside `SwitchbotOperationError`, so an unreachable device leaves the entity added and `unknown` with a debug log instead of aborting it;
- runs the read as a config entry background task, so a stuck connect is cancelled on unload rather than delaying shutdown.

Verified against two real Meter Pro CO2 meters through an ESPHome Bluetooth proxy, running the same startup on `dev` and on this branch:

| | before | after |
| --- | --- | --- |
| BLE connections opened during config entry setup | 1 per meter | 0 |
| Commands sent during config entry setup (`GET_TIME_OFFSET`, `GET_DATETIME`) | 2 per meter | 0 |
| `Setup of number/select platform switchbot is taking over 10 seconds` | 2 | 0 |
| `number` / `select` entities registered | none | both, per meter |

The before run shows the mechanism directly, including the two reads serialising on the device lock:

```
15:59:12.447  Scheduling command 570f690506   (GET_TIME_OFFSET, number)
15:59:12.447  Connecting; RSSI: -60
15:59:12.453  Scheduling command 570f6901     (GET_DATETIME, select)
15:59:12.453  Operation already in progress, waiting for it to complete
15:59:22.448  WARNING  Setup of number platform switchbot is taking over 10 seconds.
15:59:22.454  WARNING  Setup of select platform switchbot is taking over 10 seconds.
```

The connect had still not completed when that run ended, so the entities were never registered. On this branch the same startup produces no `Connecting; RSSI:` line at all before `EVENT_HOMEASSISTANT_STARTED`, and both meters register their full set of entities.

Two symptoms from the issue report, `Error on device update!` and `Waiting for integrations to complete setup`, are not in the table because I did not reproduce them in this rig: my test setup reaches the meters through a Bluetooth proxy, so the config entry spends time in `ConfigEntryNotReady` waiting for the proxy and ends up setting up *after* bootstrap has finished. Reporters using a local adapter have it available immediately, so for them the same blocking read lands inside bootstrap. Both lines are visible in the log attached to the issue.

Note that pySwitchbot logs an error of its own (`device not found, no longer in range, or poor RSSI`) before raising, so a user who explicitly enables these disabled-by-default entities with an unreachable meter will still see that library log line. Startup is no longer affected and the entity survives.

A follow-up branch retries a read that fails at startup, instead of leaving the entity unknown until the seven day `SCAN_INTERVAL` poll. It is kept separate to keep this fix small and easy to backport.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #167517
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

**Testing scope:** I only own SwitchBot Meter Pro CO2 devices, so that is the only hardware I have been able to test against. The changed code paths are limited to the Meter Pro CO2 number and select entities; the Standing Fan entities in the same two platform files are untouched and still covered by their existing tests. Anyone with other SwitchBot hardware confirming no regression would be very welcome.

**AI assistance:** this change was written with the help of Claude Code, and verified against my own hardware as described above.

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
