### PR TITLE
Use registry fixtures in tests (6/8)

### DIFF
--- a/tests/components/onedrive/test_init.py
+++ b/tests/components/onedrive/test_init.py
@@ -261,6 +261,7 @@ async def test_device(
 )
 async def test_data_cap_issues(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_onedrive_client: MagicMock,
     mock_drive: Drive,
@@ -274,7 +275,6 @@ async def test_data_cap_issues(
 
     await setup_integration(hass, mock_config_entry)
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, issue_key)
     assert (issue is not None) == issue_exists
 

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -28,12 +28,12 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_migrate_camera_entities_unique_ids(hass: HomeAssistant) -> None:
+async def test_migrate_camera_entities_unique_ids(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that camera entities unique ids get migrated properly."""
     config_entry = MockConfigEntry(domain=DOMAIN, unique_id=MAC)
     config_entry.add_to_hass(hass)
-
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     entity_with_only_mac = entity_registry.async_get_or_create(
         domain="camera",

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -40,6 +40,7 @@ async def test_entry_setup_unload(
 @pytest.mark.usefixtures("mock_openrgb_client")
 async def test_remove_config_entry_device_server(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that server device cannot be removed."""
@@ -48,7 +49,6 @@ async def test_remove_config_entry_device_server(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     server_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
@@ -66,6 +66,7 @@ async def test_remove_config_entry_device_server(
 @pytest.mark.usefixtures("mock_openrgb_client")
 async def test_remove_config_entry_device_still_connected(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that connected devices cannot be removed."""
@@ -73,8 +74,6 @@ async def test_remove_config_entry_device_still_connected(
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Get a device that's in coordinator.data (still connected)
     devices = dr.async_entries_for_config_entry(

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -182,6 +182,7 @@ async def test_coordinator_subsequent_run_no_energy_data(
 async def test_coordinator_migration(
     recorder_mock: Recorder,
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_opower_api: AsyncMock,
     snapshot: SnapshotAssertion,
@@ -238,7 +239,6 @@ async def test_coordinator_migration(
     assert stats == snapshot
 
     # Check that an issue was created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, "return_to_grid_migration_111111")
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
@@ -370,6 +370,7 @@ async def test_coordinator_updates_with_finer_grained_data(
 async def test_coordinator_migration_empty_source_stats(
     recorder_mock: Recorder,
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_config_entry: MockConfigEntry,
     mock_opower_api: AsyncMock,
 ) -> None:
@@ -412,7 +413,6 @@ async def test_coordinator_migration_empty_source_stats(
     # no individual stats were found
     assert migrated is False
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(DOMAIN, "return_to_grid_migration_111111")
     assert issue is None
 

--- a/tests/components/opower/test_sensor.py
+++ b/tests/components/opower/test_sensor.py
@@ -19,6 +19,7 @@ from tests.common import MockConfigEntry
 async def test_sensors(
     recorder_mock: Recorder,
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_opower_api: AsyncMock,
 ) -> None:
@@ -38,8 +39,6 @@ async def test_sensors(
         mock_utcnow.return_value = datetime(2023, 1, 2, 8, 0, 0, tzinfo=dt_util.UTC)
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Check electric sensors
     entry = entity_registry.async_get(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -181,9 +181,6 @@ async def test_migration_v1_to_v3(
     entry.add_to_hass(hass)
     assert entry.version == 1
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-
     vm_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, f"{entry.entry_id}_vm_100")},

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -468,6 +468,7 @@ async def test_update_unavailability_threshold(
 
 async def test_cloud_api_repair(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_roborock_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
 ) -> None:
@@ -480,7 +481,6 @@ async def test_cloud_api_repair(
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     await hass.async_block_till_done()
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 1
     # Check that both expected device names are present, regardless of order
     assert all(
@@ -507,6 +507,7 @@ async def test_cloud_api_repair(
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_cloud_api_repair_cleared_on_update(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     mock_roborock_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
     freezer: FrozenDateTimeFactory,
@@ -523,7 +524,6 @@ async def test_cloud_api_repair_cleared_on_update(
     await hass.async_block_till_done()
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 1
 
     # Fake that the device is reachable locally again.
@@ -541,7 +541,6 @@ async def test_cloud_api_repair_cleared_on_update(
     await hass.async_block_till_done()
 
     # Verify that the repair issue is cleared
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 0
 
     # Fake the device is cloud only again. Refreshing the coordinator
@@ -557,7 +556,6 @@ async def test_cloud_api_repair_cleared_on_update(
     await hass.async_block_till_done()
 
     # Verify that the repair issue still does not exist
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) == 0
 
 

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -625,6 +625,7 @@ async def test_segments_changed_issue(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     fake_vacuum: FakeDevice,
 ) -> None:
     """Test repair issue created when segments change after mapping."""
@@ -647,7 +648,7 @@ async def test_segments_changed_issue(
     await hass.async_block_till_done()
 
     issue_id = f"segments_changed_{entity_entry.id}"
-    issue = ir.async_get(hass).async_get_issue(VACUUM_DOMAIN, issue_id)  # pylint: disable=home-assistant-tests-registry-fixtures
+    issue = issue_registry.async_get_issue(VACUUM_DOMAIN, issue_id)
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
     assert issue.translation_key == "segments_changed"
@@ -657,6 +658,7 @@ async def test_segments_changed_issue_no_map_info(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     fake_vacuum: FakeDevice,
 ) -> None:
     """Test no repair issue is created when map info is not loaded/empty."""
@@ -680,7 +682,7 @@ async def test_segments_changed_issue_no_map_info(
     await hass.async_block_till_done()
 
     issue_id = f"segments_changed_{entity_entry.id}"
-    issue = ir.async_get(hass).async_get_issue(VACUUM_DOMAIN, issue_id)  # pylint: disable=home-assistant-tests-registry-fixtures
+    issue = issue_registry.async_get_issue(VACUUM_DOMAIN, issue_id)
     assert issue is None
 
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -6754,11 +6754,12 @@ async def test_exclude_attributes(hass: HomeAssistant) -> None:
     ],
 )
 async def test_clean_up_repairs(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test cleaning up repairs."""
     await async_setup_component(hass, DOMAIN, {})
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     client = await hass_ws_client()
 
     # Create some issues


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 6 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/onedrive/test_init.py`
- `tests/components/onvif/test_init.py`
- `tests/components/openrgb/test_init.py`
- `tests/components/opower/test_coordinator.py`
- `tests/components/opower/test_sensor.py`
- `tests/components/proxmoxve/test_init.py`
- `tests/components/roborock/test_init.py`
- `tests/components/roborock/test_vacuum.py`
- `tests/components/sensor/test_recorder.py`

Note: `tests/components/overkiz/test_init.py` was intentionally left with its suppression, since that test replaces the entity registry via `mock_registry(...)` after test setup, so the fixture cannot be used there.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
