### PR TITLE
Use registry fixtures in tests (4/8)

### DIFF
--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -93,11 +93,13 @@ async def test_camera_entities_snapshot(
 @pytest.mark.usefixtures("init_integration")
 async def test_no_camera_without_channel(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Devices without a channel do not get a camera entity."""
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entries = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
     assert not any(entry.domain == "camera" for entry in entries)
 
 

--- a/tests/components/imou/test_init.py
+++ b/tests/components/imou/test_init.py
@@ -63,11 +63,13 @@ async def test_setup_entry_failed_on_refresh(
 @pytest.mark.usefixtures("init_integration")
 async def test_device_registry_identifiers(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Device registry uses channel-aware identifiers from the default mock devices."""
-    registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    devices = dr.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    devices = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry.entry_id
+    )
     assert len(devices) == 1
     assert (DOMAIN, "d1") in devices[0].identifiers
 

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -78,11 +78,13 @@ async def test_switch_entities_snapshot(
 @pytest.mark.usefixtures("init_integration")
 async def test_setup_ignores_unknown_switch_types(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Unknown switch keys from the API are not turned into entities."""
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entries = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
     switch_entries = [entry for entry in entries if entry.domain == SWITCH_DOMAIN]
     assert len(switch_entries) == 1
     assert switch_entries[0].translation_key == PARAM_MOTION_DETECT

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -148,11 +148,13 @@ async def test_setup_and_remove_config_entry(
 
 
 @pytest.mark.parametrize("platform", ["sensor"])
-async def test_entry_changed(hass: HomeAssistant, platform) -> None:
+async def test_entry_changed(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    platform,
+) -> None:
     """Test reconfiguring."""
-
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     def _create_mock_entity(domain: str, name: str) -> er.RegistryEntry:
         config_entry = MockConfigEntry(

--- a/tests/components/intent/test_temperature.py
+++ b/tests/components/intent/test_temperature.py
@@ -183,7 +183,6 @@ async def test_get_temperature(
     # first floor => living room and office
     # 2nd floor => bedroom
     # 3rd floor => attic
-    floor_registry = fr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     first_floor = floor_registry.async_create("First floor")
     living_room_area = area_registry.async_update(
         living_room_area.id, floor_id=first_floor.floor_id

--- a/tests/components/iss/test_sensor.py
+++ b/tests/components/iss/test_sensor.py
@@ -56,16 +56,17 @@ async def test_sensor_attributes_show_on_map_true(
 
 
 async def test_sensor_device_info(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
 ) -> None:
     """Test sensor has correct device info."""
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entity = entity_registry.async_get("sensor.iss")
 
     assert entity is not None
     assert entity.unique_id == f"{init_integration.entry_id}_people"
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     device = device_registry.async_get(entity.device_id)
 
     assert device is not None

--- a/tests/components/knx/test_repairs.py
+++ b/tests/components/knx/test_repairs.py
@@ -38,6 +38,7 @@ async def test_create_fix_flow_raises_on_unknown_issue_id(hass: HomeAssistant) -
 async def test_data_secure_group_key_issue_only_for_configured_group_address(
     hass: HomeAssistant,
     knx: KNXTestKit,
+    issue_registry: ir.IssueRegistry,
     configured_group_address: str,
 ) -> None:
     """Test that repair issue is only created for configured group addresses."""
@@ -50,7 +51,6 @@ async def test_data_secure_group_key_issue_only_for_configured_group_address(
         }
     )
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert bool(issue_registry.issues) is False
     # An issue should only be created if this address is configured.
     knx.receive_data_secure_issue("1/2/5")
@@ -62,6 +62,7 @@ async def test_data_secure_group_key_issue_repair_flow(
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
     knx: KNXTestKit,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair flow for DataSecure group key issue."""
     await knx.setup_integration(
@@ -76,7 +77,6 @@ async def test_data_secure_group_key_issue_repair_flow(
     knx.receive_data_secure_issue("11/0/0", source="1.0.1")
     knx.receive_data_secure_issue("1/2/5", source="1.0.10")
     knx.receive_data_secure_issue("1/2/5", source="1.0.1")
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_DATA_SECURE_GROUP_KEY)
     assert issue is not None
     assert issue.translation_placeholders == {

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -149,6 +149,7 @@ async def test_store_telegram_history_sqlite(
 async def test_store_telegram_history_error_handling(
     hass: HomeAssistant,
     knx: KNXTestKit,
+    issue_registry: ir.IssueRegistry,
     side_effect: Exception,
 ) -> None:
     """Test storage initialization handling for the different failure modes."""
@@ -162,7 +163,6 @@ async def test_store_telegram_history_error_handling(
     assert telegrams_module.store is None
 
     # Check that the repair issue was created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
     assert issue is not None
 
@@ -170,6 +170,7 @@ async def test_store_telegram_history_error_handling(
 async def test_store_telegram_history_needs_migration_timeout(
     hass: HomeAssistant,
     knx: KNXTestKit,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test store init aborts when needs_migration times out and retries are off."""
 
@@ -191,7 +192,6 @@ async def test_store_telegram_history_needs_migration_timeout(
     assert telegrams_module.store is None
 
     # Check that the repair issue was created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
     assert issue is not None
 
@@ -695,6 +695,7 @@ async def test_nightly_eviction_error_handling(
 async def test_postgres_backend_init_error(
     hass: HomeAssistant,
     knx: KNXTestKit,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test PostgreSQL backend DSN handling and init failure path."""
     dsn = "postgresql://user:secret@db.local:5432/knx"
@@ -721,7 +722,6 @@ async def test_postgres_backend_init_error(
     telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
     assert telegrams_module.store is None
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
         issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
         is not None

--- a/tests/components/kulersky/test_init.py
+++ b/tests/components/kulersky/test_init.py
@@ -11,6 +11,7 @@ from tests.common import MockConfigEntry
 
 async def test_migrate_entry(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test migrate config entry from v1 to v2."""
 
@@ -22,14 +23,13 @@ async def test_migrate_entry(
 
     mock_config_entry_v1.add_to_hass(hass)
 
-    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     # Create device registry entries for old integration
-    dev_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=mock_config_entry_v1.entry_id,
         identifiers={(DOMAIN, "AA:BB:CC:11:22:33")},
         name="KuLight 1",
     )
-    dev_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=mock_config_entry_v1.entry_id,
         identifiers={(DOMAIN, "AA:BB:CC:44:55:66")},
         name="KuLight 2",

--- a/tests/components/lamarzocco/test_init.py
+++ b/tests/components/lamarzocco/test_init.py
@@ -220,6 +220,7 @@ async def test_websocket_closed_on_unload(
 )
 async def test_gateway_version_issue(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_cloud_client: MagicMock,
     version: str,
@@ -232,7 +233,6 @@ async def test_gateway_version_issue(
 
     await async_init_integration(hass, mock_config_entry)
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, "unsupported_gateway_firmware")
     assert (issue is not None) == issue_exists
 


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 4 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/imou/test_camera.py`
- `tests/components/imou/test_init.py`
- `tests/components/imou/test_switch.py`
- `tests/components/integration/test_init.py`
- `tests/components/intent/test_temperature.py`
- `tests/components/iss/test_sensor.py`
- `tests/components/knx/test_repairs.py`
- `tests/components/knx/test_telegrams.py`
- `tests/components/kulersky/test_init.py`
- `tests/components/lamarzocco/test_init.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
