### PR TITLE
Use registry fixtures in tests (3/8)

### DIFF
--- a/tests/components/hassio/test_backup.py
+++ b/tests/components/hassio/test_backup.py
@@ -1122,6 +1122,7 @@ async def test_reader_writer_create(
 )
 async def test_reader_writer_create_addon_folder_error(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     hass_supervisor_ws_client: WebSocketGenerator,
     freezer: FrozenDateTimeFactory,
     supervisor_client: AsyncMock,
@@ -1146,7 +1147,6 @@ async def test_reader_writer_create_addon_folder_error(
         ),
     ]
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert not issue_registry.issues
 
     await client.send_json_auto_id({"type": "backup/subscribe_events"})

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -970,7 +970,9 @@ async def test_invalid_service_calls_folder_duplicates(hass: HomeAssistant) -> N
 
 @pytest.mark.usefixtures("hassio_env")
 async def test_partial_backup_legacy_homeassistant_folder(
-    hass: HomeAssistant, supervisor_client: AsyncMock
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    supervisor_client: AsyncMock,
 ) -> None:
     """Test legacy "homeassistant" folder is translated to homeassistant=True."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -991,7 +993,6 @@ async def test_partial_backup_legacy_homeassistant_folder(
             folders={Folder.SSL},
         )
     )
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
         issue_registry.async_get_issue("hassio", "legacy_homeassistant_folder")
         is not None

--- a/tests/components/heos/test_diagnostics.py
+++ b/tests/components/heos/test_diagnostics.py
@@ -64,6 +64,7 @@ async def test_config_entry_diagnostics_error_getting_system(
 
 async def test_device_diagnostics(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     hass_client: ClientSessionGenerator,
     config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
@@ -71,7 +72,6 @@ async def test_device_diagnostics(
     """Test generating diagnostics for a config entry."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, "1"), config_entry.entry_id
     )

--- a/tests/components/homeassistant_hardware/test_switch.py
+++ b/tests/components/homeassistant_hardware/test_switch.py
@@ -181,6 +181,7 @@ async def test_switch_default_off_state(
 )
 async def test_switch_restore_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     switch_config_entry: ConfigEntry,
     mock_firmware_client,
     initial_state: str,
@@ -204,7 +205,6 @@ async def test_switch_restore_state(
     ]
 
     # Verify entity registry attributes
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entity_entry = entity_registry.async_get(TEST_SWITCH_ENTITY_ID)
     assert entity_entry is not None
     assert entity_entry.entity_category == EntityCategory.CONFIG

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -243,7 +243,10 @@ async def test_ble_device_only_checks_is_available(
 
 @pytest.mark.usefixtures("fake_ble_discovery", "fake_ble_pairing")
 async def test_ble_device_populates_connections(
-    hass: HomeAssistant, get_next_aid: Callable[[], int], controller
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    get_next_aid: Callable[[], int],
+    controller,
 ) -> None:
     """Test a BLE device populates connections in the device registry."""
     aid = get_next_aid()
@@ -260,9 +263,8 @@ async def test_ble_device_populates_connections(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.LOADED
-    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
-        dev_reg.async_get_device_by_connection(
+        device_registry.async_get_device_by_connection(
             ("bluetooth", "AA:BB:CC:DD:EE:FF"), config_entry.entry_id
         )
         is not None

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -925,7 +925,9 @@ async def test_hmip_water_valve_water_volume_since_open(
 
 
 async def test_hmip_smoke_detector_dirt_level(
-    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    default_mock_hap_factory: HomeFactory,
 ) -> None:
     """Test HomematicipSmokeDetectorDirtLevel."""
     entity_id = "sensor.rauchwarnmelder_dirt_level"
@@ -933,7 +935,6 @@ async def test_hmip_smoke_detector_dirt_level(
     device_model = "HmIP-SWSD"
 
     # Pre-register the entity as enabled before platform loads
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entity_registry.async_get_or_create(
         "sensor",
         DOMAIN,

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -131,6 +131,7 @@ async def test_load_detect_invalid_token(
 @pytest.mark.usefixtures("mock_homewizardenergy")
 async def test_load_creates_repair_issue(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_homewizardenergy: MagicMock,
 ) -> None:
@@ -142,8 +143,6 @@ async def test_load_creates_repair_issue(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     issue = issue_registry.async_get_issue(
         domain=DOMAIN, issue_id=f"migrate_to_v2_api_{mock_config_entry.entry_id}"
@@ -157,6 +156,8 @@ async def test_load_creates_repair_issue(
 @pytest.mark.usefixtures("mock_homewizardenergy")
 async def test_load_creates_repair_issue_when_name_is_updated(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_homewizardenergy: MagicMock,
 ) -> None:
@@ -169,7 +170,6 @@ async def test_load_creates_repair_issue_when_name_is_updated(
 
     await hass.async_block_till_done()
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue_id = f"migrate_to_v2_api_{mock_config_entry.entry_id}"
 
     issue = issue_registry.async_get_issue(domain=DOMAIN, issue_id=issue_id)
@@ -179,7 +179,6 @@ async def test_load_creates_repair_issue_when_name_is_updated(
     assert issue.translation_placeholders["title"] == "Device"
 
     # Update the device name
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     device = get_main_device(hass, mock_config_entry)
 
     # Update device name
@@ -307,6 +306,7 @@ async def test_battery_cloud_issue_updates_only_on_state_transition(
 @pytest.mark.usefixtures("mock_homewizardenergy")
 async def test_battery_cloud_issue_stale_issue_cleared_on_reload(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_homewizardenergy: MagicMock,
 ) -> None:
@@ -319,12 +319,12 @@ async def test_battery_cloud_issue_stale_issue_cleared_on_reload(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None  # pylint: disable=home-assistant-tests-registry-fixtures
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
 
     combined_data.system.cloud_enabled = True
     await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None  # pylint: disable=home-assistant-tests-registry-fixtures
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_main_device_registered_before_platform_forwarding(

--- a/tests/components/hypontech/test_sensor.py
+++ b/tests/components/hypontech/test_sensor.py
@@ -30,6 +30,7 @@ async def test_sensors(
 
 async def test_device_manufacturer_uses_oem(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_hyponcloud: AsyncMock,
 ) -> None:
     """Test device manufacturer uses the selected OEM."""
@@ -46,7 +47,6 @@ async def test_device_manufacturer_uses_oem(
     with patch("homeassistant.components.hypontech._PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     overview_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -52,11 +52,13 @@ async def test_button_entities_snapshot(
 @pytest.mark.usefixtures("init_integration")
 async def test_setup_ignores_unknown_button_types(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Unknown button keys from the API are not turned into entities."""
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entries = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
     assert len(entries) == 1
     assert entries[0].translation_key == PARAM_MUTE
 


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 3 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/hassio/test_backup.py`
- `tests/components/hassio/test_init.py`
- `tests/components/heos/test_diagnostics.py`
- `tests/components/homeassistant_hardware/test_switch.py`
- `tests/components/homekit_controller/test_init.py`
- `tests/components/homematicip_cloud/test_sensor.py`
- `tests/components/homewizard/test_init.py`
- `tests/components/hypontech/test_sensor.py`
- `tests/components/imou/test_button.py`

Note: `tests/components/harmony/test_init.py` was intentionally left with its suppression, since that test replaces the entity registry via `mock_registry(...)` after test setup, so the fixture cannot be used there.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
