### PR TITLE
Remove the Sofar waiting-ends sensor

### DIFF
--- a/homeassistant/components/sofar/__init__.py
+++ b/homeassistant/components/sofar/__init__.py
@@ -37,6 +37,16 @@ PLATFORMS: list[Platform] = [
 _IDENTITY_ATTEMPTS = 3
 
 
+def _async_remove_stale_waiting_time(hass: HomeAssistant, serial: str) -> None:
+    """Drop the removed waiting-time entity so it doesn't linger unavailable."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{serial}_waiting_time"
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
+
+
 async def _async_read_identity(entry: SofarConfigEntry, device: SofarInverter) -> None:
     """Read identity once, retrying a few times against a transient blip."""
     for attempt in range(_IDENTITY_ATTEMPTS):
@@ -77,6 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SofarConfigEntry) -> boo
     """Set up Sofar Inverter Modbus from a config entry."""
     serial = entry.unique_id
     assert serial is not None
+    _async_remove_stale_waiting_time(hass, serial)
     inverter_type, model = identify(serial)
     if not inverter_type:
         raise ConfigEntryError(

--- a/homeassistant/components/sofar/sensor.py
+++ b/homeassistant/components/sofar/sensor.py
@@ -1,13 +1,12 @@
 """Support for Sofar sensors."""
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date
 from enum import IntEnum
 from typing import cast, override
 
 from sofar_modbus.modern.device import SofarInverter
-from sofar_modbus.modern.enums import SystemState
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -31,26 +30,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util import dt as dt_util
-from homeassistant.util.variance import ignore_variance
 
-# Aliased: a module-level SCAN_INTERVAL would set the platform's poll.
-from .const import SCAN_INTERVAL as _POLL_INTERVAL
-from .coordinator import SofarConfigEntry, SofarRuntimeData
+from .coordinator import SofarConfigEntry
 from .entity import SofarEntity, SofarEntityDescription
 
 PARALLEL_UPDATES = 0
-
-# Two polls of slack, so jitter does not republish a steady countdown.
-_COUNTDOWN_VARIANCE = timedelta(seconds=_POLL_INTERVAL * 2)
-
-
-def _deadline_filter() -> Callable[[int], datetime]:
-    """Turn remaining seconds into a deadline, holding it steady."""
-    return ignore_variance(
-        lambda seconds: dt_util.utcnow() + timedelta(seconds=seconds),
-        _COUNTDOWN_VARIANCE,
-    )
 
 
 async def async_setup_entry(
@@ -114,8 +98,6 @@ def _sensor_class(
     description: SofarSensorDescription,
 ) -> type[SofarSensor | SofarTotalSensor]:
     """Pick the entity class a description's semantics ask for."""
-    if description.device_class is SensorDeviceClass.TIMESTAMP:
-        return SofarCountdownSensor
     if description.state_class in (
         SensorStateClass.TOTAL,
         SensorStateClass.TOTAL_INCREASING,
@@ -138,37 +120,6 @@ class SofarSensor(SofarEntity, SensorEntity):
         if isinstance(value, IntEnum):
             return value.name.lower()
         return cast(str | int | float | date | None, value)
-
-
-class SofarCountdownSensor(SofarSensor):
-    """Defines a Sofar countdown, published as the moment it runs out."""
-
-    # A positive register alone doesn't mean the countdown is active.
-    _ACTIVE_STATES = (SystemState.WAITING, SystemState.CHECKING)
-
-    def __init__(
-        self,
-        runtime_data: SofarRuntimeData,
-        entity_description: SofarSensorDescription,
-    ) -> None:
-        """Initialize the entity."""
-        super().__init__(runtime_data, entity_description)
-        self._deadline = _deadline_filter()
-
-    @property
-    @override
-    def native_value(self) -> datetime | None:
-        component = getattr(self.coordinator.device, self.entity_description.component)
-        seconds = getattr(component, self.entity_description.key)
-        if (
-            not isinstance(seconds, int)
-            or seconds <= 0
-            or component.system_state not in self._ACTIVE_STATES
-        ):
-            # A restart must not land inside the finished countdown's slack.
-            self._deadline = _deadline_filter()
-            return None
-        return self._deadline(seconds)
 
 
 class SofarTotalSensor(SofarEntity, RestoreSensor):
@@ -380,13 +331,6 @@ SENSOR_DESCRIPTIONS: tuple[SofarSensorDescription, ...] = (
             "upgrading",
             "self_charging",
         ],
-    ),
-    SofarSensorDescription(
-        key="waiting_time",
-        component="state",
-        translation_key="waiting_ends",
-        device_class=SensorDeviceClass.TIMESTAMP,
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SofarSensorDescription(
         key="inverter_temperature_1",

--- a/homeassistant/components/sofar/strings.json
+++ b/homeassistant/components/sofar/strings.json
@@ -512,9 +512,6 @@
       },
       "voltage_phase_l2n": {
         "name": "Voltage phase L2N"
-      },
-      "waiting_ends": {
-        "name": "Waiting ends"
       }
     }
   },

--- a/tests/components/sofar/snapshots/test_sensor.ambr
+++ b/tests/components/sofar/snapshots/test_sensor.ambr
@@ -7411,57 +7411,6 @@
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.hydxxktl_3p_waiting_ends-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.hydxxktl_3p_waiting_ends',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Waiting ends',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Waiting ends',
-    'platform': 'sofar',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'waiting_ends',
-    'unique_id': 'SP1XXES100XX_waiting_time',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.hydxxktl_3p_waiting_ends-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HYDxxKTL-3P Waiting ends',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.hydxxktl_3p_waiting_ends',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_all_entities[sensor.pv_string_1_current-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -81,6 +81,33 @@ async def test_setup_and_unload_entry(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_removes_the_stale_waiting_time_entity(
+    hass: HomeAssistant,
+    mock_connection: MockModbusConnection,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test an upgrade drops the removed waiting-time entity too."""
+    mock_config_entry.add_to_hass(hass)
+    entry = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"{MOCK_SERIAL}_waiting_time",
+        config_entry=mock_config_entry,
+    )
+
+    with patch(
+        "homeassistant.components.sofar.async_get_unit",
+        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+            unit_id
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entity_registry.async_get(entry.entity_id) is None
+
+
 async def test_setup_entry_unrecognized_inverter_raises_setup_error(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/sofar/test_sensor.py
+++ b/tests/components/sofar/test_sensor.py
@@ -20,10 +20,9 @@ from homeassistant.components.sofar.sensor import (
     SofarSensorDescription,
     SofarTotalSensor,
 )
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from . import (
     MOCK_HYBRID_MODEL,
@@ -103,13 +102,13 @@ async def test_sensor_entities_created_and_state(
 @pytest.mark.parametrize(
     ("serial", "model", "seed", "created", "enabled"),
     [
-        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 72, 22, id="pv"),
+        pytest.param(MOCK_SERIAL, MOCK_MODEL, seed_pv_inverter, 71, 21, id="pv"),
         pytest.param(
             MOCK_HYBRID_SERIAL,
             MOCK_HYBRID_MODEL,
             seed_hybrid_inverter,
-            138,
-            45,
+            137,
+            44,
             id="hybrid",
         ),
     ],
@@ -401,134 +400,3 @@ async def test_total_sensor_total_increasing_uses_corrected_value(
         assert sensor.native_value == 42.0
     mock_corrected.assert_called_once_with("load_consumption_total")
     assert sensor.available
-
-
-async def test_idle_countdown_reports_no_deadline(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    init_integration: MockConfigEntry,
-) -> None:
-    """Test a countdown at zero reports nothing, not a moment already past."""
-    entity_id = entity_registry.async_get_entity_id(
-        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_waiting_time"
-    )
-    assert entity_id is not None
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
-
-
-async def test_countdown_holds_its_deadline_until_it_restarts(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    entity_registry: er.EntityRegistry,
-    mock_connection: MockModbusConnection,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a countdown ticking with the clock keeps one deadline."""
-    mock_config_entry.add_to_hass(hass)
-    unit = mock_connection.for_unit(1)
-    unit.holding[0x0404] = 0  # Waiting
-    unit.holding[0x0417] = 300
-
-    with patch(
-        "homeassistant.components.sofar.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
-            unit_id
-        ),
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    entity_id = entity_registry.async_get_entity_id(
-        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_waiting_time"
-    )
-    assert entity_id is not None
-    # The exact moment: a wrong sign or unit must not slip through.
-    deadline = (dt_util.utcnow() + timedelta(seconds=300)).isoformat(timespec="seconds")
-    assert hass.states.get(entity_id).state == deadline
-
-    # A second of poll jitter must not republish the deadline as a new one.
-    unit.holding[0x0417] = 296
-    freezer.tick(timedelta(seconds=SCAN_INTERVAL))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == deadline
-
-    # Restarted, so it really is a different moment now.
-    unit.holding[0x0417] = 600
-    freezer.tick(timedelta(seconds=SCAN_INTERVAL))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state != deadline
-
-
-async def test_countdown_ignores_a_stale_register_while_grid_connected(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_connection: MockModbusConnection,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a positive register is ignored once the inverter is connected."""
-    mock_config_entry.add_to_hass(hass)
-    unit = mock_connection.for_unit(1)
-    unit.holding[0x0404] = 2  # Grid connected
-    unit.holding[0x0417] = 60  # Left over from the last startup wait
-
-    with patch(
-        "homeassistant.components.sofar.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
-            unit_id
-        ),
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    entity_id = entity_registry.async_get_entity_id(
-        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_waiting_time"
-    )
-    assert entity_id is not None
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
-
-
-async def test_countdown_restarting_after_idle_gets_a_new_deadline(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    entity_registry: er.EntityRegistry,
-    mock_connection: MockModbusConnection,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a finished countdown's deadline is not reused by the next one."""
-    mock_config_entry.add_to_hass(hass)
-    unit = mock_connection.for_unit(1)
-    unit.holding[0x0404] = 0  # Waiting
-    unit.holding[0x0417] = 10
-
-    with patch(
-        "homeassistant.components.sofar.async_get_unit",
-        side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
-            unit_id
-        ),
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    entity_id = entity_registry.async_get_entity_id(
-        SENSOR_DOMAIN, DOMAIN, f"{MOCK_SERIAL}_waiting_time"
-    )
-    assert entity_id is not None
-    finished = hass.states.get(entity_id).state
-
-    unit.holding[0x0417] = 0
-    freezer.tick(timedelta(seconds=SCAN_INTERVAL))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
-
-    # Close enough to the old deadline to fall inside the variance window.
-    unit.holding[0x0417] = 5
-    freezer.tick(timedelta(seconds=SCAN_INTERVAL))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    restarted = (dt_util.utcnow() + timedelta(seconds=5)).isoformat(timespec="seconds")
-    assert hass.states.get(entity_id).state == restarted
-    assert hass.states.get(entity_id).state != finished


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the Sofar `waiting_ends` sensor and the countdown machinery behind it
(`SofarCountdownSensor`, the `ignore_variance`-based deadline filter).

Verified against the vendor's own Modbus spec: the register's own documented example is
`0x003C` = 60 seconds, and real device history shows exactly that pattern, the value pins at
60 and the computed deadline slides forward every poll instead of counting down, for the
whole rest of a wait cycle. That's not a decode or caching bug on our side, it's genuine
device behavior the entity's design didn't account for.

Please include this one in the 2026.9 milestone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
