### PR TITLE
Use registry fixtures in tests (1/8)

### DIFF
--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -181,6 +181,7 @@ async def test_ssl_migrate_entry(
 async def test_uid_migrate_entry(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     sensor_domain: str,
     sensor_name: str,
     mock_id: str,
@@ -188,7 +189,6 @@ async def test_uid_migrate_entry(
     mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test migrate entry unique id."""
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     MOCK_MAC = dr.format_mac("01:23:45:67:89:AB")
     MOCK_ID = "device_id_12345"

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -257,7 +257,9 @@ async def test_device_remove_devices(
     assert response["success"]
 
 
-async def test_brand_migration_issue(hass: HomeAssistant) -> None:
+async def test_brand_migration_issue(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test removing the brand migration issue."""
     august_operative_lock = await _mock_operative_august_lock_detail(hass)
     config_entry, _ = await _create_august_with_devices(
@@ -266,10 +268,8 @@ async def test_brand_migration_issue(hass: HomeAssistant) -> None:
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     await hass.config_entries.async_remove(config_entry.entry_id)
-    assert not issue_reg.async_get_issue(DOMAIN, "yale_brand_migration")
+    assert not issue_registry.async_get_issue(DOMAIN, "yale_brand_migration")
 
 
 async def test_oauth_migration_on_legacy_entry(hass: HomeAssistant) -> None:

--- a/tests/components/autoskope/test_device_tracker.py
+++ b/tests/components/autoskope/test_device_tracker.py
@@ -190,6 +190,7 @@ async def test_reauth_failure(
 
 async def test_vehicle_name_update(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
     mock_autoskope_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
@@ -197,7 +198,6 @@ async def test_vehicle_name_update(
     """Test device name updates in device registry when vehicle is renamed."""
     await setup_integration(hass, mock_config_entry)
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "12345"), mock_config_entry.entry_id
     )

--- a/tests/components/backblaze_b2/test_repairs.py
+++ b/tests/components/backblaze_b2/test_repairs.py
@@ -32,6 +32,7 @@ def mock_entry():
 
 async def test_unauthorized_triggers_reauth(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_entry: MockConfigEntry,
 ) -> None:
     """Test that Unauthorized exception triggers reauth flow."""
@@ -42,7 +43,7 @@ async def test_unauthorized_triggers_reauth(
         await async_check_for_repair_issues(hass, mock_entry)
 
     mock_reauth.assert_called_once_with(hass)
-    assert len(ir.async_get(hass).issues) == 0  # pylint: disable=home-assistant-tests-registry-fixtures
+    assert len(issue_registry.issues) == 0
 
 
 @pytest.mark.parametrize(
@@ -55,6 +56,7 @@ async def test_unauthorized_triggers_reauth(
 )
 async def test_repair_issue_creation(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_entry: MockConfigEntry,
     exception: Exception,
     expected_issues: int,
@@ -65,7 +67,7 @@ async def test_repair_issue_creation(
         await async_check_for_repair_issues(hass, mock_entry)
 
     mock_reauth.assert_not_called()
-    assert len(ir.async_get(hass).issues) == expected_issues  # pylint: disable=home-assistant-tests-registry-fixtures
+    assert len(issue_registry.issues) == expected_issues
 
 
 async def test_async_create_fix_flow(hass: HomeAssistant) -> None:

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -947,6 +947,7 @@ async def test_initiate_backup_with_agent_error(
 )
 async def test_create_backup_success_clears_issue(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     hass_ws_client: WebSocketGenerator,
     create_backup_command: dict[str, Any],
     issues_after_create_backup: set[tuple[str, str]],
@@ -982,7 +983,6 @@ async def test_create_backup_success_clears_issue(
 
     await hass.async_block_till_done()
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert set(issue_registry.issues) == issues_after_create_backup
 
 
@@ -1309,6 +1309,7 @@ async def delayed_boom(*args, **kwargs) -> tuple[NewBackup, Any]:
 )
 async def test_create_backup_failure_raises_issue(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     hass_ws_client: WebSocketGenerator,
     create_backup: AsyncMock,
     automatic_agents: list[str],
@@ -1344,7 +1345,6 @@ async def test_create_backup_failure_raises_issue(
     assert result["success"] == create_backup_result
     await hass.async_block_till_done()
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert set(issue_registry.issues) == set(issues_after_create_backup)
     for issue_id, issue_data in issues_after_create_backup.items():
         issue = issue_registry.issues[issue_id]

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1767,6 +1767,7 @@ async def test_async_register_disappeared_callback(
 @pytest.mark.usefixtures("one_adapter")
 async def test_repair_issue_created_for_degraded_scanner_in_docker(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issue is created when scanner is in degraded mode in Docker."""
     await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -1806,8 +1807,7 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
         manager.on_scanner_start(scanner)
 
         issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
-        registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-        issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+        issue = issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id)
         assert issue is not None
         assert issue.severity == ir.IssueSeverity.WARNING
         assert not issue.is_fixable
@@ -1817,13 +1817,13 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
 @pytest.mark.usefixtures("one_adapter")
 async def test_repair_issue_deleted_when_scanner_not_degraded(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issue is deleted when scanner is not in degraded mode."""
     await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
 
     manager = _get_manager()
-    registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     scanner = HaScanner(
         mode=BluetoothScanningMode.ACTIVE,
@@ -1858,7 +1858,7 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     ):
         manager.on_scanner_start(scanner)
 
-    assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is not None
+    assert issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id) is not None
 
     with (
         patch(
@@ -1869,12 +1869,13 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     ):
         manager.on_scanner_start(scanner)
 
-    assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
+    assert issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
 
 
 @pytest.mark.usefixtures("one_adapter")
 async def test_no_repair_issue_when_not_docker(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test no repair issue is created when not running in Docker."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -1899,13 +1900,13 @@ async def test_no_repair_issue_when_not_docker(
         manager.on_scanner_start(scanner)
 
         issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
-        registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-        assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
+        assert issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
 
 
 @pytest.mark.usefixtures("one_adapter")
 async def test_no_repair_issue_for_remote_scanner(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test no repair issue is created for remote scanners."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -1925,10 +1926,9 @@ async def test_no_repair_issue_for_remote_scanner(
     ):
         manager.on_scanner_start(scanner)
 
-        registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
         issues = [
             issue
-            for issue in registry.issues.values()
+            for issue in issue_registry.issues.values()
             if issue.domain == bluetooth.DOMAIN
             and "bluetooth_adapter_missing_permissions" in issue.issue_id
         ]
@@ -1938,6 +1938,7 @@ async def test_no_repair_issue_for_remote_scanner(
 @pytest.mark.usefixtures("one_adapter")
 async def test_repair_issue_created_for_passive_mode_fallback(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issue is created when scanner falls back to passive mode."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -1962,8 +1963,7 @@ async def test_repair_issue_created_for_passive_mode_fallback(
 
     # Check repair issue is created
     issue_id = f"bluetooth_adapter_passive_mode_{scanner.source}"
-    registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+    issue = issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id)
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
     # Should default to USB translation key when adapter type is unknown
@@ -1975,6 +1975,7 @@ async def test_repair_issue_created_for_passive_mode_fallback(
 
 async def test_repair_issue_created_for_passive_mode_fallback_uart(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issue is created with UART-specific message for UART adapters."""
     with patch(
@@ -2013,8 +2014,7 @@ async def test_repair_issue_created_for_passive_mode_fallback_uart(
 
         # Check repair issue is created with UART-specific translation key
         issue_id = f"bluetooth_adapter_passive_mode_{scanner.source}"
-        registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-        issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+        issue = issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id)
         assert issue is not None
         assert issue.severity == ir.IssueSeverity.WARNING
         assert issue.translation_key == "bluetooth_adapter_passive_mode_uart"
@@ -2026,6 +2026,7 @@ async def test_repair_issue_created_for_passive_mode_fallback_uart(
 @pytest.mark.usefixtures("one_adapter")
 async def test_repair_issue_deleted_when_passive_mode_resolved(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issue is deleted when scanner no longer in passive mode."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -2050,8 +2051,7 @@ async def test_repair_issue_deleted_when_passive_mode_resolved(
 
     # Check repair issue is created
     issue_id = f"bluetooth_adapter_passive_mode_{scanner.source}"
-    registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+    issue = issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id)
     assert issue is not None
 
     # Now simulate scanner recovering to active mode
@@ -2059,7 +2059,7 @@ async def test_repair_issue_deleted_when_passive_mode_resolved(
     manager.on_scanner_start(scanner)
 
     # Check repair issue is deleted
-    issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+    issue = issue_registry.async_get_issue(bluetooth.DOMAIN, issue_id)
     assert issue is None
 
     cancel()

--- a/tests/components/bryant_evolution/test_init.py
+++ b/tests/components/bryant_evolution/test_init.py
@@ -63,6 +63,7 @@ async def test_setup_integration_client_returns_none(
 
 async def test_setup_multiple_systems_zones(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_evolution_client_factory: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -92,8 +93,6 @@ async def test_setup_multiple_systems_zones(
         assert state.attributes["current_temperature"] == zone
 
     # Check that the created devices are wired to each other as expected.
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     def find_device(name):
         return next(filter(lambda x: x.name == name, device_registry.devices))
 

--- a/tests/components/cielo_home/test_init.py
+++ b/tests/components/cielo_home/test_init.py
@@ -12,6 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_async_setup_and_unload_entry(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_cielo_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -24,10 +25,9 @@ async def test_async_setup_and_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_config_entry.runtime_data is not None
 
-    entity_reg = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entities = [
         e
-        for e in entity_reg.entities.values()
+        for e in entity_registry.entities.values()
         if e.platform == DOMAIN and e.domain == "climate"
     ]
     assert len(entities) == 1

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -178,7 +178,6 @@ async def test_set_temperature(
     # Put areas on different floors:
     # first floor => living room and office
     # upstairs => bedroom
-    floor_registry = fr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     first_floor = floor_registry.async_create("First floor")
     living_room_area = area_registry.async_update(
         living_room_area.id, floor_id=first_floor.floor_id

--- a/tests/components/coolmaster/test_init.py
+++ b/tests/components/coolmaster/test_init.py
@@ -30,13 +30,13 @@ async def test_unload_entry(
 
 async def test_registry_cleanup(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     load_int: ConfigEntry,
     hass_ws_client: WebSocketGenerator,
     unit_count: int,
 ) -> None:
     """Test being able to remove a disconnected device."""
     entry_id = load_int.entry_id
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     live_id = "L1.100"
     dead_id = "L2.200"
 


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

There are a number of existing occurrences that were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This PR fixes the first batch of these (10 test files, alphabetically), removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/airos/test_init.py`
- `tests/components/august/test_init.py`
- `tests/components/autoskope/test_device_tracker.py`
- `tests/components/backblaze_b2/test_repairs.py`
- `tests/components/backup/test_manager.py`
- `tests/components/bluetooth/test_manager.py`
- `tests/components/bryant_evolution/test_init.py`
- `tests/components/cielo_home/test_init.py`
- `tests/components/climate/test_intent.py`
- `tests/components/coolmaster/test_init.py`

Further batches will follow to clean up the remaining occurrences.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
