### PR TITLE
Use registry fixtures in tests (5/8)

### DIFF
--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -183,11 +183,11 @@ async def test_service_call_create_log_book_entry_no_message(
 
 
 async def test_filter_sensor(
-    hass_: HomeAssistant, hass_client: ClientSessionGenerator
+    hass_: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test numeric sensors are filtered."""
-
-    registry = er.async_get(hass_)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Unregistered sensor without a unit of measurement - should be in logbook
     entity_id1 = "sensor.bla"
@@ -196,7 +196,7 @@ async def test_filter_sensor(
     entity_id2 = "sensor.blu"
     attributes_2 = {ATTR_UNIT_OF_MEASUREMENT: "cats"}
     # Registered sensor with state class - should be excluded from logbook
-    entity_id3 = registry.async_get_or_create(
+    entity_id3 = entity_registry.async_get_or_create(
         "sensor",
         "test",
         "unique_3",
@@ -205,7 +205,7 @@ async def test_filter_sensor(
     ).entity_id
     attributes_3 = None
     # Registered sensor without state class or unit - should be in logbook
-    entity_id4 = registry.async_get_or_create(
+    entity_id4 = entity_registry.async_get_or_create(
         "sensor", "test", "unique_4", suggested_object_id="ble"
     ).entity_id
     attributes_4 = None
@@ -3196,6 +3196,7 @@ async def test_logbook_user_id_from_parent_context_state_changes_only(
 
 async def test_context_user_ids_lru_eviction(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that the parent context user-id cache is bounded by LRU eviction.
 
@@ -3225,13 +3226,12 @@ async def test_context_user_ids_lru_eviction(
         for_live_stream=True,
     )
     context_augmenter = logbook.processor.ContextAugmenter(logbook_run)
-    ent_reg = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     processor = logbook.processor.EventProcessor.__new__(
         logbook.processor.EventProcessor
     )
     processor.hass = hass
-    processor.ent_reg = ent_reg
+    processor.ent_reg = entity_registry
     processor.logbook_run = logbook_run
     processor.context_augmenter = context_augmenter
 
@@ -3303,6 +3303,7 @@ async def test_context_user_ids_lru_eviction(
 
 async def test_parent_user_attribution_does_not_use_origin_event_fallback(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that parent context lookup doesn't fall back to origin_event.
 
@@ -3353,13 +3354,11 @@ async def test_parent_user_attribution_does_not_use_origin_event_fallback(
         memoize_new_contexts=False,
     )
     context_augmenter = logbook.processor.ContextAugmenter(logbook_run)
-    ent_reg = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     processor = logbook.processor.EventProcessor.__new__(
         logbook.processor.EventProcessor
     )
     processor.hass = hass
-    processor.ent_reg = ent_reg
+    processor.ent_reg = entity_registry
     processor.logbook_run = logbook_run
     processor.context_augmenter = context_augmenter
 

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -363,7 +363,9 @@ async def test_lovelace_from_yaml(
 
 
 async def test_lovelace_from_yaml_creates_repair_issue(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test YAML mode creates a repair issue."""
     assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "YAML"}})
@@ -372,7 +374,6 @@ async def test_lovelace_from_yaml_creates_repair_issue(
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
 
     # Repair issue should be created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue("lovelace", "yaml_mode_deprecated")
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -16,7 +16,10 @@ from tests.common import MockConfigEntry
 
 
 async def test_setup_entry(
-    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setting up the integration."""
     mock_config_entry.add_to_hass(hass)
@@ -29,7 +32,6 @@ async def test_setup_entry(
 
     # Verify that the unique ID is generated correctly.
     # This prevents regression in unique ID generation which would be a breaking change.
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     # The light from mock_lutron has uuid="light_uuid" and guid="12345678901"
     expected_unique_id = "12345678901_light_uuid"
     entry = entity_registry.async_get("light.test_area_test_light")
@@ -68,7 +70,11 @@ async def test_setup_entry_not_ready(
 
 
 async def test_unique_id_migration(
-    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test migration of legacy unique IDs to the newer UUID-based format.
 
@@ -81,9 +87,6 @@ async def test_unique_id_migration(
 
     # Setup registries with an entry using the "legacy" unique ID format.
     # This simulates a user who had configured the integration in an older version.
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     legacy_unique_id = "12345678901_light_legacy_uuid"
     new_unique_id = "12345678901_light_uuid"
 

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -480,6 +480,7 @@ async def test_vacuum_clean_area_select_areas_failure(
 async def test_vacuum_no_issue_on_transient_empty_segments(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
@@ -506,8 +507,7 @@ async def test_vacuum_no_issue_on_transient_empty_segments(
     set_node_attribute(matter_node, 1, 336, 0, [])
     await trigger_subscription_callback(hass, matter_client)
 
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    issue = issue_reg.async_get_issue(
+    issue = issue_registry.async_get_issue(
         VACUUM_DOMAIN, f"segments_changed_{entity_entry.id}"
     )
     assert issue is None
@@ -517,6 +517,7 @@ async def test_vacuum_no_issue_on_transient_empty_segments(
 async def test_vacuum_raise_segments_changed_issue(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
@@ -542,8 +543,7 @@ async def test_vacuum_raise_segments_changed_issue(
     set_node_attribute(matter_node, 1, 97, 4, 0x02)
     await trigger_subscription_callback(hass, matter_client)
 
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    issue = issue_reg.async_get_issue(
+    issue = issue_registry.async_get_issue(
         VACUUM_DOMAIN, f"segments_changed_{entity_entry.id}"
     )
     assert issue is not None

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2600,6 +2600,7 @@ async def test_mqtt_protocol_successful_migration_to_v5(
 )
 async def test_mqtt_protocol_failed_migration_to_v5(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
     current_protocol: str,
@@ -2613,7 +2614,6 @@ async def test_mqtt_protocol_failed_migration_to_v5(
     assert len(events) == 1
     assert events[0].data["issue_id"] == "protocol_5_migration"
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 1
     issue = issue_registry.async_get_issue(DOMAIN, "protocol_5_migration")
     assert issue is not None

--- a/tests/components/mqtt/test_repairs.py
+++ b/tests/components/mqtt/test_repairs.py
@@ -69,6 +69,7 @@ async def test_subentry_reconfigure_export_settings(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     device_registry: dr.DeviceRegistry,
+    issue_registry: ir.IssueRegistry,
     hass_client: ClientSessionGenerator,
     flow_step: str,
     setup_helper: Coroutine[Any, Any, None],
@@ -144,7 +145,6 @@ async def test_subentry_reconfigure_export_settings(
     # The subentry ID is used as device identifier
     assert len(events) == 1
     issue_id = events[0].data["issue_id"]
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     repair_issue = issue_registry.async_get_issue(DOMAIN, issue_id)
     assert repair_issue.translation_key == translation_key
 

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -330,6 +330,7 @@ async def test_command_without_command_topic(
 @pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
 async def test_clean_segments_initial_setup_without_repair_issue(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test setup does not fire repair after segments are received."""
@@ -355,7 +356,6 @@ async def test_clean_segments_initial_setup_without_repair_issue(
         state.attributes.get(ATTR_SUPPORTED_FEATURES)
         & vacuum.VacuumEntityFeature.CLEAN_AREA
     )
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 0
 
 
@@ -364,6 +364,7 @@ async def test_clean_segments_command(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test cleaning segments and repair flow."""
@@ -405,7 +406,6 @@ async def test_clean_segments_command(
         & vacuum.VacuumEntityFeature.CLEAN_AREA
     )
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     # We do not expect a repair flow as the segments did not change
     assert len(issue_registry.issues) == 0
 

--- a/tests/components/music_assistant/test_init.py
+++ b/tests/components/music_assistant/test_init.py
@@ -165,6 +165,7 @@ async def test_player_config_expose_to_ha_toggle(
 
 async def test_authentication_required_triggers_reauth(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     music_assistant_client: MagicMock,
 ) -> None:
     """Test that AuthenticationRequired exception triggers reauth flow."""
@@ -185,13 +186,13 @@ async def test_authentication_required_triggers_reauth(
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue_id = f"config_entry_reauth_{DOMAIN}_{config_entry.entry_id}"
-    assert issue_reg.async_get_issue("homeassistant", issue_id)
+    assert issue_registry.async_get_issue("homeassistant", issue_id)
 
 
 async def test_authentication_required_addon_no_reauth(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     music_assistant_client: MagicMock,
 ) -> None:
     """Test that AuthenticationRequired exception does not trigger reauth for addon."""
@@ -214,6 +215,5 @@ async def test_authentication_required_addon_no_reauth(
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
-    issue_reg = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue_id = f"config_entry_reauth_{DOMAIN}_{config_entry.entry_id}"
-    assert issue_reg.async_get_issue("homeassistant", issue_id) is None
+    assert issue_registry.async_get_issue("homeassistant", issue_id) is None

--- a/tests/components/niko_home_control/test_scene.py
+++ b/tests/components/niko_home_control/test_scene.py
@@ -54,6 +54,7 @@ async def test_activate_scene(
 
 async def test_updating(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_niko_home_control_connection: AsyncMock,
     mock_config_entry: MockConfigEntry,
     scene: AsyncMock,
@@ -63,7 +64,7 @@ async def test_updating(
 
     # Resolve the created scene entity dynamically
     entity_entries = er.async_entries_for_config_entry(
-        er.async_get(hass),  # pylint: disable=home-assistant-tests-registry-fixtures
+        entity_registry,
         mock_config_entry.entry_id,
     )
     scene_entities = [e for e in entity_entries if e.domain == SCENE_DOMAIN]

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -104,9 +104,6 @@ async def test_remove_device_valid(
         list_commands_return_value=[],
     )
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    assert device_registry is not None
-
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, mock_serial_number), config_entry.entry_id
     )
@@ -136,9 +133,6 @@ async def test_remove_device_stale(
         list_ups={"ups1": "UPS 1"},
         list_commands_return_value=[],
     )
-
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    assert device_registry is not None
 
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 5 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/logbook/test_init.py`
- `tests/components/lovelace/test_dashboard.py`
- `tests/components/lutron/test_init.py`
- `tests/components/matter/test_vacuum.py`
- `tests/components/mqtt/test_init.py`
- `tests/components/mqtt/test_repairs.py`
- `tests/components/mqtt/test_vacuum.py`
- `tests/components/music_assistant/test_init.py`
- `tests/components/niko_home_control/test_scene.py`
- `tests/components/nut/test_init.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
