### PR TITLE
Migrate BraviaTV to use MAC as unique_id

### DIFF
--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -1,5 +1,6 @@
 """The Bravia TV integration."""
 
+import logging
 from typing import TYPE_CHECKING, Final
 
 from aiohttp import CookieJar
@@ -14,6 +15,8 @@ from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .const import CONF_USE_SSL, DOMAIN
 from .coordinator import BraviaTVConfigEntry, BraviaTVCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: Final[list[Platform]] = [
     Platform.BUTTON,
@@ -64,6 +67,11 @@ async def async_migrate_entry(
 
         hass.config_entries.async_update_entry(
             config_entry, unique_id=new_unique_id, version=2
+        )
+
+        _LOGGER.info(
+            "Migration to configuration version %s successful",
+            config_entry.version,
         )
 
     return True

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -1,6 +1,6 @@
 """The Bravia TV integration."""
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from aiohttp import CookieJar
 from pybravia import BraviaClient
@@ -12,7 +12,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import CONF_USE_SSL
+from .const import CONF_USE_SSL, DOMAIN
 from .coordinator import BraviaTVConfigEntry, BraviaTVCoordinator
 
 PLATFORMS: Final[list[Platform]] = [
@@ -30,13 +30,12 @@ async def async_migrate_entry(
         return True
 
     if config_entry.version == 1:
-        mac = config_entry.data.get(CONF_MAC)
-        if not mac:
-            return False
-
+        mac = config_entry.data[CONF_MAC]
         new_unique_id = dr.format_mac(mac)
+        old_unique_id = config_entry.unique_id
 
-        old_unique_id = config_entry.unique_id or ""
+        if TYPE_CHECKING:
+            assert old_unique_id is not None
 
         if old_unique_id != new_unique_id:
             ent_reg = er.async_get(hass)
@@ -59,7 +58,9 @@ async def async_migrate_entry(
             for device in dr.async_entries_for_config_entry(
                 dev_reg, config_entry.entry_id
             ):
-                dev_reg.async_update_device(device.id, new_identifiers=set())
+                dev_reg.async_update_device(
+                    device.id, new_identifiers={(DOMAIN, new_unique_id)}
+                )
 
         hass.config_entries.async_update_entry(
             config_entry, unique_id=new_unique_id, version=2

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -29,9 +29,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: BraviaTVConfigEntry
 ) -> bool:
     """Migrate old config entries to the new unique_id based on MAC."""
-    if config_entry.version > 1:
-        return True
-
     if config_entry.version == 1:
         mac = config_entry.data[CONF_MAC]
         new_unique_id = dr.format_mac(mac)

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -3,7 +3,7 @@
 from typing import Final
 
 from aiohttp import CookieJar
-from pybravia import BraviaClient, BraviaError
+from pybravia import BraviaClient
 
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_MAC, Platform
@@ -12,7 +12,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import ATTR_MAC, CONF_USE_SSL
+from .const import CONF_USE_SSL
 from .coordinator import BraviaTVConfigEntry, BraviaTVCoordinator
 
 PLATFORMS: Final[list[Platform]] = [
@@ -30,21 +30,11 @@ async def async_migrate_entry(
         return True
 
     if config_entry.version == 1:
-        host = config_entry.data[CONF_HOST]
-        mac = config_entry.data[CONF_MAC]
-        ssl = config_entry.data.get(CONF_USE_SSL, False)
-
-        session = async_create_clientsession(
-            hass, cookie_jar=CookieJar(unsafe=True, quote_cookie=False)
-        )
-        client = BraviaClient(host, mac, session=session, ssl=ssl)
-
-        try:
-            system_info = await client.get_system_info()
-        except BraviaError:
+        mac = config_entry.data.get(CONF_MAC)
+        if not mac:
             return False
 
-        new_unique_id = dr.format_mac(system_info[ATTR_MAC])
+        new_unique_id = dr.format_mac(mac)
 
         old_unique_id = config_entry.unique_id or ""
 

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -3,15 +3,16 @@
 from typing import Final
 
 from aiohttp import CookieJar
-from pybravia import BraviaClient
+from pybravia import BraviaClient, BraviaError
 
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_MAC, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import CONF_USE_SSL
+from .const import ATTR_MAC, CONF_USE_SSL
 from .coordinator import BraviaTVConfigEntry, BraviaTVCoordinator
 
 PLATFORMS: Final[list[Platform]] = [
@@ -19,6 +20,62 @@ PLATFORMS: Final[list[Platform]] = [
     Platform.MEDIA_PLAYER,
     Platform.REMOTE,
 ]
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: BraviaTVConfigEntry
+) -> bool:
+    """Migrate old config entries to the new unique_id based on MAC."""
+    if config_entry.version > 1:
+        return True
+
+    if config_entry.version == 1:
+        host = config_entry.data[CONF_HOST]
+        mac = config_entry.data[CONF_MAC]
+        ssl = config_entry.data.get(CONF_USE_SSL, False)
+
+        session = async_create_clientsession(
+            hass, cookie_jar=CookieJar(unsafe=True, quote_cookie=False)
+        )
+        client = BraviaClient(host, mac, session=session, ssl=ssl)
+
+        try:
+            system_info = await client.get_system_info()
+        except BraviaError:
+            return False
+
+        new_unique_id = dr.format_mac(system_info[ATTR_MAC])
+
+        old_unique_id = config_entry.unique_id or ""
+
+        if old_unique_id != new_unique_id:
+            ent_reg = er.async_get(hass)
+            for entity in er.async_entries_for_config_entry(
+                ent_reg, config_entry.entry_id
+            ):
+                if entity.unique_id == old_unique_id:
+                    ent_reg.async_update_entity(
+                        entity.entity_id, new_unique_id=new_unique_id
+                    )
+                elif entity.unique_id is not None and entity.unique_id.startswith(
+                    f"{old_unique_id}_"
+                ):
+                    suffix = entity.unique_id[len(old_unique_id) :]
+                    ent_reg.async_update_entity(
+                        entity.entity_id, new_unique_id=f"{new_unique_id}{suffix}"
+                    )
+
+            dev_reg = dr.async_get(hass)
+            for device in dr.async_entries_for_config_entry(
+                dev_reg, config_entry.entry_id
+            ):
+                dev_reg.async_update_device(device.id, new_identifiers=set())
+
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=new_unique_id, version=2
+        )
+
+    return True
 
 
 async def async_setup_entry(

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -84,10 +84,9 @@ class BraviaTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
         system_info = await self.client.get_system_info()
         mac = system_info[ATTR_MAC]
-        unique_id = dr.format_mac(mac)
         self.device_config[CONF_MAC] = system_info[ATTR_MAC]
 
-        await self.async_set_unique_id(unique_id)
+        await self.async_set_unique_id(dr.format_mac(mac))
         self._abort_if_unique_id_configured(
             updates={CONF_HOST: self.device_config[CONF_HOST]}
         )

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -88,7 +88,9 @@ class BraviaTVConfigFlow(ConfigFlow, domain=DOMAIN):
         self.device_config[CONF_MAC] = system_info[ATTR_MAC]
 
         await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: self.device_config[CONF_HOST]}
+        )
 
         return self.async_create_entry(
             title=f"{system_info['name']} {system_info[ATTR_MODEL]}",

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PIN,
 )
-from homeassistant.helpers import instance_id
+from homeassistant.helpers import device_registry as dr, instance_id
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
@@ -28,7 +28,6 @@ from homeassistant.helpers.service_info.ssdp import (
 from homeassistant.util.network import is_host_valid
 
 from .const import (
-    ATTR_CID,
     ATTR_MAC,
     CONF_NICKNAME,
     CONF_USE_PSK,
@@ -41,7 +40,7 @@ from .const import (
 class BraviaTVConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Bravia TV integration."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize config flow."""
@@ -84,11 +83,11 @@ class BraviaTVConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_connect_device()
 
         system_info = await self.client.get_system_info()
-        cid = system_info[ATTR_CID].lower()
-
+        mac = system_info[ATTR_MAC]
+        unique_id = dr.format_mac(mac)
         self.device_config[CONF_MAC] = system_info[ATTR_MAC]
 
-        await self.async_set_unique_id(cid)
+        await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(

--- a/homeassistant/components/braviatv/const.py
+++ b/homeassistant/components/braviatv/const.py
@@ -3,7 +3,6 @@
 from enum import StrEnum
 from typing import Final
 
-ATTR_CID: Final = "cid"
 ATTR_MAC: Final = "macAddr"
 ATTR_MANUFACTURER: Final = "Sony"
 

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_MANUFACTURER
+from .const import ATTR_MANUFACTURER, DOMAIN
 from .coordinator import BraviaTVCoordinator
 
 
@@ -24,6 +24,7 @@ class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
             assert coordinator.client.mac is not None
 
         self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
             connections={(CONNECTION_NETWORK_MAC, coordinator.client.mac)},
             manufacturer=ATTR_MANUFACTURER,
             model_id=coordinator.system_info.get("model"),

--- a/homeassistant/components/braviatv/entity.py
+++ b/homeassistant/components/braviatv/entity.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_MANUFACTURER, DOMAIN
+from .const import ATTR_MANUFACTURER
 from .coordinator import BraviaTVCoordinator
 
 
@@ -24,7 +24,6 @@ class BraviaTVEntity(CoordinatorEntity[BraviaTVCoordinator]):
             assert coordinator.client.mac is not None
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, unique_id)},
             connections={(CONNECTION_NETWORK_MAC, coordinator.client.mac)},
             manufacturer=ATTR_MANUFACTURER,
             model_id=coordinator.system_info.get("model"),

--- a/tests/components/braviatv/conftest.py
+++ b/tests/components/braviatv/conftest.py
@@ -30,3 +30,50 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.braviatv.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_bravia() -> Generator[AsyncMock]:
+    """Mock BraviaClient class."""
+    with (
+        patch(
+            "homeassistant.components.braviatv.BraviaClient", autospec=True
+        ) as mock_class,
+        patch(
+            "homeassistant.components.braviatv.config_flow.BraviaClient",
+            new=mock_class,
+        ),
+        patch(
+            "homeassistant.components.braviatv.coordinator.BraviaClient",
+            new=mock_class,
+        ),
+    ):
+        yield mock_class
+
+
+@pytest.fixture
+def mock_bravia_client(mock_bravia: AsyncMock) -> AsyncMock:
+    """Mock BraviaClient instance."""
+    client = mock_bravia.return_value
+    client.connect.return_value = None
+    client.set_wol_mode.return_value = None
+    client.get_power_status.return_value = "active"
+    client.get_external_status.return_value = []
+    client.get_app_list.return_value = []
+    client.get_content_list_all.return_value = []
+    client.get_volume_info.return_value = {}
+    client.get_playing_info.return_value = {}
+    client.send_rest_req.return_value = {}
+    client.get_system_info.return_value = {
+        "product": "TV",
+        "region": "XEU",
+        "language": "pol",
+        "model": "TV-Model",
+        "serial": "serial_number",
+        "macAddr": "AA:BB:CC:DD:EE:FF",
+        "name": "BRAVIA",
+        "generation": "5.2.0",
+        "area": "POL",
+        "cid": "very_unique_string",
+    }
+    return client

--- a/tests/components/braviatv/snapshots/test_diagnostics.ambr
+++ b/tests/components/braviatv/snapshots/test_diagnostics.ambr
@@ -22,8 +22,8 @@
       'subentries': list([
       ]),
       'title': 'BRAVIA TV-Model',
-      'unique_id': 'very_unique_string',
-      'version': 1,
+      'unique_id': 'aa:bb:cc:dd:ee:ff',
+      'version': 2,
     }),
     'device_info': dict({
       'area': 'POL',

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -143,7 +143,7 @@ async def test_ssdp_discovery(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["result"].unique_id == "very_unique_string"
+        assert result["result"].unique_id == "aa:bb:cc:dd:ee:ff"
         assert result["title"] == "BRAVIA TV-Model"
         assert result["data"] == {
             CONF_HOST: "bravia-host",
@@ -172,7 +172,7 @@ async def test_ssdp_discovery_exist(hass: HomeAssistant) -> None:
     """Test that the existed device is not discovered."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="very_unique_string",
+        unique_id="aa:bb:cc:dd:ee:ff",
         data={
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
@@ -301,7 +301,7 @@ async def test_duplicate_error(hass: HomeAssistant) -> None:
     """Test that error are shown when duplicates are added."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="very_unique_string",
+        unique_id="aa:bb:cc:dd:ee:ff",
         data={
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
@@ -387,7 +387,7 @@ async def test_create_entry(hass: HomeAssistant, use_psk, use_ssl) -> None:
         )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["result"].unique_id == "very_unique_string"
+        assert result["result"].unique_id == "aa:bb:cc:dd:ee:ff"
         assert result["title"] == "BRAVIA TV-Model"
         assert result["data"] == {
             CONF_HOST: "bravia-host",
@@ -417,7 +417,7 @@ async def test_reauth_successful(hass: HomeAssistant, use_psk, new_pin) -> None:
     """Test that the reauthorization is successful."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="very_unique_string",
+        unique_id="aa:bb:cc:dd:ee:ff",
         data={
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -192,6 +192,88 @@ async def test_ssdp_discovery_exist(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
+async def test_ssdp_duplicate_via_mac_updates_host(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with different host updates existing entry via MAC.
+
+    After migration to MAC-based unique_id, SSDP discovery uses UDN for flow
+    deduplication (ATTR_UPNP_UDN) while persistent unique_id is MAC.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+        data={
+            CONF_HOST: "bravia-host",
+            CONF_PIN: "1234",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+        },
+        title="TV-Model",
+    )
+    config_entry.add_to_hass(hass)
+
+    # Same device discovered on a new IP - UDN identical, host different.
+    ssdp_new_host = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="mock_st",
+        ssdp_location="http://bravia-host2:52323/dmr.xml",
+        upnp={
+            ATTR_UPNP_UDN: "uuid:1234",
+            ATTR_UPNP_FRIENDLY_NAME: "Living TV",
+            ATTR_UPNP_MODEL_NAME: "KE-55XH9096",
+            "X_ScalarWebAPI_DeviceInfo": {
+                "X_ScalarWebAPI_ServiceList": {
+                    "X_ScalarWebAPI_ServiceType": [
+                        "guide",
+                        "system",
+                        "audio",
+                        "avContent",
+                        "videoScreen",
+                    ],
+                },
+            },
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=ssdp_new_host,
+    )
+    # UDN/host check does not abort (host differs, UDN vs MAC mismatch),
+    # so flow proceeds to confirm/authorize.
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    with (
+        patch("pybravia.BraviaClient.connect"),
+        patch("pybravia.BraviaClient.pair"),
+        patch("pybravia.BraviaClient.set_wol_mode"),
+        patch(
+            "pybravia.BraviaClient.get_system_info",
+            return_value=BRAVIA_SYSTEM_INFO,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "authorize"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USE_PSK: False, CONF_USE_SSL: False}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pin"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: "1234"}
+        )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+        # Host is updated to the newly discovered IP via MAC duplicate check
+        assert config_entry.data[CONF_HOST] == "bravia-host2"
+
+
 async def test_user_invalid_host(hass: HomeAssistant) -> None:
     """Test that errors are shown when the host is invalid."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/braviatv/test_diagnostics.py
+++ b/tests/components/braviatv/test_diagnostics.py
@@ -53,7 +53,8 @@ async def test_entry_diagnostics(
             CONF_USE_PSK: True,
             CONF_PIN: "12345qwerty",
         },
-        unique_id="very_unique_string",
+        unique_id="aa:bb:cc:dd:ee:ff",
+        version=2,
         entry_id="3bd2acb0e4f0476d40865546d0d91921",
     )
 

--- a/tests/components/braviatv/test_init.py
+++ b/tests/components/braviatv/test_init.py
@@ -9,32 +9,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
-BRAVIA_SYSTEM_INFO = {
-    "product": "TV",
-    "region": "XEU",
-    "language": "pol",
-    "model": "TV-Model",
-    "serial": "serial_number",
-    "macAddr": "AA:BB:CC:DD:EE:FF",
-    "name": "BRAVIA",
-    "generation": "5.2.0",
-    "area": "POL",
-    "cid": "very_unique_string",
-}
-
-EMPTY_CID_SYSTEM_INFO = {
-    "product": "TV",
-    "region": "XEU",
-    "language": "pol",
-    "model": "TV-Model",
-    "serial": "2283811",
-    "macAddr": "AA:BB:CC:DD:EE:FF",
-    "name": "BRAVIA",
-    "generation": "5.2.0",
-    "area": "POL",
-    "cid": "",
-}
-
 
 async def test_migrate_entry_from_cid_to_mac(
     hass: HomeAssistant,
@@ -72,8 +46,6 @@ async def test_migrate_entry_from_cid_to_mac(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "very_unique_string")},
     )
-
-    mock_bravia_client.get_system_info.return_value = BRAVIA_SYSTEM_INFO
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -128,8 +100,6 @@ async def test_migrate_entry_with_empty_cid_to_mac(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "")},
     )
-
-    mock_bravia_client.get_system_info.return_value = EMPTY_CID_SYSTEM_INFO
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/braviatv/test_init.py
+++ b/tests/components/braviatv/test_init.py
@@ -1,0 +1,146 @@
+"""Tests for the Bravia TV integration."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.braviatv.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+BRAVIA_SYSTEM_INFO = {
+    "product": "TV",
+    "region": "XEU",
+    "language": "pol",
+    "model": "TV-Model",
+    "serial": "serial_number",
+    "macAddr": "AA:BB:CC:DD:EE:FF",
+    "name": "BRAVIA",
+    "generation": "5.2.0",
+    "area": "POL",
+    "cid": "very_unique_string",
+}
+
+EMPTY_CID_SYSTEM_INFO = {
+    "product": "TV",
+    "region": "XEU",
+    "language": "pol",
+    "model": "TV-Model",
+    "serial": "2283811",
+    "macAddr": "AA:BB:CC:DD:EE:FF",
+    "name": "BRAVIA",
+    "generation": "5.2.0",
+    "area": "POL",
+    "cid": "",
+}
+
+
+async def test_migrate_entry_from_cid_to_mac(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Test migration from cid based unique_id to mac based unique_id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="very_unique_string",
+        data={
+            CONF_HOST: "bravia-host",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+            CONF_PIN: "1234",
+        },
+        version=1,
+        title="TV-Model",
+    )
+    config_entry.add_to_hass(hass)
+
+    entity = entity_registry.async_get_or_create(
+        Platform.BUTTON,
+        DOMAIN,
+        "very_unique_string",
+        config_entry=config_entry,
+    )
+    entity_terminate = entity_registry.async_get_or_create(
+        Platform.BUTTON,
+        DOMAIN,
+        "very_unique_string_terminate_apps",
+        config_entry=config_entry,
+    )
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "very_unique_string")},
+    )
+
+    mock_bravia_client.get_system_info.return_value = BRAVIA_SYSTEM_INFO
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.unique_id == "aa:bb:cc:dd:ee:ff"
+    assert config_entry.version == 2
+
+    migrated_entity = entity_registry.async_get(entity.entity_id)
+    assert migrated_entity.unique_id == "aa:bb:cc:dd:ee:ff"
+    migrated_terminate = entity_registry.async_get(entity_terminate.entity_id)
+    assert migrated_terminate.unique_id == "aa:bb:cc:dd:ee:ff_terminate_apps"
+
+    assert not device_registry.async_get_devices(
+        identifiers={(DOMAIN, "very_unique_string")}
+    )
+    assert device_registry.async_get(device.id).identifiers == set()
+
+
+async def test_migrate_entry_with_empty_cid_to_mac(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Test migration from empty unique_id to mac based unique_id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="",
+        data={
+            CONF_HOST: "bravia-host",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
+            CONF_PIN: "1234",
+        },
+        version=1,
+        title="TV-Model",
+    )
+    config_entry.add_to_hass(hass)
+
+    entity = entity_registry.async_get_or_create(
+        Platform.BUTTON,
+        DOMAIN,
+        "",
+        config_entry=config_entry,
+    )
+    entity_terminate = entity_registry.async_get_or_create(
+        Platform.BUTTON,
+        DOMAIN,
+        "_terminate_apps",
+        config_entry=config_entry,
+    )
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "")},
+    )
+
+    mock_bravia_client.get_system_info.return_value = EMPTY_CID_SYSTEM_INFO
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.unique_id == "aa:bb:cc:dd:ee:ff"
+    assert config_entry.version == 2
+
+    migrated_entity = entity_registry.async_get(entity.entity_id)
+    assert migrated_entity.unique_id == "aa:bb:cc:dd:ee:ff"
+    migrated_terminate = entity_registry.async_get(entity_terminate.entity_id)
+    assert migrated_terminate.unique_id == "aa:bb:cc:dd:ee:ff_terminate_apps"
+
+    assert not device_registry.async_get_devices(identifiers={(DOMAIN, "")})
+    assert device_registry.async_get(device.id).identifiers == set()

--- a/tests/components/braviatv/test_init.py
+++ b/tests/components/braviatv/test_init.py
@@ -61,7 +61,9 @@ async def test_migrate_entry_from_cid_to_mac(
     assert not device_registry.async_get_devices(
         identifiers={(DOMAIN, "very_unique_string")}
     )
-    assert device_registry.async_get(device.id).identifiers == set()
+    assert device_registry.async_get(device.id).identifiers == {
+        (DOMAIN, "aa:bb:cc:dd:ee:ff")
+    }
 
 
 async def test_migrate_entry_with_empty_cid_to_mac(
@@ -113,4 +115,6 @@ async def test_migrate_entry_with_empty_cid_to_mac(
     assert migrated_terminate.unique_id == "aa:bb:cc:dd:ee:ff_terminate_apps"
 
     assert not device_registry.async_get_devices(identifiers={(DOMAIN, "")})
-    assert device_registry.async_get(device.id).identifiers == set()
+    assert device_registry.async_get(device.id).identifiers == {
+        (DOMAIN, "aa:bb:cc:dd:ee:ff")
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, BraviaTV integration uses the `cid` value as the `unique_id`, but new TV models return empty strings as the `cid`.

This PR migrates the integration to use the MAC address as the `unique_id`. Since the MAC address is already present in `config_entry.data`, migration can be performed while the device is offline, which is quite often for some BraviaTV models when they are in stand-by mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160322
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
