### PR TITLE
Use registry fixtures in tests (8/8)

### DIFF
--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -634,13 +634,13 @@ async def test_time_remaining_trigger_entity_removed_from_target(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
 ) -> None:
     """Test trigger cancels scheduled fire when entity is removed from the target."""
     now = dt_util.utcnow()
     calls: list[dict[str, Any]] = []
 
-    label_reg = lr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    label = label_reg.async_create("Test Time Remaining")
+    label = label_registry.async_create("Test Time Remaining")
 
     entry = entity_registry.async_get_or_create(
         domain=DOMAIN, platform="test", unique_id="time_remaining_remove"
@@ -683,13 +683,13 @@ async def test_time_remaining_trigger_entity_added_to_target(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
 ) -> None:
     """Test trigger schedules a fire for an active timer added to the target later."""
     now = dt_util.utcnow()
     calls: list[dict[str, Any]] = []
 
-    label_reg = lr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    label = label_reg.async_create("Test Time Remaining Add")
+    label = label_registry.async_create("Test Time Remaining Add")
 
     entry = entity_registry.async_get_or_create(
         domain=DOMAIN, platform="test", unique_id="time_remaining_add"

--- a/tests/components/traccar/test_device_tracker.py
+++ b/tests/components/traccar/test_device_tracker.py
@@ -29,13 +29,15 @@ def mock_dev_track(mock_device_tracker_conf: list[Device]) -> None:
     """Mock device tracker config loading."""
 
 
-async def test_restore_state(hass: HomeAssistant) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test that the previous location is restored for a known device."""
     assert await async_setup_component(hass, DEVICE_TRACKER_DOMAIN, {})
 
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_WEBHOOK_ID: "webhook_id"})
     entry.add_to_hass(hass)
-    dr.async_get(hass).async_get_or_create(  # pylint: disable=home-assistant-tests-registry-fixtures
+    device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, DEVICE_ID)},
     )

--- a/tests/components/tuya/test_services.py
+++ b/tests/components/tuya/test_services.py
@@ -195,6 +195,7 @@ async def test_get_tuya_device_error_device_not_found(
 @pytest.mark.parametrize("mock_device_code", ["cwwsq_wfkzyy0evslzsmoi"])
 async def test_get_tuya_device_error_non_tuya_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
@@ -202,7 +203,6 @@ async def test_get_tuya_device_error_non_tuya_device(
     """Test service error when target device is not a Tuya device."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     non_tuya_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("other_domain", "some_id")},
@@ -224,6 +224,7 @@ async def test_get_tuya_device_error_non_tuya_device(
 @pytest.mark.parametrize("mock_device_code", ["cwwsq_wfkzyy0evslzsmoi"])
 async def test_get_tuya_device_error_unknown_tuya_device(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
@@ -231,7 +232,6 @@ async def test_get_tuya_device_error_unknown_tuya_device(
     """Test service error when Tuya identifier is not present in manager map."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     tuya_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={(DOMAIN, "unknown_tuya_id")},

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -981,6 +981,7 @@ async def test_binary_sensor_doorbell_ring(
 
 async def test_aiport_no_binary_sensor_entities(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     ufp: MockUFPFixture,
     aiport: AiPort,
 ) -> None:
@@ -990,7 +991,6 @@ async def test_aiport_no_binary_sensor_entities(
     # AI Port should not create any camera-specific binary sensors
     # (motion, smart detection, etc.)
     # NVR HDD sensors will still be created, but no AI Port-specific entities
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     entities = er.async_entries_for_config_entry(entity_registry, ufp.entry.entry_id)
 
     for entity in entities:

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -132,6 +132,7 @@ async def test_doorbell_setup(
 
 async def test_first_active_quality_is_default(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     ufp: MockUFPFixture,
     camera_all: ProtectCamera,
     issue_registry: ir.IssueRegistry,
@@ -152,7 +153,6 @@ async def test_first_active_quality_is_default(
         == camera_all.channels[1].rtsps_no_srtp_url
     )
 
-    entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     assert entity_registry.async_get(_channel_entity_id(camera_all, 0)) is None
     assert entity_registry.async_get(_channel_entity_id(camera_all, 2)) is None
     assert (
@@ -408,7 +408,10 @@ async def test_aiport_no_camera_entities(
 
 
 async def test_public_only_camera(
-    hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    ufp: MockUFPFixture,
+    camera: ProtectCamera,
 ) -> None:
     """A public-only camera builds a working entity with degraded diagnostics."""
     # This camera is intentionally kept out of the private bootstrap; wire the
@@ -439,7 +442,6 @@ async def test_public_only_camera(
 
     # device identity degrades to name-only, but the NVR link still resolves
     # from the public bootstrap
-    device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
     device = device_registry.async_get_device_by_connection(
         (dr.CONNECTION_NETWORK_MAC, public.mac), ufp.entry.entry_id
     )

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -136,19 +136,20 @@ async def test_with_service_calls(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("recorder_mock")
-async def test_multiple_entities_in_one_call(hass: HomeAssistant) -> None:
+async def test_multiple_entities_in_one_call(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test handling of service calls with multiple entity IDs."""
     user_id = str(uuid.uuid4())
 
-    ent_reg = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         "light",
         "test",
         "living_room",
         suggested_object_id="living_room",
         hidden_by=er.RegistryEntryHider.USER,
     )
-    ent_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         "light",
         "test",
         "kitchen",

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -496,7 +496,9 @@ async def test_last_seen_segments(
 
 @pytest.mark.usefixtures("config_flow_fixture")
 async def test_segments_changed_issue(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test segments changed issue."""
     mock_vacuum = MockVacuumWithCleanArea(name="Testing", entity_id="vacuum.testing")
@@ -531,7 +533,7 @@ async def test_segments_changed_issue(
     mock_vacuum.async_create_segments_issue()
 
     issue_id = f"segments_changed_{entity_entry.id}"
-    issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)  # pylint: disable=home-assistant-tests-registry-fixtures
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
     assert issue.translation_key == "segments_changed"
@@ -549,4 +551,4 @@ async def test_segments_changed_issue(
     )
     await hass.async_block_till_done()
 
-    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None  # pylint: disable=home-assistant-tests-registry-fixtures
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None

--- a/tests/components/vacuum/test_intent.py
+++ b/tests/components/vacuum/test_intent.py
@@ -121,12 +121,11 @@ async def test_return_to_base_without_name(hass: HomeAssistant) -> None:
     assert call.data == {"entity_id": entity_id}
 
 
-async def test_clean_area(hass: HomeAssistant) -> None:
+async def test_clean_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) -> None:
     """Test HassVacuumCleanArea intent."""
     await vacuum_intent.async_setup_intents(hass)
 
-    area_reg = ar.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    kitchen = area_reg.async_create("Kitchen")
+    kitchen = area_registry.async_create("Kitchen")
 
     vacuum_1 = f"{DOMAIN}.vacuum_1"
     vacuum_2 = f"{DOMAIN}.vacuum_2"
@@ -179,12 +178,13 @@ async def test_clean_area(hass: HomeAssistant) -> None:
     }
 
 
-async def test_clean_area_no_matching_vacuum(hass: HomeAssistant) -> None:
+async def test_clean_area_no_matching_vacuum(
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
+) -> None:
     """Test HassVacuumCleanArea intent with no matching vacuum."""
     await vacuum_intent.async_setup_intents(hass)
 
-    area_reg = ar.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    area_reg.async_create("Kitchen")
+    area_registry.async_create("Kitchen")
 
     # No vacuums at all
     with pytest.raises(intent.MatchFailedError) as err:
@@ -234,12 +234,13 @@ async def test_clean_area_invalid_area(hass: HomeAssistant) -> None:
     assert err.value.result.no_match_name == "Nonexistent room"
 
 
-async def test_clean_area_service_failure(hass: HomeAssistant) -> None:
+async def test_clean_area_service_failure(
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
+) -> None:
     """Test HassVacuumCleanArea intent when the service call fails."""
     await vacuum_intent.async_setup_intents(hass)
 
-    area_reg = ar.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    area_reg.async_create("Kitchen")
+    area_registry.async_create("Kitchen")
 
     entity_id = f"{DOMAIN}.test_vacuum"
     hass.states.async_set(
@@ -248,7 +249,7 @@ async def test_clean_area_service_failure(hass: HomeAssistant) -> None:
         {ATTR_SUPPORTED_FEATURES: VacuumEntityFeature.CLEAN_AREA},
     )
 
-    kitchen = area_reg.async_get_area_by_name("Kitchen")
+    kitchen = area_registry.async_get_area_by_name("Kitchen")
     assert kitchen is not None
 
     with (

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -154,7 +154,9 @@ async def test_migrate_entry_token_failure(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_migrate_entry_creates_repair_issue(hass: HomeAssistant) -> None:
+async def test_migrate_entry_creates_repair_issue(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test migration creates a repair issue for redirect URI update."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -181,7 +183,7 @@ async def test_migrate_entry_creates_repair_issue(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    issue = ir.async_get(hass).async_get_issue(DOMAIN, "update_redirect_uri")  # pylint: disable=home-assistant-tests-registry-fixtures
+    issue = issue_registry.async_get_issue(DOMAIN, "update_redirect_uri")
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
 

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -51,6 +51,7 @@ def _empty_wav(framerate=16000) -> bytes:
 
 async def test_is_valid_call(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
     call_info: CallInfo,
@@ -60,8 +61,7 @@ async def test_is_valid_call(
     protocol = HassVoipDatagramProtocol(hass, voip_devices)
     assert not protocol.is_valid_call(call_info)
 
-    ent_reg = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    allowed_call_entity_id = ent_reg.async_get_entity_id(
+    allowed_call_entity_id = entity_registry.async_get_entity_id(
         "switch", voip.DOMAIN, f"{voip_device.voip_id}-allow_call"
     )
     assert allowed_call_entity_id is not None

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -92,6 +92,7 @@ def _get_platform_entity(
 
 async def test_dynamic_entity_lifecycle(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
@@ -132,11 +133,10 @@ async def test_dynamic_entity_lifecycle(
         ),
     )
     await hass.async_block_till_done()
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    assert registry.async_get(entity_id) is None
+    assert entity_registry.async_get(entity_id) is None
     assert hass.states.get(entity_id) is None
     # The binary_sensor with the same unique_id is untouched.
-    assert registry.async_get(binary_sensor_id) is not None
+    assert entity_registry.async_get(binary_sensor_id) is not None
     assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
     ha_zha_data = get_zha_data(hass)
@@ -170,7 +170,7 @@ async def test_dynamic_entity_lifecycle(
     assert len(matching_refs) == 1
 
     # Soft remove: registry entry is kept, state goes unavailable.
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry is not None
     zha_device_proxy.device.emit(
         DeviceEntityRemovedEvent.event_type,
@@ -181,7 +181,7 @@ async def test_dynamic_entity_lifecycle(
         ),
     )
     await hass.async_block_till_done()
-    assert registry.async_get(entity_id) is not None
+    assert entity_registry.async_get(entity_id) is not None
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
@@ -191,6 +191,7 @@ async def test_dynamic_entity_lifecycle(
 
 async def test_unknown_unique_id_is_noop(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
@@ -201,7 +202,6 @@ async def test_unknown_unique_id_is_noop(
     assert entity_id is not None
 
     ha_zha_data = get_zha_data(hass)
-    registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
 
     # Added: nothing queued, no dispatcher signal fired.
     with patch(
@@ -231,12 +231,13 @@ async def test_unknown_unique_id_is_noop(
         )
         await hass.async_block_till_done()
 
-        assert registry.async_get(entity_id) is not None
+        assert entity_registry.async_get(entity_id) is not None
         assert hass.states.get(entity_id) is not None
 
 
 async def test_remove_entity_reference_when_ieee_already_cleared(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
@@ -255,7 +256,7 @@ async def test_remove_entity_reference_when_ieee_already_cleared(
     ieee = zha_device_proxy.device.ieee
     gateway_proxy._ha_entity_refs.pop(ieee, None)
 
-    er.async_get(hass).async_remove(entity_id)  # pylint: disable=home-assistant-tests-registry-fixtures
+    entity_registry.async_remove(entity_id)
     await hass.async_block_till_done()
 
     assert ieee not in gateway_proxy._ha_entity_refs


### PR DESCRIPTION
## Proposed change

A while back a pylint checker (`home-assistant-tests-registry-fixtures`) was added to enforce that tests use the standard registry fixtures defined in `tests/conftest.py` (`area_registry`, `category_registry`, `device_registry`, `entity_registry`, `floor_registry`, `issue_registry`, `label_registry`) instead of calling `<registry>.async_get(hass)` directly.

A number of existing occurrences were suppressed with inline `# pylint: disable=home-assistant-tests-registry-fixtures` comments. This is batch 8 of a series that fixes these occurrences, removing the suppressions and switching to the appropriate registry fixture.

Files in this batch:
- `tests/components/timer/test_trigger.py`
- `tests/components/traccar/test_device_tracker.py`
- `tests/components/tuya/test_services.py`
- `tests/components/unifiprotect/test_binary_sensor.py`
- `tests/components/unifiprotect/test_camera.py`
- `tests/components/usage_prediction/test_common_control.py`
- `tests/components/vacuum/test_init.py`
- `tests/components/vacuum/test_intent.py`
- `tests/components/vicare/test_init.py`
- `tests/components/voip/test_voip.py`
- `tests/components/zha/test_dynamic_entities.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
