### PR TITLE
Use registry fixtures in tests (7/8)

### DIFF
--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -98,7 +98,10 @@ async def test_not_configuring_sonos_not_creates_entry(hass: HomeAssistant) -> N
 
 
 async def test_upnp_disabled_discovery(
-    hass: HomeAssistant, config_entry: MockConfigEntry, soco: MockSoCo
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    config_entry: MockConfigEntry,
+    soco: MockSoCo,
 ) -> None:
     """Test issue creation when discovery processing fails with 403."""
 
@@ -116,7 +119,6 @@ async def test_upnp_disabled_discovery(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
         issue_registry.async_get_issue(
             sonos.DOMAIN, f"{UPNP_ISSUE_ID}_{soco.ip_address}"
@@ -127,6 +129,7 @@ async def test_upnp_disabled_discovery(
 
 async def test_upnp_disabled_manual_hosts(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     soco_factory: SoCoMockFactory,
 ) -> None:
     """Test issue creation when manual host processing fails with 403."""
@@ -145,7 +148,6 @@ async def test_upnp_disabled_manual_hosts(
     ):
         await _setup_hass(hass)
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issue = issue_registry.async_get_issue(
         sonos.DOMAIN, f"{UPNP_ISSUE_ID}_{soco.ip_address}"
     )

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -312,7 +312,9 @@ async def test_event_listener_error_handling(
 
 
 async def test_yaml_filter_only_no_deprecation_issue(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    mock_hass_splunk: AsyncMock,
 ) -> None:
     """Test YAML with only filter does not create deprecation issue."""
     assert await async_setup_component(
@@ -334,7 +336,6 @@ async def test_yaml_filter_only_no_deprecation_issue(
     assert len(entries) == 0
 
     # Verify no deprecation issue was created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     issues = issue_registry.issues
     assert not any(
         issue_id[0] == DOMAIN and "deprecated" in issue_id[1] for issue_id in issues
@@ -347,7 +348,9 @@ async def test_yaml_filter_only_no_deprecation_issue(
 
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_yaml_with_connection_creates_deprecation_issue(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    mock_hass_splunk: AsyncMock,
 ) -> None:
     """Test YAML with connection settings creates deprecation issue."""
     assert await async_setup_component(
@@ -370,12 +373,13 @@ async def test_yaml_with_connection_creates_deprecation_issue(
     assert entries[0].source == SOURCE_IMPORT
 
     # Verify deprecation issue was created in homeassistant domain
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}") in issue_registry.issues
 
 
 async def test_yaml_import_error_creates_specific_issue(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    mock_hass_splunk: AsyncMock,
 ) -> None:
     """Test YAML import with connection error creates specific issue."""
     # Config flow client fails connectivity check
@@ -400,7 +404,6 @@ async def test_yaml_import_error_creates_specific_issue(
     assert len(entries) == 0
 
     # Verify error-specific issue was created
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (
         DOMAIN,
         "deprecated_yaml_import_issue_cannot_connect",
@@ -409,7 +412,10 @@ async def test_yaml_import_error_creates_specific_issue(
 
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_yaml_import_already_configured_creates_deprecation_issue(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test YAML import when already configured still creates deprecation issue."""
     # Add existing config entry before YAML import
@@ -432,5 +438,4 @@ async def test_yaml_import_already_configured_creates_deprecation_issue(
     await hass.async_block_till_done()
 
     # Verify deprecation issue was still created (single_instance_allowed is ok)
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert (HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}") in issue_registry.issues

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -496,12 +496,14 @@ async def test_dhcp_unknown_player(
 
 
 async def test_dhcp_known_player(
-    hass: HomeAssistant, dhcp_info: dict[str, Any], mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    dhcp_info: dict[str, Any],
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test DHCP discovery aborts if player is already registered."""
     mock_config_entry.add_to_hass(hass)
 
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entity_registry.async_get_or_create(
         MP_DOMAIN, DOMAIN, "aa:bb:cc:dd:ee:ff", config_entry=mock_config_entry
     )

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -60,7 +60,9 @@ async def test_setup_g3(hass: HomeAssistant, subaru_config_entry) -> None:
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_g4(hass: HomeAssistant, subaru_config_entry) -> None:
+async def test_setup_g4(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, subaru_config_entry
+) -> None:
     """Test setup with a G4 vehicle (2026+ models report api_gen "g4")."""
     await setup_subaru_config_entry(
         hass,
@@ -74,7 +76,6 @@ async def test_setup_g4(hass: HomeAssistant, subaru_config_entry) -> None:
     assert check_entry.state is ConfigEntryState.LOADED
     # Gen4 must receive both Gen2+ and Gen3+ sensor sets; without this, only
     # the odometer was created on 2026 model year vehicles.
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert entity_registry.async_get_entity_id(
         "sensor", DOMAIN, f"{TEST_VIN_4_G4}_AVG_FUEL_CONSUMPTION"
     )

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -396,11 +396,11 @@ async def test_uptime_sensor(
 
 async def test_hub_device_info_mac_connections(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     setup_dsm_with_usb: MagicMock,
 ) -> None:
     """Test that the hub DeviceInfo includes MAC address connections."""
-    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device = dev_reg.async_get_device_by_identifier(
+    device = device_registry.async_get_device_by_identifier(
         (DOMAIN, SERIAL), setup_dsm_with_usb.mock_entry.entry_id
     )
     assert device is not None
@@ -412,21 +412,23 @@ async def test_hub_device_info_mac_connections(
 
 async def test_storage_device_via_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     setup_dsm_with_usb: MagicMock,
 ) -> None:
     """Test that storage/USB child devices link to the hub via via_device_id."""
-    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entry_id = setup_dsm_with_usb.mock_entry.entry_id
-    hub_device = dev_reg.async_get_device_by_identifier((DOMAIN, SERIAL), entry_id)
+    hub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), entry_id
+    )
     assert hub_device is not None
 
-    volume_device = dev_reg.async_get_device_by_identifier(
+    volume_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, f"{SERIAL}_volume_1"), entry_id
     )
     assert volume_device is not None
     assert volume_device.via_device_id == hub_device.id
 
-    usb_partition_device = dev_reg.async_get_device_by_identifier(
+    usb_partition_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, f"{SERIAL}_USB Disk 1 Partition 1"), entry_id
     )
     assert usb_partition_device is not None

--- a/tests/components/tag/test_event.py
+++ b/tests/components/tag/test_event.py
@@ -20,6 +20,7 @@ from tests.typing import WebSocketGenerator
 @pytest.fixture
 def storage_setup_named_tag(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     hass_storage: dict[str, Any],
 ):
     """Storage setup for test case of named tags."""
@@ -41,7 +42,6 @@ def storage_setup_named_tag(
             }
         else:
             hass_storage[DOMAIN] = items
-        entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
         entry = entity_registry.async_get_or_create(DOMAIN, DOMAIN, TEST_TAG_ID)
         entity_registry.async_update_entity(entry.entity_id, name=TEST_TAG_NAME)
         config = {DOMAIN: {}}

--- a/tests/components/tag/test_init.py
+++ b/tests/components/tag/test_init.py
@@ -22,7 +22,11 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-def storage_setup(hass: HomeAssistant, hass_storage: dict[str, Any]):
+def storage_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
+):
     """Storage setup."""
 
     async def _storage(items=None):
@@ -44,7 +48,6 @@ def storage_setup(hass: HomeAssistant, hass_storage: dict[str, Any]):
             }
         else:
             hass_storage[DOMAIN] = items
-        entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
         _create_entry(entity_registry, TEST_TAG_ID, TEST_TAG_NAME)
         _create_entry(entity_registry, TEST_TAG_ID_2, TEST_TAG_NAME_2)
         config = {DOMAIN: {}}

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -1141,7 +1141,9 @@ async def test_invalid_segments(
 )
 @pytest.mark.usefixtures("setup_vacuum")
 async def test_raise_segments_changed_issue(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test that issue is raised on segments change."""
     hass.states.async_set(TEST_ATTRIBUTE_ENTITY_ID, "Bedroom")
@@ -1160,7 +1162,6 @@ async def test_raise_segments_changed_issue(
     hass.states.async_set(TEST_ATTRIBUTE_ENTITY_ID, "Bathroom")
     await hass.async_block_till_done()
 
-    issue_registry = ir.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert len(issue_registry.issues) != 0
 
 

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -146,11 +146,13 @@ async def test_setup_and_remove_config_entry(
 
 
 @pytest.mark.parametrize("platform", ["sensor"])
-async def test_entry_changed(hass: HomeAssistant, platform) -> None:
+async def test_entry_changed(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    platform,
+) -> None:
     """Test reconfiguring."""
-
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     def _create_mock_entity(domain: str, name: str) -> er.RegistryEntry:
         config_entry = MockConfigEntry(


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 7 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/sonos/test_init.py`
- `tests/components/splunk/test_init.py`
- `tests/components/squeezebox/test_config_flow.py`
- `tests/components/subaru/test_init.py`
- `tests/components/synology_dsm/test_sensor.py`
- `tests/components/tag/test_event.py`
- `tests/components/tag/test_init.py`
- `tests/components/template/test_vacuum.py`
- `tests/components/threshold/test_init.py`

Note: `tests/components/sleepiq/test_init.py` was intentionally left with its suppression, since that test replaces the entity registry via `mock_registry(...)` after test setup, so the fixture cannot be used there.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
