### PR TITLE
Use reactive power device class for iotawatt VAR sensors

### DIFF
--- a/homeassistant/components/iotawatt/const.py
+++ b/homeassistant/components/iotawatt/const.py
@@ -5,7 +5,6 @@ import json
 import httpx
 
 DOMAIN = "iotawatt"
-VOLT_AMPERE_REACTIVE = "VAR"
 VOLT_AMPERE_REACTIVE_HOURS = "VARh"
 
 CONNECTION_ERRORS = (KeyError, json.JSONDecodeError, httpx.HTTPError)

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfReactivePower,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -29,7 +30,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import VOLT_AMPERE_REACTIVE, VOLT_AMPERE_REACTIVE_HOURS
+from .const import VOLT_AMPERE_REACTIVE_HOURS
 from .coordinator import IotawattConfigEntry, IotawattUpdater
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,9 +88,9 @@ ENTITY_DESCRIPTION_KEY_MAP: dict[str, IotaWattSensorEntityDescription] = {
     ),
     "VAR": IotaWattSensorEntityDescription(
         key="VAR",
-        native_unit_of_measurement=VOLT_AMPERE_REACTIVE,
+        native_unit_of_measurement=UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:flash",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
         entity_registry_enabled_default=False,
     ),
     "VARh": IotaWattSensorEntityDescription(

--- a/tests/components/iotawatt/__init__.py
+++ b/tests/components/iotawatt/__init__.py
@@ -23,3 +23,13 @@ OUTPUT_SENSOR = Sensor(
     mac_addr="mock-mac",
     fromStart=True,
 )
+VAR_OUTPUT_SENSOR = Sensor(
+    channel="N/A",
+    base_name="My VAR Sensor",
+    suffix=None,
+    io_type="Output",
+    unit="VAR",
+    value=500,
+    begin="",
+    mac_addr="mock-mac",
+)

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -18,12 +18,13 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfReactivePower,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from . import INPUT_SENSOR, OUTPUT_SENSOR
+from . import INPUT_SENSOR, OUTPUT_SENSOR, VAR_OUTPUT_SENSOR
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -122,3 +123,24 @@ async def test_output_sensor_not_attached_to_device(
     assert entity_registry.async_get("sensor.my_watthour_sensor") is None
 
     assert "attempts to attach a device to an entity" not in caplog.text
+
+
+async def test_sensor_type_output_reactive_power(
+    hass: HomeAssistant, mock_iotawatt: MagicMock
+) -> None:
+    """Test reactive power output sensors work."""
+    mock_iotawatt.getSensors.return_value["sensors"]["my_var_sensor_key"] = (
+        VAR_OUTPUT_SENSOR
+    )
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.my_var_sensor")
+    assert state is not None
+    assert state.state == "500"
+    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
+    assert (
+        state.attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == UnitOfReactivePower.VOLT_AMPERE_REACTIVE
+    )
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.REACTIVE_POWER


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

IoTaWatt reactive power sensors now use Home Assistant's reactive power device class, which changes their unit of measurement from `VAR` to `var`.

These sensors exist if an output on your IoTaWatt is configured with the unit `VAR`. If you have such a sensor and it has recorded long-term statistics, Home Assistant creates a repair issue about the changed unit after the update. Pick the offered option to update the statistics to the new unit; no data is lost.

In return, these sensors can now be displayed in `mvar`, `var` or `kvar`, and are shown as reactive power in the UI.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SensorDeviceClass.REACTIVE_POWER` has been around for years and `UnitOfReactivePower` was added in #117153, so the integration no longer needs its own `VOLT_AMPERE_REACTIVE = "VAR"` constant. Set the device class and use the core unit, which enables unit conversion and drops the hand-picked `mdi:flash` icon in favour of the device class icon. The state class stays `MEASUREMENT`, which is what the device class allows.

The unit change was previously part of #117153 and reverted in #124393, because it was a breaking change buried in a PR touching many integrations ([review comment](https://github.com/home-assistant/core/pull/117153#discussion_r1725145807): *"I think we should revert this change for the iotawatt integration. If we want to change this it should go in a separate PR."*). This is that separate PR, with the breaking change documented.

Not included: the `VARh` sensors, which need more than a unit change. `SensorDeviceClass.REACTIVE_ENERGY` allows only the `TOTAL` and `TOTAL_INCREASING` state classes, while the library queries `VARh` outputs over the polling interval, so the value is the reactive energy of the last 30 seconds rather than a meter reading. Making those sensors accumulate requires a change in `ha-iotawattpy` first and is left for a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
