### PR TITLE
Use registry fixtures in tests (2/8)

### DIFF
--- a/tests/components/doorbird/test_repairs.py
+++ b/tests/components/doorbird/test_repairs.py
@@ -15,6 +15,7 @@ from tests.typing import ClientSessionGenerator
 
 async def test_change_schedule_fails(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     doorbird_mocker: DoorbirdMockerType,
     hass_client: ClientSessionGenerator,
 ) -> None:
@@ -24,9 +25,8 @@ async def test_change_schedule_fails(
         favorites_side_effect=mock_not_found_exception()
     )
     assert doorbird_entry.entry.state is ConfigEntryState.SETUP_RETRY
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    assert len(issue_reg.issues) == 1
-    issue = list(issue_reg.issues.values())[0]
+    assert len(issue_registry.issues) == 1
+    issue = list(issue_registry.issues.values())[0]
     issue_id = issue.issue_id
     assert issue.domain == DOMAIN
 

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -458,14 +458,15 @@ async def test_remote_sensors(hass: HomeAssistant) -> None:
 
 
 async def test_remote_sensor_devices(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test remote sensor devices."""
     await setup_platform(hass, [const.Platform.CLIMATE, const.Platform.SENSOR])
     freezer.tick(100)
     async_fire_time_changed(hass)
     state = hass.states.get(ENTITY_ID)
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     for device in device_registry.devices:
         if device.name == "Remote Sensor 1":
             remote_sensor_1_id = device.id
@@ -545,7 +546,9 @@ async def test_remote_sensor_ids_names(hass: HomeAssistant) -> None:
     assert sorted(name_by_user_list) == sorted(["Remote Sensor 1", "ecobee"])
 
 
-async def test_remote_sensors_ignore_non_ecobee_devices(hass: HomeAssistant) -> None:
+async def test_remote_sensors_ignore_non_ecobee_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Devices from other integrations sharing a sensor's name are not matched.
 
     Regression test: the remote-sensor device lookup matched by device name across
@@ -553,7 +556,6 @@ async def test_remote_sensors_ignore_non_ecobee_devices(hass: HomeAssistant) -> 
     an ecobee sensor's name was wrongly reported as a participating sensor.
     """
     await setup_platform(hass, [const.Platform.CLIMATE, const.Platform.SENSOR])
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # A device from another integration that shares the ecobee sensor's name.
     other_entry = MockConfigEntry(domain="other")
@@ -579,11 +581,12 @@ async def test_remote_sensors_ignore_non_ecobee_devices(hass: HomeAssistant) -> 
     assert sorted(name_by_user_list) == sorted(["Remote Sensor 1", "ecobee"])
 
 
-async def test_set_sensors_used_in_climate(hass: HomeAssistant) -> None:
+async def test_set_sensors_used_in_climate(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test set sensors used in climate."""
     # Get device_id of remote sensor from the device registry.
     await setup_platform(hass, [const.Platform.CLIMATE, const.Platform.SENSOR])
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     for device in device_registry.devices:
         if device.name == "Remote Sensor 1":
             remote_sensor_1_id = device.id

--- a/tests/components/ecovacs/test_vacuum.py
+++ b/tests/components/ecovacs/test_vacuum.py
@@ -375,6 +375,7 @@ async def test_clean_area_room_from_not_current_map(
 async def test_raise_segment_changed_issue(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     controller: EcovacsController,
     entity_id: str,
     events: tuple[Event, ...],
@@ -390,7 +391,7 @@ async def test_raise_segment_changed_issue(
 
     entity_entry = entity_registry.async_get(entity_id)
     issue_id = f"{vacuum.ISSUE_SEGMENTS_CHANGED}_{entity_entry.id}"
-    issue = ir.async_get(hass).async_get_issue(vacuum.DOMAIN, issue_id)  # pylint: disable=home-assistant-tests-registry-fixtures
+    issue = issue_registry.async_get_issue(vacuum.DOMAIN, issue_id)
     assert issue is not None
 
 

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -747,13 +747,12 @@ async def test_deep_sleep_added_after_setup(
 
 async def test_entity_assignment_to_sub_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test entities are assigned to correct sub devices."""
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     # Define sub devices
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="Motion Sensor", area_id=0),

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2385,6 +2385,7 @@ async def test_entry_missing_bluetooth_mac_address(
 
 async def test_device_adds_friendly_name(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
     caplog: pytest.LogCaptureFixture,
@@ -2395,8 +2396,7 @@ async def test_device_adds_friendly_name(
         device_info={"name": "nofriendlyname", "friendly_name": ""},
     )
     await hass.async_block_till_done()
-    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    dev = dev_reg.async_get_device_by_connection(
+    dev = device_registry.async_get_device_by_connection(
         (dr.CONNECTION_NETWORK_MAC, device.entry.unique_id), device.entry.entry_id
     )
     assert dev.name == "Nofriendlyname"
@@ -2418,7 +2418,7 @@ async def test_device_adds_friendly_name(
     )
     await device.mock_connect()
     await hass.async_block_till_done()
-    dev = dev_reg.async_get_device_by_connection(
+    dev = device_registry.async_get_device_by_connection(
         (dr.CONNECTION_NETWORK_MAC, device.entry.unique_id), device.entry.entry_id
     )
     assert dev.name == "I have a friendly name"
@@ -2477,11 +2477,11 @@ async def test_assist_in_progress_issue_deleted(
 async def test_sub_device_creation(
     hass: HomeAssistant,
     area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test sub devices are created in device registry."""
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Define areas
     areas = [
@@ -2548,11 +2548,11 @@ async def test_sub_device_creation(
 
 async def test_sub_device_cleanup(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test sub devices are removed when they no longer exist."""
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Initial sub devices
     sub_devices_initial = [
@@ -2645,11 +2645,11 @@ async def test_sub_device_cleanup(
 
 async def test_sub_device_with_empty_name(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test sub devices with empty names are handled correctly."""
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Define sub devices with empty names
     sub_devices = [
@@ -2690,11 +2690,11 @@ async def test_sub_device_with_empty_name(
 async def test_sub_device_references_main_device_area(
     hass: HomeAssistant,
     area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
     """Test sub devices can reference the main device's area."""
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Define areas - note we don't include area_id=0 in the areas list
     areas = [

--- a/tests/components/ezviz/test_init.py
+++ b/tests/components/ezviz/test_init.py
@@ -87,6 +87,7 @@ async def test_last_alarm_pic_sensor_not_created(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_ezviz_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that last_alarm_pic sensor is not created."""
     # Mock coordinator data with all sensor fields
@@ -115,8 +116,7 @@ async def test_last_alarm_pic_sensor_not_created(
     assert last_alarm_pic_state is None
 
     # But other sensors should be created
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    battery_entity = registry.async_get("sensor.camera_1_battery")
+    battery_entity = entity_registry.async_get("sensor.camera_1_battery")
     assert battery_entity is not None
 
 

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -271,6 +271,7 @@ async def test_cleanup_button(
 async def test_cleanup_button_deprecation_issue(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     fc_class_mock,
     fh_class_mock,
     fs_class_mock,
@@ -283,7 +284,6 @@ async def test_cleanup_button_deprecation_issue(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert issue_registry.async_get_issue(DOMAIN, "deprecated_cleanup_button")
 
 
@@ -291,6 +291,7 @@ async def test_cleanup_button_deprecation_issue(
 async def test_firmware_update_button_deprecation_issue(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     fc_class_mock,
     fh_class_mock,
     fs_class_mock,
@@ -303,5 +304,4 @@ async def test_firmware_update_button_deprecation_issue(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert issue_registry.async_get_issue(DOMAIN, "deprecated_firmware_update_button")

--- a/tests/components/google_air_quality/test_services.py
+++ b/tests/components/google_air_quality/test_services.py
@@ -26,9 +26,10 @@ async def test_get_forecast_service(
     mock_config_entry: MockConfigEntry,
     mock_api: AsyncMock,
     snapshot: SnapshotAssertion,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test fetching a forecast for a subentry."""
-    device = dr.async_get(hass).async_get_device_by_identifier(  # pylint: disable=home-assistant-tests-registry-fixtures
+    device = device_registry.async_get_device_by_identifier(
         (DOMAIN, f"{mock_config_entry.entry_id}_home-subentry-id"),
         mock_config_entry.entry_id,
     )

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -834,6 +834,7 @@ async def test_dynamic_device_added(
     mock_growatt_v1_api,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that new devices are dynamically added when discovered during a scan."""
@@ -881,7 +882,6 @@ async def test_dynamic_device_added(
     # Verify multiple entity types to confirm end-to-end dynamic device support
     assert hass.states.get("switch.new456789_charge_from_grid") is not None
     # Additional check: verify entities exist in the entity registry
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     new_device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "NEW456789"), mock_config_entry.entry_id
     )


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 2 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/doorbird/test_repairs.py`
- `tests/components/ecobee/test_climate.py`
- `tests/components/ecovacs/test_vacuum.py`
- `tests/components/esphome/test_entity.py`
- `tests/components/esphome/test_manager.py`
- `tests/components/ezviz/test_init.py`
- `tests/components/fritz/test_button.py`
- `tests/components/google_air_quality/test_services.py`
- `tests/components/growatt_server/test_init.py`

Note: `tests/components/device_automation/test_init.py` was intentionally left with the suppression, since the relevant test uses `@pytest.mark.parametrize("load_registries", [False])` and sets up/loads the registries manually, so the fixtures cannot be used there.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
