### PR TITLE
Bump neopool-modbus to 4.6.2

### DIFF
--- a/homeassistant/components/neopool/manifest.json
+++ b/homeassistant/components/neopool/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["neopool_modbus"],
   "quality_scale": "silver",
-  "requirements": ["neopool-modbus==4.6.0"]
+  "requirements": ["neopool-modbus==4.6.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1689,7 +1689,7 @@ nad-receiver==0.4.0
 ndms2-client==0.1.2
 
 # homeassistant.components.neopool
-neopool-modbus==4.6.0
+neopool-modbus==4.6.2
 
 # homeassistant.components.ness_alarm
 nessclient==1.3.1


### PR DESCRIPTION
## Proposed change

Bump `neopool-modbus` from 4.6.0 to 4.6.2.

This spans two library releases that together close a read-modify-write vs poll race on the packed configuration register. In this integration the register backs two switches, `hidro_cover_enable` and `hidro_temp_shutdown`, whose separate bits live in one shared word (`MBF_PAR_HIDRO_COVER_ENABLE`) and are toggled through `async_set_bitmask_flag`:

- 4.6.1 serializes each masked write's read-compute-write-back against concurrent polls with a dedicated cache lock, so a poll can no longer observe or interleave with a torn cache.
- 4.6.2 adds a freshness guard on top of that mutual exclusion: each poll captures a monotonic write generation before its device I/O and, when merging its snapshot back into the cache, skips any key a write committed after that snapshot. Without it, a poll that read the old packed word before a write ran could still merge that stale word afterwards and undo the field the write just committed.

Diff: https://github.com/svasek/python-neopool-modbus/compare/v4.6.0...v4.6.2

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
